### PR TITLE
add kaggle notebook for training

### DIFF
--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -518,7 +518,10 @@ def cli(
     if prev_config:
         with open(prev_config) as f:
             cfg = json.load(f)
-        prev_phoneme_id_map = cfg["phoneme_id_map"]
+        # flatten list, same models (eg. piper) use a list of ids
+        prev_phoneme_id_map = {k: v if not isinstance(v, list) else v[0]
+                               for k, v in cfg["phoneme_id_map"].items()}
+
         prev_num_symbols = cfg.get("num_symbols", MAX_PHONEMES)
         _LOGGER.info(f"Loaded phoneme map from previous config: '{prev_config}'")
         all_phonemes.update(prev_phoneme_id_map.keys())

--- a/phoonnx_train/train_kaggle.ipynb
+++ b/phoonnx_train/train_kaggle.ipynb
@@ -1,0 +1,171 @@
+{
+ "metadata": {
+  "kernelspec": {
+   "language": "python",
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.13",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  },
+  "kaggle": {
+   "accelerator": "none",
+   "dataSources": [
+    {
+     "sourceId": 13336070,
+     "sourceType": "datasetVersion",
+     "datasetId": 8456015
+    }
+   ],
+   "dockerImageVersionId": 31089,
+   "isInternetEnabled": true,
+   "language": "python",
+   "sourceType": "notebook",
+   "isGpuEnabled": false
+  }
+ },
+ "nbformat_minor": 4,
+ "nbformat": 4,
+ "cells": [
+  {
+   "cell_type": "code",
+   "source": [
+    "import os\n",
+    "os.environ[\"LANG\"] = \"sv\"\n",
+    "os.environ[\"PHONEMIZER\"] = \"espeak\"\n",
+    "os.environ[\"ALPHABET\"] = \"ipa\"\n",
+    "os.environ[\"BASE_CKPT_URL\"] = \"https://huggingface.co/OpenVoiceOS/phoonnx_eu-ES_miro_espeak/resolve/main/epoch%3D299-step%3D99600.ckpt\"\n",
+    "os.environ[\"BASE_CONFIG_URL\"] = \"https://huggingface.co/OpenVoiceOS/phoonnx_eu-ES_miro_espeak/resolve/main/miro_eu-ES.json\"\n",
+    "os.environ[\"HF_DATASET\"] = \"TigreGotico/tts-train-synthetic-miro_sv-SE\"\n",
+    "#os.environ[\"HF_TOKEN\"] = \"hf_xxxxx\"  # hugging face token, for private datasets and to avoid rate limiting\n",
+    "os.environ[\"UV_VENV_CLEAR\"] = \"1\"\n",
+    "os.environ[\"ACCELERATOR\"] = 'gpu'  # gpu or cpu\n",
+    "os.environ[\"CUDA\"] = \"1\"  # tell ByT5 phonemizer to use gpu\n",
+    "os.environ[\"LOCAL_CKPT_PATH\"] = \"checkpoints/prev.ckpt\"\n",
+    "os.environ[\"LOCAL_CONFIG_PATH\"] = \"checkpoints/prev.ckpt.json\"\n",
+    "os.environ[\"LOCAL_DATASET_PATH\"] = \"/kaggle/working/dataset\"  # /kaggle/working/dataset  or /kaggle/input/xxx if you uploaded dataset\n",
+    "os.environ[\"PHONEMIZED_DATASET_PATH\"] = \"/kaggle/working/training\"  # output of preprocess.py - you may upload it instead of preprocessing in kaggle"
+   ],
+   "metadata": {
+    "_uuid": "8f2839f25d086af736a60e9eeb907d3b93b6e0e5",
+    "_cell_guid": "b1076dfc-b9ad-4769-8c92-a6c4dae69d19",
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "!python3 -m pip install uv\n!uv pip install --system wheel 'setuptools==68' 'huggingface_hub[cli]'\n!uv venv --python 3.10",
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "!git clone https://github.com/TigreGotico/phoonnx",
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# NOTE: add any extra dependencies here, lang specific phonemizer etc\n!uv pip install -e phoonnx[train] --python /kaggle/working/.venv/bin/python3.10",
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# NOTE: skip if not using espeak phonemizer\n",
+    "!apt-get install --reinstall -y espeak-ng"
+   ],
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# NOTE: skip this if you uploaded the dataset to kaggle\n",
+    "!huggingface-cli download $HF_DATASET --quiet --repo-type dataset --local-dir $LOCAL_DATASET_PATH"
+   ],
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# NOTE: skip this if you uploaded the checkpoint to kaggle\n!wget $BASE_CKPT_URL -O $LOCAL_CKPT_PATH\n!wget $BASE_CONFIG_URL -O $LOCAL_CONFIG_PATH",
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "!source .venv/bin/activate && cd phoonnx/phoonnx_train/vits/monotonic_align && \\\n",
+    "mkdir -p monotonic_align && \\\n",
+    "cythonize -i core.pyx && \\\n",
+    "mv core*.so monotonic_align && ls monotonic_align"
+   ],
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "# NOTE: skip this if you uploaded the preprocessed data to kaggle\n!source .venv/bin/activate && python phoonnx/phoonnx_train/preprocess.py \\\n  --language $LANG \\\n  --input-dir $LOCAL_DATASET_PATH \\\n  --output-dir $PHONEMIZED_DATASET_PATH \\\n  --single-speaker \\\n  --sample-rate 22050 \\\n  --phoneme-type $PHONEMIZER \\\n  --alphabet $ALPHABET  \\\n  --prev-config $LOCAL_CONFIG_PATH  # if finetuning, reutilizes previous phoneme_id_map\n # --add-diacritics # arabic and hebrew\n # --phonemizer-model OpenVoiceOS/g2p-mbyt5-12l-ipa-childes-espeak-onnx  # uncomment if using byt5",
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# wait until finished or timeout\n",
+    "!source .venv/bin/activate && python phoonnx/phoonnx_train/train.py \\\n",
+    "    --dataset-dir $PHONEMIZED_DATASET_PATH \\\n",
+    "    --accelerator $ACCELERATOR \\\n",
+    "    --devices 1 \\\n",
+    "    --batch-size 16 \\\n",
+    "    --validation-split 0.05 \\\n",
+    "    --max-epochs 1000 \\\n",
+    "    --checkpoint-epochs 1 \\\n",
+    "    --precision 32 \\\n",
+    "    --resume-from-checkpoint $LOCAL_CKPT_PATH"
+   ],
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ready-to-run Kaggle notebook for end-to-end training, including environment setup, dependency installation, dataset/checkpoint handling, preprocessing, and configurable training runs (devices, batch size, validation split, epochs, precision, resume).

* **Bug Fixes**
  * Improved preprocessing robustness by correctly handling phoneme mapping entries provided as lists, ensuring broader config compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->