### PR TITLE
Bump requirements and allow training with torch.compile

### DIFF
--- a/phoonnx_train/export_onnx.py
+++ b/phoonnx_train/export_onnx.py
@@ -240,7 +240,7 @@ def cli(
         _LOGGER.error(f"Error loading model checkpoint {checkpoint}: {e}")
         return
 
-    model_g: torch.nn.Module = model.model_g
+    model_g: torch.nn.Module = model.model_g.cpu()
     num_symbols: int = model_g.n_vocab
     num_speakers: int = model_g.n_speakers
 

--- a/phoonnx_train/export_onnx.py
+++ b/phoonnx_train/export_onnx.py
@@ -3,12 +3,19 @@ import click
 import logging
 import json
 import os
+import pathlib
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple
 
 import torch
 from phoonnx_train.vits.lightning import VitsModel
 from phoonnx.version import VERSION_STR
+
+
+# Allow unpickling those classes
+torch.serialization.add_safe_globals([pathlib.PosixPath])
+torch.serialization.safe_globals([pathlib.PosixPath])
+
 
 # Basic logging configuration
 logging.basicConfig(level=logging.DEBUG)

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -45,6 +45,8 @@ def load_state_dict(model, saved_state_dict):
 @click.option('--num-workers', type=click.IntRange(min=1), default=os.cpu_count() or 1, help='Number of data loader workers (default: CPU count)')
 @click.option('--validation-split', type=float, default=0.05, help='Proportion of data used for validation (default: 0.05)')
 @click.option('--discard-encoder', type=bool, default=False, help='Discard the encoder weights from base checkpoint (default: False)')
+@click.option('--compile', 'use_compile', is_flag=True, default=False, help='Compile the model with torch.compile for faster training (default: False)')
+@click.option('--compile-mode', default='default', type=click.Choice(['default', 'reduce-overhead', 'max-autotune']), help='torch.compile mode (default: default)')
 def main(
     dataset_dir,
     checkpoint_epochs,
@@ -61,7 +63,9 @@ def main(
     batch_size,
     num_workers,
     validation_split,
-    discard_encoder
+    discard_encoder,
+    use_compile,
+    compile_mode,
 ):
     logging.basicConfig(level=logging.DEBUG)
 
@@ -192,6 +196,11 @@ def main(
         load_state_dict(model.model_g, g_dict)
         load_state_dict(model.model_d, model_single.model_d.state_dict())
         _LOGGER.info('Successfully converted single-speaker checkpoint to multi-speaker')
+
+    if use_compile:
+        _LOGGER.info('Compiling model with torch.compile (mode=%s)', compile_mode)
+        model.model_g = torch.compile(model.model_g, mode=compile_mode)
+        model.model_d = torch.compile(model.model_d, mode=compile_mode)
 
     _LOGGER.info('training started!!')
     trainer.fit(model)

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -81,17 +81,19 @@ def main(
     with open(config_path, 'r', encoding='utf-8') as config_file:
         config = json.load(config_file)
 
+    callbacks = []
+    if checkpoint_epochs is not None:
+        callbacks.append(ModelCheckpoint(every_n_epochs=checkpoint_epochs))
+        _LOGGER.info('Checkpoints will be saved every %s epoch(s)', checkpoint_epochs)
+
     trainer = Trainer(
         max_epochs=max_epochs,
         devices=devices,
         accelerator=accelerator,
         default_root_dir=default_root_dir,
-        precision=precision
+        precision=precision,
+        callbacks=callbacks,
     )
-
-    if checkpoint_epochs is not None:
-        trainer.callbacks = [ModelCheckpoint(every_n_epochs=checkpoint_epochs)]
-        _LOGGER.info('Checkpoints will be saved every %s epoch(s)', checkpoint_epochs)
 
     dict_args = dict(
         seed=seed,

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -108,8 +108,19 @@ def main(
         logging.getLogger("pytorch_lightning").setLevel(logging.ERROR)
 
     if use_compile:
+        # In notebook mode, suppress to CRITICAL: autotuning trial failures
+        # (E0324 ... Runtime error during autotuning: Ignoring this choice) are
+        # expected fallbacks, not real errors, but are logged at ERROR level by
+        # torch._logging's TorchLoggingHandler — setLevel() alone doesn't reach
+        # that handler, so we also call torch._logging.set_logs() which is the
+        # canonical PyTorch API for controlling it.
+        _compile_log_level = logging.CRITICAL if notebook else logging.ERROR
+        import torch._logging as _tl
+        _set_logs = getattr(_tl, "set_logs", None)
+        if _set_logs is not None:
+            _set_logs(dynamo=_compile_log_level, aot=_compile_log_level, inductor=_compile_log_level)
         for name in _TORCH_COMPILE_LOGGERS:
-            logging.getLogger(name).setLevel(logging.ERROR)
+            logging.getLogger(name).setLevel(_compile_log_level)
 
     dataset_dir = Path(dataset_dir)
     if default_root_dir is None:

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -79,7 +79,7 @@ def load_state_dict(model, saved_state_dict):
 @click.option('--validation-split', type=float, default=0.05, help='Proportion of data used for validation (default: 0.05)')
 @click.option('--discard-encoder', type=bool, default=False, help='Discard the encoder weights from base checkpoint (default: False)')
 @click.option('--compile', 'use_compile', is_flag=True, default=False, help='Compile the model with torch.compile for faster training (default: False)')
-@click.option('--compile-mode', default='default', type=click.Choice(['default', 'reduce-overhead', 'max-autotune', 'reduce-overhead-no-cudagraphs', 'max-autotune-no-cudagraphs']), help='torch.compile mode (default: default)')
+@click.option('--compile-mode', default='default', type=click.Choice(['default', 'reduce-overhead', 'max-autotune', 'max-autotune-no-cudagraphs']), help='torch.compile mode (default: default)')
 @click.option('--notebook', is_flag=True, default=False, help='Notebook-friendly output: suppress all logs below ERROR, show compilation/training progress bars only (default: False)')
 def main(
     dataset_dir,

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import os
 import torch
 import click
-from pytorch_lightning import Trainer
+from pytorch_lightning import Callback, Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
+from tqdm.auto import tqdm
 
 from phoonnx_train.vits.lightning import VitsModel
 
@@ -20,6 +21,28 @@ torch.serialization.safe_globals([pathlib.PosixPath])
 
 
 _LOGGER = logging.getLogger(__package__)
+
+_TORCH_COMPILE_LOGGERS = [
+    "torch._dynamo",
+    "torch._inductor",
+    "torch._functorch",
+    "torch._logging",
+]
+
+
+class _CompileStatusCallback(Callback):
+    """Displays an elapsed-time indicator while the first training step compiles."""
+
+    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
+        if batch_idx == 0 and trainer.current_epoch == 0:
+            self._bar = tqdm(desc="Compiling", bar_format="{desc}: {elapsed}", leave=True)
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        bar = getattr(self, "_bar", None)
+        if bar is not None:
+            bar.set_description("Compiled")
+            bar.close()
+            self._bar = None
 
 
 def load_state_dict(model, saved_state_dict):
@@ -57,6 +80,7 @@ def load_state_dict(model, saved_state_dict):
 @click.option('--discard-encoder', type=bool, default=False, help='Discard the encoder weights from base checkpoint (default: False)')
 @click.option('--compile', 'use_compile', is_flag=True, default=False, help='Compile the model with torch.compile for faster training (default: False)')
 @click.option('--compile-mode', default='default', type=click.Choice(['default', 'reduce-overhead', 'max-autotune', 'reduce-overhead-no-cudagraphs', 'max-autotune-no-cudagraphs']), help='torch.compile mode (default: default)')
+@click.option('--notebook', is_flag=True, default=False, help='Notebook-friendly output: suppress all logs below ERROR, show compilation/training progress bars only (default: False)')
 def main(
     dataset_dir,
     checkpoint_epochs,
@@ -76,8 +100,16 @@ def main(
     discard_encoder,
     use_compile,
     compile_mode,
+    notebook,
 ):
-    logging.basicConfig(level=logging.DEBUG)
+    log_level = logging.ERROR if notebook else logging.DEBUG
+    logging.basicConfig(level=log_level, force=True)
+    if notebook:
+        logging.getLogger("pytorch_lightning").setLevel(logging.ERROR)
+
+    if use_compile:
+        for name in _TORCH_COMPILE_LOGGERS:
+            logging.getLogger(name).setLevel(logging.ERROR)
 
     dataset_dir = Path(dataset_dir)
     if default_root_dir is None:
@@ -99,6 +131,8 @@ def main(
     if checkpoint_epochs is not None:
         callbacks.append(ModelCheckpoint(every_n_epochs=checkpoint_epochs))
         _LOGGER.info('Checkpoints will be saved every %s epoch(s)', checkpoint_epochs)
+    if notebook and use_compile:
+        callbacks.append(_CompileStatusCallback())
 
     trainer = Trainer(
         max_epochs=max_epochs,

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pathlib
 from pathlib import Path
 import os
 import torch
@@ -8,6 +9,15 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 
 from phoonnx_train.vits.lightning import VitsModel
+
+
+# Set the precision for matrix multiplications
+torch.set_float32_matmul_precision('high')
+
+# Allow unpickling those classes
+torch.serialization.add_safe_globals([pathlib.PosixPath])
+torch.serialization.safe_globals([pathlib.PosixPath])
+
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -38,7 +48,7 @@ def load_state_dict(model, saved_state_dict):
 @click.option('--devices', default=1, help='Number of devices or list of device IDs to train on (default: 1)')
 @click.option('--accelerator', default='auto', help='Hardware accelerator to use (cpu, gpu, tpu, mps, etc.)  (default: "auto")')
 @click.option('--default-root-dir', type=click.Path(file_okay=False), default=None, help='Default root directory for logs and checkpoints (default: None)')
-@click.option('--precision', default=32, help='Precision used in training (e.g. 16, 32, bf16) (default: 32)')
+@click.option('--precision', type=str, default="32", help='Precision used in training (e.g. 16, 32, bf16) (default: "32")')
 # Model-specific arguments
 @click.option('--learning-rate', type=float, default=2e-4, help='Learning rate for optimizer (default: 2e-4)')
 @click.option('--batch-size', type=int, default=16, help='Training batch size (default: 16)')
@@ -46,7 +56,7 @@ def load_state_dict(model, saved_state_dict):
 @click.option('--validation-split', type=float, default=0.05, help='Proportion of data used for validation (default: 0.05)')
 @click.option('--discard-encoder', type=bool, default=False, help='Discard the encoder weights from base checkpoint (default: False)')
 @click.option('--compile', 'use_compile', is_flag=True, default=False, help='Compile the model with torch.compile for faster training (default: False)')
-@click.option('--compile-mode', default='default', type=click.Choice(['default', 'reduce-overhead', 'max-autotune']), help='torch.compile mode (default: default)')
+@click.option('--compile-mode', default='default', type=click.Choice(['default', 'reduce-overhead', 'max-autotune', 'reduce-overhead-no-cudagraphs', 'max-autotune-no-cudagraphs']), help='torch.compile mode (default: default)')
 def main(
     dataset_dir,
     checkpoint_epochs,

--- a/phoonnx_train/vits/dataset.py
+++ b/phoonnx_train/vits/dataset.py
@@ -89,8 +89,8 @@ class PhoonnxDataset(Dataset):
         utt = self.utterances[idx]
         return UtteranceTensors(
             phoneme_ids=LongTensor(utt.phoneme_ids),
-            audio_norm=torch.load(utt.audio_norm_path),
-            spectrogram=torch.load(utt.audio_spec_path),
+            audio_norm=torch.load(utt.audio_norm_path, weights_only=True),
+            spectrogram=torch.load(utt.audio_spec_path, weights_only=True),
             speaker_id=LongTensor([utt.speaker_id])
             if utt.speaker_id is not None
             else None,

--- a/phoonnx_train/vits/lightning.py
+++ b/phoonnx_train/vits/lightning.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Tuple, Union
 
 import pytorch_lightning as pl
 import torch
-from torch import autocast
 from torch.nn import functional as F
 from torch.utils.data import DataLoader, Dataset, random_split
 
@@ -77,6 +76,7 @@ class VitsModel(pl.LightningModule):
     ):
         super().__init__()
         self.save_hyperparameters()
+        self.automatic_optimization = False
 
         if (self.hparams.num_speakers > 1) and (self.hparams.gin_channels <= 0):
             # Default gin_channels for multi-speaker model
@@ -198,14 +198,25 @@ class VitsModel(pl.LightningModule):
             batch_size=self.hparams.batch_size,
         )
 
-    def training_step(self, batch: Batch, batch_idx: int, optimizer_idx: int):
-        if optimizer_idx == 0:
-            return self.training_step_g(batch)
+    def training_step(self, batch: Batch, batch_idx: int):
+        opt_g, opt_d = self.optimizers()
 
-        if optimizer_idx == 1:
-            return self.training_step_d(batch)
+        opt_g.zero_grad()
+        loss_gen_all = self._step_g(batch)
+        self.manual_backward(loss_gen_all)
+        opt_g.step()
 
-    def training_step_g(self, batch: Batch):
+        opt_d.zero_grad()
+        loss_disc_all = self._step_d(batch)
+        self.manual_backward(loss_disc_all)
+        opt_d.step()
+
+    def on_train_epoch_end(self):
+        sch_g, sch_d = self.lr_schedulers()
+        sch_g.step()
+        sch_d.step()
+
+    def _step_g(self, batch: Batch):
         x, x_lengths, y, _, spec, spec_lengths, speaker_ids = (
             batch.phoneme_ids,
             batch.phoneme_lengths,
@@ -260,7 +271,7 @@ class VitsModel(pl.LightningModule):
 
         _y_d_hat_r, y_d_hat_g, fmap_r, fmap_g = self.model_d(y, y_hat)
 
-        with autocast(self.device.type, enabled=False):
+        with torch.amp.autocast(self.device.type, enabled=False):
             # Generator loss
             loss_dur = torch.sum(l_length.float())
             loss_mel = F.l1_loss(y_mel, y_hat_mel) * self.hparams.c_mel
@@ -274,13 +285,13 @@ class VitsModel(pl.LightningModule):
 
             return loss_gen_all
 
-    def training_step_d(self, batch: Batch):
-        # From training_step_g
+    def _step_d(self, batch: Batch):
+        # From _step_g
         y = self._y
         y_hat = self._y_hat
         y_d_hat_r, y_d_hat_g, _, _ = self.model_d(y, y_hat.detach())
 
-        with autocast(self.device.type, enabled=False):
+        with torch.amp.autocast(self.device.type, enabled=False):
             # Discriminator
             loss_disc, _losses_disc_r, _losses_disc_g = discriminator_loss(
                 y_d_hat_r, y_d_hat_g
@@ -292,7 +303,7 @@ class VitsModel(pl.LightningModule):
             return loss_disc_all
 
     def validation_step(self, batch: Batch, batch_idx: int):
-        val_loss = self.training_step_g(batch) + self.training_step_d(batch)
+        val_loss = self._step_g(batch) + self._step_d(batch)
         self.log("val_loss", val_loss)
 
         # Generate audio examples

--- a/phoonnx_train/vits/lightning.py
+++ b/phoonnx_train/vits/lightning.py
@@ -118,6 +118,14 @@ class VitsModel(pl.LightningModule):
         self._y = None
         self._y_hat = None
 
+    def on_load_checkpoint(self, checkpoint: dict) -> None:
+        # Checkpoints saved with torch.compile have "_orig_mod." in every key.
+        # Strip it so the state dict loads cleanly whether compile is on or off.
+        state_dict = checkpoint.get("state_dict", {})
+        checkpoint["state_dict"] = {
+            k.replace("._orig_mod.", "."): v for k, v in state_dict.items()
+        }
+
     def _load_datasets(
         self,
         validation_split: float,

--- a/phoonnx_train/vits/transforms.py
+++ b/phoonnx_train/vits/transforms.py
@@ -7,6 +7,7 @@ DEFAULT_MIN_BIN_HEIGHT = 1e-3
 DEFAULT_MIN_DERIVATIVE = 1e-3
 
 
+@torch.compiler.disable
 def piecewise_rational_quadratic_transform(
     inputs,
     unnormalized_widths,
@@ -47,6 +48,7 @@ def searchsorted(bin_locations, inputs, eps=1e-6):
     return torch.sum(inputs[..., None] >= bin_locations, dim=-1) - 1
 
 
+@torch.compiler.disable
 def unconstrained_rational_quadratic_spline(
     inputs,
     unnormalized_widths,
@@ -98,6 +100,7 @@ def unconstrained_rational_quadratic_spline(
     return outputs, logabsdet
 
 
+@torch.compiler.disable
 def rational_quadratic_spline(
     inputs,
     unnormalized_widths,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,10 @@ train = [
     "cython>=0.29.0,<1",
     "librosa>=0.9.2,<1",
     "numpy>=1.19.0,<2",
-    "pytorch-lightning<2.0",
-    "torch>=1.11.0,<2",
+    "pytorch-lightning>=2.5",
+    "torch>=2.8",
+    "huggingface_hub>1.2.0",
+    "onnx",
 ]
 ar = ["epitran"]
 ca = ["epitran"]

--- a/requirements/train.txt
+++ b/requirements/train.txt
@@ -5,3 +5,4 @@ pytorch-lightning>=2.5
 torch==2.8.0
 click
 huggingface_hub>1.2.0
+onnx

--- a/requirements/train.txt
+++ b/requirements/train.txt
@@ -2,5 +2,6 @@ cython>=0.29.0,<1
 librosa>=0.9.2,<1
 numpy>=1.19.0,<2
 pytorch-lightning>=2.5
-torch>=2.8
+torch==2.8.0
 click
+huggingface_hub>1.2.0

--- a/requirements/train.txt
+++ b/requirements/train.txt
@@ -1,6 +1,6 @@
 cython>=0.29.0,<1
 librosa>=0.9.2,<1
 numpy>=1.19.0,<2
-pytorch-lightning<2.0
-torch>=1.11.0,<2
+pytorch-lightning>=2.5
+torch>=2.8
 click


### PR DESCRIPTION
Bump requirements and allow training with torch.compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional model compilation with CLI flags (including compile mode) and an interactive notebook mode with quieter logging.
* **Improvements**
  * Updated training dependencies (PyTorch 2.8.0, PyTorch Lightning 2.5+, plus ONNX and HuggingFace Hub).
  * Enhanced checkpoint/serialization handling and safer tensor loading for dataset inputs.
  * Revised training loop to use explicit generator/discriminator optimization and step both learning-rate schedulers each epoch.
  * Excluded specific numerical transforms from compilation for stability.
* **Bug Fixes**
  * Improved checkpoint compatibility when switching between compiled and non-compiled runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->