### PR TITLE
feat: phoneme alignment support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ For anyone extending phoonnx or debugging a voice.
 
 - [Voice cloning](cloning.md) — zero-shot cloning from a reference clip
 - [Streaming](streaming.md) — low-latency streaming for VITS voices
+- [Phoneme alignment](alignment.md) — per-phoneme timing for visemes, karaoke, subtitles
 - [OVOS plugin](ovos_plugin.md) — the `ovos-tts-plugin-phoonnx` TTS plugin
 - [Docker / TTS server](docker.md)
 

--- a/docs/alignment.md
+++ b/docs/alignment.md
@@ -1,0 +1,194 @@
+# Phoneme Alignment
+
+Phoneme alignment gives you per-phoneme timing: how many audio samples each phoneme
+occupies in the synthesized output. This is the foundation for visemes (lip-sync),
+karaoke-style word highlighting, and subtitle generation.
+
+> **Model support required.** Alignment is an optional second output of the ONNX
+> model. Standard exported models do **not** include it. See
+> [Exporting a model with alignment support](#exporting-a-model-with-alignment-support)
+> below.
+
+---
+
+## Getting alignments from `synthesize()`
+
+Pass `include_alignments=True` to `TTSVoice.synthesize()`:
+
+```python
+from phoonnx.voice import TTSVoice
+
+voice = TTSVoice.load("model-aligned.onnx")
+
+for chunk in voice.synthesize("Hello world.", include_alignments=True):
+    print(f"phonemes : {chunk.phonemes}")
+    print(f"phoneme ids: {chunk.phoneme_ids}")
+
+    if chunk.phoneme_alignments:
+        for align in chunk.phoneme_alignments:
+            duration_ms = align.num_samples / chunk.sample_rate * 1000
+            print(f"  {align.phoneme!r:6s}  {duration_ms:6.1f} ms")
+    else:
+        # Model does not expose alignment output, or reconstruction failed
+        print("  (no alignment available)")
+```
+
+### `AudioChunk` alignment fields
+
+| Field | Type | Description |
+|---|---|---|
+| `phonemes` | `list[str]` | Phoneme tokens for this sentence |
+| `phoneme_ids` | `list[int]` | Integer IDs passed to the ONNX model |
+| `phoneme_id_samples` | `np.ndarray \| None` | Raw sample counts per phoneme ID (from model) |
+| `phoneme_alignments` | `list[PhonemeAlignment] \| None` | Reconstructed per-phoneme timings |
+
+`phoneme_alignments` is `None` when:
+- `include_alignments=False` (default)
+- The model has only one output (does not support alignment)
+- The alignment reconstruction fails (ID sequence mismatch)
+
+`phonemes` and `phoneme_ids` are always populated regardless of `include_alignments`.
+
+### `PhonemeAlignment`
+
+```python
+@dataclass
+class PhonemeAlignment:
+    phoneme: str      # the phoneme token, e.g. "h", "ɛ", "l"
+    num_samples: int  # number of PCM samples occupied by this phoneme
+```
+
+Convert `num_samples` to milliseconds: `num_samples / chunk.sample_rate * 1000`.
+
+---
+
+## Lower-level: `phoneme_ids_to_audio()`
+
+If you are working at the phoneme-ID level you can call the method directly:
+
+```python
+audio_or_tuple = voice.phoneme_ids_to_audio(phoneme_ids, include_alignments=True)
+
+if isinstance(audio_or_tuple, tuple):
+    audio, phoneme_id_samples = audio_or_tuple
+    # phoneme_id_samples[i] = samples for phoneme_ids[i], or None if unsupported
+else:
+    audio = audio_or_tuple  # include_alignments=False
+```
+
+---
+
+## `hop_length`
+
+The raw model output is a duration in frames; phoonnx converts frames to samples
+using `hop_length` (default **256**, matching the standard VITS vocoder hop size).
+
+Override it in the voice config JSON:
+
+```json
+{
+  "hop_length": 256
+}
+```
+
+Or via `VoiceConfig`:
+
+```python
+voice.config.hop_length = 256
+```
+
+---
+
+## Engine support matrix
+
+Alignment works uniformly across every duration-predictor engine adapter — not
+just VITS. Each adapter's `parse_outputs` looks for a per-phoneme duration
+tensor among the model's ONNX outputs by name (see `DURATION_OUTPUT_NAMES` on
+each adapter class), and `TTSVoice.phoneme_ids_to_audio` converts whatever it
+finds to samples the same way for every engine: `samples = frames * hop_length`.
+This holds for single-stage engines (the "frames" are the internal
+duration-predictor's frame rate, matching the decoder's implicit hop) and for
+two-stage engines (the "frames" are literal mel frames, and `hop_length` is
+the mel→waveform vocoder's hop size).
+
+| Engine family | Native durations today? | Units | Conversion rule |
+|---|---|---|---|
+| VITS (piper/mimic3/coqui/phoonnx) | Yes, in phoonnx's own `--add-phoneme-alignment` exports (`phoneme_id_samples`) | duration-predictor frames | `samples = frames * hop_length` |
+| YourTTS | Same VITS-family contract; yes if the export adds a second output | duration-predictor frames | `samples = frames * hop_length` |
+| OptiSpeech | Yes — `durations` is a standard third output (`[wav, wav_lengths, durations]`) | duration-predictor frames | `samples = frames * hop_length` |
+| FastPitch / Mixer-TTS | No — standard exports emit only `mel_spec` | mel frames (if a future export adds one) | `samples = frames * hop_length` |
+| GlowTTS (Larynx/Coqui) | No — standard exports emit only the mel tensor(s) | mel frames (if a future export adds one) | `samples = frames * hop_length` |
+| Matcha-TTS | No — standard two-stage exports emit `[mel, mel_lengths]`; end-to-end fused exports have no separate mel/durations at all | mel frames (if a future export adds one) | `samples = frames * hop_length` |
+| StyleTTS2 / Kokoro | No — standard exports emit only the waveform | model frames (if a future export adds one) | `samples = frames * hop_length` |
+| ZipVoice | **Not supported.** In-context flow-matching with no discrete duration predictor — there is nothing to align to a token. `synthesize()` never populates `phoneme_id_samples`. | — | — |
+
+For the "No" rows, the adapter still implements name-based detection
+(`DURATION_OUTPUT_NAMES` lists plausible output names such as `durations`,
+`dur`, `w_ceil`, `logw`, `pred_dur`) so a model re-exported with that tensor
+exposed lights up alignment automatically, with no adapter code changes. Until
+then, `include_alignments=True` degrades gracefully: `phoneme_id_samples` and
+`phoneme_alignments` come back `None`, exactly like an unpatched VITS model —
+synthesis itself is never affected.
+
+**Future work — forced alignment.** ZipVoice and any other in-context /
+autoregressive engine without a discrete duration predictor cannot expose
+native alignment this way. A forced-alignment fallback (e.g. running a
+phoneme-to-audio aligner such as CTC-segmentation or MFA over the generated
+audio) would be needed to support those engines; it is not implemented here.
+
+---
+
+## Exporting a model with alignment support
+
+Standard VITS models expose only the audio tensor. To expose the phoneme-duration
+tensor as a second output, use the `--add-phoneme-alignment` flag when exporting:
+
+```bash
+python -m phoonnx_train.export_onnx checkpoint.ckpt -c config.json --add-phoneme-alignment
+```
+
+This modifies the exported `.onnx` graph to surface the `Ceil` node output (phoneme
+durations) as a named model output. The modification is done by
+`add_phoneme_alignment_output()` in `phoonnx_train/export_onnx.py`.
+
+You can also apply it post-hoc to an already-exported model:
+
+```python
+from phoonnx_train.export_onnx import add_phoneme_alignment_output
+from pathlib import Path
+
+add_phoneme_alignment_output(
+    model_path=Path("model.onnx"),
+    output_path=Path("model-aligned.onnx"),  # omit to overwrite in place
+    tensor_name="autodetect",                # or pass the tensor name explicitly
+)
+```
+
+> **Compatibility note.** Adding the alignment output may break third-party
+> frameworks (e.g. Piper) that expect a single output tensor. Keep a separate
+> copy of the model for standard TTS use.
+
+---
+
+## Use cases
+
+### Visemes / lip-sync
+
+Map each phoneme to a viseme index, then schedule face-rig blend-shape changes
+at the sample offset accumulated from `num_samples`:
+
+```python
+VISEME = {"p": 0, "b": 0, "m": 0, "f": 1, "v": 1, ...}  # your mapping
+
+offset = 0
+for align in chunk.phoneme_alignments or []:
+    t = offset / chunk.sample_rate
+    viseme = VISEME.get(align.phoneme, -1)
+    schedule_viseme(t, viseme)
+    offset += align.num_samples
+```
+
+### Karaoke / subtitle highlighting
+
+Accumulate sample offsets to get word-start timestamps, then use them to
+synchronise text highlights with audio playback.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ from phoonnx.config import VoiceConfig
 | `noise_scale` | `float` | `0.667` | Default generator noise scale |
 | `length_scale` | `float` | `1.0` | Default phoneme length scale |
 | `noise_w_scale` | `float` | `0.8` | Default phoneme width noise scale |
+| `hop_length` | `int` | `256` | Model frames → audio samples factor for [phoneme alignment](alignment.md) |
 | `add_diacritics` | `bool` | `False` | Auto-add diacritics (Arabic/Hebrew) |
 | `diacritizer_model` | `str` | `rawi-ensemble` | Diacritizer model name (Arabic `text2tashkeel`); round-tripped through the config's `inference` block |
 | `phonemizer_model` | `str` \| `None` | `None` | Model path/id or variant selector for phonemizers that take one (ByT5, AhoTTS, Cotovia, arbtok) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,6 +94,24 @@ phoneme_ids = [1, 5, 23, 7, 2]  # example IDs
 audio: np.ndarray = voice.phoneme_ids_to_audio(phoneme_ids)
 ```
 
+### Phoneme Alignment
+
+Every `AudioChunk` carries the `phonemes` and `phoneme_ids` that produced it.
+Pass `include_alignments=True` to also get per-phoneme timing — how many audio
+samples each phoneme spans — when the model exposes a duration output:
+
+```python
+for chunk in voice.synthesize("Hello world.", include_alignments=True):
+    for align in chunk.phoneme_alignments or []:
+        ms = align.num_samples / chunk.sample_rate * 1000
+        print(f"{align.phoneme!r:6s} {ms:6.1f} ms")
+```
+
+`include_alignments=False` (the default) is a strict no-op on the audio, and
+models without a duration output degrade gracefully — `phoneme_alignments`
+comes back `None`. See [Phoneme alignment](alignment.md) for the full guide,
+the engine support matrix, and how to export a VITS model with alignment.
+
 ## SynthesisConfig
 
 `SynthesisConfig` controls synthesis parameters at runtime:

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -10,6 +10,7 @@ from phoonnx.tokenizer import (TTSTokenizer, Vocabulary, BlankBetween,
 DEFAULT_NOISE_SCALE = 0.667
 DEFAULT_LENGTH_SCALE = 1.0
 DEFAULT_NOISE_W_SCALE = 0.8
+DEFAULT_HOP_LENGTH = 256
 
 
 class Engine(str, Enum):
@@ -186,6 +187,12 @@ class VoiceConfig:
     add_diacritics: bool = None # arabic and hebrew
     # diacritizer model name (for languages that need one — e.g. Arabic uses text2tashkeel models like "rawi-ensemble")
     diacritizer_model: str = "rawi-ensemble"
+
+    # samples per model frame — used to convert per-phoneme durations (in model
+    # frames) to audio samples for the phoneme-alignment feature (see
+    # docs/usage.md). Matches the vocoder/decoder hop length; 256 for the
+    # standard 22.05 kHz VITS/HiFi-GAN exports.
+    hop_length: int = DEFAULT_HOP_LENGTH
 
     # tokenization settings
     tokenizer: Optional[TTSTokenizer] = None
@@ -507,6 +514,7 @@ class VoiceConfig:
             noise_w_scale=inference.get("noise_w", DEFAULT_NOISE_W_SCALE),
             add_diacritics=diacritics,
             diacritizer_model=ar_diacritizer_model,
+            hop_length=config.get("hop_length", DEFAULT_HOP_LENGTH),
             lang_code=lang_code,
             alphabet=Alphabet(alphabet) if isinstance(alphabet, str) else alphabet,
             engine=Engine(engine) if isinstance(engine, str) else engine,

--- a/phoonnx/engines/base.py
+++ b/phoonnx/engines/base.py
@@ -69,7 +69,19 @@ class BaseOnnxAdapter(ABC):
     - ``parse_config``     — pull engine-specific fields from JSON config
     - ``parse_onnx_meta``  — pull engine-specific fields from ONNX metadata
     - ``param_labels``     — human-readable names for UI sliders
+    - ``DURATION_OUTPUT_NAMES`` — candidate ONNX output names that carry a
+                             per-phoneme duration/frame-count tensor, used by
+                             :meth:`_find_duration_output` for the alignment
+                             feature (see ``docs/usage.md``).
     """
+
+    # Candidate ONNX output names that expose per-phoneme durations for this
+    # engine family (matched case-insensitively against
+    # ``session.get_outputs()`` names by :meth:`_find_duration_output`).
+    # Empty by default: engines opt in per-family. Listing a name here does
+    # NOT guarantee a given checkpoint's export has it — real exports vary;
+    # this only makes detection automatic once a model *does* expose one.
+    DURATION_OUTPUT_NAMES: List[str] = []
 
     # ------------------------------------------------------------------
     # Required
@@ -91,10 +103,18 @@ class BaseOnnxAdapter(ABC):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
         """
         Extract the audio waveform (and optional extras) from the raw
         list of ONNX output tensors.
+
+        ``output_names`` — the names reported by ``session.get_outputs()``,
+        positionally aligned with ``outputs`` when available (``None`` if the
+        session doesn't expose them, e.g. in unit tests with a bare mock).
+        Engines that support alignment use this (via
+        :meth:`_find_duration_output`) to locate a durations tensor by name
+        rather than by hardcoded position.
         """
 
     @abstractmethod
@@ -140,7 +160,15 @@ class BaseOnnxAdapter(ABC):
         """
         feed = self.build_feed_dict(request, session)
         outputs = session.run(None, feed)
-        return self.parse_outputs(outputs, request)
+        try:
+            return self.parse_outputs(
+                outputs, request, output_names=self._safe_output_names(session)
+            )
+        except TypeError:
+            # Third-party / test subclasses that predate the ``output_names``
+            # parameter and don't accept **kwargs — fall back to the
+            # original two-argument call so they keep working unmodified.
+            return self.parse_outputs(outputs, request)
 
     @staticmethod
     def detect(
@@ -213,3 +241,42 @@ class BaseOnnxAdapter(ABC):
     ) -> Dict[str, np.ndarray]:
         expected = {inp.name for inp in session.get_inputs()}
         return {k: v for k, v in args.items() if k in expected}
+
+    @staticmethod
+    def _safe_output_names(
+        session: onnxruntime.InferenceSession,
+    ) -> Optional[List[str]]:
+        """Best-effort ``session.get_outputs()`` names, positionally aligned
+        with ``session.run(None, ...)``'s return list.
+
+        Never raises: a mocked/minimal session (as used in unit tests) simply
+        yields ``None``, and callers must treat that as "duration detection by
+        name is unavailable" rather than crashing normal synthesis.
+        """
+        try:
+            return [getattr(o, "name", None) for o in session.get_outputs()]
+        except Exception:
+            return None
+
+    def _find_duration_output(
+        self,
+        outputs: List[np.ndarray],
+        output_names: Optional[List[str]],
+    ) -> Optional[np.ndarray]:
+        """Locate a per-phoneme duration/frame-count tensor among ``outputs``
+        by matching ``output_names`` against ``self.DURATION_OUTPUT_NAMES``.
+
+        Returns the raw tensor (still in the model's native unit — mel
+        frames for two-stage engines, audio-decoder frames for single-stage
+        ones; converted to samples uniformly in ``TTSVoice.phoneme_ids_to_audio``
+        via ``VoiceConfig.hop_length``), or ``None`` if this particular
+        export doesn't expose one. Never raises — callers degrade to "no
+        alignment available" when this returns ``None``.
+        """
+        if not output_names or not self.DURATION_OUTPUT_NAMES:
+            return None
+        candidates = {c.lower() for c in self.DURATION_OUTPUT_NAMES}
+        for name, arr in zip(output_names, outputs):
+            if name and name.lower() in candidates and arr is not None:
+                return np.asarray(arr)
+        return None

--- a/phoonnx/engines/glowtts.py
+++ b/phoonnx/engines/glowtts.py
@@ -35,6 +35,13 @@ from phoonnx.engines.vocoders.base import BaseVocoder
 class GlowTTSAdapter(BaseOnnxAdapter):
     """Adapter for GlowTTS / Larynx ONNX models (flow-matching mel + vocoder)."""
 
+    # GlowTTS derives durations from the flow's log-determinant (``logw`` /
+    # ``w_ceil`` in the reference Coqui implementation). Standard Larynx/Coqui
+    # exports don't expose it as a graph output today, so this resolves to
+    # None on those checkpoints; listed so a re-export exposing it under one
+    # of these names lights up automatically (see docs/alignment.md).
+    DURATION_OUTPUT_NAMES = ["durations", "dur", "w_ceil", "logw"]
+
     def __init__(self, vocoder: Optional[BaseVocoder] = None):
         self.vocoder = vocoder
         self._engine_params: Dict[str, Any] = {}
@@ -94,6 +101,7 @@ class GlowTTSAdapter(BaseOnnxAdapter):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
         arrays = [np.asarray(o) for o in outputs if o is not None]
         # Larynx glow_tts emits two rank-3 ``[B, n_mels, T]`` tensors. The mel the
@@ -112,7 +120,13 @@ class GlowTTSAdapter(BaseOnnxAdapter):
         vocoder = self._require_vocoder()
         denoise = bool(request.params.get("denoise", False)) and vocoder.supports_denoise
         audio = vocoder.mel_to_audio(mel.astype(np.float32), denoise=denoise)
-        return AdapterSynthesisResult(audio=np.asarray(audio).reshape(-1))
+
+        extras: Dict[str, Any] = {}
+        durations = self._find_duration_output(outputs, output_names)
+        if durations is not None:
+            extras["phoneme_id_samples"] = durations.squeeze()
+
+        return AdapterSynthesisResult(audio=np.asarray(audio).reshape(-1), extras=extras)
 
     def _larynx_mel_to_vocoder(self, mel: np.ndarray) -> np.ndarray:
         """

--- a/phoonnx/engines/matcha.py
+++ b/phoonnx/engines/matcha.py
@@ -44,6 +44,11 @@ from phoonnx.engines.vocoders.base import BaseVocoder
 class MatchaAdapter(BaseOnnxAdapter):
     """Adapter for Matcha-TTS ONNX models (flow-matching mel model + vocoder)."""
 
+    # Matcha-TTS's duration predictor (borrowed from Glow-TTS) is not exposed
+    # as a graph output in standard exports today; listed so a future
+    # re-export lights up alignment automatically (see docs/alignment.md).
+    DURATION_OUTPUT_NAMES = ["durations", "dur", "w_ceil", "logw"]
+
     def __init__(self, vocoder: Optional[BaseVocoder] = None):
         self.vocoder = vocoder
         # Raw engine params, retained so the vocoder can be built lazily if the
@@ -117,6 +122,7 @@ class MatchaAdapter(BaseOnnxAdapter):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
         """
         Produce the waveform from the mel model's outputs.
@@ -157,7 +163,13 @@ class MatchaAdapter(BaseOnnxAdapter):
         vocoder = self._require_vocoder()
         denoise = bool(request.params.get("denoise", True)) and vocoder.supports_denoise
         audio = vocoder.mel_to_audio(mel.astype(np.float32), denoise=denoise)
-        return AdapterSynthesisResult(audio=np.asarray(audio).reshape(-1))
+
+        extras: Dict[str, Any] = {}
+        durations = self._find_duration_output(outputs, output_names)
+        if durations is not None:
+            extras["phoneme_id_samples"] = durations.squeeze()
+
+        return AdapterSynthesisResult(audio=np.asarray(audio).reshape(-1), extras=extras)
 
     def default_params(self) -> Dict[str, float]:
         return {

--- a/phoonnx/engines/mixertts.py
+++ b/phoonnx/engines/mixertts.py
@@ -35,6 +35,14 @@ from phoonnx.engines.vocoders.base import BaseVocoder
 class MixerTTSAdapter(BaseOnnxAdapter):
     """Adapter for Mixer-TTS ONNX models (mel + separate vocoder)."""
 
+    # Standard Mixer-TTS/FastPitch ONNX exports emit only ``mel_spec`` — no
+    # duration output. These candidates cover the raw duration-predictor
+    # tensor some FastPitch training code calls "durations" (in mel frames),
+    # so a future re-export exposing it lights up alignment automatically;
+    # with today's typical exports this resolves to None (see
+    # docs/alignment.md).
+    DURATION_OUTPUT_NAMES = ["durations", "dur", "log_durations"]
+
     def __init__(self, vocoder: Optional[BaseVocoder] = None):
         self.vocoder = vocoder
         self._engine_params: Dict[str, Any] = {}
@@ -90,6 +98,7 @@ class MixerTTSAdapter(BaseOnnxAdapter):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
         arrays = [np.asarray(o) for o in outputs if o is not None]
         mel = next((a for a in arrays if a.ndim == 3 and 16 <= a.shape[1] <= 256), None)
@@ -98,7 +107,17 @@ class MixerTTSAdapter(BaseOnnxAdapter):
         vocoder = self._require_vocoder()
         denoise = bool(request.params.get("denoise", False)) and vocoder.supports_denoise
         audio = vocoder.mel_to_audio(mel.astype(np.float32), denoise=denoise)
-        return AdapterSynthesisResult(audio=np.asarray(audio).reshape(-1))
+
+        extras: Dict[str, Any] = {}
+        # Mel-frame durations, when the export exposes them. Converted to
+        # audio samples uniformly by TTSVoice.phoneme_ids_to_audio via
+        # VoiceConfig.hop_length (mel frame rate == vocoder hop_length for
+        # the standard HiFi-GAN/Vocos vocoders this adapter pairs with).
+        durations = self._find_duration_output(outputs, output_names)
+        if durations is not None:
+            extras["phoneme_id_samples"] = durations.squeeze()
+
+        return AdapterSynthesisResult(audio=np.asarray(audio).reshape(-1), extras=extras)
 
     def default_params(self) -> Dict[str, float]:
         return {"pace": 1.0, "pitch_mul": 1.0, "pitch_add": 0.0, "emotion": 0}

--- a/phoonnx/engines/optispeech.py
+++ b/phoonnx/engines/optispeech.py
@@ -48,6 +48,10 @@ LOG = logging.getLogger(__name__)
 class OptiSpeechAdapter(BaseOnnxAdapter):
     """Adapter for OptiSpeech ONNX models."""
 
+    # OptiSpeech's own contract names this output "durations" (see module
+    # docstring); other names are speculative fallbacks for foreign exports.
+    DURATION_OUTPUT_NAMES = ["durations", "dur", "phoneme_id_samples"]
+
     def __init__(self):
         self._onnx_meta: Optional[Dict[str, Any]] = None
 
@@ -85,15 +89,28 @@ class OptiSpeechAdapter(BaseOnnxAdapter):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
-        # OptiSpeech returns [wav, wav_lengths, durations]
+        # OptiSpeech returns [wav, wav_lengths, durations]. ``durations`` is a
+        # per-phoneme frame count from the internal duration predictor (like
+        # VITS's w_ceil) — exposed as ``phoneme_id_samples`` so
+        # ``TTSVoice.phoneme_ids_to_audio`` picks it up uniformly and scales
+        # it to samples via ``VoiceConfig.hop_length``.
         audio = outputs[0].squeeze()
 
         extras: Dict[str, Any] = {}
         if len(outputs) > 1:
             extras["wav_lengths"] = outputs[1]
-        if len(outputs) > 2:
-            extras["durations"] = outputs[2]
+
+        durations = self._find_duration_output(outputs, output_names)
+        if durations is None and len(outputs) > 2 and outputs[2] is not None:
+            durations = outputs[2]
+        if durations is not None:
+            # Keep the historical "durations" key for back-compat, and also
+            # expose the value as "phoneme_id_samples" — the name
+            # TTSVoice.phoneme_ids_to_audio looks for uniformly across engines.
+            extras["durations"] = durations
+            extras["phoneme_id_samples"] = np.asarray(durations).squeeze()
 
         return AdapterSynthesisResult(audio=audio, extras=extras)
 

--- a/phoonnx/engines/styletts2.py
+++ b/phoonnx/engines/styletts2.py
@@ -27,6 +27,16 @@ _PAD_ID = 0  # "$" in the StyleTTS2 vocab
 class StyleTTS2Adapter(BaseOnnxAdapter):
     """Adapter for StyleTTS2 / Kokoro single-graph ONNX models."""
 
+    # StyleTTS2/Kokoro's internal duration predictor (``pred_dur``) is not
+    # exposed as a graph output in standard single-waveform exports today;
+    # listed so a future re-export lights up alignment automatically (see
+    # docs/usage.md). Note the token sequence fed to the graph is padded
+    # (see build_feed_dict), so a duration tensor here would be one-or-two
+    # tokens longer than ``request.phoneme_ids`` — TTSVoice's length check
+    # already degrades to "alignments unavailable" rather than crashing on
+    # that mismatch.
+    DURATION_OUTPUT_NAMES = ["durations", "dur", "pred_dur"]
+
     def __init__(self, style_pack: Optional[np.ndarray] = None,
                  speaker_encoder: Optional[Any] = None):
         # [N, 256] per-voice style indexed by token length (Kokoro); None when the
@@ -96,10 +106,15 @@ class StyleTTS2Adapter(BaseOnnxAdapter):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
         # the only meaningful output is the waveform (1-D)
         wav = max(outputs, key=lambda o: np.asarray(o).size)
-        return AdapterSynthesisResult(audio=np.asarray(wav, dtype=np.float32).reshape(-1))
+        extras: Dict[str, Any] = {}
+        durations = self._find_duration_output(outputs, output_names)
+        if durations is not None:
+            extras["phoneme_id_samples"] = np.asarray(durations).squeeze()
+        return AdapterSynthesisResult(audio=np.asarray(wav, dtype=np.float32).reshape(-1), extras=extras)
 
     @staticmethod
     def detect(

--- a/phoonnx/engines/vits.py
+++ b/phoonnx/engines/vits.py
@@ -30,6 +30,11 @@ from phoonnx.engines.base import (
 class VitsAdapter(BaseOnnxAdapter):
     """Adapter for VITS-family ONNX models (piper, mimic3, coqui, phoonnx)."""
 
+    # phoonnx's own exports name the alignment output "phoneme_id_samples";
+    # other candidate names are speculative, for future/foreign exports that
+    # expose a raw duration-predictor tensor under a common name.
+    DURATION_OUTPUT_NAMES = ["phoneme_id_samples", "durations", "w_ceil", "dur"]
+
     # ------------------------------------------------------------------
     # Required
     # ------------------------------------------------------------------
@@ -89,11 +94,29 @@ class VitsAdapter(BaseOnnxAdapter):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
-        """Extract audio waveform from VITS ONNX outputs."""
+        """Extract audio waveform from VITS ONNX outputs.
+
+        Some phoonnx exports emit a second output tensor with per-phoneme
+        sample counts (used for alignment). When present, it is exposed via
+        ``AdapterSynthesisResult.extras["phoneme_id_samples"]``.
+
+        Detection prefers matching by name (``DURATION_OUTPUT_NAMES``) when
+        ``output_names`` is available; falls back to the historical
+        positional convention (second output tensor) for sessions that don't
+        expose output names (e.g. minimal test mocks), preserving prior
+        behavior.
+        """
         # VITS returns a single output tensor — squeeze to 1-D
         audio = outputs[0].squeeze()
-        return AdapterSynthesisResult(audio=audio)
+        extras: Dict[str, Any] = {}
+        durations = self._find_duration_output(outputs, output_names)
+        if durations is None and len(outputs) > 1 and outputs[1] is not None:
+            durations = outputs[1]
+        if durations is not None:
+            extras["phoneme_id_samples"] = np.asarray(durations).squeeze()
+        return AdapterSynthesisResult(audio=audio, extras=extras)
 
     def default_params(self) -> Dict[str, float]:
         return {

--- a/phoonnx/engines/yourtts.py
+++ b/phoonnx/engines/yourtts.py
@@ -25,6 +25,10 @@ from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult
 class YourTTSAdapter(BaseOnnxAdapter):
     """Adapter for YourTTS (multilingual VITS + d-vector conditioning)."""
 
+    # Same VITS-family duration-predictor contract as VitsAdapter — a second
+    # output tensor with per-phoneme frame counts, when the export has one.
+    DURATION_OUTPUT_NAMES = ["phoneme_id_samples", "durations", "w_ceil", "dur"]
+
     def __init__(self, d_vector: Optional[np.ndarray] = None, langid: int = 0,
                  speaker_encoder: Optional[Any] = None):
         self.d_vector = None if d_vector is None else np.asarray(d_vector, np.float32).reshape(1, -1)
@@ -88,9 +92,14 @@ class YourTTSAdapter(BaseOnnxAdapter):
         self,
         outputs: List[np.ndarray],
         request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
     ) -> AdapterSynthesisResult:
         wav = max(outputs, key=lambda o: np.asarray(o).size)
-        return AdapterSynthesisResult(audio=np.asarray(wav, dtype=np.float32).reshape(-1))
+        extras: Dict[str, Any] = {}
+        durations = self._find_duration_output(outputs, output_names)
+        if durations is not None:
+            extras["phoneme_id_samples"] = np.asarray(durations).squeeze()
+        return AdapterSynthesisResult(audio=np.asarray(wav, dtype=np.float32).reshape(-1), extras=extras)
 
     @staticmethod
     def detect(

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -12,7 +12,7 @@ import re
 import wave
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional, Sequence, Union, Dict
+from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union, Dict
 
 import numpy as np
 import onnxruntime
@@ -104,6 +104,14 @@ class PhoneticSpellings:
 
 
 @dataclass
+class PhonemeAlignment:
+    """A single phoneme paired with the number of audio samples it spans."""
+
+    phoneme: str
+    num_samples: int
+
+
+@dataclass
 class AudioChunk:
     """Chunk of raw audio."""
 
@@ -118,6 +126,20 @@ class AudioChunk:
 
     audio_float_array: np.ndarray
     """Audio data as float numpy array in [-1, 1]."""
+
+    phonemes: List[str] = field(default_factory=list)
+    """Phonemes that produced this audio chunk (empty for text-token models)."""
+
+    phoneme_ids: List[int] = field(default_factory=list)
+    """Phoneme/token ids that produced this audio chunk."""
+
+    phoneme_id_samples: Optional[np.ndarray] = None
+    """Number of audio samples for each phoneme id — only populated when
+    ``synthesize(include_alignments=True)`` and the model exposes durations."""
+
+    phoneme_alignments: Optional[List[PhonemeAlignment]] = None
+    """Per-phoneme (phoneme, num_samples) alignments — only populated when
+    ``synthesize(include_alignments=True)`` and the model exposes durations."""
 
     _audio_int16_array: Optional[np.ndarray] = None
     _audio_int16_bytes: Optional[bytes] = None
@@ -441,7 +463,11 @@ class TTSVoice:
             src_alphabet: Alphabet,
             tgt_alphabet: Alphabet,
     ) -> Iterable[tuple]:
-        """Lazily yield ``(phoneme_ids, language_ids)`` per sentence.
+        """Lazily yield ``(phonemes, phoneme_ids, language_ids)`` per sentence.
+
+        ``phonemes`` is the per-sentence symbol list (``None`` for text-token
+        models whose adapter owns text→ids); it is carried through only so the
+        yielded :class:`AudioChunk` can expose the phonemes that produced it.
 
         Preserves the exact dispatch semantics of :meth:`synthesize` while
         deferring per-sentence phonemize/diacritize/tokenize work until each item
@@ -458,14 +484,14 @@ class TTSVoice:
                 if do_diacritics:
                     text = self._diacritize(text, diacritizer_model)
                 for ids in self.adapter.encode_text(text, self, syn_config):
-                    yield ids, None
+                    yield None, ids, None
             else:
                 # Already-phonemic input in the model's own alphabet: pass through.
                 if do_diacritics:
                     text = self._diacritize(text, diacritizer_model)
                 for phonemes in _phonemic_chunks(text, tgt_alphabet):
                     if phonemes:
-                        yield self.phonemes_to_ids(phonemes), None
+                        yield phonemes, self.phonemes_to_ids(phonemes), None
             return
 
         if src_alphabet == Alphabet.GRAPHEMES:
@@ -478,7 +504,7 @@ class TTSVoice:
                 for part in self._text_parts(text, do_diacritics, diacritizer_model):
                     for phonemes, language_ids in lazy_lang_ids(part, lang):
                         if phonemes:
-                            yield self.phonemes_to_ids(phonemes), language_ids
+                            yield phonemes, self.phonemes_to_ids(phonemes), language_ids
             elif hasattr(self.phonemizer, "phonemize_with_language_ids"):
                 # Language-aware phonemizer without a lazy variant: eager fallback.
                 if do_diacritics:
@@ -487,7 +513,7 @@ class TTSVoice:
                     self.phonemizer.phonemize_with_language_ids(text, lang))
                 for phonemes, language_ids in zip(sentence_phonemes, sentence_language_ids):
                     if phonemes:
-                        yield self.phonemes_to_ids(phonemes), language_ids
+                        yield phonemes, self.phonemes_to_ids(phonemes), language_ids
             elif _PHONEME_BLOCK_PATTERN.search(text):
                 # Inline [[phoneme]] blocks merge into adjacent sentences; keep the
                 # (eager) whole-text handling that owns that merge logic.
@@ -495,7 +521,7 @@ class TTSVoice:
                     text = self._diacritize(text, diacritizer_model)
                 for phonemes in self.phonemize(text):
                     if phonemes:
-                        yield self.phonemes_to_ids(phonemes), None
+                        yield phonemes, self.phonemes_to_ids(phonemes), None
             else:
                 # Lazy per-sentence phonemization; a phonemizer without a lazy
                 # variant falls back to its eager whole-text phonemize().
@@ -505,7 +531,7 @@ class TTSVoice:
                                  else self.phonemizer.phonemize(part, lang))
                     for phonemes in sentences:
                         if phonemes:
-                            yield self.phonemes_to_ids(phonemes), None
+                            yield phonemes, self.phonemes_to_ids(phonemes), None
             return
 
         # Already-phonemic input in a different alphabet: transcode to the model's
@@ -529,22 +555,31 @@ class TTSVoice:
             sentence_phonemes = _phonemic_chunks(converted, tgt_alphabet)
         for phonemes in sentence_phonemes:
             if phonemes:
-                yield self.phonemes_to_ids(phonemes), None
+                yield phonemes, self.phonemes_to_ids(phonemes), None
 
     def synthesize(
             self,
             text: str,
             syn_config: Optional[SynthesisConfig] = None,
+            include_alignments: bool = False,
     ) -> Iterable[AudioChunk]:
         """
         Synthesize speech from input text, yielding one AudioChunk per sentence.
-        
+
         Generates sentence-level audio by phonemizing the input text and synthesizing each sentence into a float32 PCM audio array in the range [-1.0, 1.0]. If enabled in the synthesis configuration, user-provided phonetic spellings and diacritic augmentation are applied before phonemization. Output audio may be normalized and volume-scaled according to the configuration; samples are clipped to [-1.0, 1.0].
-        
+
         Parameters:
             text (str): The input text to synthesize.
             syn_config (Optional[SynthesisConfig]): Optional synthesis options (e.g., enable_phonetic_spellings, add_diacritics, normalize_audio, volume). If omitted, a default SynthesisConfig is used.
-        
+            include_alignments (bool): When True, and the model exposes a
+                per-phoneme duration output, each yielded AudioChunk also carries
+                ``phoneme_id_samples`` and reconstructed ``phoneme_alignments``.
+                When False (the default) this is a strict no-op — the exact same
+                inference runs and the same audio is produced, only the extra
+                per-sentence alignment reconstruction is skipped and both fields
+                stay ``None``. Models that don't expose durations degrade
+                gracefully: the audio is unchanged and both fields stay ``None``.
+
         Returns:
             Iterable[AudioChunk]: An iterable that yields one AudioChunk per synthesized sentence. Each AudioChunk contains a float32 audio array, sample rate taken from the voice config, 2-byte sample width, and 1 channel.
         """
@@ -591,11 +626,31 @@ class TTSVoice:
             src_alphabet, tgt_alphabet,
         )
 
-        for phoneme_ids, language_ids in id_stream:
+        # Special-token ids for alignment reconstruction — read once, only when
+        # alignments are requested (keeps the default path free of this work).
+        _idx2char: dict = {}
+        _blank_id = _bos_id = _eos_id = None
+        if include_alignments:
+            _tok = self.config.tokenizer
+            _vocab = _tok.vocabulary
+            _idx2char = _vocab.idx2char
+            _blank_id = _tok.blank_id
+            _bos_id = _vocab.bos_id
+            _eos_id = _vocab.eos_id
+
+        for phonemes, phoneme_ids, language_ids in id_stream:
             if not phoneme_ids:
                 continue
 
-            audio = self.phoneme_ids_to_audio(phoneme_ids, syn_config, language_ids=language_ids)
+            phoneme_id_samples: Optional[np.ndarray] = None
+            audio_result = self.phoneme_ids_to_audio(
+                phoneme_ids, syn_config, language_ids=language_ids,
+                include_alignments=include_alignments,
+            )
+            if isinstance(audio_result, tuple):
+                audio, phoneme_id_samples = audio_result
+            else:
+                audio = audio_result
 
             if syn_config.normalize_audio:
                 max_val = np.max(np.abs(audio))
@@ -610,12 +665,61 @@ class TTSVoice:
 
             audio = np.clip(audio, -1.0, 1.0).astype(np.float32)
 
+            phoneme_alignments = self._reconstruct_alignments(
+                phoneme_ids, phoneme_id_samples,
+                _idx2char, _blank_id, _bos_id, _eos_id,
+            ) if phoneme_id_samples is not None else None
+
             yield AudioChunk(
                 sample_rate=self.config.sample_rate,
                 sample_width=2,
                 sample_channels=1,
                 audio_float_array=audio,
+                phonemes=list(phonemes) if phonemes else [],
+                phoneme_ids=list(phoneme_ids),
+                phoneme_id_samples=phoneme_id_samples,
+                phoneme_alignments=phoneme_alignments,
             )
+
+    @staticmethod
+    def _reconstruct_alignments(
+            phoneme_ids: List[int],
+            phoneme_id_samples: np.ndarray,
+            idx2char: dict,
+            blank_id: Optional[int],
+            bos_id: Optional[int],
+            eos_id: Optional[int],
+    ) -> Optional[List[PhonemeAlignment]]:
+        """Fold per-id sample counts onto the real phonemes.
+
+        Walk ``phoneme_ids`` and their per-id sample counts together. Blank/bos
+        durations are absorbed forward into the next real phoneme; eos duration
+        is absorbed backward into the last real phoneme. This works regardless
+        of the tokenizer's blank_at_start/end settings. Returns ``None`` when
+        the sample counts don't line up one-to-one with the ids (e.g. a padded
+        model input), so callers degrade to "alignments unavailable" rather
+        than emitting a wrong alignment.
+        """
+        if len(phoneme_id_samples) != len(phoneme_ids):
+            return None
+        alignments: List[PhonemeAlignment] = []
+        pending: int = 0
+        for pid, n_samples in zip(phoneme_ids, phoneme_id_samples.tolist()):
+            if pid == bos_id or pid == blank_id:
+                pending += n_samples
+            elif pid == eos_id:
+                if alignments:
+                    prev = alignments[-1]
+                    alignments[-1] = PhonemeAlignment(prev.phoneme, prev.num_samples + n_samples)
+            else:
+                token = idx2char.get(pid, "?")
+                alignments.append(PhonemeAlignment(token, pending + n_samples))
+                pending = 0
+        # Absorb any leftover pending (e.g. trailing blank with no phoneme after).
+        if pending and alignments:
+            prev = alignments[-1]
+            alignments[-1] = PhonemeAlignment(prev.phoneme, prev.num_samples + pending)
+        return alignments or None
 
     def synthesize_wav(
             self,
@@ -670,8 +774,9 @@ class TTSVoice:
 
     def phoneme_ids_to_audio(
             self, phoneme_ids: list[int], syn_config: Optional[SynthesisConfig] = None,
-            language_ids: Optional[list[int]] = None
-    ) -> np.ndarray:
+            language_ids: Optional[list[int]] = None,
+            include_alignments: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Optional[np.ndarray]]]:
         """
         Synthesize raw audio from phoneme ids.
 
@@ -681,7 +786,15 @@ class TTSVoice:
         :param phoneme_ids: List of phoneme ids.
         :param syn_config: Synthesis configuration.
         :param language_ids: Optional per-phoneme language IDs (for language-aware engines).
+        :param include_alignments: When True, also return per-phoneme sample counts.
         :return: Audio float numpy array (unnormalized, in range [-1, 1]).
+
+        When ``include_alignments`` is True the return value is instead a
+        ``(audio, phoneme_id_samples)`` tuple, where ``phoneme_id_samples`` is
+        the per-id audio-sample count (durations scaled from model frames via
+        ``VoiceConfig.hop_length``), or ``None`` when this model doesn't expose
+        a duration output. The audio itself is byte-for-byte identical to the
+        no-alignment call — the same inference runs either way.
         """
         syn_config = syn_config or SynthesisConfig()
 
@@ -747,7 +860,20 @@ class TTSVoice:
         # build_feed_dict → run → parse_outputs; iterative engines override).
         result = self.adapter.synthesize(request, self.session)
 
-        return result.audio
+        if not include_alignments:
+            return result.audio
+
+        phoneme_id_samples = result.extras.get("phoneme_id_samples")
+        if phoneme_id_samples is None:
+            # Alignment is not available from this voice model.
+            return result.audio, None
+
+        # Model durations are in native frames — convert to audio samples.
+        phoneme_id_samples = (
+            np.asarray(phoneme_id_samples) * self.config.hop_length
+        ).astype(np.int64)
+
+        return result.audio, phoneme_id_samples
 
 if __name__ == "__main__":
     from phoonnx.phonemizers.gl import CotoviaPhonemizer

--- a/phoonnx_train/export_onnx.py
+++ b/phoonnx_train/export_onnx.py
@@ -14,6 +14,7 @@ use the OptiSpeech export procedure, metadata format, etc.
 import logging
 import os
 from pathlib import Path
+from typing import Optional, Set
 import click
 import torch
 
@@ -21,6 +22,76 @@ from phoonnx_train.engines import get_engine, list_engines
 
 logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger("phoonnx_train.export_onnx")
+
+
+def add_phoneme_alignment_output(
+    model_path: Path,
+    output_path: Optional[Path] = None,
+    tensor_name: str = "autodetect",
+) -> None:
+    """Expose a per-phoneme duration tensor as an extra ONNX graph output.
+
+    Standard VITS exports emit only the audio tensor; the phoneme-alignment
+    feature (see ``docs/alignment.md``) needs the duration-predictor's
+    per-phoneme frame counts surfaced as a named output. This walks the graph,
+    finds the (single) ``Ceil`` node output — the rounded durations — and marks
+    it as a graph output.
+
+    This may break third-party frameworks (e.g. piper) that expect a single
+    output tensor, so keep a separate copy for standard TTS use.
+
+    Args:
+        model_path: Path to the input ONNX model file.
+        output_path: Where to save the modified model (defaults to overwriting).
+        tensor_name: Tensor to mark as an output. ``"autodetect"`` looks for a
+            unique ``Ceil`` node output.
+    """
+    import onnx
+
+    output_path = output_path or model_path
+
+    try:
+        model: "onnx.ModelProto" = onnx.load(model_path)
+    except Exception as e:
+        _LOGGER.fatal(f"Failed to load ONNX model from {model_path}: {e}")
+        return
+
+    if tensor_name != "autodetect":
+        ceil_tensor_name = tensor_name
+    else:
+        ceil_tensor_names: Set[str] = set()
+        for node in model.graph.node:
+            if node.op_type != "Ceil":
+                continue
+            ceil_tensor_names.update(node.output)
+
+        if not ceil_tensor_names:
+            _LOGGER.fatal(f"No ceil tensors detected in {model_path}. Use --tensor-name manually.")
+            return
+        if len(ceil_tensor_names) > 1:
+            names_str = ', '.join(sorted(ceil_tensor_names))
+            _LOGGER.fatal(
+                f"Multiple ceil tensors detected in {model_path}. Use --tensor-name manually: {names_str}"
+            )
+            return
+        ceil_tensor_name = next(iter(ceil_tensor_names))
+        _LOGGER.info(f"Detected tensor name: {ceil_tensor_name}")
+
+    if any(output.name == ceil_tensor_name for output in model.graph.output):
+        _LOGGER.fatal(f"Tensor '{ceil_tensor_name}' is already marked as output. Aborting.")
+        return
+
+    ceil_value_info = onnx.helper.ValueInfoProto()
+    ceil_value_info.name = ceil_tensor_name
+    model.graph.output.append(ceil_value_info)
+
+    try:
+        onnx.save(model, output_path)
+    except Exception as e:
+        _LOGGER.fatal(f"Failed to save modified ONNX model to {output_path}: {e}")
+        return
+
+    _LOGGER.info(f"Successfully wrote modified model with new output '{ceil_tensor_name}' to {output_path}")
 
 
 def _validate_engine(ctx, param, value):
@@ -66,6 +137,12 @@ def _validate_engine(ctx, param, value):
     is_flag=True,
     help="Generate a piper-compatible JSON file.",
 )
+@click.option(
+    "-a", "--add-phoneme-alignment",
+    is_flag=True,
+    help="Expose the phoneme duration tensor as an extra ONNX output for "
+         "alignment (VITS only; may break piper-style single-output consumers).",
+)
 def cli(
     checkpoint: Path,
     config: Path,
@@ -73,6 +150,7 @@ def cli(
     engine: str,
     generate_tokens: bool,
     piper: bool,
+    add_phoneme_alignment: bool,
 ) -> None:
     torch.manual_seed(1234)
 
@@ -90,6 +168,10 @@ def cli(
         generate_tokens=generate_tokens,
         piper=piper,
     )
+
+    if add_phoneme_alignment:
+        _LOGGER.info("Adding phoneme-alignment output to %s", onnx_path)
+        add_phoneme_alignment_output(Path(onnx_path))
 
     _LOGGER.info("Export complete: %s", onnx_path)
 

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,673 @@
+"""Tests for phoneme alignment (PhonemeAlignment, AudioChunk, TTSVoice alignment logic).
+
+Unit tests are hermetic — no real models, no network.
+Integration tests require the downloaded eu-ES dii espeak voice and a patched
+alignment ONNX model at ALIGNED_MODEL (set up by setUpClass).
+
+Run unit tests only:
+    pytest tests/test_alignment.py -k "not Integration"
+
+Run everything (requires network on first run to download the voice):
+    pytest tests/test_alignment.py
+"""
+import os
+import shutil
+import tempfile
+import unittest
+from dataclasses import fields, is_dataclass
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from phoonnx.config import VoiceConfig, DEFAULT_HOP_LENGTH, PhonemeType, Alphabet
+from phoonnx.engines.vits import VitsAdapter
+from phoonnx.voice import AudioChunk, PhonemeAlignment, TTSVoice
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures / helpers
+# ---------------------------------------------------------------------------
+
+class _Input:
+    """Minimal stand-in for an onnxruntime model input."""
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakePhonemizer:
+    """A phonemizer with just ``phonemize`` — deliberately *without* the
+    ``phonemize_lazy`` / ``phonemize_with_language_ids*`` methods, so
+    :meth:`TTSVoice._iter_synthesis_ids` takes the plain per-sentence hot path
+    (a MagicMock would spuriously satisfy those ``getattr``/``hasattr`` checks).
+    """
+    def __init__(self, result):
+        self._result = result
+
+    def phonemize(self, text, lang=None):
+        return self._result
+
+    def add_diacritics(self, text, lang, model=None):
+        return text
+
+
+def _fake_audio(n=200):
+    return np.linspace(-0.5, 0.5, n, dtype=np.float32)
+
+
+def _make_vocab(char2idx=None):
+    """Build a minimal Vocabulary mock with the standard special tokens."""
+    char2idx = char2idx or {"_": 0, "^": 1, "$": 2, "h": 3, "e": 4, "l": 5, "o": 6}
+    idx2char = {v: k for k, v in char2idx.items()}
+    vocab = MagicMock()
+    vocab.char2idx = char2idx
+    vocab.idx2char = idx2char
+    vocab.blank_id = 0
+    vocab.bos_id = 1
+    vocab.eos_id = 2
+    vocab.pad_id = 0
+    vocab.blank = "_"
+    vocab.bos = "^"
+    vocab.eos = "$"
+    vocab.pad = "_"
+    return vocab
+
+
+def _make_tokenizer(char2idx=None):
+    """Build a minimal TTSTokenizer mock."""
+    vocab = _make_vocab(char2idx)
+    tok = MagicMock()
+    tok.vocabulary = vocab
+    tok.blank_id = 0
+    tok.pad_id = 0
+    tok.add_blank_char = True
+    tok.use_eos_bos = True
+    tok.blank_at_start = True
+    tok.blank_at_end = True
+    return tok
+
+
+def _make_voice(session_outputs, phonemize_result=None, token_ids=None, char2idx=None):
+    """Build a TTSVoice with a mocked ONNX session.
+
+    ``voice.phonemize`` and ``voice.phonemes_to_ids`` are mocked at the
+    instance level to bypass all text-processing paths.
+
+    session_outputs: list of numpy arrays the fake session.run() returns.
+    token_ids: the full sequence including bos/blank/eos that the tokenizer
+               would normally produce (matches what phoneme_id_samples covers).
+    """
+    if phonemize_result is None:
+        phonemize_result = [["h", "e", "l", "l", "o"]]
+    if token_ids is None:
+        # Simple sequence: [bos, blank, h, blank, e, blank, l, blank, l, blank, o, blank, eos]
+        token_ids = [1, 0, 3, 0, 4, 0, 5, 0, 5, 0, 6, 0, 2]
+
+    session = MagicMock()
+    session.get_inputs.return_value = [_Input("input"), _Input("input_lengths")]
+    session.run.return_value = session_outputs
+
+    cfg = MagicMock(spec=VoiceConfig)
+    cfg.lang_code = "en-US"
+    cfg.sample_rate = 22050
+    cfg.num_speakers = 1
+    cfg.phoneme_type = PhonemeType.UNICODE
+    # A phoneme model (tgt != GRAPHEMES) so synthesize's alphabet dispatch takes
+    # the phonemize hot path (src GRAPHEMES -> tgt IPA), exercising the lazy
+    # per-sentence stream that carries phonemes + ids into each AudioChunk.
+    cfg.alphabet = Alphabet.IPA
+    cfg.noise_scale = 0.667
+    cfg.length_scale = 1.0
+    cfg.noise_w_scale = 0.8
+    cfg.hop_length = DEFAULT_HOP_LENGTH
+    cfg.enable_phonetic_spellings = False
+    cfg.add_diacritics = False
+    cfg.diacritizer_model = None
+    cfg.engine_params = {}
+    cfg.tokenizer = _make_tokenizer(char2idx)
+
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.session = session
+    voice.config = cfg
+    voice.phonemizer = _FakePhonemizer(phonemize_result)
+    voice.phonetic_spellings = None
+    voice.adapter = VitsAdapter()
+    voice.phonemes_to_ids = MagicMock(return_value=token_ids)
+    return voice
+
+
+# ---------------------------------------------------------------------------
+# PhonemeAlignment dataclass
+# ---------------------------------------------------------------------------
+
+class TestPhonemeAlignment(unittest.TestCase):
+    def test_is_dataclass(self):
+        self.assertTrue(is_dataclass(PhonemeAlignment))
+
+    def test_fields(self):
+        pa = PhonemeAlignment(phoneme="a", num_samples=512)
+        self.assertEqual(pa.phoneme, "a")
+        self.assertEqual(pa.num_samples, 512)
+
+    def test_equality(self):
+        self.assertEqual(PhonemeAlignment("b", 100), PhonemeAlignment("b", 100))
+        self.assertNotEqual(PhonemeAlignment("b", 100), PhonemeAlignment("b", 200))
+
+
+# ---------------------------------------------------------------------------
+# AudioChunk new fields
+# ---------------------------------------------------------------------------
+
+class TestAudioChunkFields(unittest.TestCase):
+    def _chunk(self, **kw):
+        defaults = dict(
+            sample_rate=22050, sample_width=2, sample_channels=1,
+            audio_float_array=_fake_audio(), phonemes=[], phoneme_ids=[],
+        )
+        defaults.update(kw)
+        return AudioChunk(**defaults)
+
+    def test_phonemes_and_ids_stored(self):
+        c = self._chunk(phonemes=["h", "i"], phoneme_ids=[3, 4])
+        self.assertEqual(c.phonemes, ["h", "i"])
+        self.assertEqual(c.phoneme_ids, [3, 4])
+
+    def test_optional_fields_default_none(self):
+        c = self._chunk()
+        self.assertIsNone(c.phoneme_id_samples)
+        self.assertIsNone(c.phoneme_alignments)
+
+    def test_alignment_objects_stored(self):
+        aligns = [PhonemeAlignment("h", 256), PhonemeAlignment("i", 512)]
+        c = self._chunk(phoneme_alignments=aligns)
+        self.assertEqual(c.phoneme_alignments[0].phoneme, "h")
+
+    def test_id_samples_array_stored(self):
+        arr = np.array([100, 200, 300], dtype=np.int64)
+        c = self._chunk(phoneme_id_samples=arr)
+        np.testing.assert_array_equal(c.phoneme_id_samples, arr)
+
+
+# ---------------------------------------------------------------------------
+# VoiceConfig hop_length
+# ---------------------------------------------------------------------------
+
+class TestHopLength(unittest.TestCase):
+    def test_default_hop_length_constant(self):
+        self.assertEqual(DEFAULT_HOP_LENGTH, 256)
+
+    def test_hop_length_field_default(self):
+        hop_field = next(f for f in fields(VoiceConfig) if f.name == "hop_length")
+        self.assertEqual(hop_field.default, DEFAULT_HOP_LENGTH)
+
+    def _phoonnx_cfg(self, **extra):
+        cfg = {
+            "phoonnx_version": "0.0.1",
+            "phoneme_type": "espeak",
+            "alphabet": "ipa",
+            "audio": {"sample_rate": 22050},
+            "inference": {},
+            "phoneme_id_map": {"_": 0, "^": 1, "$": 2},
+        }
+        cfg.update(extra)
+        return cfg
+
+    def test_from_dict_parses_hop_length(self):
+        cfg = VoiceConfig.from_dict(self._phoonnx_cfg(hop_length=512))
+        self.assertEqual(cfg.hop_length, 512)
+
+    def test_from_dict_hop_length_default(self):
+        cfg = VoiceConfig.from_dict(self._phoonnx_cfg())
+        self.assertEqual(cfg.hop_length, DEFAULT_HOP_LENGTH)
+
+
+# ---------------------------------------------------------------------------
+# phoneme_ids_to_audio — return-value shape
+# ---------------------------------------------------------------------------
+
+class TestPhonemeIdsToAudio(unittest.TestCase):
+    def test_without_alignments_returns_ndarray(self):
+        voice = _make_voice([_fake_audio()[np.newaxis, np.newaxis, :]])
+        result = voice.phoneme_ids_to_audio([3, 4, 5], include_alignments=False)
+        self.assertIsInstance(result, np.ndarray)
+
+    def test_with_alignments_single_output_returns_tuple_none(self):
+        voice = _make_voice([_fake_audio()[np.newaxis, np.newaxis, :]])
+        audio, samples = voice.phoneme_ids_to_audio([1, 0, 3, 0, 2], include_alignments=True)
+        self.assertIsInstance(audio, np.ndarray)
+        self.assertIsNone(samples)
+
+    def test_with_alignments_two_outputs_returns_tuple_array(self):
+        ids = [1, 0, 3, 0, 4, 0, 2]
+        audio_arr = _fake_audio()[np.newaxis, np.newaxis, :]
+        dur_arr = np.ones((1, len(ids)), dtype=np.float32)
+        voice = _make_voice([audio_arr, dur_arr])
+        audio, samples = voice.phoneme_ids_to_audio(ids, include_alignments=True)
+        self.assertIsInstance(samples, np.ndarray)
+        self.assertEqual(samples.dtype, np.int64)
+        self.assertEqual(len(samples), len(ids))
+
+    def test_hop_length_scales_duration(self):
+        """Model durations (in frames) are multiplied by hop_length to get samples."""
+        ids = [1, 0, 3, 0, 4, 0, 2]
+        raw = np.array([[2.0, 1.0, 3.0, 1.0, 4.0, 1.0, 2.0]], dtype=np.float32)
+        voice = _make_voice([_fake_audio()[np.newaxis, np.newaxis, :], raw])
+        voice.config.hop_length = 100
+        _, samples = voice.phoneme_ids_to_audio(ids, include_alignments=True)
+        expected = np.array([200, 100, 300, 100, 400, 100, 200], dtype=np.int64)
+        np.testing.assert_array_equal(samples, expected)
+
+
+# ---------------------------------------------------------------------------
+# synthesize — alignment reconstruction
+# ---------------------------------------------------------------------------
+
+class TestAlignmentReconstruction(unittest.TestCase):
+    """Tests for the id→phoneme walk in synthesize(include_alignments=True).
+
+    The new implementation uses tokenizer.vocabulary.idx2char to look up each
+    id and folds blank/bos/eos durations into adjacent real phonemes.
+    """
+
+    def _synth(self, token_ids, durations, phonemes=None, char2idx=None):
+        """Run synthesize and return the single AudioChunk."""
+        if phonemes is None:
+            phonemes = ["h", "e", "l"]
+        audio = _fake_audio()
+        dur_arr = np.array([durations], dtype=np.float32)
+        voice = _make_voice(
+            [audio[np.newaxis, np.newaxis, :], dur_arr],
+            phonemize_result=[phonemes],
+            token_ids=token_ids,
+            char2idx=char2idx,
+        )
+        voice.config.hop_length = 1  # frame == sample for easy arithmetic
+        chunks = list(voice.synthesize("x", include_alignments=True))
+        self.assertEqual(len(chunks), 1)
+        return chunks[0]
+
+    def test_real_phonemes_extracted(self):
+        # ids: [bos=1, blank=0, h=3, blank=0, e=4, blank=0, l=5, blank=0, eos=2]
+        ids = [1, 0, 3, 0, 4, 0, 5, 0, 2]
+        durs = [10, 5, 20, 5, 30, 5, 40, 5, 10]
+        chunk = self._synth(ids, durs, phonemes=["h", "e", "l"])
+        self.assertIsNotNone(chunk.phoneme_alignments)
+        names = [a.phoneme for a in chunk.phoneme_alignments]
+        self.assertEqual(names, ["h", "e", "l"])
+
+    def test_blank_before_phoneme_absorbed_forward(self):
+        # ids: bos(10), blank(5), h(20), trailing-blank(5), eos(10)
+        # bos + blank_before_h → pending=15; h appended with 15+20=35
+        # trailing blank → pending=5; eos → absorbed into h: 35+10=45
+        # after loop: trailing pending 5 → absorbed into h: 45+5=50
+        ids = [1, 0, 3, 0, 2]
+        durs = [10, 5, 20, 5, 10]
+        chunk = self._synth(ids, durs, phonemes=["h"])
+        self.assertEqual(chunk.phoneme_alignments[0].num_samples, 50)
+
+    def test_eos_absorbed_into_last_phoneme(self):
+        # ids: bos, blank, h, blank, eos(10)
+        ids = [1, 0, 3, 0, 2]
+        durs = [0, 0, 20, 5, 10]
+        chunk = self._synth(ids, durs, phonemes=["h"])
+        # h = 0+0 (bos+blank_bos) + 20 + 5 (trailing blank) + 10 (eos) = 35
+        # bos=0, blank=0 → pending=0; h=20 → PhonemeAlignment("h",0+20)=20; blank=5 → pending=5; eos=10 → absorbed into last → 20+10=30; then trailing pending 5 absorbed → 35
+        # Actually: bos=0 pending=0, blank_bos=0 pending=0, h=20 → align(h,20), blank=5 → pending=5, eos=10 → absorbed into last: h.num_samples=20+10=30, then pending=5 absorbed into last: 30+5=35
+        self.assertEqual(chunk.phoneme_alignments[0].num_samples, 35)
+
+    def test_total_samples_equal_sum_of_durations(self):
+        ids = [1, 0, 3, 0, 4, 0, 5, 0, 2]
+        durs = [10, 5, 20, 5, 30, 5, 40, 5, 10]
+        chunk = self._synth(ids, durs, phonemes=["h", "e", "l"])
+        total_aligned = sum(a.num_samples for a in chunk.phoneme_alignments)
+        self.assertEqual(total_aligned, sum(durs))
+
+    def test_length_mismatch_alignments_none(self):
+        """phoneme_id_samples length != phoneme_ids length → alignments stay None."""
+        # 3 duration values but 9 ids
+        audio = _fake_audio()
+        ids = [1, 0, 3, 0, 4, 0, 5, 0, 2]
+        voice = _make_voice(
+            [audio[np.newaxis, np.newaxis, :],
+             np.array([[10.0, 20.0, 30.0]], dtype=np.float32)],
+            phonemize_result=[["h", "e", "l"]],
+            token_ids=ids,
+        )
+        voice.config.hop_length = 1
+        chunk = list(voice.synthesize("x", include_alignments=True))[0]
+        self.assertIsNone(chunk.phoneme_alignments)
+
+    def test_unknown_id_becomes_question_mark(self):
+        """An id not in idx2char maps to '?' but doesn't crash or fail."""
+        char2idx = {"_": 0, "^": 1, "$": 2, "h": 3}
+        ids = [1, 0, 3, 0, 99, 0, 2]  # id 99 unknown
+        durs = [5, 5, 20, 5, 20, 5, 5]
+        chunk = self._synth(ids, durs, phonemes=["h", "?"], char2idx=char2idx)
+        # reconstruction should succeed; unknown id maps to "?"
+        self.assertIsNotNone(chunk.phoneme_alignments)
+        names = [a.phoneme for a in chunk.phoneme_alignments]
+        self.assertIn("?", names)
+
+    def test_no_alignments_requested_fields_none(self):
+        ids = [1, 0, 3, 0, 4, 0, 2]
+        audio = _fake_audio()
+        dur = np.ones((1, len(ids)), dtype=np.float32)
+        voice = _make_voice([audio[np.newaxis, np.newaxis, :], dur],
+                            phonemize_result=[["h", "e"]], token_ids=ids)
+        chunk = list(voice.synthesize("hi", include_alignments=False))[0]
+        self.assertIsNone(chunk.phoneme_id_samples)
+        self.assertIsNone(chunk.phoneme_alignments)
+
+    def test_phonemes_and_ids_always_populated(self):
+        ids = [1, 0, 3, 0, 4, 0, 2]
+        audio = _fake_audio()
+        voice = _make_voice([audio[np.newaxis, np.newaxis, :]],
+                            phonemize_result=[["h", "e"]], token_ids=ids)
+        chunk = list(voice.synthesize("hi", include_alignments=False))[0]
+        self.assertEqual(chunk.phonemes, ["h", "e"])
+        self.assertEqual(chunk.phoneme_ids, ids)
+
+    def test_empty_phonemes_yields_no_chunk(self):
+        audio = _fake_audio()
+        voice = _make_voice([audio[np.newaxis, np.newaxis, :]],
+                            phonemize_result=[[]], token_ids=[])
+        chunks = list(voice.synthesize("", include_alignments=True))
+        self.assertEqual(chunks, [])
+
+    def test_model_without_alignment_output_gives_none(self):
+        ids = [1, 0, 3, 0, 4, 0, 2]
+        audio = _fake_audio()
+        voice = _make_voice([audio[np.newaxis, np.newaxis, :]],
+                            phonemize_result=[["h", "e"]], token_ids=ids)
+        chunk = list(voice.synthesize("hi", include_alignments=True))[0]
+        self.assertIsNone(chunk.phoneme_id_samples)
+        self.assertIsNone(chunk.phoneme_alignments)
+
+
+# ---------------------------------------------------------------------------
+# include_alignments=False is a strict no-op on the audio
+# ---------------------------------------------------------------------------
+
+class _OrderPhonemizer:
+    """A lazy phonemizer that records the index of each sentence as it is
+    actually produced, so a test can assert nothing downstream forced later
+    sentences to be phonemized early."""
+    def __init__(self, sentences, log):
+        self._sentences = sentences
+        self._log = log
+
+    def phonemize_lazy(self, text, lang=None):
+        for i, sentence in enumerate(self._sentences):
+            self._log.append(i)
+            yield sentence
+
+    def add_diacritics(self, text, lang, model=None):
+        return text
+
+
+class TestAlignmentNoOp(unittest.TestCase):
+    def test_off_produces_byte_identical_audio_to_on(self):
+        """A two-output (alignment-capable) VITS voice must produce the exact
+        same waveform whether alignments are requested or not — the same
+        inference runs either way, only post-processing differs."""
+        ids = [1, 0, 3, 0, 4, 0, 2]
+        audio = _fake_audio()
+        dur = np.ones((1, len(ids)), dtype=np.float32)
+
+        v_off = _make_voice([audio[np.newaxis, np.newaxis, :], dur.copy()],
+                            phonemize_result=[["h", "e"]], token_ids=ids)
+        v_on = _make_voice([audio[np.newaxis, np.newaxis, :], dur.copy()],
+                           phonemize_result=[["h", "e"]], token_ids=ids)
+
+        a_off = list(v_off.synthesize("hi", include_alignments=False))[0]
+        a_on = list(v_on.synthesize("hi", include_alignments=True))[0]
+
+        np.testing.assert_array_equal(a_off.audio_float_array, a_on.audio_float_array)
+        self.assertEqual(a_off.audio_float_array.tobytes(),
+                         a_on.audio_float_array.tobytes())
+        # off is the no-op: alignment fields stay None, on is populated.
+        self.assertIsNone(a_off.phoneme_id_samples)
+        self.assertIsNone(a_off.phoneme_alignments)
+        self.assertIsNotNone(a_on.phoneme_alignments)
+
+    def test_lazy_second_sentence_not_phonemized_before_first_yield(self):
+        """The lazy stream must stay lazy: pulling the first AudioChunk must not
+        phonemize the second sentence."""
+        log = []
+        voice = _make_voice([_fake_audio()[np.newaxis, np.newaxis, :]],
+                            phonemize_result=None, token_ids=[1, 0, 3, 0, 2])
+        voice.phonemizer = _OrderPhonemizer([["h"], ["e"]], log)
+
+        gen = voice.synthesize("s1. s2", include_alignments=True)
+        next(gen)
+        self.assertEqual(log, [0], "second sentence phonemized before first yield")
+        next(gen)
+        self.assertEqual(log, [0, 1])
+
+
+# ---------------------------------------------------------------------------
+# Two-stage engines (mel frames -> samples via hop_length) — voice.py level
+# ---------------------------------------------------------------------------
+
+class TestTwoStageEngineAlignment(unittest.TestCase):
+    """TTSVoice.phoneme_ids_to_audio scales a two-stage engine's mel-frame
+    durations to samples the same way it does VITS's frame-domain durations:
+    uniformly, via VoiceConfig.hop_length, regardless of which adapter
+    produced them (see phoonnx/engines/mixertts.py / matcha.py / glowtts.py).
+    """
+
+    def _make_two_stage_voice(self, mel_frames, durations, hop_length):
+        from phoonnx.engines.mixertts import MixerTTSAdapter
+        from phoonnx.engines.vocoders.base import BaseVocoder
+
+        n_mel_frames = int(sum(mel_frames))
+
+        class _FakeVocoder(BaseVocoder):
+            def mel_to_audio(self, mel, denoise=False):
+                return np.zeros(mel.shape[-1], dtype=np.float32)
+
+        mel = np.zeros((1, 80, n_mel_frames), dtype=np.float32)
+        durs = np.array([durations], dtype=np.float32)
+
+        session = MagicMock()
+        session.get_inputs.return_value = [_Input("token_ids")]
+        session.run.return_value = [mel, durs]
+        out_mel, out_durs = _Input("mel_spec"), _Input("durations")
+        session.get_outputs.return_value = [out_mel, out_durs]
+
+        cfg = MagicMock(spec=VoiceConfig)
+        cfg.hop_length = hop_length
+        cfg.noise_scale = None
+        cfg.length_scale = None
+        cfg.noise_w_scale = None
+        cfg.engine_params = {}
+
+        voice = TTSVoice.__new__(TTSVoice)
+        voice.session = session
+        voice.config = cfg
+        voice.adapter = MixerTTSAdapter(vocoder=_FakeVocoder())
+        return voice
+
+    def test_mel_frames_scaled_to_samples_by_hop_length(self):
+        """hop=256, 3 phonemes with mel-frame durations [2, 1, 4] ->
+        per-phoneme sample spans [0, 512), [512, 768), [768, 1792)."""
+        voice = self._make_two_stage_voice(mel_frames=[2, 1, 4], durations=[2, 1, 4], hop_length=256)
+        audio, samples = voice.phoneme_ids_to_audio([10, 11, 12], include_alignments=True)
+        np.testing.assert_array_equal(samples, [512, 256, 1024])
+        # spans derived from cumulative sums
+        starts = np.concatenate([[0], np.cumsum(samples)[:-1]])
+        ends = np.cumsum(samples)
+        np.testing.assert_array_equal(starts, [0, 512, 768])
+        np.testing.assert_array_equal(ends, [512, 768, 1792])
+
+    def test_no_duration_output_gives_none(self):
+        from phoonnx.engines.mixertts import MixerTTSAdapter
+        from phoonnx.engines.vocoders.base import BaseVocoder
+
+        class _FakeVocoder(BaseVocoder):
+            def mel_to_audio(self, mel, denoise=False):
+                return np.zeros(mel.shape[-1], dtype=np.float32)
+
+        mel = np.zeros((1, 80, 9), dtype=np.float32)
+        session = MagicMock()
+        session.get_inputs.return_value = [_Input("token_ids")]
+        session.run.return_value = [mel]
+        session.get_outputs.return_value = [_Input("mel_spec")]
+
+        cfg = MagicMock(spec=VoiceConfig)
+        cfg.hop_length = 256
+        cfg.noise_scale = None
+        cfg.length_scale = None
+        cfg.noise_w_scale = None
+        cfg.engine_params = {}
+
+        voice = TTSVoice.__new__(TTSVoice)
+        voice.session = session
+        voice.config = cfg
+        voice.adapter = MixerTTSAdapter(vocoder=_FakeVocoder())
+
+        audio, samples = voice.phoneme_ids_to_audio([10, 11], include_alignments=True)
+        self.assertIsNone(samples)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real model, real synthesis
+# ---------------------------------------------------------------------------
+
+VOICE_ID = "OpenVoiceOS/phoonnx_eu-ES_dii_espeak"
+ALIGNED_MODEL = "/tmp/phoonnx_test_aligned_eu-ES.onnx"
+VOICE_CONFIG = None  # set in setUpClass
+
+
+def _ensure_model():
+    """Download voice + patch alignment output; return (onnx_path, config_path)."""
+    from phoonnx.model_manager import TTSModelManager
+    m = TTSModelManager()
+    m.merge_default_voices()
+    v = m.voices.get(VOICE_ID)
+    if v is None:
+        raise unittest.SkipTest(f"Voice {VOICE_ID} not in registry")
+    v.download_config()
+    v.download_model()
+    import glob
+    voice_path = v.voice_path
+    onnx_files = glob.glob(os.path.join(voice_path, "*.onnx"))
+    json_files = glob.glob(os.path.join(voice_path, "*.json"))
+    if not onnx_files or not json_files:
+        raise unittest.SkipTest("Voice files not downloaded")
+    return onnx_files[0], json_files[0]
+
+
+def _patch_alignment(src_onnx, dst_onnx):
+    """Add the Ceil alignment output to an ONNX model."""
+    import onnx
+    model = onnx.load(src_onnx)
+    ceil_names = {o for node in model.graph.node
+                  if node.op_type == "Ceil" for o in node.output}
+    if not ceil_names:
+        raise unittest.SkipTest("No Ceil node found in model — alignment not patchable")
+    if len(ceil_names) > 1:
+        raise unittest.SkipTest("Multiple Ceil nodes — cannot autodetect")
+    # Check not already an output
+    existing = {o.name for o in model.graph.output}
+    name = next(iter(ceil_names))
+    if name not in existing:
+        vinfo = onnx.helper.ValueInfoProto()
+        vinfo.name = name
+        model.graph.output.append(vinfo)
+        onnx.save(model, dst_onnx)
+    else:
+        shutil.copy(src_onnx, dst_onnx)
+
+
+class TestAlignmentIntegration(unittest.TestCase):
+    """End-to-end tests with a real ONNX model.
+
+    Skipped automatically when onnx is not installed or the voice cannot be
+    downloaded (no network, CI without model cache, etc.).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import onnx  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("onnx not installed")
+
+        try:
+            src_onnx, config_path = _ensure_model()
+        except unittest.SkipTest:
+            raise
+        except Exception as e:
+            raise unittest.SkipTest(f"Could not set up model: {e}")
+
+        _patch_alignment(src_onnx, ALIGNED_MODEL)
+        cls.voice = TTSVoice.load(ALIGNED_MODEL, config_path)
+        cls.voice_no_align = TTSVoice.load(src_onnx, config_path)
+
+    def test_synthesize_produces_audio(self):
+        chunks = list(self.voice.synthesize("kaixo"))
+        self.assertGreater(len(chunks), 0)
+        self.assertGreater(len(chunks[0].audio_float_array), 0)
+
+    def test_without_alignments_fields_are_none(self):
+        chunk = list(self.voice.synthesize("kaixo", include_alignments=False))[0]
+        self.assertIsNone(chunk.phoneme_id_samples)
+        self.assertIsNone(chunk.phoneme_alignments)
+
+    def test_phonemes_and_ids_always_present(self):
+        chunk = list(self.voice.synthesize("kaixo", include_alignments=False))[0]
+        self.assertGreater(len(chunk.phonemes), 0)
+        self.assertGreater(len(chunk.phoneme_ids), 0)
+
+    def test_with_alignments_populated(self):
+        chunk = list(self.voice.synthesize("kaixo", include_alignments=True))[0]
+        self.assertIsNotNone(chunk.phoneme_id_samples)
+        self.assertIsNotNone(chunk.phoneme_alignments)
+        self.assertGreater(len(chunk.phoneme_alignments), 0)
+
+    def test_alignment_total_equals_audio_length(self):
+        """Sum of per-phoneme sample counts must equal the audio frame count."""
+        chunk = list(self.voice.synthesize("kaixo", include_alignments=True))[0]
+        total = sum(a.num_samples for a in chunk.phoneme_alignments)
+        self.assertEqual(total, len(chunk.audio_float_array))
+
+    def test_alignment_covers_all_phonemes(self):
+        """Every real phoneme from phonemization appears in the alignment list."""
+        chunk = list(self.voice.synthesize("kaixo mundua", include_alignments=True))[0]
+        aligned_phonemes = [a.phoneme for a in chunk.phoneme_alignments]
+        for p in chunk.phonemes:
+            self.assertIn(p, aligned_phonemes)
+
+    def test_all_durations_positive(self):
+        chunk = list(self.voice.synthesize("kaixo mundua", include_alignments=True))[0]
+        for a in chunk.phoneme_alignments:
+            self.assertGreater(a.num_samples, 0,
+                               f"phoneme {a.phoneme!r} has zero duration")
+
+    def test_model_without_alignment_output_gives_none(self):
+        """Unpatched model (single output) gives phoneme_alignments=None."""
+        chunk = list(self.voice_no_align.synthesize("kaixo", include_alignments=True))[0]
+        self.assertIsNone(chunk.phoneme_id_samples)
+        self.assertIsNone(chunk.phoneme_alignments)
+
+    def test_multiple_sentences(self):
+        """Multi-sentence input: each chunk is independently aligned."""
+        chunks = list(self.voice.synthesize(
+            "kaixo mundua. zer moduz zaude?", include_alignments=True
+        ))
+        for chunk in chunks:
+            if chunk.phoneme_alignments:
+                total = sum(a.num_samples for a in chunk.phoneme_alignments)
+                self.assertEqual(total, len(chunk.audio_float_array))
+
+    def test_alignment_phoneme_strings_are_real(self):
+        """Alignment phoneme strings are non-empty and not all '?'."""
+        chunk = list(self.voice.synthesize("kaixo", include_alignments=True))[0]
+        phonemes = [a.phoneme for a in chunk.phoneme_alignments]
+        self.assertTrue(all(p for p in phonemes), "empty phoneme string in alignments")
+        unknown = [p for p in phonemes if p == "?"]
+        self.assertEqual(unknown, [], f"unknown ids in alignment: {phonemes}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fastpitch.py
+++ b/tests/test_fastpitch.py
@@ -50,6 +50,11 @@ def test_build_feed_dict_inherited():
     assert feed["pace"][0] == pytest.approx(0.9)
 
 
+def test_inherits_duration_output_names():
+    """FastPitch reuses Mixer-TTS's parsing, including alignment detection."""
+    assert FastPitchAdapter.DURATION_OUTPUT_NAMES == MixerTTSAdapter.DURATION_OUTPUT_NAMES
+
+
 def test_config_bridge_fastpitch_engine():
     vc = voice_config_from_mixer(["_pad_", "_+_", "<", "b"], lang_code="ar",
                                  phoneme_type=PhonemeType.MANTOQ, alphabet=Alphabet.BUCKWALTER,

--- a/tests/test_glowtts.py
+++ b/tests/test_glowtts.py
@@ -81,6 +81,27 @@ def test_without_vocoder_raises():
         GlowTTSAdapter().parse_outputs([np.zeros((1, 80, 4), np.float32)], _req())
 
 
+# --- phoneme alignment (durations) ---------------------------------------
+
+def test_parse_outputs_no_durations_by_default():
+    """Standard Larynx/Coqui exports don't expose durations as an output."""
+    adapter = GlowTTSAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 7), np.float32)
+    other = np.zeros((1, 7, 322), np.float32)
+    res = adapter.parse_outputs([other, mel], _req(), output_names=["3453", "output"])
+    assert "phoneme_id_samples" not in res.extras
+
+
+def test_parse_outputs_picks_up_named_durations():
+    adapter = GlowTTSAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 7), np.float32)
+    durs = np.array([[1, 2, 3, 4, 5]], dtype=np.float32)
+    res = adapter.parse_outputs(
+        [mel, durs], _req(n=5), output_names=["output", "w_ceil"]
+    )
+    np.testing.assert_array_equal(res.extras["phoneme_id_samples"], [1, 2, 3, 4, 5])
+
+
 def test_default_params():
     assert GlowTTSAdapter().default_params() == {"noise_scale": 0.667, "length_scale": 1.0}
 

--- a/tests/test_lazy_synthesis.py
+++ b/tests/test_lazy_synthesis.py
@@ -112,7 +112,7 @@ def _make_lazy_voice(events, alphabet=Alphabet.IPA):
 
     voice.phonemes_to_ids = lambda phonemes: [1] * len(phonemes)
 
-    def _synth(phoneme_ids, syn_config=None, language_ids=None):
+    def _synth(phoneme_ids, syn_config=None, language_ids=None, include_alignments=False):
         events.append(("run", tuple(phoneme_ids)))
         return np.zeros(4, dtype=np.float32)
 

--- a/tests/test_matcha_adapter.py
+++ b/tests/test_matcha_adapter.py
@@ -127,6 +127,41 @@ def test_two_stage_without_vocoder_raises():
         adapter.parse_outputs([mel], _request())
 
 
+# --- phoneme alignment (durations) ---------------------------------------
+
+def test_two_stage_no_durations_by_default():
+    """Standard Matcha exports emit [mel, mel_lengths] — no durations."""
+    adapter = MatchaAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 7), dtype=np.float32)
+    mel_lengths = np.array([5], dtype=np.int64)
+    result = adapter.parse_outputs(
+        [mel, mel_lengths], _request(), output_names=["mel", "mel_lengths"]
+    )
+    assert "phoneme_id_samples" not in result.extras
+
+
+def test_two_stage_picks_up_named_durations():
+    adapter = MatchaAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 7), dtype=np.float32)
+    mel_lengths = np.array([7], dtype=np.int64)
+    durs = np.array([[1, 2, 3, 4, 5, 6]], dtype=np.float32)
+    result = adapter.parse_outputs(
+        [mel, mel_lengths, durs], _request(n=6),
+        output_names=["mel", "mel_lengths", "durations"],
+    )
+    np.testing.assert_array_equal(
+        result.extras["phoneme_id_samples"], [1, 2, 3, 4, 5, 6]
+    )
+
+
+def test_end_to_end_has_no_durations_extra():
+    """The fused end-to-end path returns early without inspecting durations."""
+    adapter = MatchaAdapter()
+    waveform = np.sin(np.linspace(0, 6.28, 100)).astype(np.float32)[None, :]
+    result = adapter.parse_outputs([waveform], _request(), output_names=["waveform"])
+    assert result.extras == {}
+
+
 def test_configure_from_voice_config_engine_params(monkeypatch):
     built = {}
 

--- a/tests/test_mixertts.py
+++ b/tests/test_mixertts.py
@@ -78,6 +78,40 @@ def test_without_vocoder_raises():
         MixerTTSAdapter().parse_outputs([np.zeros((1, 80, 4), np.float32)], _req())
 
 
+# --- phoneme alignment (durations) ---------------------------------------
+
+def test_parse_outputs_no_durations_by_default():
+    """Standard Mixer-TTS exports emit only mel_spec — no alignment extras."""
+    adapter = MixerTTSAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 9), np.float32)
+    res = adapter.parse_outputs([mel], _req(), output_names=["mel_spec"])
+    assert "phoneme_id_samples" not in res.extras
+
+
+def test_parse_outputs_picks_up_named_durations():
+    """A future re-export exposing a 'durations' output lights up alignment
+    automatically via DURATION_OUTPUT_NAMES, without any adapter changes."""
+    adapter = MixerTTSAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 9), np.float32)
+    durs = np.array([[2, 3, 4, 5]], dtype=np.float32)
+    res = adapter.parse_outputs(
+        [mel, durs], _req(n=4), output_names=["mel_spec", "durations"]
+    )
+    np.testing.assert_array_equal(res.extras["phoneme_id_samples"], [2, 3, 4, 5])
+
+
+def test_parse_outputs_ignores_unnamed_duration_lookalike():
+    """Without output_names, an extra tensor is NOT guessed to be durations —
+    detection is strictly name-driven for two-stage engines (unlike VITS's
+    positional fallback, since a second output here is far more likely to be
+    an intermediate mel-model tensor than a duration vector)."""
+    adapter = MixerTTSAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 9), np.float32)
+    extra = np.array([[2, 3, 4, 5]], dtype=np.float32)
+    res = adapter.parse_outputs([mel, extra], _req(n=4), output_names=None)
+    assert "phoneme_id_samples" not in res.extras
+
+
 def test_default_params():
     assert MixerTTSAdapter().default_params() == {"pace": 1.0, "pitch_mul": 1.0, "pitch_add": 0.0, "emotion": 0}
 

--- a/tests/test_optispeech.py
+++ b/tests/test_optispeech.py
@@ -85,6 +85,17 @@ def test_parse_outputs_wav_and_extras():
         [np.zeros((1, 1, 512), np.float32), np.array([512]), np.array([[3, 4]])], _req())
     assert res.audio.shape == (512,)
     assert "durations" in res.extras and "wav_lengths" in res.extras
+    # also exposed under the uniform key TTSVoice.phoneme_ids_to_audio reads
+    assert "phoneme_id_samples" in res.extras
+    np.testing.assert_array_equal(res.extras["phoneme_id_samples"], [3, 4])
+
+
+def test_parse_outputs_durations_by_name():
+    res = OptiSpeechAdapter().parse_outputs(
+        [np.zeros((1, 1, 512), np.float32), np.array([512]), np.array([[3, 4]])],
+        _req(), output_names=["wav", "wav_lengths", "durations"],
+    )
+    np.testing.assert_array_equal(res.extras["phoneme_id_samples"], [3, 4])
 
 
 def test_default_params():

--- a/tests/test_styletts2.py
+++ b/tests/test_styletts2.py
@@ -57,6 +57,26 @@ def test_parse_outputs_picks_waveform():
     assert r.audio.ndim == 1 and r.audio.size == 20000
 
 
+# --- phoneme alignment (durations) ---------------------------------------
+
+def test_parse_outputs_no_durations_by_default():
+    """Standard StyleTTS2/Kokoro exports emit only the waveform."""
+    r = StyleTTS2Adapter().parse_outputs(
+        [np.zeros((1, 512, 8), np.float32), np.ones(20000, np.float32)],
+        _req(), output_names=["decoder_hidden", "audio"],
+    )
+    assert "phoneme_id_samples" not in r.extras
+
+
+def test_parse_outputs_picks_up_named_durations():
+    durs = np.array([[1, 2, 3, 4, 5]], dtype=np.float32)
+    r = StyleTTS2Adapter().parse_outputs(
+        [np.ones(20000, np.float32), durs],
+        _req(), output_names=["audio", "pred_dur"],
+    )
+    np.testing.assert_array_equal(r.extras["phoneme_id_samples"], [1, 2, 3, 4, 5])
+
+
 def test_configure_loads_style_pack_from_engine_params(tmp_path):
     """Kokoro: the manager downloads a style blob; configure() reshapes it to [N,256]."""
     import numpy as np

--- a/tests/test_yourtts.py
+++ b/tests/test_yourtts.py
@@ -76,6 +76,25 @@ def test_speaker_reference_loads_and_flows(tmp_path):
     assert s2 == 16000 and a2.shape == (100,)
 
 
+# --- phoneme alignment (durations) ---------------------------------------
+
+def test_parse_outputs_no_durations_single_output():
+    a = YourTTSAdapter()
+    audio = np.zeros((1, 1, 400), np.float32)
+    res = a.parse_outputs([audio], _req(), output_names=["output"])
+    assert "phoneme_id_samples" not in res.extras
+
+
+def test_parse_outputs_picks_up_named_durations():
+    a = YourTTSAdapter()
+    audio = np.zeros((1, 1, 400), np.float32)
+    durs = np.array([[1, 2, 3, 4, 5]], dtype=np.float32)
+    res = a.parse_outputs(
+        [audio, durs], _req(), output_names=["output", "w_ceil"]
+    )
+    np.testing.assert_array_equal(res.extras["phoneme_id_samples"], [1, 2, 3, 4, 5])
+
+
 def test_reference_audio_outranks_bundled_dvector():
     class _Enc:
         def encode(self, audio, sr): return np.full(512, 0.9, np.float32)


### PR DESCRIPTION
Optional per-phoneme timing for synthesis — the number of audio samples each
phoneme spans — the foundation for visemes/lip-sync, karaoke-style highlighting,
and subtitle generation.

## API

- `TTSVoice.synthesize(text, syn_config=None, include_alignments=False)`. When
  `include_alignments=True` and the model exposes a duration output, each yielded
  `AudioChunk` also carries `phoneme_id_samples` and reconstructed
  `phoneme_alignments`. The default (`False`) is a strict no-op on the audio: the
  same inference runs and the same waveform is produced, only the extra
  reconstruction is skipped.
- Every `AudioChunk` now carries the `phonemes` and `phoneme_ids` that produced
  it, regardless of `include_alignments`.
- `PhonemeAlignment(phoneme: str, num_samples: int)`.
- `TTSVoice.phoneme_ids_to_audio(..., include_alignments=False)` returns an
  `(audio, phoneme_id_samples)` tuple when alignments are requested.
- `VoiceConfig.hop_length` (default `256`) converts model frames to audio samples.

## How it works

Each engine adapter locates a per-phoneme duration tensor among the ONNX outputs
by name (`DURATION_OUTPUT_NAMES` per adapter) and exposes it as
`extras["phoneme_id_samples"]`. `TTSVoice.phoneme_ids_to_audio` scales it to
samples uniformly via `hop_length` for every engine. Reconstruction folds
blank/bos/eos durations onto the adjacent real phonemes and runs per sentence
inside the lazy synthesis stream, so time-to-first-audio is unchanged.

Alignment is an optional model output: standard exports do not include it, and
those models degrade gracefully (`phoneme_alignments` comes back `None`).
`python -m phoonnx_train.export_onnx ... --add-phoneme-alignment` surfaces the
VITS duration tensor as an extra ONNX output; in-context engines without a
discrete duration predictor (e.g. ZipVoice) are unsupported.

## Tests

- `tests/test_alignment.py` — hermetic unit tests for `PhonemeAlignment`,
  `AudioChunk` fields, `hop_length` config, `phoneme_ids_to_audio` return shapes
  and frame→sample scaling, the id→phoneme reconstruction walk, two-stage engine
  scaling, graceful degradation on models without a duration output, byte-identical
  audio between `include_alignments` off and on, and per-sentence laziness of the
  alignment path. Plus per-engine adapter coverage and integration tests behind an
  auto-skip.

## Docs

`docs/alignment.md` (linked from the docs index and `usage.md`), plus the
`hop_length` field in `configuration.md`.

Supersedes #41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional phoneme-level alignment data to speech synthesis, including timing information for visemes, karaoke, and subtitles.
  * Added support for detecting alignment outputs across supported voice engines.
  * Added an export option for including alignment data in compatible models.
  * Added configurable hop length for converting model timing frames to audio samples.

* **Documentation**
  * Added detailed alignment guidance, configuration details, usage examples, and model export instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->