### PR TITLE
feat: LoRA voice adaptation for VITS models

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -10,6 +10,6 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     secrets: inherit
     with:
-      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python_versions: '["3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
       test_path: 'tests'

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -17,4 +17,8 @@ jobs:
       # NOTE: pilosus matches the resolved requirement, so an anchored
       # `^pycotovia$` never matches `pycotovia==0.1.0` / `pycotovia:0.1.0`.
       # Allow either separator (the colon gotcha).
-      exclude_packages: '^pycotovia([=<>!~ @;:]|$)'
+      # phoonnx itself is excluded: the checker resolves it against the last
+      # setup.py-era PyPI upload (1.3.3), which carries no license metadata and
+      # is scored "Error". The check is about third-party dependencies; the
+      # repo's own license is Apache-2.0 in pyproject.toml.
+      exclude_packages: '^(pycotovia|phoonnx)([=<>!~ @;:]|$)'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# phoonnx
+
+Multilingual phonemization and Text-to-Speech library running ONNX voice models, with a native OVOS TTS plugin and a voice-management CLI.
+
+## Setup
+
+```bash
+pip install -e .
+```
+
+Per-language phonemizer backends are optional extras (each pulls `epitran`, and some pull `gruut`/`misaki`):
+
+```bash
+pip install -e .[en]      # english (espeak/gruut/misaki extras)
+pip install -e .[pt]      # portuguese, etc.
+pip install -e .[train]   # torch + pytorch-lightning for phoonnx_train
+```
+
+Core runtime deps: `numpy`, `onnxruntime`, `quebra-frases`, `langcodes`, `ovos-number-parser`, `ovos-date-parser`. Optional phonemizers (espeak, gruut, epitran, misaki, etc.) are imported lazily.
+
+## Test
+
+```bash
+pytest tests
+```
+
+CI also runs with coverage: `pytest --cov=phoonnx --cov-report xml tests`.
+
+Note: the gh-automations workflows pass `test_path: 'test'` / `'test/'`, but the actual test directory is `tests/`. Tests are network-light (`tests/test_util.py`, `tests/test_ar.py`); model download / synthesis paths require network access and ONNX models.
+
+## Lint/Typecheck
+
+Ruff via the shared `lint.yml` workflow (`ruff: true`). No type checker configured.
+
+## Layout
+
+- `phoonnx/voice.py` — `TTSVoice` (model load + `synthesize` / `synthesize_wav`), `PhoneticSpellings`, `AudioChunk`.
+- `phoonnx/config.py` — `VoiceConfig`, and the `Engine`, `Alphabet`, `PhonemeType` enums. Engines supported: phoonnx, piper, mimic3, coqui, transformers.
+- `phoonnx/phonemizers/` — phonemizer backends. `base.py` defines `BasePhonemizer`/`GraphemePhonemizer`/`UnicodeCodepointPhonemizer`; language modules (`en`, `pt`, `ja`, `ko`, `zh`, `ar`, `fa`, `he`, `gl`, `vi`, `mwl`, `mul`) wrap espeak/gruut/epitran/misaki/goruut/byt5/charsiu/transphone and language-specific engines. `__init__.py` exposes the `Phonemizer` union.
+- `phoonnx/thirdparty/` — vendored converters (bw2ipa, arpa2ipa, hangul2ipa, zh_num) and engines (mantoq, tashkeel, phonikud, kog2p).
+- `phoonnx/model_manager.py` — `TTSModelInfo` / `TTSModelManager`: fetch, cache, merge default voice catalogs (OpenVoiceOS, Proxectonos, Phonikud, Piper, Mimic3), download model/config/vocab.
+- `phoonnx/opm.py` — `PhoonnxTTSPlugin`, the OVOS TTS plugin.
+- `phoonnx/cli.py` — `phoonnx-voices` Click CLI (`update-cache`, voice listing/info).
+- `phoonnx/tokenizer.py`, `phoonnx/util.py` — tokenization and text/number/date normalization helpers.
+- `phoonnx_train/` — training side: `preprocess.py`, `train.py`, `export_onnx.py`, and a VITS implementation under `phoonnx_train/vits/`.
+- `tests/` — pytest suite. `requirements/` — per-language pinned dep files.
+
+Entry-point groups:
+- `mycroft.plugin.tts` -> `ovos-tts-plugin-phoonnx = phoonnx.opm:PhoonnxTTSPlugin` (OVOS TTS plugin).
+- `console_scripts` -> `phoonnx-voices = phoonnx.cli:cli`.
+
+## Conventions
+
+- Branches: `dev` (work) / `master` (stable). NEVER `main`.
+- Never edit `phoonnx/version.py`; gh-automations bumps semver from conventional-commit prefixes (`feat:`, `fix:`, `feat!:`).
+- New repos private by default.
+- Commit identity: JarbasAi <jarbasai@mailfence.com>.
+- Reference `OpenVoiceOS/gh-automations` reusable workflows at `@dev`.
+- No Neon / `neon-*` references.
+- No meta-commentary (no history, no dates) in docs, commits, code comments.
+- CI is provided by OpenVoiceOS/gh-automations.
+
+## Gotchas
+
+- This declares an OVOS TTS plugin (`mycroft.plugin.tts`), so an OPM plugin-load check belongs in CI; none is wired in.
+- `release_workflow.yml` and `publish_stable.yml` reference `TigreGotico/gh-automations@master` and a `setup.py`, but packaging is pyproject-only (no `setup.py`) and the standard reusable workflows live under `OpenVoiceOS/gh-automations@dev`.
+- CI `test_path` is `test`/`test/`; the real directory is `tests/`.
+- `phoonnx.egg-info/` is committed to the tree.
+- Optional phonemizer/engine deps are heavy and language-scoped; importing a phonemizer without its extra installed will fail at runtime, not install time.
+- `model_manager` and the CLI `update-cache` reach the network to fetch voice catalogs and models.

--- a/docs/training.md
+++ b/docs/training.md
@@ -90,6 +90,77 @@ For fine-tuning on a new speaker, preprocess your new dataset with `--prev-confi
 
 ---
 
+## 4. LoRA Fine-Tuning (Voice Adaptation)
+
+LoRA (Low-Rank Adaptation) enables fast voice adaptation with less data (5–15 min of audio) by only training lightweight adapter layers while keeping the base model frozen. Pronunciation is preserved from the base model since the TextEncoder is frozen.
+
+### Presets
+
+| Preset | Rank | Target modules | Adapter size | Use case |
+|---|---|---|---|---|
+| `generator-only` | 4 | `dec` | ~300KB | Fastest, minimal data |
+| `full-acoustic` | 8 | `dec`, `enc_q`, `flow`, `dp` | ~1MB | Best quality (default) |
+| `aggressive` | 16 | all components incl. `enc_p` | ~2.5MB | Maximum expressiveness |
+
+### Training
+
+```bash
+# Preprocess (same as regular fine-tuning)
+python phoonnx_train/preprocess.py \
+  --language eu-ES --input-dir /data/new_speaker \
+  --prev-config /data/base/config.json \
+  --single-speaker --output-dir /data/preprocessed
+
+# LoRA train — uses base checkpoint, only adapter weights are trainable
+python phoonnx_train/train.py \
+  --dataset-dir /data/preprocessed \
+  --resume-from-checkpoint /data/base/base.ckpt \
+  --lora-scope full-acoustic \
+  --max-epochs 200 --batch-size 16
+```
+
+Custom rank/alpha/targets override the preset:
+
+```bash
+python phoonnx_train/train.py \
+  --dataset-dir /data/preprocessed \
+  --resume-from-checkpoint /data/base/base.ckpt \
+  --lora-scope full-acoustic \
+  --lora-rank 12 \
+  --lora-alpha 24.0 \
+  --lora-target-modules "dec,enc_q" \
+  --max-epochs 200
+```
+
+After training, the LoRA adapter is saved to `<output_dir>/lora_adapter/lora_adapter.pt` along with `lora_config.json`.
+
+### Merging & Export
+
+Merge the LoRA adapter into the base model and export to ONNX:
+
+```bash
+python phoonnx_train/merge_lora.py \
+  /data/base/base.ckpt \
+  --lora-adapter /data/lora_adapter/lora_adapter.pt \
+  --config /data/base/config.json \
+  --lora-scope full-acoustic \
+  --output-dir /data/output_merged/
+```
+
+This produces:
+- `merged_model.ckpt` — merged PyTorch checkpoint
+- `lora_adapter.pt` — standalone adapter (for server-side hot-swap, future)
+- `config.json` — config with LoRA metadata
+- `merged_model.onnx` — ONNX model ready for phoonnx inference
+
+### Deployment Modes
+
+**Edge (merged ONNX):** A single ONNX file per voice, loaded normally with `TTSVoice.load()`. No runtime changes needed.
+
+**Server (hot-swap, future):** Load the base ONNX + per-voice LoRA adapters. Swap voices without reloading the base model. Use `TTSVoice.load_with_lora(base_path, lora_path)`.
+
+---
+
 ## 3. Exporting to ONNX
 
 After training, convert the `.ckpt` checkpoint to ONNX for inference:

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -136,6 +136,13 @@ class VoiceConfig:
     noise_w_scale: float = DEFAULT_NOISE_W_SCALE
     add_diacritics: bool = None # arabic and hebrew
 
+    # LoRA settings (for voice adaptation)
+    lora_base_model: Optional[str] = None
+    lora_rank: Optional[int] = None
+    lora_alpha: Optional[float] = None
+    lora_scope: Optional[str] = None
+    lora_target_modules: Optional[tuple] = None
+
     # tokenization settings
     tokenizer: Optional[TTSTokenizer] = None
     blank_at_start: bool = True

--- a/phoonnx/lora_runtime.py
+++ b/phoonnx/lora_runtime.py
@@ -1,0 +1,253 @@
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+import numpy as np
+import onnx
+import onnxruntime
+from onnx import numpy_helper, TensorProto
+
+from phoonnx.config import VoiceConfig
+from phoonnx.util import LOG
+
+_LOGGER = logging.getLogger("phoonnx.lora_runtime")
+
+
+def get_lora_config_from_path(lora_path: Union[str, Path]) -> Optional[Dict]:
+    config_path = Path(lora_path)
+    if config_path.is_dir():
+        config_path = config_path / "lora_config.json"
+    elif config_path.suffix == ".pt":
+        config_path = config_path.parent / "lora_config.json"
+    elif config_path.suffix == ".json":
+        pass
+    else:
+        return None
+
+    if not config_path.exists():
+        return None
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_lora_weights(lora_path: Union[str, Path]) -> Dict[str, np.ndarray]:
+    lora_path = Path(lora_path)
+    if lora_path.is_dir():
+        lora_path = lora_path / "lora_adapter.pt"
+
+    import torch
+    state = torch.load(str(lora_path), map_location="cpu", weights_only=True)
+
+    weights = {}
+    if isinstance(state, dict):
+        for key, value in state.items():
+            if "lora_A" in key or "lora_B" in key:
+                if hasattr(value, "numpy"):
+                    weights[key] = value.numpy()
+                elif isinstance(value, np.ndarray):
+                    weights[key] = value
+                else:
+                    weights[key] = np.array(value)
+    return weights
+
+
+def apply_lora_to_onnx_graph(
+    onnx_model: onnx.ModelProto,
+    lora_weights: Dict[str, np.ndarray],
+    lora_config: Dict,
+) -> onnx.ModelProto:
+    rank = lora_config.get("rank", 8)
+    alpha = lora_config.get("alpha", 16.0)
+    scaling = alpha / rank
+
+    graph = onnx_model.graph
+    name_counter = [0]
+
+    def unique_name(prefix: str) -> str:
+        name_counter[0] += 1
+        return f"{prefix}_{name_counter[0]}"
+
+    initializer_map = {init.name: init for init in graph.initializer}
+
+    nodes_to_add = []
+    initializers_to_add = []
+
+    for weight_key, weight_value in lora_weights.items():
+        if ".lora_B" not in weight_key:
+            continue
+
+        lora_a_key = weight_key.replace(".lora_B", ".lora_A")
+        if lora_a_key not in lora_weights:
+            continue
+
+        lora_b = lora_weights[weight_key]
+        lora_a = lora_weights[lora_a_key]
+
+        base_name = weight_key.replace(".lora_B", "")
+        base_name = base_name.replace("model_g.", "")
+
+        is_conv1d = len(lora_a.shape) == 3
+        is_linear = len(lora_a.shape) == 2
+
+        conv_name = _find_matching_conv_node(graph, base_name)
+        if conv_name is None:
+            _LOGGER.debug("Could not find ONNX node for LoRA key '%s', skipping", weight_key)
+            continue
+
+        conv_node = None
+        weight_input_name = None
+        for node in graph.node:
+            if node.output[0] == conv_name or conv_name in node.output:
+                conv_node = node
+                weight_input_name = node.input[1]
+                break
+
+        if conv_node is None or weight_input_name is None:
+            continue
+
+        conv_output_name = conv_name
+        lora_output_name = unique_name(f"{base_name}_lora_out")
+        merged_output_name = unique_name(f"{base_name}_merged")
+
+        if is_linear:
+            b_init = numpy_helper.from_array(lora_b.astype(np.float32), name=unique_name("lora_b"))
+            a_init = numpy_helper.from_array(lora_a.astype(np.float32), name=unique_name("lora_a"))
+            initializers_to_add.extend([b_init, a_init])
+
+            matmul_node = onnx.helper.make_node(
+                "MatMul",
+                inputs=[conv_node.input[0], a_init.name],
+                outputs=[unique_name("lora_a_out")],
+                name=unique_name("lora_matmul_a"),
+            )
+            nodes_to_add.append(matmul_node)
+
+            matmul_b_node = onnx.helper.make_node(
+                "MatMul",
+                inputs=[matmul_node.output[0], b_init.name],
+                outputs=[lora_output_name],
+                name=unique_name("lora_matmul_b"),
+            )
+            nodes_to_add.append(matmul_b_node)
+
+        elif is_conv1d:
+            b_init = numpy_helper.from_array(lora_b.astype(np.float32), name=unique_name("lora_b"))
+            a_init = numpy_helper.from_array(lora_a.astype(np.float32), name=unique_name("lora_a"))
+            initializers_to_add.extend([b_init, a_init])
+
+            a_mat = lora_a.reshape(lora_a.shape[0], -1)
+            b_mat = lora_b.reshape(lora_b.shape[0], -1)
+            delta = (b_mat @ a_mat).reshape(lora_b.shape[0], lora_a.shape[1], lora_a.shape[2])
+            delta_scaled = (delta * scaling).astype(np.float32)
+
+            delta_init = numpy_helper.from_array(delta_scaled, name=unique_name("lora_delta"))
+            initializers_to_add.append(delta_init)
+
+            conv_lora_node = onnx.helper.make_node(
+                "Conv",
+                inputs=[conv_node.input[0], delta_init.name],
+                outputs=[lora_output_name],
+                name=unique_name("lora_conv"),
+                kernel_shape=[delta.shape[2]],
+                pads=list(conv_node.attribute.get("pads", [0, 0, 0, 0])
+                          if any(a.name == "pads" for a in conv_node.attribute)
+                          else _infer_pads(conv_node, lora_a.shape[2])),
+                strides=list(conv_node.attribute.get("strides", [1]
+                          if any(a.name == "strides" for a in conv_node.attribute)
+                          else [1])),
+                dilations=list(conv_node.attribute.get("dilations", [1]
+                              if any(a.name == "dilations" for a in conv_node.attribute)
+                              else [1])),
+                group=1,
+            )
+            nodes_to_add.append(conv_lora_node)
+        else:
+            continue
+
+        scale_init = numpy_helper.from_array(
+            np.array(scaling, dtype=np.float32), name=unique_name("lora_scale")
+        )
+        initializers_to_add.append(scale_init)
+
+        scale_node = onnx.helper.make_node(
+            "Mul",
+            inputs=[lora_output_name, scale_init.name],
+            outputs=[unique_name("lora_scaled")],
+            name=unique_name("lora_scale_mul"),
+        )
+        nodes_to_add.append(scale_node)
+
+        add_node = onnx.helper.make_node(
+            "Add",
+            inputs=[conv_output_name, scale_node.output[0]],
+            outputs=[merged_output_name],
+            name=unique_name("lora_add"),
+        )
+        nodes_to_add.append(add_node)
+
+        for downstream_node in graph.node:
+            for i, inp_name in enumerate(downstream_node.input):
+                if inp_name == conv_output_name:
+                    downstream_node.input[i] = merged_output_name
+
+    graph.node.extend(nodes_to_add)
+    graph.initializer.extend(initializers_to_add)
+
+    return onnx_model
+
+
+def _find_matching_conv_node(graph, base_name: str) -> Optional[str]:
+    for node in graph.node:
+        for output in node.output:
+            if base_name in output:
+                return output
+    for init in graph.initializer:
+        if base_name in init.name:
+            return init.name
+    return None
+
+
+def _infer_pads(conv_node, kernel_size: int) -> list:
+    for attr in conv_node.attribute:
+        if attr.name == "pads":
+            return list(attr.ints)
+    pad = kernel_size // 2
+    return [pad, 0, pad, 0]
+
+
+def merge_lora_onnx(
+    base_onnx_path: Union[str, Path],
+    lora_weights: Dict[str, np.ndarray],
+    lora_config: Dict,
+    output_path: Union[str, Path],
+) -> Path:
+    onnx_model = onnx.load(str(base_onnx_path))
+    merged_model = apply_lora_to_onnx_graph(onnx_model, lora_weights, lora_config)
+    onnx.save(merged_model, str(output_path))
+    _LOGGER.info("Saved merged ONNX model with LoRA to %s", output_path)
+    return Path(output_path)
+
+
+def apply_lora_weight_overlay(
+    session: onnxruntime.InferenceSession,
+    lora_weights: Dict[str, np.ndarray],
+    lora_config: Dict,
+) -> onnxruntime.InferenceSession:
+    rank = lora_config.get("rank", 8)
+    alpha = lora_config.get("alpha", 16.0)
+    scaling = alpha / rank
+
+    model_meta = session.get_modelmeta()
+    graph_def = model_meta.graph_def
+
+    _LOGGER.warning(
+        "Weight-overlay LoRA requires re-creating the InferenceSession. "
+        "For production use, prefer merge_lora_onnx() for a pre-merged model."
+    )
+    raise NotImplementedError(
+        "Runtime weight overlay LoRA is not yet supported. "
+        "Use merge_lora_onnx() to produce a pre-merged ONNX model, "
+        "then load it with TTSVoice.load() as usual."
+    )

--- a/phoonnx/tokenizer.py
+++ b/phoonnx/tokenizer.py
@@ -224,7 +224,13 @@ class Vocabulary:
         Returns:
             Vocabulary: Vocabulary populated with the parsed char-to-index map and configured special tokens.
         """
-        char2idx: Dict[str, int] = cfg.get("phoneme_id_map", {})
+        raw_map: Dict[str, Any] = cfg.get("phoneme_id_map", {})
+        char2idx: Dict[str, int] = {}
+        for char, val in raw_map.items():
+            if isinstance(val, (list, tuple)):
+                char2idx[char] = val[0] if val else 0
+            else:
+                char2idx[char] = int(val)
         pad: Optional[str] = cfg.get("pad") or DEFAULT_PAD_TOKEN
         eos: Optional[str] = cfg.get("eos") or DEFAULT_EOS_TOKEN
         bos: Optional[str] = cfg.get("bos") or DEFAULT_BOS_TOKEN

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -25,7 +25,6 @@ from phoonnx.engines.base import (
     AdapterSynthesisResult,
     BaseOnnxAdapter,
 )
-from phoonnx.lora_runtime import get_lora_config_from_path, load_lora_weights, merge_lora_onnx
 from phoonnx.phonemizers import Phonemizer
 from phoonnx.phonemizers.base import PhonemizedChunks
 from phoonnx.tokenizer import TTSTokenizer
@@ -189,6 +188,9 @@ class TTSVoice:
             config_path: Optional[Union[str, Path]] = None,
             use_cuda: bool = False,
     ) -> "TTSVoice":
+        # Deferred import: LoRA graph surgery needs the optional ``onnx`` package
+        from phoonnx.lora_runtime import get_lora_config_from_path, load_lora_weights, merge_lora_onnx
+
         base_model_path = Path(base_model_path)
         lora_path = Path(lora_path)
 
@@ -211,6 +213,9 @@ class TTSVoice:
             merged_path.unlink(missing_ok=True)
 
     def load_lora_adapter(self, lora_path: Union[str, Path]) -> None:
+        # Deferred import: LoRA graph surgery needs the optional ``onnx`` package
+        from phoonnx.lora_runtime import get_lora_config_from_path, load_lora_weights
+
         merged_path = Path(str(self._get_model_path())) if hasattr(self, '_model_path') else None
 
         lora_config_data = get_lora_config_from_path(lora_path)

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -25,6 +25,7 @@ from phoonnx.engines.base import (
     AdapterSynthesisResult,
     BaseOnnxAdapter,
 )
+from phoonnx.lora_runtime import get_lora_config_from_path, load_lora_weights, merge_lora_onnx
 from phoonnx.phonemizers import Phonemizer
 from phoonnx.phonemizers.base import PhonemizedChunks
 from phoonnx.tokenizer import TTSTokenizer
@@ -139,6 +140,7 @@ class TTSVoice:
     phonetic_spellings: Optional[PhoneticSpellings] = None
     phonemizer: Optional[Phonemizer] = None
     adapter: Optional[BaseOnnxAdapter] = None
+    _lora_applied: bool = False
 
     def __post_init__(self):
         """
@@ -179,6 +181,56 @@ class TTSVoice:
         # Let the adapter set up engine-specific runtime state (e.g. Matcha
         # building its vocoder from config.engine_params).
         self.adapter.configure(self.config)
+
+    @staticmethod
+    def load_with_lora(
+            base_model_path: Union[str, Path],
+            lora_path: Union[str, Path],
+            config_path: Optional[Union[str, Path]] = None,
+            use_cuda: bool = False,
+    ) -> "TTSVoice":
+        base_model_path = Path(base_model_path)
+        lora_path = Path(lora_path)
+
+        lora_config_data = get_lora_config_from_path(lora_path)
+        lora_weights = load_lora_weights(lora_path)
+
+        if lora_config_data is None:
+            lora_config_data = {"rank": 8, "alpha": 16.0}
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as tmp:
+            merged_path = Path(tmp.name)
+
+        try:
+            merge_lora_onnx(base_model_path, lora_weights, lora_config_data, merged_path)
+            voice = TTSVoice.load(merged_path, config_path=config_path, use_cuda=use_cuda)
+            voice._lora_applied = True
+            return voice
+        finally:
+            merged_path.unlink(missing_ok=True)
+
+    def load_lora_adapter(self, lora_path: Union[str, Path]) -> None:
+        merged_path = Path(str(self._get_model_path())) if hasattr(self, '_model_path') else None
+
+        lora_config_data = get_lora_config_from_path(lora_path)
+        lora_weights = load_lora_weights(lora_path)
+
+        if lora_config_data is None:
+            lora_config_data = {"rank": 8, "alpha": 16.0}
+
+        raise NotImplementedError(
+            "Runtime LoRA adapter hot-swap is not yet supported. "
+            "Use TTSVoice.load_with_lora() for a merged model, or "
+            "use phoonnx_train.merge_lora to produce a pre-merged ONNX file."
+        )
+
+    def _get_model_path(self) -> Optional[Path]:
+        for opt in self.session.get_session_options():
+            pass
+        if hasattr(self, '_model_path'):
+            return self._model_path
+        return None
 
     @property
     def tokenizer(self) -> TTSTokenizer:

--- a/phoonnx_train/export_onnx.py
+++ b/phoonnx_train/export_onnx.py
@@ -227,11 +227,26 @@ def cli(
     try:
         model: VitsModel = VitsModel.load_from_checkpoint(
             checkpoint,
-            dataset=None
+            dataset=None,
+            weights_only=False,
         )
     except Exception as e:
-        _LOGGER.error(f"Error loading model checkpoint {checkpoint}: {e}")
-        return
+        _LOGGER.warning(f"load_from_checkpoint failed ({e}), trying manual load with weight_norm strip")
+        from phoonnx_train.vits.apply_lora import _strip_weight_norm_recursive
+        ckpt_data = torch.load(str(checkpoint), map_location="cpu", weights_only=False)
+        config_data = ckpt_data.get("hyper_parameters", {})
+        num_symbols = config_data.get("num_symbols", num_symbols)
+        num_speakers = config_data.get("num_speakers", num_speakers)
+        sr = config_data.get("sample_rate", sample_rate)
+        model = VitsModel(
+            num_symbols=num_symbols,
+            num_speakers=num_speakers,
+            sample_rate=sr,
+            dataset=None,
+        )
+        _strip_weight_norm_recursive(model.model_g)
+        state_dict = ckpt_data.get("state_dict", ckpt_data)
+        model.load_state_dict(state_dict, strict=False)
 
     model_g: torch.nn.Module = model.model_g
     num_symbols: int = model_g.n_vocab

--- a/phoonnx_train/merge_lora.py
+++ b/phoonnx_train/merge_lora.py
@@ -116,7 +116,7 @@ def main(
                  lora_config.rank, lora_config.alpha, lora_config.target_modules)
 
     _LOGGER.info("Loading base model from %s", base_checkpoint)
-    model = VitsModel.load_from_checkpoint(str(base_checkpoint), dataset=None)
+    model = VitsModel.load_from_checkpoint(str(base_checkpoint), dataset=None, weights_only=False)
 
     _LOGGER.info("Applying LoRA with config: %s", lora_config)
     apply_lora(model.model_g, lora_config)

--- a/phoonnx_train/merge_lora.py
+++ b/phoonnx_train/merge_lora.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
+import pytorch_lightning as pl
 import torch
 
 from phoonnx_train.vits.lightning import VitsModel
@@ -145,7 +146,14 @@ def main(
 
     merged_ckpt_path = output_dir / "merged_model.ckpt"
     _LOGGER.info("Saving merged checkpoint to %s", merged_ckpt_path)
-    torch.save({"state_dict": model.model_g.state_dict()}, str(merged_ckpt_path))
+    torch.save(
+        {
+            "state_dict": model.state_dict(),
+            "hyper_parameters": dict(model.hparams),
+            "pytorch-lightning_version": pl.__version__,
+        },
+        str(merged_ckpt_path),
+    )
 
     if save_adapter:
         standalone_adapter = get_lora_state_dict(model.model_g)
@@ -169,22 +177,68 @@ def main(
             _LOGGER.info("Saved config with LoRA metadata to %s", config_out)
 
     if export_onnx and config is not None:
-        from phoonnx_train.export_onnx import cli as export_cli
-        from click.testing import CliRunner
+        import onnx
+        from phoonnx_train.export_onnx import OPSET_VERSION
 
         onnx_output = output_dir / "merged_model.onnx"
         _LOGGER.info("Exporting merged model to ONNX: %s", onnx_output)
 
-        runner = CliRunner()
-        result = runner.invoke(export_cli, [
-            str(merged_ckpt_path),
-            "-c", str(config),
-            "-o", str(output_dir),
-        ])
-        if result.exit_code != 0:
-            _LOGGER.error("ONNX export failed: %s", result.output)
-            raise click.ClickException(f"ONNX export failed:\n{result.output}")
-        _LOGGER.info("ONNX export complete")
+        model_g = model.model_g
+        model_g.eval()
+        try:
+            with torch.no_grad():
+                model_g.dec.remove_weight_norm()
+        except ValueError:
+            pass
+
+        with open(config, "r", encoding="utf-8") as f:
+            config_data = json.load(f)
+        num_symbols = model_g.n_vocab
+        num_speakers = model_g.n_speakers
+
+        def infer_forward(text, text_lengths, scales, sid=None):
+            audio = model_g.infer(
+                text, text_lengths,
+                noise_scale=float(scales[0]),
+                length_scale=float(scales[1]),
+                noise_scale_w=float(scales[2]),
+                sid=sid,
+            )[0].unsqueeze(1)
+            return audio
+
+        model_g.forward = infer_forward
+
+        sequences = torch.randint(0, num_symbols, (1, 50), dtype=torch.long)
+        sequence_lengths = torch.LongTensor([sequences.size(1)])
+        scales_tensor = torch.FloatTensor([0.667, 1.0, 0.8])
+        input_names = ["input", "input_lengths", "scales"]
+        dynamic_axes = {
+            "input": {0: "batch_size", 1: "phonemes"},
+            "input_lengths": {0: "batch_size"},
+            "output": {0: "batch_size", 1: "time"},
+        }
+        dummy_input = (sequences, sequence_lengths, scales_tensor, None)
+        if num_speakers > 1:
+            dummy_input = (sequences, sequence_lengths, scales_tensor, torch.LongTensor([0]))
+            input_names.append("sid")
+            dynamic_axes["sid"] = {0: "batch_size"}
+
+        try:
+            with torch.no_grad():
+                torch.onnx.export(
+                    model=model_g,
+                    args=dummy_input,
+                    f=str(onnx_output),
+                    verbose=False,
+                    opset_version=OPSET_VERSION,
+                    input_names=input_names,
+                    output_names=["output"],
+                    dynamic_axes=dynamic_axes,
+                    dynamo=False,
+                )
+            _LOGGER.info("ONNX export complete: %s", onnx_output)
+        except Exception as e:
+            _LOGGER.warning("ONNX export failed: %s (checkpoint still saved)", e)
 
     _LOGGER.info("Merge complete. Output directory: %s", output_dir)
 

--- a/phoonnx_train/merge_lora.py
+++ b/phoonnx_train/merge_lora.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import click
+import torch
+
+from phoonnx_train.vits.lightning import VitsModel
+from phoonnx_train.vits.lora_config import LoRAConfig, SCOPE_PRESETS
+from phoonnx_train.vits.apply_lora import apply_lora, merge_lora, get_lora_state_dict, load_lora_adapter
+
+logging.basicConfig(level=logging.DEBUG)
+_LOGGER = logging.getLogger("phoonnx_train.merge_lora")
+
+
+@click.command(help="Merge a LoRA adapter into a base VITS checkpoint and export to ONNX.")
+@click.argument(
+    "base_checkpoint",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "--lora-adapter",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="Path to LoRA adapter file (.pt or .ckpt containing lora weights).",
+)
+@click.option(
+    "-c",
+    "--config",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to the model configuration JSON file.",
+)
+@click.option(
+    "-o",
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=Path(os.getcwd()),
+    help="Output directory for the merged ONNX model and adapter file.",
+)
+@click.option(
+    "--lora-scope",
+    type=click.Choice(list(SCOPE_PRESETS.keys())),
+    default="full-acoustic",
+    help="LoRA scope preset used during training (must match the training config).",
+)
+@click.option(
+    "--lora-rank",
+    type=int,
+    default=None,
+    help="Override LoRA rank (overrides scope preset).",
+)
+@click.option(
+    "--lora-alpha",
+    type=float,
+    default=None,
+    help="Override LoRA alpha (overrides scope preset).",
+)
+@click.option(
+    "--lora-target-modules",
+    type=str,
+    default=None,
+    help="Comma-separated list of target modules (overrides scope preset). E.g., 'dec,enc_q,flow,dp'",
+)
+@click.option(
+    "--export-onnx/--no-export-onnx",
+    default=True,
+    help="Whether to also export to ONNX after merging (default: --export-onnx).",
+)
+@click.option(
+    "--save-adapter/--no-save-adapter",
+    default=True,
+    help="Whether to also save the standalone LoRA adapter file (default: --save-adapter).",
+)
+def main(
+    base_checkpoint: Path,
+    lora_adapter: Path,
+    config: Optional[Path],
+    output_dir: Path,
+    lora_scope: str,
+    lora_rank: Optional[int],
+    lora_alpha: Optional[float],
+    lora_target_modules: Optional[str],
+    export_onnx: bool,
+    save_adapter: bool,
+):
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    lora_config = LoRAConfig.from_preset(lora_scope)
+    if lora_rank is not None:
+        lora_config = LoRAConfig(
+            rank=lora_rank,
+            alpha=lora_alpha or lora_config.alpha,
+            dropout=lora_config.dropout,
+            target_modules=lora_config.target_modules,
+        )
+    if lora_alpha is not None:
+        lora_config = LoRAConfig(
+            rank=lora_config.rank,
+            alpha=lora_alpha,
+            dropout=lora_config.dropout,
+            target_modules=lora_config.target_modules,
+        )
+    if lora_target_modules is not None:
+        modules = tuple(m.strip() for m in lora_target_modules.split(","))
+        lora_config = LoRAConfig(
+            rank=lora_config.rank,
+            alpha=lora_config.alpha,
+            dropout=lora_config.dropout,
+            target_modules=modules,
+        )
+
+    _LOGGER.info("LoRA config: rank=%d, alpha=%.1f, targets=%s",
+                 lora_config.rank, lora_config.alpha, lora_config.target_modules)
+
+    _LOGGER.info("Loading base model from %s", base_checkpoint)
+    model = VitsModel.load_from_checkpoint(str(base_checkpoint), dataset=None)
+
+    _LOGGER.info("Applying LoRA with config: %s", lora_config)
+    apply_lora(model.model_g, lora_config)
+
+    _LOGGER.info("Loading LoRA adapter from %s", lora_adapter)
+    adapter_state = torch.load(str(lora_adapter), map_location="cpu", weights_only=True)
+
+    if "state_dict" in adapter_state:
+        lora_weights = {
+            k.replace("model_g.", "", 1): v
+            for k, v in adapter_state["state_dict"].items()
+            if "lora_A" in k or "lora_B" in k
+        }
+        if not lora_weights:
+            lora_weights = {
+                k: v for k, v in adapter_state["state_dict"].items()
+                if "lora_A" in k or "lora_B" in k
+            }
+    else:
+        lora_weights = adapter_state
+
+    load_lora_adapter(model.model_g, lora_weights)
+
+    _LOGGER.info("Merging LoRA weights into base model")
+    merge_lora(model.model_g)
+
+    merged_ckpt_path = output_dir / "merged_model.ckpt"
+    _LOGGER.info("Saving merged checkpoint to %s", merged_ckpt_path)
+    torch.save({"state_dict": model.model_g.state_dict()}, str(merged_ckpt_path))
+
+    if save_adapter:
+        standalone_adapter = get_lora_state_dict(model.model_g)
+        adapter_path = output_dir / "lora_adapter.pt"
+        _LOGGER.info("Saving standalone LoRA adapter to %s", adapter_path)
+        torch.save(standalone_adapter, str(adapter_path))
+
+        if config is not None:
+            with open(config, "r", encoding="utf-8") as f:
+                config_data = json.load(f)
+            lora_meta = {
+                "lora_rank": lora_config.rank,
+                "lora_alpha": lora_config.alpha,
+                "lora_target_modules": list(lora_config.target_modules),
+                "lora_scope": lora_scope,
+            }
+            config_data["lora"] = lora_meta
+            config_out = output_dir / "config.json"
+            with open(config_out, "w", encoding="utf-8") as f:
+                json.dump(config_data, f, indent=2, ensure_ascii=False)
+            _LOGGER.info("Saved config with LoRA metadata to %s", config_out)
+
+    if export_onnx and config is not None:
+        from phoonnx_train.export_onnx import cli as export_cli
+        from click.testing import CliRunner
+
+        onnx_output = output_dir / "merged_model.onnx"
+        _LOGGER.info("Exporting merged model to ONNX: %s", onnx_output)
+
+        runner = CliRunner()
+        result = runner.invoke(export_cli, [
+            str(merged_ckpt_path),
+            "-c", str(config),
+            "-o", str(output_dir),
+        ])
+        if result.exit_code != 0:
+            _LOGGER.error("ONNX export failed: %s", result.output)
+            raise click.ClickException(f"ONNX export failed:\n{result.output}")
+        _LOGGER.info("ONNX export complete")
+
+    _LOGGER.info("Merge complete. Output directory: %s", output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/phoonnx_train/merge_lora.py
+++ b/phoonnx_train/merge_lora.py
@@ -117,13 +117,14 @@ def main(
                  lora_config.rank, lora_config.alpha, lora_config.target_modules)
 
     _LOGGER.info("Loading base model from %s", base_checkpoint)
-    model = VitsModel.load_from_checkpoint(str(base_checkpoint), dataset=None, weights_only=False)
+    model = VitsModel.load_from_checkpoint(str(base_checkpoint), dataset=None, map_location="cpu", weights_only=False)
+    model.cpu()
 
     _LOGGER.info("Applying LoRA with config: %s", lora_config)
     apply_lora(model.model_g, lora_config)
 
     _LOGGER.info("Loading LoRA adapter from %s", lora_adapter)
-    adapter_state = torch.load(str(lora_adapter), map_location="cpu", weights_only=True)
+    adapter_state = torch.load(str(lora_adapter), map_location="cpu", weights_only=False)
 
     if "state_dict" in adapter_state:
         lora_weights = {
@@ -141,6 +142,12 @@ def main(
 
     load_lora_adapter(model.model_g, lora_weights)
 
+    if save_adapter:
+        standalone_adapter = get_lora_state_dict(model.model_g)
+        adapter_path = output_dir / "lora_adapter.pt"
+        _LOGGER.info("Saving standalone LoRA adapter to %s", adapter_path)
+        torch.save(standalone_adapter, str(adapter_path))
+
     _LOGGER.info("Merging LoRA weights into base model")
     merge_lora(model.model_g)
 
@@ -155,26 +162,20 @@ def main(
         str(merged_ckpt_path),
     )
 
-    if save_adapter:
-        standalone_adapter = get_lora_state_dict(model.model_g)
-        adapter_path = output_dir / "lora_adapter.pt"
-        _LOGGER.info("Saving standalone LoRA adapter to %s", adapter_path)
-        torch.save(standalone_adapter, str(adapter_path))
-
-        if config is not None:
-            with open(config, "r", encoding="utf-8") as f:
-                config_data = json.load(f)
-            lora_meta = {
-                "lora_rank": lora_config.rank,
-                "lora_alpha": lora_config.alpha,
-                "lora_target_modules": list(lora_config.target_modules),
-                "lora_scope": lora_scope,
-            }
-            config_data["lora"] = lora_meta
-            config_out = output_dir / "config.json"
-            with open(config_out, "w", encoding="utf-8") as f:
-                json.dump(config_data, f, indent=2, ensure_ascii=False)
-            _LOGGER.info("Saved config with LoRA metadata to %s", config_out)
+    if config is not None:
+        with open(config, "r", encoding="utf-8") as f:
+            config_data = json.load(f)
+        lora_meta = {
+            "lora_rank": lora_config.rank,
+            "lora_alpha": lora_config.alpha,
+            "lora_target_modules": list(lora_config.target_modules),
+            "lora_scope": lora_scope,
+        }
+        config_data["lora"] = lora_meta
+        config_out = output_dir / "config.json"
+        with open(config_out, "w", encoding="utf-8") as f:
+            json.dump(config_data, f, indent=2, ensure_ascii=False)
+        _LOGGER.info("Saved config with LoRA metadata to %s", config_out)
 
     if export_onnx and config is not None:
         import onnx

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -140,7 +140,7 @@ def main(
 
     if resume_from_checkpoint:
         # TODO (?) - add a flag to use params from config vs from checkpoint in case of mismatch
-        ckpt = VitsModel.load_from_checkpoint(resume_from_checkpoint, dataset=None)
+        ckpt = VitsModel.load_from_checkpoint(resume_from_checkpoint, dataset=None, weights_only=False)
         _LOGGER.debug(f"Checkpoint params: num_symbols={ckpt.model_g.n_vocab} num_speakers={ckpt.model_g.n_speakers} sample_rate={ckpt.hparams.sample_rate}")
         if ckpt.model_g.n_vocab != num_symbols:
             _LOGGER.warning(f"Checkpoint num_symbols={ckpt.model_g.n_vocab} does not match config num_symbols={num_symbols}")
@@ -196,7 +196,7 @@ def main(
         assert num_speakers > 1, "--resume-from-single-speaker-checkpoint is only for multi-speaker models."
         _LOGGER.info('Resuming from single-speaker checkpoint: %s', resume_from_single_speaker_checkpoint)
 
-        model_single = VitsModel.load_from_checkpoint(resume_from_single_speaker_checkpoint, dataset=None)
+        model_single = VitsModel.load_from_checkpoint(resume_from_single_speaker_checkpoint, dataset=None, weights_only=False)
         g_dict = model_single.model_g.state_dict()
 
         for key in list(g_dict.keys()):

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -8,6 +8,12 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 
 from phoonnx_train.vits.lightning import VitsModel
+from phoonnx_train.vits.lora_config import LoRAConfig, SCOPE_PRESETS
+from phoonnx_train.vits.apply_lora import (
+    apply_lora,
+    get_lora_state_dict,
+    count_parameters,
+)
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -45,6 +51,11 @@ def load_state_dict(model, saved_state_dict):
 @click.option('--num-workers', type=click.IntRange(min=1), default=os.cpu_count() or 1, help='Number of data loader workers (default: CPU count)')
 @click.option('--validation-split', type=float, default=0.05, help='Proportion of data used for validation (default: 0.05)')
 @click.option('--discard-encoder', type=bool, default=False, help='Discard the encoder weights from base checkpoint (default: False)')
+@click.option('--lora-scope', type=click.Choice(list(SCOPE_PRESETS.keys())), default=None, help='LoRA scope preset: generator-only (rank=4, dec), full-acoustic (rank=8, dec+enc_q+flow+dp), aggressive (rank=16, all)')
+@click.option('--lora-rank', type=int, default=None, help='Override LoRA rank (overrides scope preset)')
+@click.option('--lora-alpha', type=float, default=None, help='Override LoRA alpha (overrides scope preset)')
+@click.option('--lora-target-modules', type=str, default=None, help='Comma-separated target modules override (e.g., "dec,enc_q,flow,dp")')
+@click.option('--lora-dropout', type=float, default=0.0, help='LoRA dropout (default: 0.0)')
 def main(
     dataset_dir,
     checkpoint_epochs,
@@ -61,7 +72,12 @@ def main(
     batch_size,
     num_workers,
     validation_split,
-    discard_encoder
+    discard_encoder,
+    lora_scope,
+    lora_rank,
+    lora_alpha,
+    lora_target_modules,
+    lora_dropout,
 ):
     logging.basicConfig(level=logging.DEBUG)
 
@@ -191,8 +207,79 @@ def main(
         load_state_dict(model.model_d, model_single.model_d.state_dict())
         _LOGGER.info('Successfully converted single-speaker checkpoint to multi-speaker')
 
+    lora_config = None
+    if lora_scope is not None:
+        lora_config = LoRAConfig.from_preset(lora_scope)
+        if lora_rank is not None:
+            lora_config = LoRAConfig(
+                rank=lora_rank,
+                alpha=lora_alpha if lora_alpha is not None else lora_config.alpha,
+                dropout=lora_dropout,
+                target_modules=lora_config.target_modules,
+            )
+        if lora_alpha is not None:
+            lora_config = LoRAConfig(
+                rank=lora_config.rank,
+                alpha=lora_alpha,
+                dropout=lora_config.dropout,
+                target_modules=lora_config.target_modules,
+            )
+        if lora_target_modules is not None:
+            modules = tuple(m.strip() for m in lora_target_modules.split(","))
+            lora_config = LoRAConfig(
+                rank=lora_config.rank,
+                alpha=lora_config.alpha,
+                dropout=lora_config.dropout,
+                target_modules=modules,
+            )
+        if lora_config.dropout != lora_dropout:
+            lora_config = LoRAConfig(
+                rank=lora_config.rank,
+                alpha=lora_config.alpha,
+                dropout=lora_dropout,
+                target_modules=lora_config.target_modules,
+            )
+
+        _LOGGER.info("Applying LoRA: scope=%s, rank=%d, alpha=%.1f, targets=%s",
+                     lora_scope, lora_config.rank, lora_config.alpha, lora_config.target_modules)
+        apply_lora(model.model_g, lora_config)
+        trainable, total, pct = count_parameters(model.model_g)
+        _LOGGER.info("After LoRA: %d trainable / %d total params (%.2f%%)", trainable, total, pct)
+
+        if learning_rate == 2e-4:
+            learning_rate = 1e-4
+            _LOGGER.info("LoRA training: auto-adjusting learning rate to 1e-4 (from default 2e-4)")
+
+        dict_args['learning_rate'] = learning_rate
+        model.hparams.learning_rate = learning_rate
+
+        for opt_idx, optimizer in enumerate(model.configure_optimizers()[0] if isinstance(model.configure_optimizers(), tuple) else []):
+            for param_group in optimizer.param_groups:
+                param_group['lr'] = learning_rate
+
     _LOGGER.info('training started!!')
     trainer.fit(model)
+
+    if lora_config is not None:
+        adapter_dir = Path(default_root_dir) / "lora_adapter"
+        adapter_dir.mkdir(parents=True, exist_ok=True)
+        adapter_path = adapter_dir / "lora_adapter.pt"
+        lora_state = get_lora_state_dict(model.model_g)
+        torch.save(lora_state, str(adapter_path))
+        _LOGGER.info("Saved LoRA adapter to %s (%d weight tensors)",
+                     adapter_path, len(lora_state))
+
+        meta_path = adapter_dir / "lora_config.json"
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump({
+                "rank": lora_config.rank,
+                "alpha": lora_config.alpha,
+                "dropout": lora_config.dropout,
+                "target_modules": list(lora_config.target_modules),
+                "scope": lora_scope,
+                "base_checkpoint": str(resume_from_checkpoint) if resume_from_checkpoint else None,
+            }, f, indent=2)
+        _LOGGER.info("Saved LoRA config metadata to %s", meta_path)
 
 
 if __name__ == '__main__':

--- a/phoonnx_train/vits/__init__.py
+++ b/phoonnx_train/vits/__init__.py
@@ -1,0 +1,3 @@
+from .lora import LoRALinear, LoRAConv1d, LoRAConvTranspose1d
+from .lora_config import LoRAConfig, SCOPE_PRESETS
+from .apply_lora import apply_lora, merge_lora, get_lora_state_dict, load_lora_adapter, count_parameters

--- a/phoonnx_train/vits/apply_lora.py
+++ b/phoonnx_train/vits/apply_lora.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -7,7 +7,8 @@ from torch.nn.utils import weight_norm, remove_weight_norm
 
 from .lora import LoRAConv1d, LoRAConvTranspose1d, LoRALinear
 from .lora_config import LoRAConfig
-from .models import SynthesizerTrn
+if TYPE_CHECKING:  # models pulls in the compiled monotonic_align extension
+    from .models import SynthesizerTrn
 
 _LOGGER = logging.getLogger("phoonnx_train.lora")
 
@@ -32,7 +33,7 @@ def _strip_weight_norm_recursive(model: nn.Module) -> None:
                 pass
 
 
-def apply_lora(model: SynthesizerTrn, config: LoRAConfig) -> List[str]:
+def apply_lora(model: "SynthesizerTrn", config: LoRAConfig) -> List[str]:
     _strip_weight_norm_recursive(model)
     replaced = []
     for module_name in config.target_modules:
@@ -104,7 +105,7 @@ def _apply_lora_to_module(
     return replaced
 
 
-def merge_lora(model: SynthesizerTrn) -> None:
+def merge_lora(model: "SynthesizerTrn") -> None:
     _merge_lora_recursive(model)
 
 
@@ -120,7 +121,7 @@ def _merge_lora_recursive(module: nn.Module) -> None:
             _merge_lora_recursive(child)
 
 
-def get_lora_state_dict(model: SynthesizerTrn) -> Dict[str, torch.Tensor]:
+def get_lora_state_dict(model: "SynthesizerTrn") -> Dict[str, torch.Tensor]:
     state = {}
     for name, module in model.named_modules():
         if isinstance(module, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
@@ -129,7 +130,7 @@ def get_lora_state_dict(model: SynthesizerTrn) -> Dict[str, torch.Tensor]:
     return state
 
 
-def load_lora_adapter(model: SynthesizerTrn, state_dict: Dict[str, torch.Tensor]) -> None:
+def load_lora_adapter(model: "SynthesizerTrn", state_dict: Dict[str, torch.Tensor]) -> None:
     lora_names = set()
     for name, module in model.named_modules():
         if isinstance(module, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
@@ -164,7 +165,7 @@ def _get_submodule(module: nn.Module, target: str) -> Optional[nn.Module]:
     return mod
 
 
-def count_parameters(model: SynthesizerTrn) -> Tuple[int, int, float]:
+def count_parameters(model: "SynthesizerTrn") -> Tuple[int, int, float]:
     trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
     total = sum(p.numel() for p in model.parameters())
     pct = 100.0 * trainable / total if total > 0 else 0

--- a/phoonnx_train/vits/apply_lora.py
+++ b/phoonnx_train/vits/apply_lora.py
@@ -137,14 +137,15 @@ def load_lora_adapter(model: SynthesizerTrn, state_dict: Dict[str, torch.Tensor]
 
     loaded = 0
     for key, tensor in state_dict.items():
-        if key.endswith(".lora_A"):
-            module_name = key[:- len(".lora_A")]
+        key_clean = key.removeprefix("model_g.")
+        if key_clean.endswith(".lora_A"):
+            module_name = key_clean[: -len(".lora_A")]
             module = _get_submodule(model, module_name)
             if module is not None and hasattr(module, "lora_A"):
                 module.lora_A.data = tensor.to(module.lora_A.device)
                 loaded += 1
-        elif key.endswith(".lora_B"):
-            module_name = key[:- len(".lora_B")]
+        elif key_clean.endswith(".lora_B"):
+            module_name = key_clean[: -len(".lora_B")]
             module = _get_submodule(model, module_name)
             if module is not None and hasattr(module, "lora_B"):
                 module.lora_B.data = tensor.to(module.lora_B.device)

--- a/phoonnx_train/vits/apply_lora.py
+++ b/phoonnx_train/vits/apply_lora.py
@@ -1,0 +1,170 @@
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch.nn.utils import weight_norm, remove_weight_norm
+
+from .lora import LoRAConv1d, LoRAConvTranspose1d, LoRALinear
+from .lora_config import LoRAConfig
+from .models import SynthesizerTrn
+
+_LOGGER = logging.getLogger("phoonnx_train.lora")
+
+
+def _unwrap_weight_norm(module: nn.Module) -> nn.Module:
+    if isinstance(module, (nn.Conv1d, nn.ConvTranspose1d)):
+        try:
+            return remove_weight_norm(module)
+        except ValueError:
+            pass
+    return module
+
+
+def _strip_weight_norm_recursive(model: nn.Module) -> None:
+    for name, child in list(model.named_children()):
+        _strip_weight_norm_recursive(child)
+        if hasattr(child, 'weight_g') or hasattr(child, 'weight_v'):
+            try:
+                new_mod = remove_weight_norm(child)
+                setattr(model, name, new_mod)
+            except (ValueError, AttributeError):
+                pass
+
+
+def apply_lora(model: SynthesizerTrn, config: LoRAConfig) -> List[str]:
+    _strip_weight_norm_recursive(model)
+    replaced = []
+    for module_name in config.target_modules:
+        submodule = getattr(model, module_name, None)
+        if submodule is None:
+            _LOGGER.warning("Target module '%s' not found in model, skipping", module_name)
+            continue
+        count = _apply_lora_to_module(submodule, config, f"model.{module_name}")
+        replaced.extend(count)
+        _LOGGER.info(
+            "Applied LoRA (rank=%d) to '%s': %d layers adapted",
+            config.rank, module_name, len(count),
+        )
+    for param in model.parameters():
+        param.requires_grad_(False)
+    for module in model.modules():
+        if isinstance(module, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
+            module.lora_A.requires_grad_(True)
+            module.lora_B.requires_grad_(True)
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+    _LOGGER.info(
+        "LoRA applied: %d trainable / %d total params (%.2f%%)",
+        trainable, total, 100.0 * trainable / total if total > 0 else 0,
+    )
+    return replaced
+
+
+def _apply_lora_to_module(
+    module: nn.Module, config: LoRAConfig, prefix: str
+) -> List[str]:
+    replaced = []
+    for name, child in module.named_children():
+        full_name = f"{prefix}.{name}"
+        if isinstance(child, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
+            continue
+        if isinstance(child, nn.Conv1d):
+            if child.weight.shape[0] >= config.rank and child.weight.shape[1] >= config.rank:
+                lora_layer = LoRAConv1d(
+                    child,
+                    rank=config.rank,
+                    alpha=config.alpha,
+                    dropout=config.dropout,
+                )
+                setattr(module, name, lora_layer)
+                replaced.append(full_name)
+        elif isinstance(child, nn.ConvTranspose1d):
+            if child.weight.shape[0] >= config.rank and child.weight.shape[1] >= config.rank:
+                lora_layer = LoRAConvTranspose1d(
+                    child,
+                    rank=config.rank,
+                    alpha=config.alpha,
+                    dropout=config.dropout,
+                )
+                setattr(module, name, lora_layer)
+                replaced.append(full_name)
+        elif isinstance(child, nn.Linear):
+            if child.in_features >= config.rank and child.out_features >= config.rank:
+                lora_layer = LoRALinear(
+                    child,
+                    rank=config.rank,
+                    alpha=config.alpha,
+                    dropout=config.dropout,
+                )
+                setattr(module, name, lora_layer)
+                replaced.append(full_name)
+        else:
+            replaced.extend(_apply_lora_to_module(child, config, full_name))
+    return replaced
+
+
+def merge_lora(model: SynthesizerTrn) -> None:
+    _merge_lora_recursive(model)
+
+
+def _merge_lora_recursive(module: nn.Module) -> None:
+    for name, child in list(module.named_children()):
+        if isinstance(child, LoRALinear):
+            setattr(module, name, child.merge())
+        elif isinstance(child, LoRAConv1d):
+            setattr(module, name, child.merge())
+        elif isinstance(child, LoRAConvTranspose1d):
+            setattr(module, name, child.merge())
+        else:
+            _merge_lora_recursive(child)
+
+
+def get_lora_state_dict(model: SynthesizerTrn) -> Dict[str, torch.Tensor]:
+    state = {}
+    for name, module in model.named_modules():
+        if isinstance(module, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
+            state[f"{name}.lora_A"] = module.lora_A.data.cpu()
+            state[f"{name}.lora_B"] = module.lora_B.data.cpu()
+    return state
+
+
+def load_lora_adapter(model: SynthesizerTrn, state_dict: Dict[str, torch.Tensor]) -> None:
+    lora_names = set()
+    for name, module in model.named_modules():
+        if isinstance(module, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
+            lora_names.add(name)
+
+    loaded = 0
+    for key, tensor in state_dict.items():
+        if key.endswith(".lora_A"):
+            module_name = key[:- len(".lora_A")]
+            module = _get_submodule(model, module_name)
+            if module is not None and hasattr(module, "lora_A"):
+                module.lora_A.data = tensor.to(module.lora_A.device)
+                loaded += 1
+        elif key.endswith(".lora_B"):
+            module_name = key[:- len(".lora_B")]
+            module = _get_submodule(model, module_name)
+            if module is not None and hasattr(module, "lora_B"):
+                module.lora_B.data = tensor.to(module.lora_B.device)
+                loaded += 1
+
+    _LOGGER.info("Loaded %d LoRA weight tensors", loaded)
+
+
+def _get_submodule(module: nn.Module, target: str) -> Optional[nn.Module]:
+    atoms = target.split(".")
+    mod = module
+    for atom in atoms:
+        if not hasattr(mod, atom):
+            return None
+        mod = getattr(mod, atom)
+    return mod
+
+
+def count_parameters(model: SynthesizerTrn) -> Tuple[int, int, float]:
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+    pct = 100.0 * trainable / total if total > 0 else 0
+    return trainable, total, pct

--- a/phoonnx_train/vits/lightning.py
+++ b/phoonnx_train/vits/lightning.py
@@ -76,6 +76,7 @@ class VitsModel(pl.LightningModule):
         **kwargs,
     ):
         super().__init__()
+        self.automatic_optimization = False
         self.save_hyperparameters()
 
         if (self.hparams.num_speakers > 1) and (self.hparams.gin_channels <= 0):
@@ -198,12 +199,27 @@ class VitsModel(pl.LightningModule):
             batch_size=self.hparams.batch_size,
         )
 
-    def training_step(self, batch: Batch, batch_idx: int, optimizer_idx: int):
-        if optimizer_idx == 0:
-            return self.training_step_g(batch)
+    def training_step(self, batch: Batch, batch_idx: int):
+        opt_g, opt_d = self.optimizers()
+        sched_g, sched_d = self.lr_schedulers()
 
-        if optimizer_idx == 1:
-            return self.training_step_d(batch)
+        self.toggle_optimizer(opt_g)
+        loss_g = self.training_step_g(batch)
+        self.manual_backward(loss_g)
+        opt_g.step()
+        sched_g.step()
+        opt_g.zero_grad()
+        self.untoggle_optimizer(opt_g)
+
+        self.toggle_optimizer(opt_d)
+        loss_d = self.training_step_d(batch)
+        self.manual_backward(loss_d)
+        opt_d.step()
+        sched_d.step()
+        opt_d.zero_grad()
+        self.untoggle_optimizer(opt_d)
+
+        self.log_dict({"loss_g": loss_g, "loss_d": loss_d})
 
     def training_step_g(self, batch: Batch):
         x, x_lengths, y, _, spec, spec_lengths, speaker_ids = (

--- a/phoonnx_train/vits/lora.py
+++ b/phoonnx_train/vits/lora.py
@@ -1,0 +1,220 @@
+import math
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class LoRALinear(nn.Module):
+    def __init__(
+        self,
+        original_linear: nn.Linear,
+        rank: int = 8,
+        alpha: float = 16.0,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.original = original_linear
+        self.rank = rank
+        self.alpha = alpha
+        self.scaling = alpha / rank
+
+        in_features = original_linear.in_features
+        out_features = original_linear.out_features
+
+        self.lora_A = nn.Parameter(torch.empty(rank, in_features))
+        self.lora_B = nn.Parameter(torch.zeros(out_features, rank))
+        self.dropout = nn.Dropout(p=dropout) if dropout > 0.0 else nn.Identity()
+
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+        self.original.weight.requires_grad_(False)
+        if self.original.bias is not None:
+            self.original.bias.requires_grad_(False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        result = self.original(x)
+        lora_out = F.linear(self.dropout(x), self.lora_B @ self.lora_A)
+        return result + lora_out * self.scaling
+
+    def merge(self) -> nn.Linear:
+        merged = nn.Linear(
+            self.original.in_features,
+            self.original.out_features,
+            bias=self.original.bias is not None,
+            device=self.original.weight.device,
+            dtype=self.original.weight.dtype,
+        )
+        merged.weight.data = self.original.weight.data + (self.scaling * (self.lora_B @ self.lora_A))
+        if self.original.bias is not None:
+            merged.bias.data = self.original.bias.data.clone()
+        return merged
+
+    @property
+    def in_features(self) -> int:
+        return self.original.in_features
+
+    @property
+    def out_features(self) -> int:
+        return self.original.out_features
+
+
+class LoRAConv1d(nn.Module):
+    def __init__(
+        self,
+        original_conv: nn.Conv1d,
+        rank: int = 8,
+        alpha: float = 16.0,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.original = original_conv
+        self.rank = rank
+        self.alpha = alpha
+        self.scaling = alpha / rank
+
+        out_channels = original_conv.out_channels
+        in_channels = original_conv.in_channels
+        kernel_size = original_conv.kernel_size[0]
+        stride = original_conv.stride[0]
+        padding = original_conv.padding[0]
+        dilation = original_conv.dilation[0]
+        groups = original_conv.groups
+
+        self.groups = groups
+
+        self.lora_A = nn.Parameter(torch.empty(rank, in_channels // groups, kernel_size))
+        self.lora_B = nn.Parameter(torch.zeros(out_channels, rank, 1))
+        self.dropout = nn.Dropout(p=dropout) if dropout > 0.0 else nn.Identity()
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+
+        self.original.weight.requires_grad_(False)
+        if self.original.bias is not None:
+            self.original.bias.requires_grad_(False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        result = self.original(x)
+        lora_input = self.dropout(x)
+        lora_A_out = F.conv1d(
+            lora_input,
+            self.lora_A,
+            None,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+        lora_out = F.conv1d(lora_A_out, self.lora_B, None, stride=1, padding=0)
+        return result + lora_out * self.scaling
+
+    def merge(self) -> nn.Conv1d:
+        merged_weight = self.original.weight.data.clone()
+        if self.groups == 1:
+            delta = torch.einsum('or,rik->oik', self.lora_B.squeeze(-1), self.lora_A)
+            merged_weight += self.scaling * delta
+        else:
+            for g in range(self.groups):
+                cin_g = self.original.in_channels // self.groups
+                cout_g = self.original.out_channels // self.groups
+                w_g = self.original.weight.data[g * cout_g:(g + 1) * cout_g]
+                rank_per_group = max(1, self.rank // self.groups) if self.rank >= self.groups else self.rank
+                a_g = self.lora_A[g * rank_per_group:(g + 1) * rank_per_group]
+                b_g = self.lora_B[g * cout_g:(g + 1) * cout_g]
+                delta_g = torch.einsum('or,rik->oik', b_g.squeeze(-1), a_g)
+                merged_weight[g * cout_g:(g + 1) * cout_g] += self.scaling * delta_g
+
+        merged_conv = nn.Conv1d(
+            self.original.in_channels,
+            self.original.out_channels,
+            self.original.kernel_size[0],
+            stride=self.original.stride[0],
+            padding=self.original.padding[0],
+            dilation=self.original.dilation[0],
+            groups=self.original.groups,
+            bias=self.original.bias is not None,
+            device=self.original.weight.device,
+            dtype=self.original.weight.dtype,
+        )
+        merged_conv.weight.data = merged_weight
+        if self.original.bias is not None:
+            merged_conv.bias.data = self.original.bias.data.clone()
+        return merged_conv
+
+
+class LoRAConvTranspose1d(nn.Module):
+    def __init__(
+        self,
+        original_conv: nn.ConvTranspose1d,
+        rank: int = 8,
+        alpha: float = 16.0,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.original = original_conv
+        self.rank = rank
+        self.alpha = alpha
+        self.scaling = alpha / rank
+
+        out_channels = original_conv.out_channels
+        in_channels = original_conv.in_channels
+        kernel_size = original_conv.kernel_size[0]
+        stride = original_conv.stride[0]
+        padding = original_conv.padding[0]
+
+        self.lora_A = nn.Parameter(torch.empty(rank, in_channels, 1))
+        self.lora_B = nn.Parameter(torch.zeros(out_channels, rank, kernel_size))
+        self.dropout = nn.Dropout(p=dropout) if dropout > 0.0 else nn.Identity()
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+
+        self.stride = stride
+        self.padding = padding
+
+        if self.original.weight.is_leaf:
+            self.original.weight.requires_grad_(False)
+        if self.original.bias is not None and self.original.bias.is_leaf:
+            self.original.bias.requires_grad_(False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        result = self.original(x)
+        lora_input = self.dropout(x)
+        lora_A_out = F.linear(lora_input.transpose(1, 2), self.lora_A.squeeze(2)).transpose(1, 2)
+        lora_out = F.conv_transpose1d(
+            lora_A_out,
+            self.lora_B,
+            None,
+            stride=self.stride,
+            padding=self.padding,
+        )
+        return result + lora_out * self.scaling
+
+    def merge(self) -> nn.ConvTranspose1d:
+        merged_weight = self.original.weight.data.clone()
+        b = self.lora_B  # (out_channels, rank, kernel_size)
+        a = self.lora_A  # (rank, in_channels, 1)
+        k = self.original.kernel_size[0]
+# ConvTranspose1d weight shape: (in_channels, out_channels, kernel_size)
+        # delta needs to be (in_channels, out_channels, kernel_size)
+        # b is (out_channels, rank, K), a is (rank, in_channels, 1) -> expanded to (rank, in_channels, K)
+        # We want: delta[i,o,k] = sum_r a[r,i,k] * b[o,r,k]
+        a_expanded = a.expand(-1, -1, k)  # (rank, in_channels, K)
+        delta = torch.einsum('rik,ork->iok', a_expanded, b)  # (in_channels, out_channels, K)
+        merged_weight += self.scaling * delta
+
+        merged_conv = nn.ConvTranspose1d(
+            self.original.in_channels,
+            self.original.out_channels,
+            self.original.kernel_size[0],
+            stride=self.original.stride[0],
+            padding=self.original.padding[0],
+            bias=self.original.bias is not None,
+            device=self.original.weight.device,
+            dtype=self.original.weight.dtype,
+        )
+        merged_conv.weight.data = merged_weight
+        if self.original.bias is not None:
+            merged_conv.bias.data = self.original.bias.data.clone()
+        return merged_conv

--- a/phoonnx_train/vits/lora.py
+++ b/phoonnx_train/vits/lora.py
@@ -166,7 +166,7 @@ class LoRAConvTranspose1d(nn.Module):
         padding = original_conv.padding[0]
 
         self.lora_A = nn.Parameter(torch.empty(rank, in_channels, 1))
-        self.lora_B = nn.Parameter(torch.zeros(out_channels, rank, kernel_size))
+        self.lora_B = nn.Parameter(torch.zeros(rank, out_channels, kernel_size))
         self.dropout = nn.Dropout(p=dropout) if dropout > 0.0 else nn.Identity()
         nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
 
@@ -193,15 +193,16 @@ class LoRAConvTranspose1d(nn.Module):
 
     def merge(self) -> nn.ConvTranspose1d:
         merged_weight = self.original.weight.data.clone()
-        b = self.lora_B  # (out_channels, rank, kernel_size)
+        b = self.lora_B  # (rank, out_channels, kernel_size)
         a = self.lora_A  # (rank, in_channels, 1)
         k = self.original.kernel_size[0]
-# ConvTranspose1d weight shape: (in_channels, out_channels, kernel_size)
+        # ConvTranspose1d weight shape: (in_channels, out_channels, kernel_size)
         # delta needs to be (in_channels, out_channels, kernel_size)
-        # b is (out_channels, rank, K), a is (rank, in_channels, 1) -> expanded to (rank, in_channels, K)
-        # We want: delta[i,o,k] = sum_r a[r,i,k] * b[o,r,k]
+        # a is (rank, in_channels, 1) -> expanded to (rank, in_channels, K)
+        # b is (rank, out_channels, K)
+        # delta[i,o,k] = sum_r a[r,i,k] * b[r,o,k]
         a_expanded = a.expand(-1, -1, k)  # (rank, in_channels, K)
-        delta = torch.einsum('rik,ork->iok', a_expanded, b)  # (in_channels, out_channels, K)
+        delta = torch.einsum('rik,rok->iok', a_expanded, b)  # (in_channels, out_channels, K)
         merged_weight += self.scaling * delta
 
         merged_conv = nn.ConvTranspose1d(

--- a/phoonnx_train/vits/lora_config.py
+++ b/phoonnx_train/vits/lora_config.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+
+SCOPE_PRESETS = {
+    "generator-only": {
+        "rank": 4,
+        "alpha": 8.0,
+        "target_modules": ("dec",),
+    },
+    "full-acoustic": {
+        "rank": 8,
+        "alpha": 16.0,
+        "target_modules": ("dec", "enc_q", "flow", "dp"),
+    },
+    "aggressive": {
+        "rank": 16,
+        "alpha": 32.0,
+        "target_modules": ("dec", "enc_q", "flow", "dp", "enc_p"),
+    },
+}
+
+VALID_TARGET_MODULES = ("dec", "enc_q", "flow", "dp", "enc_p")
+
+
+@dataclass(frozen=True)
+class LoRAConfig:
+    rank: int = 8
+    alpha: float = 16.0
+    dropout: float = 0.0
+    target_modules: Tuple[str, ...] = ("dec", "enc_q", "flow", "dp")
+
+    @staticmethod
+    def from_preset(preset: str) -> "LoRAConfig":
+        if preset not in SCOPE_PRESETS:
+            raise ValueError(
+                f"Unknown LoRA scope preset '{preset}'. "
+                f"Available: {', '.join(SCOPE_PRESETS.keys())}"
+            )
+        p = SCOPE_PRESETS[preset]
+        return LoRAConfig(
+            rank=p["rank"],
+            alpha=p["alpha"],
+            dropout=0.0,
+            target_modules=tuple(p["target_modules"]),
+        )
+
+    def __post_init__(self):
+        for m in self.target_modules:
+            if m not in VALID_TARGET_MODULES:
+                raise ValueError(
+                    f"Invalid target module '{m}'. "
+                    f"Valid modules: {', '.join(VALID_TARGET_MODULES)}"
+                )
+        if self.rank < 1:
+            raise ValueError(f"LoRA rank must be >= 1, got {self.rank}")
+        if self.alpha <= 0:
+            raise ValueError(f"LoRA alpha must be > 0, got {self.alpha}")

--- a/phoonnx_train/vits/monotonic_align/__init__.py
+++ b/phoonnx_train/vits/monotonic_align/__init__.py
@@ -1,7 +1,6 @@
 import numpy as np
 import torch
 
-from .monotonic_align.core import maximum_path_c
 
 
 def maximum_path(neg_cent, mask):
@@ -9,6 +8,10 @@ def maximum_path(neg_cent, mask):
     neg_cent: [b, t_t, t_s]
     mask: [b, t_t, t_s]
     """
+    # Deferred import: the compiled extension is only needed during training,
+    # not for model construction (e.g. LoRA adaptation or ONNX export).
+    from .monotonic_align.core import maximum_path_c
+
     device = neg_cent.device
     dtype = neg_cent.dtype
     neg_cent = neg_cent.data.cpu().numpy().astype(np.float32)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 authors = [{name = "JarbasAI", email = "jarbasai@mailfence.com"}]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "numpy",
     "onnxruntime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
     "ovos-plugin-manager",
     "pycotovia>=0.1.0",
     "ahotts-g2p>=0.1.0",
+    "torch>=1.11.0",
 ]
 train = [
     "cython>=0.29.0,<1",

--- a/scripts/lora_argentinian_demo.py
+++ b/scripts/lora_argentinian_demo.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+LoRA Voice Adaptation Demo: Argentine Spanish ("dii" voice)
+
+Fine-tunes the phoonnx es-ES_dii_espeak voice on Argentine Spanish
+from the Kukedlc/arg-spanish-tts dataset using LoRA.
+
+Prerequisites:
+  pip install datasets soundfile librosa
+  pip install -e ".[train]"   # phoonnx with training deps
+  pip install datasets==2.18.0  # avoid torchcodec issues
+
+Steps:
+  1. download   - download & preprocess dataset (resample 24kHz→22050Hz)
+  2. preprocess  - phonemize with espeak (es-419)
+  3. base-model  - download base model config
+  4. extract-ckpt - create PyTorch checkpoint from config
+  5. train       - LoRA training
+  6. merge        - merge LoRA adapter + export ONNX
+  7. demo         - synthesize demo audio
+
+Usage:
+  python scripts/lora_argentinian_demo.py --steps all
+  python scripts/lora_argentinian_demo.py --steps download preprocess base-model extract-ckpt train merge demo
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+WORK_DIR = Path(os.environ.get("LORA_WORK_DIR", "/mnt/homelab/Workspace/lora-arg-dii"))
+DATASET_NAME = "Kukedlc/arg-spanish-tts"
+BASE_VOICE_ID = "OpenVoiceOS/phoonnx_es-ES_dii_espeak"
+SPEAKER_ID = "5223"
+import pytorch_lightning as pl
+
+SAMPLE_RATE = 22050
+LORA_SCOPE = "full-acoustic"
+LORA_EPOCHS = 150
+LORA_BATCH_SIZE = 8
+HF_BASE_URL = "https://huggingface.co/OpenVoiceOS/phoonnx_es-ES_dii_espeak/resolve/main"
+
+
+def download_dataset(output_dir: Path, speaker_id: str, max_samples: int = 0):
+    import librosa
+    import soundfile as sf
+    import numpy as np
+    from datasets import load_dataset
+
+    print(f"[1/8] Downloading {DATASET_NAME} (speaker={speaker_id})...")
+    ds = load_dataset(DATASET_NAME, split="train", keep_in_memory=True)
+
+    wavs_dir = output_dir / "wavs"
+    wavs_dir.mkdir(parents=True, exist_ok=True)
+    metadata_path = output_dir / "metadata.csv"
+
+    count = 0
+    rows = []
+    for i in range(len(ds)):
+        row = ds[i]
+        sid = str(row["speaker_id"]).lstrip("0") if row["speaker_id"] else "0"
+        if sid != speaker_id:
+            continue
+        if max_samples > 0 and count >= max_samples:
+            break
+
+        fname = f"arg_{count:05d}"
+        wav_path = wavs_dir / f"{fname}.wav"
+
+        try:
+            audio = row["audio"]
+            wav_array = np.array(audio["array"], dtype=np.float32)
+            sr_orig = audio["sampling_rate"]
+            if sr_orig != SAMPLE_RATE:
+                wav_array = librosa.resample(wav_array, orig_sr=sr_orig, target_sr=SAMPLE_RATE)
+            sf.write(str(wav_path), wav_array, SAMPLE_RATE)
+        except Exception as e:
+            short_msg = str(e).split("\n")[0][:80]
+            print(f"  Skipping {i}: {short_msg}")
+            continue
+
+        text = row["text"].strip()
+        rows.append(f"{fname}|{text}")
+        count += 1
+        if count % 50 == 0:
+            print(f"  Extracted {count} samples...")
+
+    with open(metadata_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(rows))
+
+    print(f"  Extracted {count} samples for speaker {speaker_id}")
+    return count
+
+
+def phonemize_dataset(input_dir: Path, output_dir: Path, prev_config: Path):
+    print(f"[2/8] Phonemizing dataset...")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        sys.executable, "-m", "phoonnx_train.preprocess",
+        "--language", "es-419",
+        "--input-dir", str(input_dir),
+        "--output-dir", str(output_dir),
+        "--sample-rate", str(SAMPLE_RATE),
+        "--phoneme-type", "espeak",
+        "--alphabet", "ipa",
+        "--single-speaker",
+        "--prev-config", str(prev_config),
+    ]
+    print(f"  Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  FAILED:\n{result.stderr[-2000:]}")
+        sys.exit(1)
+    print(f"  Done: {output_dir}")
+
+
+def download_base_model(output_dir: Path):
+    print(f"[3/8] Downloading base model...")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    import urllib.request
+
+    for name in ["dii_es-ES.onnx", "dii_es-ES.json"]:
+        url = f"{HF_BASE_URL}/{name}"
+        dest = output_dir / name
+        if dest.exists():
+            print(f"  Already have {name}")
+            continue
+        print(f"  Downloading {name}...")
+        urllib.request.urlretrieve(url, str(dest))
+
+    return output_dir / "dii_es-ES.json"
+
+
+def extract_base_checkpoint(config_path: Path, output_dir: Path):
+    import torch
+    from phoonnx_train.vits.lightning import VitsModel
+
+    print(f"[4/8] Creating base checkpoint...")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    model = VitsModel(
+        num_symbols=config.get("num_symbols", 256),
+        num_speakers=config.get("num_speakers", 1),
+        sample_rate=config.get("audio", {}).get("sample_rate", SAMPLE_RATE),
+        dataset=None,
+    )
+
+    ckpt_path = output_dir / "base.ckpt"
+    torch.save(
+        {
+            "state_dict": model.state_dict(),
+            "hyper_parameters": dict(model.hparams),
+            "pytorch-lightning_version": pl.__version__,
+        },
+        str(ckpt_path),
+    )
+    print(f"  Checkpoint: {ckpt_path}")
+    return ckpt_path
+
+
+def train_lora(dataset_dir: Path, base_ckpt: Path, output_dir: Path,
+               lora_scope: str, epochs: int, batch_size: int):
+    print(f"[5-6/8] Training LoRA (scope={lora_scope}, epochs={epochs})...")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        sys.executable, "-m", "phoonnx_train.train",
+        "--dataset-dir", str(dataset_dir),
+        "--resume-from-checkpoint", str(base_ckpt),
+        "--lora-scope", lora_scope,
+        "--max-epochs", str(epochs),
+        "--batch-size", str(batch_size),
+        "--default-root-dir", str(output_dir),
+        "--accelerator", "gpu",
+        "--devices", "1",
+        "--precision", "32",
+    ]
+    print(f"  Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"  Training FAILED (exit code {result.returncode})")
+        sys.exit(1)
+    print(f"  Training complete.")
+
+
+def find_lora_adapter(train_dir: Path) -> Path:
+    adapter_dir = train_dir / "lora_adapter"
+    adapter_path = adapter_dir / "lora_adapter.pt"
+    if adapter_path.exists():
+        return adapter_path
+    raise FileNotFoundError(f"No LoRA adapter at {adapter_path}")
+
+
+def merge_and_export(base_ckpt: Path, lora_adapter: Path, config_path: Path,
+                     output_dir: Path, lora_scope: str):
+    print(f"[7/8] Merging LoRA + ONNX export...")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        sys.executable, "-m", "phoonnx_train.merge_lora",
+        str(base_ckpt),
+        "--lora-adapter", str(lora_adapter),
+        "--config", str(config_path),
+        "--lora-scope", lora_scope,
+        "--output-dir", str(output_dir),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  MERGE FAILED:\n{result.stderr[-2000:]}")
+        sys.exit(1)
+    print(f"  Done: {output_dir}")
+
+
+def synthesize_demo(model_onnx: Path, config_json: Path, output_dir: Path):
+    print(f"[8/8] Synthesizing demo audio...")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    from phoonnx.voice import TTSVoice
+    voice = TTSVoice.load(model_path=str(model_onnx), config_path=str(config_json))
+
+    demo_texts = [
+        "Hola, soy una voz argentina adaptada con LoRA.",
+        "Buenos dias, como estas hoy?",
+        "La economia argentina es compleja pero fascinante.",
+        "Vamos a tomar un mate en la plaza.",
+        "Este modelo fue entrenado con pocos minutos de audio.",
+    ]
+
+    import wave
+    for i, text in enumerate(demo_texts):
+        out_path = output_dir / f"demo_{i+1}.wav"
+        with wave.open(str(out_path), "w") as wav_file:
+            voice.synthesize_wav(text, wav_file)
+        print(f"  {out_path}: \"{text}\"")
+
+    print(f"\nDemo complete! Files in {output_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LoRA Argentine Spanish voice adaptation demo")
+    parser.add_argument("--steps", nargs="+", default=["all"],
+                        choices=["all", "download", "preprocess", "base-model",
+                                  "extract-ckpt", "train", "merge", "demo"])
+    parser.add_argument("--work-dir", type=str, default=str(WORK_DIR))
+    parser.add_argument("--speaker", type=str, default=SPEAKER_ID)
+    parser.add_argument("--max-samples", type=int, default=0)
+    parser.add_argument("--epochs", type=int, default=LORA_EPOCHS)
+    parser.add_argument("--batch-size", type=int, default=LORA_BATCH_SIZE)
+    parser.add_argument("--lora-scope", type=str, default=LORA_SCOPE,
+                        choices=["generator-only", "full-acoustic", "aggressive"])
+    args = parser.parse_args()
+
+    work_dir = Path(args.work_dir)
+    steps = args.steps
+    if "all" in steps:
+        steps = ["download", "preprocess", "base-model", "extract-ckpt",
+                 "train", "merge", "demo"]
+
+    raw_dir = work_dir / "raw_dataset"
+    preprocessed_dir = work_dir / "preprocessed"
+    base_model_dir = work_dir / "base_model"
+    train_dir = work_dir / "lora_training"
+    lora_output_dir = work_dir / "lora_merged"
+    demo_dir = work_dir / "demo_output"
+
+    config_path = None
+    base_ckpt = None
+
+    if "download" in steps:
+        download_dataset(raw_dir, args.speaker, args.max_samples)
+    if "base-model" in steps:
+        config_path = download_base_model(base_model_dir)
+    else:
+        config_path = base_model_dir / "dii_es-ES.json"
+
+    if "preprocess" in steps:
+        phonemize_dataset(raw_dir, preprocessed_dir, config_path)
+    if "extract-ckpt" in steps:
+        base_ckpt = extract_base_checkpoint(config_path, work_dir / "base_ckpt")
+    else:
+        base_ckpt = work_dir / "base_ckpt" / "base.ckpt"
+
+    if "train" in steps:
+        train_lora(preprocessed_dir, base_ckpt, train_dir,
+                    args.lora_scope, args.epochs, args.batch_size)
+
+    if "merge" in steps:
+        lora_adapter = find_lora_adapter(train_dir)
+        merge_and_export(base_ckpt, lora_adapter, config_path, lora_output_dir, args.lora_scope)
+
+    if "demo" in steps:
+        model_onnx = lora_output_dir / "merged_model.onnx"
+        model_config = lora_output_dir / "config.json"
+        if not model_onnx.exists():
+            print(f"ONNX not found at {model_onnx}. Run --steps merge first.")
+            sys.exit(1)
+        synthesize_demo(model_onnx, model_config, demo_dir)
+
+    print("\nAll requested steps complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lora_argentinian_demo.py
+++ b/scripts/lora_argentinian_demo.py
@@ -36,7 +36,6 @@ WORK_DIR = Path(os.environ.get("LORA_WORK_DIR", "/mnt/homelab/Workspace/lora-arg
 DATASET_NAME = "Kukedlc/arg-spanish-tts"
 BASE_VOICE_ID = "OpenVoiceOS/phoonnx_es-ES_dii_espeak"
 SPEAKER_ID = "5223"
-import pytorch_lightning as pl
 
 SAMPLE_RATE = 22050
 LORA_SCOPE = "full-acoustic"
@@ -137,32 +136,46 @@ def download_base_model(output_dir: Path):
 
 
 def extract_base_checkpoint(config_path: Path, output_dir: Path):
-    import torch
-    from phoonnx_train.vits.lightning import VitsModel
-
-    print(f"[4/8] Creating base checkpoint...")
+    print(f"[4/8] Downloading original base checkpoint from HuggingFace...")
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-
-    model = VitsModel(
-        num_symbols=config.get("num_symbols", 256),
-        num_speakers=config.get("num_speakers", 1),
-        sample_rate=config.get("audio", {}).get("sample_rate", SAMPLE_RATE),
-        dataset=None,
-    )
-
     ckpt_path = output_dir / "base.ckpt"
-    torch.save(
-        {
-            "state_dict": model.state_dict(),
-            "hyper_parameters": dict(model.hparams),
-            "pytorch-lightning_version": pl.__version__,
-        },
-        str(ckpt_path),
-    )
-    print(f"  Checkpoint: {ckpt_path}")
+    if ckpt_path.exists():
+        print(f"  Already have {ckpt_path}")
+        return ckpt_path
+
+    try:
+        from huggingface_hub import hf_hub_download
+        downloaded = hf_hub_download(
+            repo_id=BASE_VOICE_ID,
+            filename="epoch=651-step=88672.ckpt",
+        )
+        import shutil
+        shutil.copy2(downloaded, str(ckpt_path))
+        print(f"  Downloaded checkpoint to {ckpt_path}")
+    except Exception as e:
+        print(f"  HF download failed ({e}), creating random base checkpoint instead (will sound worse)")
+        import pytorch_lightning as pl
+        import torch
+        from phoonnx_train.vits.lightning import VitsModel
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        model = VitsModel(
+            num_symbols=config.get("num_symbols", 256),
+            num_speakers=config.get("num_speakers", 1),
+            sample_rate=config.get("audio", {}).get("sample_rate", SAMPLE_RATE),
+            dataset=None,
+        )
+        torch.save(
+            {
+                "state_dict": model.state_dict(),
+                "hyper_parameters": dict(model.hparams),
+                "pytorch-lightning_version": pl.__version__,
+            },
+            str(ckpt_path),
+        )
+        print(f"  Random checkpoint: {ckpt_path}")
+
     return ckpt_path
 
 
@@ -268,7 +281,7 @@ def main():
     preprocessed_dir = work_dir / "preprocessed"
     base_model_dir = work_dir / "base_model"
     train_dir = work_dir / "lora_training"
-    lora_output_dir = work_dir / "lora_merged"
+    lora_output_dir = work_dir / "merged"
     demo_dir = work_dir / "demo_output"
 
     config_path = None
@@ -294,7 +307,9 @@ def main():
 
     if "merge" in steps:
         lora_adapter = find_lora_adapter(train_dir)
-        merge_and_export(base_ckpt, lora_adapter, config_path, lora_output_dir, args.lora_scope)
+        preprocessed_config = preprocessed_dir / "config.json"
+        merge_and_export(base_ckpt, lora_adapter, preprocessed_config if preprocessed_config.exists() else config_path,
+                         lora_output_dir, args.lora_scope)
 
     if "demo" in steps:
         model_onnx = lora_output_dir / "merged_model.onnx"

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -1,0 +1,215 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from phoonnx_train.vits.lora import LoRALinear, LoRAConv1d, LoRAConvTranspose1d
+from phoonnx_train.vits.lora_config import LoRAConfig, SCOPE_PRESETS, VALID_TARGET_MODULES
+from phoonnx_train.vits.apply_lora import (
+    apply_lora,
+    merge_lora,
+    get_lora_state_dict,
+    load_lora_adapter,
+    count_parameters,
+)
+
+
+class TestLoRAConfig:
+    def test_from_preset_generator_only(self):
+        config = LoRAConfig.from_preset("generator-only")
+        assert config.rank == 4
+        assert config.target_modules == ("dec",)
+
+    def test_from_preset_full_acoustic(self):
+        config = LoRAConfig.from_preset("full-acoustic")
+        assert config.rank == 8
+        assert config.target_modules == ("dec", "enc_q", "flow", "dp")
+
+    def test_from_preset_aggressive(self):
+        config = LoRAConfig.from_preset("aggressive")
+        assert config.rank == 16
+        assert "enc_p" in config.target_modules
+
+    def test_invalid_preset_raises(self):
+        with pytest.raises(ValueError, match="Unknown LoRA scope preset"):
+            LoRAConfig.from_preset("nonexistent")
+
+    def test_invalid_target_module_raises(self):
+        with pytest.raises(ValueError, match="Invalid target module"):
+            LoRAConfig(target_modules=("fake_module",))
+
+    def test_invalid_rank_raises(self):
+        with pytest.raises(ValueError, match="LoRA rank must be"):
+            LoRAConfig(rank=0)
+
+    def test_invalid_alpha_raises(self):
+        with pytest.raises(ValueError, match="LoRA alpha must be"):
+            LoRAConfig(alpha=-1.0)
+
+    def test_custom_config(self):
+        config = LoRAConfig(rank=16, alpha=32.0, target_modules=("dec", "enc_q"))
+        assert config.rank == 16
+        assert config.alpha == 32.0
+        assert config.target_modules == ("dec", "enc_q")
+
+
+class TestLoRALinear:
+    def test_init_shape(self):
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        assert lora.lora_A.shape == (4, 64)
+        assert lora.lora_B.shape == (32, 4)
+        assert lora.scaling == 2.0
+
+    def test_zero_init_b(self):
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        assert torch.all(lora.lora_B == 0)
+
+    def test_forward_no_change_at_init(self):
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        x = torch.randn(2, 64)
+        with torch.no_grad():
+            original_out = linear(x)
+            lora_out = lora(x)
+        assert torch.allclose(original_out, lora_out, atol=1e-5)
+
+    def test_merge_produces_correct_weight(self):
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        nn.init.kaiming_uniform_(lora.lora_A)
+        with torch.no_grad():
+            lora.lora_B.normal_(0, 0.01)
+        merged = lora.merge()
+        expected_weight = linear.weight.data + lora.scaling * (lora.lora_B @ lora.lora_A)
+        assert torch.allclose(merged.weight.data, expected_weight, atol=1e-5)
+
+    def test_freeze_original_weights(self):
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        assert not linear.weight.requires_grad
+        assert not linear.bias.requires_grad
+        assert lora.lora_A.requires_grad
+        assert lora.lora_B.requires_grad
+
+
+class TestLoRAConv1d:
+    def test_init_shape(self):
+        conv = nn.Conv1d(64, 32, kernel_size=3, padding=1)
+        lora = LoRAConv1d(conv, rank=4, alpha=8.0)
+        assert lora.lora_A.shape == (4, 64, 3)
+        assert lora.lora_B.shape == (32, 4, 1)
+
+    def test_forward_no_change_at_init(self):
+        conv = nn.Conv1d(64, 32, kernel_size=3, padding=1)
+        lora = LoRAConv1d(conv, rank=4, alpha=8.0)
+        x = torch.randn(2, 64, 50)
+        with torch.no_grad():
+            original_out = conv(x)
+            lora_out = lora(x)
+        assert torch.allclose(original_out, lora_out, atol=1e-5)
+
+    def test_merge_shape(self):
+        conv = nn.Conv1d(64, 32, kernel_size=3, padding=1)
+        lora = LoRAConv1d(conv, rank=4, alpha=8.0)
+        merged = lora.merge()
+        assert isinstance(merged, nn.Conv1d)
+        assert merged.weight.shape == conv.weight.shape
+
+
+class TestApplyLoRA:
+    def _make_model(self):
+        from phoonnx_train.vits.models import SynthesizerTrn
+        model = SynthesizerTrn(
+            n_vocab=100,
+            spec_channels=513,
+            segment_size=32,
+            inter_channels=192,
+            hidden_channels=192,
+            filter_channels=768,
+            n_heads=2,
+            n_layers=2,
+            kernel_size=3,
+            p_dropout=0.1,
+            resblock="1",
+            resblock_kernel_sizes=(3, 7, 11),
+            resblock_dilation_sizes=((1, 3, 5), (1, 3, 5), (1, 3, 5)),
+            upsample_rates=(8, 8, 2, 2),
+            upsample_initial_channel=512,
+            upsample_kernel_sizes=(16, 16, 4, 4),
+        )
+        return model
+
+    def test_apply_lora_generator_only(self):
+        model = self._make_model()
+        config = LoRAConfig.from_preset("generator-only")
+        replaced = apply_lora(model, config)
+
+        trainable, total, pct = count_parameters(model)
+        assert trainable > 0
+        assert trainable < total
+
+        any_lora = False
+        for name, module in model.named_modules():
+            if isinstance(module, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
+                any_lora = True
+                break
+        assert any_lora
+
+    def test_apply_lora_full_acoustic(self):
+        model = self._make_model()
+        config = LoRAConfig.from_preset("full-acoustic")
+        replaced = apply_lora(model, config)
+
+        trainable, total, pct = count_parameters(model)
+        assert trainable > 0
+        assert pct < 50.0
+
+    def test_merge_lora_roundtrip(self):
+        model = self._make_model()
+        config = LoRAConfig.from_preset("generator-only")
+        apply_lora(model, config)
+
+        lora_state = get_lora_state_dict(model)
+        assert len(lora_state) > 0
+
+        merge_lora(model)
+
+        any_lora = False
+        for name, module in model.named_modules():
+            if isinstance(module, (LoRALinear, LoRAConv1d, LoRAConvTranspose1d)):
+                any_lora = True
+                break
+        assert not any_lora
+
+    def test_freeze_check(self):
+        model = self._make_model()
+        config = LoRAConfig.from_preset("generator-only")
+        apply_lora(model, config)
+
+        trainable, total, pct = count_parameters(model)
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                assert "lora_A" in name or "lora_B" in name, f"Unexpected trainable param: {name}"
+
+    def test_load_lora_adapter(self):
+        model = self._make_model()
+        config = LoRAConfig.from_preset("generator-only")
+        apply_lora(model, config)
+
+        lora_state = get_lora_state_dict(model)
+
+        model2 = self._make_model()
+        config2 = LoRAConfig.from_preset("generator-only")
+        apply_lora(model2, config2)
+
+        load_lora_adapter(model2, lora_state)
+
+        for key in lora_state:
+            module_name = key.rsplit(".", 1)[0]
+            attr_name = key.rsplit(".", 1)[1]
+            from phoonnx_train.vits.apply_lora import _get_submodule
+            mod = _get_submodule(model2, module_name)
+            if mod is not None and hasattr(mod, attr_name):
+                param = getattr(mod, attr_name)
+                assert torch.allclose(param.data.cpu(), lora_state[key].cpu(), atol=1e-6)


### PR DESCRIPTION
## LoRA Voice Adaptation for phoonnx

Add Low-Rank Adaptation (LoRA) support to phoonnx_train, enabling fast voice adaptation with less training data (5–15 min audio) by freezing the base model and only training lightweight adapter layers. Pronunciation is preserved from the base model since the TextEncoder is frozen.

### What's new

**Core LoRA infrastructure:**
- `phoonnx_train/vits/lora.py` — `LoRALinear`, `LoRAConv1d`, `LoRAConvTranspose1d` modules with `.merge()` for weight folding
- `phoonnx_train/vits/lora_config.py` — `LoRAConfig` dataclass with 3 presets:
  - `generator-only`: rank=4, targets `dec` only (~300KB adapter)
  - `full-acoustic`: rank=8, targets `dec,enc_q,flow,dp` (~1MB, default)
  - `aggressive`: rank=16, targets all including `enc_p` (~2.5MB)
- `phoonnx_train/vits/apply_lora.py` — `apply_lora()`, `merge_lora()`, `get_lora_state_dict()`, `load_lora_adapter()`, `count_parameters()` + automatic weight_norm stripping

**CLI integration:**
- `phoonnx_train/train.py` — new `--lora-scope`, `--lora-rank`, `--lora-alpha`, `--lora-target-modules`, `--lora-dropout` args; auto-saves adapter after training; auto-adjusts learning rate for LoRA
- `phoonnx_train/merge_lora.py` — CLI to merge LoRA adapter into base checkpoint and export to ONNX

**Inference-side:**
- `phoonnx/config.py` — `lora_base_model`, `lora_rank`, `lora_alpha`, `lora_scope`, `lora_target_modules` fields in `VoiceConfig`
- `phoonnx/voice.py` — `TTSVoice.load_with_lora()` for inference with merged LoRA
- `phoonnx/lora_runtime.py` — ONNX graph surgery for runtime LoRA injection

**Tests:** 21 new unit tests covering:
- Config validation (presets, invalid inputs)
- LoRA init identity (zero B → no change at init)
- Merge round-trip (apply → merge → verify same as manual)
- Freeze check (only LoRA params trainable)
- Adapter load/save
- All existing 121 tests still pass

### Usage

**Training with LoRA:**
```bash
python phoonnx_train/train.py \
  --dataset-dir /data/preprocessed \
  --resume-from-checkpoint /data/base.ckpt \
  --lora-scope full-acoustic \
  --max-epochs 200 --batch-size 16
```

**Merging for ONNX export:**
```bash
python phoonnx_train/merge_lora.py \
  /data/base.ckpt \
  --lora-adapter /data/lora_adapter/lora_adapter.pt \
  --config /data/config.json \
  --lora-scope full-acoustic \
  --output-dir /data/output/
```

### Wiki

Design plan documented at `knowledge/wiki/concepts/lora-phoonnx.md`