### PR TITLE
feat(engines): Matcha-TTS inference adapter

### DIFF
--- a/docs/matcha.md
+++ b/docs/matcha.md
@@ -1,0 +1,140 @@
+# Matcha-TTS Engine
+
+Matcha-TTS is a non-autoregressive TTS architecture based on **conditional flow matching**. It uses a Transformer text encoder, a duration predictor, and a flow-matching decoder to generate mel spectrograms from phoneme sequences.
+
+## Inference
+
+Matcha-TTS inference uses a **two-stage ONNX pipeline**:
+
+1. **Mel model** — flow-matching acoustic model (phoneme IDs → mel spectrogram)
+2. **Vocoder** — Vocos-style vocoder (mel → waveform)
+
+Both models are separate ONNX files. The ``MatchaAdapter`` holds the vocoder session internally and chains inference end-to-end.
+
+### ONNX Inputs (mel model)
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| ``x`` | int64 | ``[B, T]`` | Phoneme IDs (interspersed with blank=0) |
+| ``x_lengths`` | int64 | ``[B]`` | Sequence lengths |
+| ``scales`` | float32 | ``[2]`` | ``[temperature, length_scale]`` |
+| ``spks`` | int64 | ``[B]`` | Speaker ID (optional) |
+
+### ONNX Outputs (mel model)
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| ``mel`` | float32 | ``[B, n_mels, T_mel]`` | Generated mel spectrogram |
+| ``mel_lengths`` | int64 | ``[B]`` | Mel lengths |
+
+The vocoder is run internally by the adapter, producing a float32 waveform via inverse STFT with overlap-add and optional spectral denoising.
+
+### Loading a Matcha-TTS voice
+
+```python
+from phoonnx import TTSVoice
+
+voice = TTSVoice.load(
+    model_path="matcha_multispeaker_cat_all_opset_15_10_steps.onnx",
+    config_path="matcha_config.json",
+)
+```
+
+The JSON config must include:
+
+```json
+{
+    "engine": "matcha",
+    "engine_params": {
+        "vocoder_path": "mel_spec_22khz_cat.onnx",
+        "vocoder_config": {
+            "feature_extractor": {
+                "init_args": {
+                    "n_fft": 1024,
+                    "hop_length": 256,
+                    "sample_rate": 22050
+                }
+            }
+        }
+    }
+}
+```
+
+### Text processing
+
+Matcha-TTS uses phoonnx's standard phonemizer and tokenizer. The tokenizer must be configured with ``blank_id = 0`` so that interspersed blanks are already present in the phoneme sequence fed to ONNX. The adapter does **not** re-intersperse — it passes the tokenized sequence directly to the mel model.
+
+### Parameters
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| ``temperature`` | 0.667 | Sampling temperature for the flow-matching decoder |
+| ``length_scale`` | 1.0 | Speech rate multiplier (higher = slower) |
+| ``denoise`` | true | Spectral subtraction denoising via vocoder bias |
+
+## Training
+
+Matcha-TTS training requires the upstream ``matcha-tts`` package. It is installed automatically as a development dependency when working in the shared venv.
+
+### Quick start
+
+```bash
+python -m phoonnx_train.train \
+    --engine matcha \
+    --dataset-dir ./dataset \
+    --output-dir ./checkpoints
+```
+
+### Quality presets
+
+| Preset | Encoder channels | Decoder channels | Heads / Layers |
+|--------|-----------------|------------------|----------------|
+| ``x-low`` | 128 | [192, 192] | 2 heads / 4 layers |
+| ``medium`` | 192 | [256, 256] | 2 heads / 6 layers |
+| ``high`` | 256 | [384, 384] | 4 heads / 8 layers |
+
+Use ``--quality <preset>`` or set ``quality`` in ``extra`` config.
+
+### Architecture overview
+
+- **Text encoder** — Transformer with RoPE positional embeddings, ConvReluNorm prenet, duration predictor
+- **CFM decoder** — Conditional flow matching with UNet1D estimator (ResNet blocks + Transformer/Conformer blocks)
+- **Losses** — Duration loss (MSE), prior loss (Gaussian), flow-matching loss (MSE on velocity field)
+
+### ONNX export
+
+After training, export the mel model to ONNX:
+
+```bash
+python -m phoonnx_train.export_onnx \
+    --engine matcha \
+    --checkpoint matcha.ckpt \
+    --output-dir ./onnx
+```
+
+The exported ONNX file is the **mel model only**. You still need a separate vocoder ONNX (e.g. Vocos) for full speech synthesis. The inference adapter chains both automatically.
+
+### Data statistics
+
+Matcha-TTS normalizes mel spectrograms using dataset statistics. Compute them beforehand:
+
+```bash
+python -m matcha.utils.generate_data_statistics \
+    --config configs/data/your_dataset.yaml
+```
+
+Then pass ``mel_mean`` and ``mel_std`` via engine config ``extra``:
+
+```json
+{
+    "extra": {
+        "mel_mean": -5.536622,
+        "mel_std": 2.116101
+    }
+}
+```
+
+## References
+
+- [Matcha-TTS paper (ICASSP 2024)](https://arxiv.org/abs/2309.03199)
+- [Upstream repository](https://github.com/shivammehta25/Matcha-TTS)

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -115,8 +115,10 @@ def list_engines() -> List[str]:
 
 def _register_builtins() -> None:
     from phoonnx.engines.vits import VitsAdapter
+    from phoonnx.engines.matcha import MatchaAdapter
 
     register_engine("vits", VitsAdapter, detect_priority=50)
+    register_engine("matcha", MatchaAdapter, detect_priority=40)
 
 
 _register_builtins()

--- a/phoonnx/engines/matcha.py
+++ b/phoonnx/engines/matcha.py
@@ -1,0 +1,248 @@
+"""
+Matcha-TTS inference adapter.
+
+Matcha-TTS (flow-matching TTS) uses a two-stage ONNX pipeline:
+
+1. **Mel model** — flow-matching acoustic model that converts phoneme IDs
+   → mel spectrogram.
+2. **Vocoder** — Vocos-style vocoder that converts mel spectrogram → waveform.
+
+Both models are separate ONNX files.  The adapter holds the vocoder session
+internally and runs the full pipeline in ``parse_outputs``.
+
+ONNX inputs (mel model):
+  ``x``          int64      [B, T]      phoneme IDs (interspersed with 0)
+  ``x_lengths``  int64      [B]         sequence lengths
+  ``scales``     float32    [2]         [temperature, length_scale]
+  ``spks``       int64      [B]         speaker ID
+
+ONNX outputs (mel model):
+  ``mel``        float32    [B, n_mels, T_mel]
+  ``mel_lengths`` int64     [B]
+
+ONNX inputs (vocoder):
+  ``mels``       float32    [B, n_mels, T_mel]
+
+ONNX outputs (vocoder):
+  ``mag``        float32    [B, n_fft//2+1, T]
+  ``x``          float32    [B, n_fft//2+1, T]   real part
+  ``y``          float32    [B, n_fft//2+1, T]   imaginary part
+
+The vocoder outputs are combined into a complex spectrogram, then inverse
+STFT with overlap-add produces the final waveform.
+"""
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+from scipy.fft import irfft
+from scipy.signal.windows import hann
+
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest,
+    AdapterSynthesisResult,
+    BaseOnnxAdapter,
+)
+
+
+class MatchaAdapter(BaseOnnxAdapter):
+    """Adapter for Matcha-TTS ONNX models (flow-matching TTS + Vocos vocoder)."""
+
+    def __init__(self, vocoder_path: Optional[str] = None,
+                 vocoder_config: Optional[Dict[str, Any]] = None):
+        self.vocoder_path = vocoder_path
+        self.vocoder_config = vocoder_config or {}
+        self._vocoder_session: Optional[onnxruntime.InferenceSession] = None
+
+    # ------------------------------------------------------------------
+    # Vocoder lazy loading
+    # ------------------------------------------------------------------
+
+    def _load_vocoder(self) -> onnxruntime.InferenceSession:
+        if self._vocoder_session is not None:
+            return self._vocoder_session
+        if not self.vocoder_path:
+            raise RuntimeError(
+                "MatchaAdapter requires 'vocoder_path' in config.engine_params"
+            )
+        opts = onnxruntime.SessionOptions()
+        self._vocoder_session = onnxruntime.InferenceSession(
+            self.vocoder_path, sess_options=opts,
+            providers=["CPUExecutionProvider"],
+        )
+        return self._vocoder_session
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    def build_feed_dict(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> Dict[str, np.ndarray]:
+        """Build ONNX feed dict for the Matcha mel model."""
+        params = request.params
+        defaults = self.default_params()
+        temperature = np.float32(params.get("temperature", defaults["temperature"]))
+        length_scale = np.float32(params.get("length_scale", defaults["length_scale"]))
+
+        # Phoneme IDs from the request are produced by phoonnx's tokenizer.
+        # For Matcha the tokenizer should be configured with blank_id=0 so
+        # that the interspersed blanks are already present in the sequence.
+        x = request.phoneme_ids.astype(np.int64)
+        x_lengths = request.phoneme_lengths.astype(np.int64)
+
+        args: Dict[str, np.ndarray] = {
+            "x": x,
+            "x_lengths": x_lengths,
+            "scales": np.array([temperature, length_scale], dtype=np.float32),
+        }
+
+        # Optional speaker ID
+        spk_id = request.params.get("spk_id", request.speaker_id)
+        if spk_id is not None:
+            args["spks"] = np.array([int(spk_id)], dtype=np.int64)
+
+        return self._filter_inputs(args, session)
+
+    def parse_outputs(
+        self,
+        outputs: List[np.ndarray],
+        request: AdapterSynthesisRequest,
+    ) -> AdapterSynthesisResult:
+        """Run vocoder on mel output and reconstruct waveform."""
+        # outputs[0] = mel, outputs[1] = mel_lengths
+        mel = outputs[0]
+
+        # Run vocoder
+        vocoder = self._load_vocoder()
+        mag, x_real, y_imag = vocoder.run(None, {"mels": mel})
+
+        # Combine into complex spectrogram
+        spectrogram = mag * (x_real + 1j * y_imag)
+
+        # Optional denoising
+        denoise = request.params.get("denoise", True)
+        if denoise:
+            spectrogram = self._denoise(mel, spectrogram, vocoder)
+
+        # Inverse STFT + overlap-add
+        audio = self._istft_overlap_add(spectrogram)
+        return AdapterSynthesisResult(audio=audio.squeeze())
+
+    def default_params(self) -> Dict[str, float]:
+        return {
+            "temperature": 0.667,
+            "length_scale": 1.0,
+        }
+
+    # ------------------------------------------------------------------
+    # Optional
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def detect(
+        config: Optional[Dict[str, Any]] = None,
+        session: Optional[onnxruntime.InferenceSession] = None,
+    ) -> bool:
+        if config is not None:
+            engine = config.get("engine", "")
+            if engine in ("matcha", "matcha-tts"):
+                return True
+            if config.get("model_type") == "matcha":
+                return True
+            # Matcha signature: has vocoder_path and mel model inputs x/x_lengths/scales
+            if "vocoder_path" in config:
+                return True
+        if session is not None:
+            inputs = {inp.name for inp in session.get_inputs()}
+            if {"x", "x_lengths", "scales"}.issubset(inputs):
+                return True
+        return False
+
+    def parse_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract Matcha-specific params from JSON config."""
+        params: Dict[str, Any] = {}
+        inference = config.get("inference", {})
+        params["temperature"] = inference.get("temperature", 0.667)
+        params["length_scale"] = inference.get("length_scale", 1.0)
+        params["denoise"] = inference.get("denoise", True)
+
+        # Engine-specific config
+        engine_params = config.get("engine_params", {})
+        self.vocoder_path = engine_params.get("vocoder_path", self.vocoder_path)
+        self.vocoder_config = engine_params.get("vocoder_config", self.vocoder_config)
+        params["spk_id"] = engine_params.get("spk_id")
+
+        return params
+
+    def param_labels(self) -> Dict[str, str]:
+        return {
+            "temperature": "Temperature",
+            "length_scale": "Length Scale",
+        }
+
+    # ------------------------------------------------------------------
+    # Vocoder post-processing
+    # ------------------------------------------------------------------
+
+    def _denoise(
+        self,
+        mel: np.ndarray,
+        spectrogram: np.ndarray,
+        vocoder: onnxruntime.InferenceSession,
+    ) -> np.ndarray:
+        """Spectral subtraction denoising using a bias spectrogram."""
+        mel_rand = np.zeros_like(mel)
+        mag_bias, x_bias, y_bias = vocoder.run(None, {"mels": mel_rand.astype(np.float32)})
+        spec_bias = mag_bias * (x_bias + 1j * y_bias)
+
+        # Magnitudes
+        spec = np.stack([np.real(spectrogram), np.imag(spectrogram)], axis=-1)
+        mag_spec = np.sqrt(np.sum(spec ** 2, axis=-1))
+
+        spec_bias_c = np.stack([np.real(spec_bias), np.imag(spec_bias)], axis=-1)
+        mag_spec_bias = np.sqrt(np.sum(spec_bias_c ** 2, axis=-1))
+
+        # Subtract
+        strength = 0.0025
+        mag_spec_denoised = mag_spec - mag_spec_bias * strength
+        mag_spec_denoised = np.clip(mag_spec_denoised, 0.0, None)
+
+        # Reconstruct complex spectrogram with original phase
+        angle = np.arctan2(np.imag(spectrogram), np.real(spectrogram))
+        return mag_spec_denoised * (np.cos(angle) + 1j * np.sin(angle))
+
+    def _istft_overlap_add(self, spectrogram: np.ndarray) -> np.ndarray:
+        """Inverse STFT with Hann window and overlap-add."""
+        cfg = self.vocoder_config.get("feature_extractor", {}).get("init_args", {})
+        n_fft = cfg.get("n_fft", 1024)
+        hop_length = cfg.get("hop_length", 256)
+        win_length = n_fft
+
+        window = hann(win_length, sym=False)
+        pad = (win_length - hop_length) // 2
+
+        B, N, T = spectrogram.shape
+
+        # Inverse FFT per frame
+        ifft = irfft(spectrogram, n=n_fft, axis=1)
+        ifft *= window[None, :, None]
+
+        # Overlap-add
+        output_size = (T - 1) * hop_length + win_length
+        y = np.zeros((B, output_size))
+        for b in range(B):
+            for t in range(T):
+                y[b, t * hop_length:t * hop_length + win_length] += ifft[b, :, t]
+
+        # Window envelope normalization
+        window_sq = np.expand_dims(window ** 2, axis=0)
+        window_envelope = np.zeros((B, output_size))
+        for b in range(B):
+            for t in range(T):
+                window_envelope[b, t * hop_length:t * hop_length + win_length] += window_sq[0]
+
+        y /= np.maximum(window_envelope, 1e-11)
+        return y


### PR DESCRIPTION
## Summary

Adds Matcha-TTS (flow-matching TTS) inference support on top of the pluggable engine framework (#131).

### Changes
- MatchaAdapter with dual-session support (mel model + Vocos vocoder)
- Vocoder post-processing: ISTFT overlap-add + optional spectral denoising
- Uses phoonnx tokenizer blank_id=0 (no duplicate intersperse)
- Temperature and length_scale control parameters

### Verified
- Catalan Matxa model works end-to-end through phoonnx (synthesis + playback tested)

### Testing
- 121 tests pass, 1 skipped

**Depends on:** #131