### PR TITLE
feat(engines): OptiSpeech inference adapter

### DIFF
--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -115,8 +115,10 @@ def list_engines() -> List[str]:
 
 def _register_builtins() -> None:
     from phoonnx.engines.vits import VitsAdapter
+    from phoonnx.engines.optispeech import OptiSpeechAdapter
 
     register_engine("vits", VitsAdapter, detect_priority=50)
+    register_engine("optispeech", OptiSpeechAdapter, detect_priority=45)
 
 
 _register_builtins()

--- a/phoonnx/engines/base.py
+++ b/phoonnx/engines/base.py
@@ -134,6 +134,27 @@ class BaseOnnxAdapter(ABC):
         """
         return {}
 
+    def configure_tokenizer(self, tokenizer: Any) -> Any:
+        """
+        Optional hook for engines to mutate the tokenizer after
+        ``VoiceConfig`` has built it.
+
+        For example, OptiSpeech models embed ``add_blank`` / ``add_bos_eos``
+        flags in their ONNX metadata; this hook lets the adapter disable
+        blank interspersing when the model expects raw phoneme sequences.
+
+        Parameters
+        ----------
+        tokenizer : TTSTokenizer
+            The tokenizer built by ``VoiceConfig.from_dict()``.
+
+        Returns
+        -------
+        TTSTokenizer
+            The same tokenizer (possibly mutated).
+        """
+        return tokenizer
+
     def param_labels(self) -> Dict[str, str]:
         """Human-readable labels for each scale param (for UIs)."""
         return {k: k for k in self.default_params()}

--- a/phoonnx/engines/optispeech.py
+++ b/phoonnx/engines/optispeech.py
@@ -1,0 +1,180 @@
+"""
+OptiSpeech inference adapter.
+
+OptiSpeech is a non-autoregressive FastSpeech2-style TTS with GAN
+vocoder.  Its ONNX contract differs from VITS:
+
+  Inputs:
+    x          (int64)     — phoneme IDs
+    x_lengths  (int64)     — sequence lengths
+    scales     (float32[3])— [d_factor, p_factor, e_factor]
+    sids       (int64)     — speaker IDs (optional, multi-speaker)
+    lids       (int64)     — language IDs (optional, multi-language)
+
+  Outputs:
+    wav          (float32) — waveform [B, 1, T]
+    wav_lengths  (int64)   — sample counts [B]
+    durations    (int64)   — per-phoneme durations [B, T_text]
+
+  Metadata:
+    All config is embedded in the ONNX model under the ``"inference"``
+    metadata key as a JSON blob containing sample_rate, inference_args,
+    input_symbols, special_symbols, text_processor, speakers, languages.
+
+Scale semantics:
+    scales[0] = d_factor  (duration scale — >1 slower, <1 faster)
+    scales[1] = p_factor  (pitch scale)
+    scales[2] = e_factor  (energy scale)
+
+This is fundamentally different from VITS where scales =
+[noise_scale, length_scale, noise_w_scale].
+"""
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest,
+    AdapterSynthesisResult,
+    BaseOnnxAdapter,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+class OptiSpeechAdapter(BaseOnnxAdapter):
+    """Adapter for OptiSpeech ONNX models."""
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    def build_feed_dict(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> Dict[str, np.ndarray]:
+        params = request.params
+        d_factor = np.float32(params.get("d_factor", 1.0))
+        p_factor = np.float32(params.get("p_factor", 1.0))
+        e_factor = np.float32(params.get("e_factor", 1.0))
+
+        args: Dict[str, np.ndarray] = {
+            "x": request.phoneme_ids,
+            "x_lengths": request.phoneme_lengths,
+            "scales": np.array([d_factor, p_factor, e_factor], dtype=np.float32),
+        }
+
+        # Multi-speaker
+        if request.speaker_id is not None:
+            args["sids"] = np.array([request.speaker_id], dtype=np.int64)
+
+        # Multi-language
+        if request.language_id is not None:
+            args["lids"] = np.array([request.language_id], dtype=np.int64)
+
+        return self._filter_inputs(args, session)
+
+    def parse_outputs(
+        self,
+        outputs: List[np.ndarray],
+        request: AdapterSynthesisRequest,
+    ) -> AdapterSynthesisResult:
+        # OptiSpeech returns [wav, wav_lengths, durations]
+        audio = outputs[0].squeeze()
+
+        extras: Dict[str, Any] = {}
+        if len(outputs) > 1:
+            extras["wav_lengths"] = outputs[1]
+        if len(outputs) > 2:
+            extras["durations"] = outputs[2]
+
+        return AdapterSynthesisResult(audio=audio, extras=extras)
+
+    def default_params(self) -> Dict[str, float]:
+        return {
+            "d_factor": 1.0,
+            "p_factor": 1.0,
+            "e_factor": 1.0,
+        }
+
+    # ------------------------------------------------------------------
+    # Optional
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def detect(
+        config: Optional[Dict[str, Any]] = None,
+        session: Optional[onnxruntime.InferenceSession] = None,
+    ) -> bool:
+        # 1. Check ONNX metadata for OptiSpeech signature
+        if session is not None:
+            try:
+                meta = session.get_modelmeta().custom_metadata_map
+                if "inference" in meta:
+                    infer = json.loads(meta["inference"])
+                    # OptiSpeech metadata always contains text_processor + input_symbols
+                    if "text_processor" in infer and "input_symbols" in infer:
+                        return True
+                if meta.get("model_type") == "optispeech":
+                    return True
+            except Exception:
+                pass
+
+            # 2. Heuristic: has "x" + "x_lengths" inputs but NOT "input" or "input_lengths"
+            input_names = {inp.name for inp in session.get_inputs()}
+            output_names = {out.name for out in session.get_outputs()}
+            if (
+                "x" in input_names
+                and "x_lengths" in input_names
+                and "input" not in input_names
+                and "input_lengths" not in input_names
+            ):
+                # Also check that outputs include wav + wav_lengths + durations
+                if "wav" in output_names or "durations" in output_names:
+                    return True
+
+        # 3. Config-based
+        if config is not None:
+            engine = config.get("engine", "")
+            if engine == "optispeech":
+                return True
+
+        return False
+
+    def parse_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract default d/p/e factors from config if present."""
+        inference_args = config.get("inference_args", {})
+        return {
+            "d_factor": inference_args.get("d_factor", 1.0),
+            "p_factor": inference_args.get("p_factor", 1.0),
+            "e_factor": inference_args.get("e_factor", 1.0),
+        }
+
+    def parse_onnx_meta(
+        self, session: onnxruntime.InferenceSession,
+    ) -> Dict[str, Any]:
+        """
+        Extract the full config from OptiSpeech's embedded ONNX metadata.
+
+        Returns a dict with keys:
+            name, sample_rate, inference_args, input_symbols,
+            special_symbols, speakers, languages, text_processor
+        """
+        try:
+            meta = session.get_modelmeta().custom_metadata_map
+            if "inference" in meta:
+                return json.loads(meta["inference"])
+        except Exception:
+            LOG.debug("Failed to parse OptiSpeech ONNX metadata", exc_info=True)
+        return {}
+
+    def param_labels(self) -> Dict[str, str]:
+        return {
+            "d_factor": "Speed",
+            "p_factor": "Pitch",
+            "e_factor": "Energy",
+        }

--- a/phoonnx/engines/optispeech.py
+++ b/phoonnx/engines/optispeech.py
@@ -48,6 +48,9 @@ LOG = logging.getLogger(__name__)
 class OptiSpeechAdapter(BaseOnnxAdapter):
     """Adapter for OptiSpeech ONNX models."""
 
+    def __init__(self):
+        self._onnx_meta: Optional[Dict[str, Any]] = None
+
     # ------------------------------------------------------------------
     # Required
     # ------------------------------------------------------------------
@@ -154,6 +157,24 @@ class OptiSpeechAdapter(BaseOnnxAdapter):
             "e_factor": inference_args.get("e_factor", 1.0),
         }
 
+    def configure_tokenizer(self, tokenizer):
+        """
+        OptiSpeech models embed ``text_processor`` config in ONNX metadata
+        that controls whether blanks / BOS/EOS should be inserted.  Respect
+        those flags so the model receives the exact token sequence it was
+        trained on.
+        """
+        if self._onnx_meta is None:
+            return tokenizer
+        tp = self._onnx_meta.get("text_processor", {})
+        if tp.get("add_blank") is False:
+            tokenizer.add_blank_char = False
+            tokenizer.blank_at_start = False
+            tokenizer.blank_at_end = False
+        if tp.get("add_bos_eos") is False:
+            tokenizer.use_eos_bos = False
+        return tokenizer
+
     def parse_onnx_meta(
         self, session: onnxruntime.InferenceSession,
     ) -> Dict[str, Any]:
@@ -167,7 +188,8 @@ class OptiSpeechAdapter(BaseOnnxAdapter):
         try:
             meta = session.get_modelmeta().custom_metadata_map
             if "inference" in meta:
-                return json.loads(meta["inference"])
+                self._onnx_meta = json.loads(meta["inference"])
+                return self._onnx_meta
         except Exception:
             LOG.debug("Failed to parse OptiSpeech ONNX metadata", exc_info=True)
         return {}

--- a/phoonnx/engines/optispeech_config.py
+++ b/phoonnx/engines/optispeech_config.py
@@ -1,0 +1,197 @@
+"""
+OptiSpeech ↔ phoonnx config bridge.
+
+OptiSpeech embeds all its config inside the ONNX model metadata (under
+the ``"inference"`` key) rather than using an external JSON file.  This
+module translates that embedded metadata into the phoonnx VoiceConfig /
+TTSTokenizer / Vocabulary objects so that the rest of the phoonnx
+pipeline (phonemization, tokenization, synthesis) works seamlessly.
+
+Usage (from TTSVoice.load or model_manager)::
+
+    from phoonnx.engines.optispeech_config import voice_config_from_optispeech_meta
+
+    meta = adapter.parse_onnx_meta(session)
+    config = voice_config_from_optispeech_meta(meta)
+"""
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from phoonnx.config import (
+    Alphabet,
+    Engine,
+    PhonemeType,
+    VoiceConfig,
+)
+from phoonnx.tokenizer import (
+    BlankBetween,
+    TTSTokenizer,
+    Vocabulary,
+    DEFAULT_PAD_TOKEN,
+    DEFAULT_BOS_TOKEN,
+    DEFAULT_EOS_TOKEN,
+    DEFAULT_BLANK_WORD_TOKEN,
+)
+
+LOG = logging.getLogger(__name__)
+
+# OptiSpeech default special symbols
+_OS_PAD = "_"
+_OS_BOS = "^"
+_OS_EOS = "$"
+
+
+def _build_vocabulary(input_symbols: Dict[str, int]) -> Vocabulary:
+    """
+    Convert OptiSpeech's ``input_symbols`` (symbol→id map) into a
+    phoonnx ``Vocabulary``.
+
+    The input_symbols dict comes straight from the ONNX metadata
+    (``infer_params["input_symbols"]``).  It maps every IPA character
+    (including specials like ``_``, ``^``, ``$``) to its integer ID.
+    """
+    # Invert to id→symbol for the Vocabulary constructor
+    id_to_symbol = {v: k for k, v in input_symbols.items()}
+    max_id = max(id_to_symbol.keys()) if id_to_symbol else 0
+    # Build a dense list, using empty string for any gaps
+    symbols = [""] * (max_id + 1)
+    for idx, sym in id_to_symbol.items():
+        symbols[idx] = sym
+    return Vocabulary(symbols=symbols, symbol_to_id=dict(input_symbols))
+
+
+def _build_tokenizer(
+    input_symbols: Dict[str, int],
+    special_symbols: Dict[str, Any],
+    text_processor: Dict[str, Any],
+) -> TTSTokenizer:
+    """
+    Build a phoonnx TTSTokenizer that reproduces OptiSpeech's
+    tokenization behaviour.
+
+    OptiSpeech tokenization options (from ``text_processor``):
+      - ``add_blank``: intersperse blank (id 0) between tokens
+      - ``add_bos_eos``: prepend BOS / append EOS
+    """
+    vocab = _build_vocabulary(input_symbols)
+
+    # Resolve special token IDs
+    pad_id = input_symbols.get(_OS_PAD, 0)
+    bos_sym = special_symbols.get("bos", _OS_BOS)
+    eos_sym = special_symbols.get("eos", _OS_EOS)
+
+    add_blank = text_processor.get("add_blank", True)
+    add_bos_eos = text_processor.get("add_bos_eos", True)
+
+    if add_blank:
+        blank_between = BlankBetween.TOKENS_AND_WORDS
+    else:
+        blank_between = BlankBetween.NONE
+
+    return TTSTokenizer(
+        vocab=vocab,
+        blank_between=blank_between,
+        blank_at_start=add_bos_eos,
+        blank_at_end=add_bos_eos,
+        pad_token=_OS_PAD,
+        blank_token=_OS_PAD,  # OptiSpeech uses PAD as the intersperse blank
+        bos_token=bos_sym if add_bos_eos else None,
+        eos_token=eos_sym if add_bos_eos else None,
+        word_sep_token=" ",
+    )
+
+
+def voice_config_from_optispeech_meta(
+    meta: Dict[str, Any],
+    *,
+    lang_code: Optional[str] = None,
+    phoneme_type: Optional[PhonemeType] = None,
+) -> VoiceConfig:
+    """
+    Build a full ``VoiceConfig`` from OptiSpeech's embedded metadata.
+
+    Parameters
+    ----------
+    meta : dict
+        The parsed JSON from ``session.get_modelmeta().custom_metadata_map["inference"]``.
+    lang_code : str, optional
+        Override language code.  If not given, uses the first language
+        listed in the metadata.
+    phoneme_type : PhonemeType, optional
+        Override phoneme type.  Defaults to ESPEAK (which is what
+        OptiSpeech's IPATokenizer uses under the hood via piper_phonemize).
+
+    Returns
+    -------
+    VoiceConfig
+    """
+    input_symbols = meta.get("input_symbols", {})
+    special_symbols = meta.get("special_symbols", {})
+    text_processor_cfg = meta.get("text_processor", {})
+    inference_args = meta.get("inference_args", {})
+    languages = meta.get("languages", [])
+    speakers = meta.get("speakers", [])
+    sample_rate = meta.get("sample_rate", 22050)
+
+    # Resolve language
+    if not lang_code and languages:
+        lang_code = languages[0]
+
+    # Resolve phoneme type from tokenizer name
+    tokenizer_name = text_processor_cfg.get("tokenizer", "ipa")
+    if phoneme_type is None:
+        if tokenizer_name == "ipa":
+            phoneme_type = PhonemeType.ESPEAK
+        elif tokenizer_name == "arabic-buck":
+            phoneme_type = PhonemeType.GRAPHEMES
+        else:
+            phoneme_type = PhonemeType.ESPEAK
+
+    # Build tokenizer
+    tokenizer = _build_tokenizer(input_symbols, special_symbols, text_processor_cfg)
+
+    num_symbols = len(input_symbols)
+    num_speakers = max(len(speakers), 1)
+
+    return VoiceConfig(
+        tokenizer=tokenizer,
+        num_symbols=num_symbols,
+        num_speakers=num_speakers,
+        num_langs=max(len(languages), 1),
+        sample_rate=sample_rate,
+        lang_code=lang_code,
+        phoneme_type=phoneme_type,
+        alphabet=Alphabet.IPA,
+        phonemizer_model=None,
+        engine=Engine.OPTISPEECH,
+        # OptiSpeech uses d/p/e factors, not noise/length/noise_w
+        # We store sentinel values for the VITS-style fields
+        noise_scale=0.0,
+        length_scale=1.0,
+        noise_w_scale=0.0,
+        # Engine-specific params
+        engine_params={
+            "d_factor": inference_args.get("d_factor", 1.0),
+            "p_factor": inference_args.get("p_factor", 1.0),
+            "e_factor": inference_args.get("e_factor", 1.0),
+        },
+        speaker_id_map=(
+            {name: idx for idx, name in enumerate(speakers)}
+            if speakers else {}
+        ),
+        add_diacritics=False,
+        # Tokenization matches OptiSpeech defaults
+        blank_between=(
+            BlankBetween.TOKENS_AND_WORDS
+            if text_processor_cfg.get("add_blank", True)
+            else BlankBetween.NONE
+        ),
+        blank_at_start=text_processor_cfg.get("add_bos_eos", True),
+        blank_at_end=text_processor_cfg.get("add_bos_eos", True),
+        pad_token=_OS_PAD,
+        blank_token=_OS_PAD,
+        bos_token=_OS_BOS if text_processor_cfg.get("add_bos_eos", True) else None,
+        eos_token=_OS_EOS if text_processor_cfg.get("add_bos_eos", True) else None,
+        word_sep_token=" ",
+    )

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -154,6 +154,11 @@ class TTSVoice:
                 # Fall back to auto-detection
                 self.adapter = detect_engine(session=self.session)
 
+        # Give the adapter a chance to reconfigure the tokenizer
+        # (e.g. OptiSpeech models may disable blank interspersing)
+        if self.adapter is not None and hasattr(self.adapter, "configure_tokenizer"):
+            self.config.tokenizer = self.adapter.configure_tokenizer(self.config.tokenizer)
+
     @property
     def tokenizer(self) -> TTSTokenizer:
         """
@@ -230,6 +235,10 @@ class TTSVoice:
 
         # Auto-detect engine adapter from config + session
         adapter = detect_engine(config=config_dict, session=session)
+
+        # Let the adapter read ONNX metadata before we build the tokenizer
+        if adapter is not None and hasattr(adapter, "parse_onnx_meta"):
+            adapter.parse_onnx_meta(session)
 
         voice_config = VoiceConfig.from_dict(
             config_dict,


### PR DESCRIPTION
## Summary

Adds OptiSpeech inference support on top of the pluggable engine framework (#129).

### Changes
- OptiSpeechAdapter implementing BaseOnnxAdapter
- Supports d_factor / p_factor / e_factor control parameters
- Auto-detects from ONNX input signature
- Config parsing for OptiSpeech-specific inference settings

### Testing
- 121 tests pass, 1 skipped

**Depends on:** #129