### PR TITLE
feat(engines): pluggable multi-engine inference framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It supports over 1000 languages and voices from various frameworks (phoonnx, pip
 - **Multiple Phonemizers:** Integrates with various phonemizers like eSpeak, Gruut, and Epitran to convert text to phonemes.
 - **Advanced Text Normalization:** Includes robust utilities for expanding contractions and pronouncing numbers and dates.
 - **Dataset Preprocessing:** Provides a command-line tool to prepare LJSpeech-style datasets for training.
+- **Pluggable Engine Architecture:** VITS, OptiSpeech, and future architectures share a single adapter framework for both inference and training.
 - **Model Export:** A script is included to convert trained models into the ONNX format, ready for deployment.
 
 -----
@@ -138,6 +139,12 @@ phoonnx-voices download OpenVoiceOS/phoonnx_pt-PT_miro_tugaphone
 ```
 
 -----
+
+### Engine Architecture
+
+`phoonnx` uses a pluggable engine framework so new TTS architectures can be added without touching the core voice or CLI code.  Both **inference** (ONNX adapters) and **training** (PyTorch Lightning modules) are registry-based.
+
+See [docs/engines.md](./docs/engines.md) for the full developer guide on adding new engines.
 
 ### Training
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -1,0 +1,247 @@
+# Engine Architecture
+
+`phoonnx` supports multiple TTS back-ends through a small, engine-agnostic adapter framework.  Both **inference** (`phoonnx/engines/`) and **training** (`phoonnx_train/engines/`) are pluggable, so adding a new architecture (VITS, OptiSpeech, Matcha-TTS, …) only requires implementing a handful of methods.
+
+---
+
+## Inference Adapters
+
+### Responsibilities
+
+An inference adapter lives in `phoonnx/engines/` and implements `BaseOnnxAdapter`.  Its job is to translate between the generic `phoonnx` voice layer and a specific ONNX model layout:
+
+* **Input names** – VITS models accept `input`/`input_lengths`/`scales`; other engines may use `input_ids`/`attention_mask` or entirely different names.
+* **Scale / control parameters** – VITS uses `noise_scale`/`length_scale`/`noise_w_scale`; OptiSpeech uses `d_factor`/`p_factor`/`e_factor`.
+* **Output layout** – some engines return raw waveform, others return mel-spectrograms that still need a vocoder.
+
+### Adapter Lifecycle
+
+```python
+from phoonnx.engines import detect_engine, get_adapter
+
+# 1. Auto-detect the right adapter from config + ONNX session
+adapter = detect_engine(config=cfg, session=sess)
+
+# 2. Or look one up explicitly
+adapter = get_adapter("vits")
+
+# 3. Build a feed dict and run ONNX
+request = AdapterSynthesisRequest(
+    phoneme_ids=ids,
+    phoneme_lengths=lengths,
+    params={"noise_scale": 0.667, "length_scale": 1.0}
+)
+feed = adapter.build_feed_dict(request, session)
+outputs = session.run(None, feed)
+
+# 4. Parse outputs back to audio
+result = adapter.parse_outputs(outputs, request)
+```
+
+### Registration
+
+Add a new adapter by subclassing `BaseOnnxAdapter` and calling `register_engine`:
+
+```python
+# phoonnx/engines/my_engine.py
+from phoonnx.engines.base import BaseOnnxAdapter, AdapterSynthesisRequest, AdapterSynthesisResult
+from phoonnx.engines import register_engine
+
+class MyEngineAdapter(BaseOnnxAdapter):
+    def build_feed_dict(self, request, session):
+        ...
+
+    def parse_outputs(self, outputs, request):
+        ...
+
+    def default_params(self):
+        return {"speed": 1.0}
+
+    @staticmethod
+    def detect(config=None, session=None):
+        if config and config.get("model_type") == "my_engine":
+            return True
+        return False
+
+register_engine("my_engine", MyEngineAdapter, detect_priority=50)
+```
+
+Lower `detect_priority` values are probed first during auto-detection.
+
+### Existing Adapters
+
+| Adapter | File | Detection |
+|---|---|---|
+| VITS / Piper / Mimic3 / Coqui | `phoonnx/engines/vits.py` | `model_type == "vits"`, `"scales"` input, piper/mimic3 signatures |
+
+---
+
+## Training Engines
+
+### Responsibilities
+
+A training engine lives in `phoonnx_train/engines/` and implements `BaseTrainingEngine`.  It encapsulates everything that differs between architectures:
+
+* **Model creation** – build the PyTorch Lightning module with the right hyper-parameters.
+* **ONNX export** – convert a checkpoint to ONNX and embed any architecture-specific metadata.
+* **Quality presets** – map tier names (`x-low`, `medium`, `high`) to hyper-parameter overrides.
+* **Checkpoint loading** – custom resume logic (e.g. encoder size mismatch tolerance).
+
+### Engine Lifecycle
+
+```python
+from phoonnx_train.engines import get_engine
+from phoonnx_train.engines.base import TrainingEngineConfig
+
+engine = get_engine("vits")
+
+# 1. Create model
+cfg = TrainingEngineConfig(
+    num_symbols=133,
+    num_speakers=1,
+    sample_rate=22050,
+    extra={"inter_channels": 192, "hidden_channels": 192}
+)
+model = engine.create_model(cfg, dataset_paths=[Path("/data")])
+
+# 2. Train with PyTorch Lightning …
+
+# 3. Export to ONNX
+onnx_path = engine.export_onnx(
+    checkpoint_path=Path("epoch=100.ckpt"),
+    config_path=Path("config.json"),
+    output_dir=Path("./exported"),
+)
+```
+
+### Registration
+
+Add a new training engine by subclassing `BaseTrainingEngine` and calling `register_engine`:
+
+```python
+# phoonnx_train/engines/my_engine.py
+from phoonnx_train.engines.base import BaseTrainingEngine, TrainingEngineConfig
+from phoonnx_train.engines import register_engine
+
+class MyTrainingEngine(BaseTrainingEngine):
+    def create_model(self, config, dataset_paths, **kwargs):
+        ...
+
+    def export_onnx(self, checkpoint_path, config_path, output_dir, **kwargs):
+        ...
+
+    def quality_presets(self):
+        return {
+            "x-low":  {"hidden": 64},
+            "medium": {"hidden": 128},
+            "high":   {"hidden": 256},
+        }
+
+register_engine("my_engine", MyTrainingEngine)
+```
+
+### Existing Engines
+
+| Engine | File | Quality Presets |
+|---|---|---|
+| VITS | `phoonnx_train/engines/vits.py` | `x-low`, `medium`, `high` |
+
+---
+
+## Engine-Aware CLI
+
+### Training
+
+`train.py` now accepts `--engine` and delegates model creation / checkpoint loading to the selected engine:
+
+```bash
+python -m phoonnx_train.train \
+  --dataset-dir /data \
+  --engine vits \
+  --quality medium \
+  --max-epochs 1000
+```
+
+`--quality` is validated lazily against the engine’s `quality_presets()` so custom engines can define their own tier names.
+
+### ONNX Export
+
+`export_onnx.py` accepts `--engine` and passes all CLI flags through to the engine’s `export_onnx()` method:
+
+```bash
+python -m phoonnx_train.export_onnx epoch=500.ckpt \
+  --config config.json \
+  --engine vits \
+  --output-dir ./exported \
+  --generate-tokens \
+  --piper
+```
+
+Engine-specific flags can be added by the engine via `extra_cli_options()`.
+
+---
+
+## Configuration
+
+### VoiceConfig engine params
+
+`VoiceConfig` stores engine-specific metadata in `engine_params` (parsed from JSON config at load time):
+
+```python
+from phoonnx.config import VoiceConfig
+
+cfg = VoiceConfig.from_dict(config, engine_params={"noise_scale": 0.5})
+```
+
+These are forwarded to the adapter as `request.params` at synthesis time.
+
+### SynthesisConfig extra params
+
+Per-call overrides go through `SynthesisConfig.extra_params`:
+
+```python
+from phoonnx.config import SynthesisConfig
+
+syn = SynthesisConfig(
+    length_scale=1.2,
+    extra_params={"d_factor": 0.9}
+)
+```
+
+---
+
+## Adding a New Engine (Checklist)
+
+1. **Inference**
+   - Subclass `BaseOnnxAdapter`.
+   - Implement `build_feed_dict`, `parse_outputs`, `default_params`.
+   - Implement `detect()` for auto-discovery.
+   - Call `register_engine()` in your module.
+
+2. **Training**
+   - Subclass `BaseTrainingEngine`.
+   - Implement `create_model`, `export_onnx`, `quality_presets`.
+   - Optionally override `load_checkpoint()` for custom resume logic.
+   - Call `register_engine()` in your module.
+
+3. **CLI / packaging**
+   - Ensure your module is imported somewhere (e.g. in `__init__.py`) so registration runs.
+   - Add tests that exercise `detect_engine()` and `get_engine("your_engine")`.
+
+---
+
+## Testing
+
+The built-in test suite should already cover engine-agnostic paths.  When adding a new engine, verify:
+
+```python
+from phoonnx.engines import detect_engine, get_adapter, list_engines
+from phoonnx_train.engines import get_engine, list_engines as list_train_engines
+
+assert "your_engine" in list_engines()
+assert "your_engine" in list_train_engines()
+
+# Auto-detection
+adapter = detect_engine(config={"model_type": "your_engine"})
+assert adapter.__class__.__name__ == "YourEngineAdapter"
+```

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -132,6 +132,9 @@ class VoiceConfig:
     word_sep_token: Optional[str] = DEFAULT_BLANK_WORD_TOKEN
     blank_between: BlankBetween = BlankBetween.TOKENS_AND_WORDS
 
+    # Adapter-specific parameters parsed from config JSON
+    engine_params: Dict[str, Any] = field(default_factory=dict)
+
     def __post_init__(self):
         """
         Finalize dataclass defaults after initialization.
@@ -222,8 +225,9 @@ class VoiceConfig:
                   tokens_txt: Optional[str] = None,  # sherpa/mimic3
                   lang_code: Optional[str] = None,
                   phoneme_type: Optional[Union[str, PhonemeType]] = None,
+                  alphabet: Optional[Union[str, Alphabet]] = None,
                   engine: Optional[Union[str, Engine]] = None,
-                  alphabet: Optional[Union[str, Alphabet]] = None) -> "VoiceConfig":
+                   engine_params: Optional[Dict[str, Any]] = None) -> "VoiceConfig":
         """
         Create a VoiceConfig from a model configuration dictionary and optional external phoneme data.
         
@@ -396,7 +400,8 @@ class VoiceConfig:
             blank_token=config.get("blank"),
             bos_token=config.get("bos"),
             eos_token=config.get("eos"),
-            word_sep_token=config.get("word_sep_token") or config.get("blank_word", " ")
+            word_sep_token=config.get("word_sep_token") or config.get("blank_word", " "),
+            engine_params=engine_params or {}
         )
 
 
@@ -429,6 +434,9 @@ class SynthesisConfig:
 
     """for arabic and hebrew models"""
     add_diacritics: bool = True
+
+    # Engine-specific per-call params (d_factor, p_factor, e_factor, …)
+    extra_params: Dict[str, Any] = field(default_factory=dict)
 
 
 def get_phonemizer(phoneme_type: PhonemeType,

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -1,0 +1,122 @@
+"""
+Inference engine registry.
+
+New architectures register themselves here so that TTSVoice can
+auto-select the right ONNX adapter at load time.
+
+Usage::
+
+    from phoonnx.engines import get_adapter, detect_engine
+
+    # Auto-detect from config + session
+    adapter = detect_engine(config=cfg, session=sess)
+
+    # Or look up by name
+    adapter = get_adapter("vits")
+"""
+import logging
+from typing import Any, Dict, List, Optional, Type
+
+import onnxruntime
+
+from phoonnx.engines.base import BaseOnnxAdapter
+
+LOG = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------
+# Registry
+# ------------------------------------------------------------------
+
+_REGISTRY: Dict[str, Type[BaseOnnxAdapter]] = {}
+_DETECT_ORDER: List[str] = []
+_PRIORITIES: Dict[str, int] = {}
+
+
+def register_engine(
+    name: str,
+    adapter_cls: Type[BaseOnnxAdapter],
+    *,
+    detect_priority: int = 100,
+) -> None:
+    """
+    Register an inference adapter class under *name*.
+
+    Parameters
+    ----------
+    name : str
+        Short identifier (e.g. ``"vits"``, ``"optispeech"``).
+    adapter_cls : Type[BaseOnnxAdapter]
+        The adapter class (not an instance).
+    detect_priority : int
+        Lower = checked first during auto-detection.  Default 100.
+    """
+    _REGISTRY[name] = adapter_cls
+    _PRIORITIES[name] = detect_priority
+    _DETECT_ORDER.clear()
+    _DETECT_ORDER.extend(
+        sorted(_REGISTRY, key=lambda n: _PRIORITIES.get(n, 100))
+    )
+    LOG.debug("Registered inference engine %r (priority %d)", name, detect_priority)
+
+
+def get_adapter(name: str) -> BaseOnnxAdapter:
+    """
+    Return a *new instance* of the adapter registered under *name*.
+
+    Raises ``KeyError`` if the name is unknown.
+    """
+    if name not in _REGISTRY:
+        raise KeyError(
+            f"Unknown inference engine {name!r}. "
+            f"Registered engines: {list(_REGISTRY)}"
+        )
+    return _REGISTRY[name]()
+
+
+def detect_engine(
+    config: Optional[Dict[str, Any]] = None,
+    session: Optional[onnxruntime.InferenceSession] = None,
+) -> BaseOnnxAdapter:
+    """
+    Probe registered adapters and return the first one whose
+    ``detect()`` returns ``True``.
+
+    Falls back to the VITS adapter if nothing matches (since it is the
+    most common engine in the phoonnx ecosystem).
+    """
+    for name in _DETECT_ORDER:
+        cls = _REGISTRY[name]
+        try:
+            if cls.detect(config=config, session=session):
+                LOG.debug("Auto-detected inference engine: %s", name)
+                return cls()
+        except Exception:
+            LOG.debug("detect() failed for %s, skipping", name, exc_info=True)
+
+    # Fallback
+    if "vits" in _REGISTRY:
+        LOG.warning("No engine matched — falling back to VITS adapter")
+        return _REGISTRY["vits"]()
+
+    raise RuntimeError(
+        "Could not detect ONNX engine and no fallback available. "
+        f"Registered engines: {list(_REGISTRY)}"
+    )
+
+
+def list_engines() -> List[str]:
+    """Return the names of all registered inference engines."""
+    return list(_REGISTRY)
+
+
+# ------------------------------------------------------------------
+# Built-in registrations
+# ------------------------------------------------------------------
+
+def _register_builtins() -> None:
+    from phoonnx.engines.vits import VitsAdapter
+
+    register_engine("vits", VitsAdapter, detect_priority=50)
+
+
+_register_builtins()

--- a/phoonnx/engines/base.py
+++ b/phoonnx/engines/base.py
@@ -1,0 +1,155 @@
+"""
+Base adapter for ONNX TTS inference.
+
+Each TTS architecture (VITS, OptiSpeech, Matcha-TTS, etc.) has different:
+  - ONNX input names and semantics
+  - Scale parameter meanings
+  - Output tensor layouts
+  - Config/metadata formats
+
+An OnnxAdapter encapsulates these differences behind a single interface
+so that TTSVoice.phoneme_ids_to_audio works identically for any engine.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+
+
+@dataclass
+class AdapterSynthesisRequest:
+    """Architecture-agnostic container for a single synthesis call."""
+
+    phoneme_ids: np.ndarray
+    """int64 array of shape (1, T)."""
+
+    phoneme_lengths: np.ndarray
+    """int64 array of shape (1,)."""
+
+    speaker_id: Optional[int] = None
+    language_id: Optional[int] = None
+
+    # Engine-specific key→value (noise_scale, d_factor, …).
+    # Populated from SynthesisConfig + VoiceConfig defaults.
+    params: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AdapterSynthesisResult:
+    """Architecture-agnostic container returned after synthesis."""
+
+    audio: np.ndarray
+    """1-D float32 array in [-1, 1]."""
+
+    # Optional extras (durations, pitch, energy, attention, …)
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+class BaseOnnxAdapter(ABC):
+    """
+    Translates between the generic phoonnx voice layer and a specific
+    ONNX model layout.
+
+    Subclasses **must** implement
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    - ``build_feed_dict``  — SynthesisRequest → ONNX feed dict
+    - ``parse_outputs``    — raw ONNX outputs  → SynthesisResult
+    - ``default_params``   — engine-default control parameters
+
+    Subclasses **may** override
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    - ``detect``           — auto-detect whether a config/session belongs
+                             to this engine
+    - ``parse_config``     — pull engine-specific fields from JSON config
+    - ``parse_onnx_meta``  — pull engine-specific fields from ONNX metadata
+    - ``param_labels``     — human-readable names for UI sliders
+    """
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def build_feed_dict(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> Dict[str, np.ndarray]:
+        """
+        Build the exact ``{name: array}`` dict that goes into
+        ``session.run(None, feed_dict)``.
+        """
+
+    @abstractmethod
+    def parse_outputs(
+        self,
+        outputs: List[np.ndarray],
+        request: AdapterSynthesisRequest,
+    ) -> AdapterSynthesisResult:
+        """
+        Extract the audio waveform (and optional extras) from the raw
+        list of ONNX output tensors.
+        """
+
+    @abstractmethod
+    def default_params(self) -> Dict[str, float]:
+        """
+        Return the engine's default scale / control parameters.
+
+        Keys must match what the adapter reads from
+        ``request.params``.  Examples::
+
+            VITS:        {"noise_scale": 0.667, "length_scale": 1.0, "noise_w_scale": 0.8}
+            OptiSpeech:  {"d_factor": 1.0, "p_factor": 1.0, "e_factor": 1.0}
+        """
+
+    # ------------------------------------------------------------------
+    # Optional
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def detect(
+        config: Optional[Dict[str, Any]] = None,
+        session: Optional[onnxruntime.InferenceSession] = None,
+    ) -> bool:
+        """Return ``True`` if this adapter handles the given model."""
+        return False
+
+    def parse_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Extract engine-specific parameters from a JSON config dict.
+
+        Returned dict is stored on VoiceConfig and forwarded as
+        ``request.params`` at synthesis time.
+        """
+        return {}
+
+    def parse_onnx_meta(
+        self, session: onnxruntime.InferenceSession,
+    ) -> Dict[str, Any]:
+        """
+        Extract engine-specific parameters from ONNX model metadata.
+        """
+        return {}
+
+    def param_labels(self) -> Dict[str, str]:
+        """Human-readable labels for each scale param (for UIs)."""
+        return {k: k for k in self.default_params()}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _expected_inputs(session: onnxruntime.InferenceSession) -> set:
+        return {inp.name for inp in session.get_inputs()}
+
+    @staticmethod
+    def _filter_inputs(
+        args: Dict[str, np.ndarray],
+        session: onnxruntime.InferenceSession,
+    ) -> Dict[str, np.ndarray]:
+        expected = {inp.name for inp in session.get_inputs()}
+        return {k: v for k, v in args.items() if k in expected}

--- a/phoonnx/engines/vits.py
+++ b/phoonnx/engines/vits.py
@@ -1,0 +1,150 @@
+"""
+VITS / Piper / Mimic3 / Coqui inference adapter.
+
+All of these engines share the same ONNX I/O contract (they are all
+VITS variants):
+
+  Inputs:  input (int64), input_lengths (int64), scales (float32[3]),
+           [optional] sid (int64), langid (int64)
+  Outputs: output (float32) — raw waveform
+
+The ``scales`` tensor packs [noise_scale, length_scale, noise_w_scale].
+
+Some exports use alternate input names (``x`` / ``x_length`` for MMS,
+``input_ids`` / ``attention_mask`` for HuggingFace).  The adapter
+provides all variants and filters to the ones the model actually
+accepts.
+"""
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest,
+    AdapterSynthesisResult,
+    BaseOnnxAdapter,
+)
+
+
+class VitsAdapter(BaseOnnxAdapter):
+    """Adapter for VITS-family ONNX models (piper, mimic3, coqui, phoonnx)."""
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    def build_feed_dict(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> Dict[str, np.ndarray]:
+        """Build the ONNX feed dict for a VITS-family model."""
+        params = request.params
+        defaults = self.default_params()
+        noise_scale = np.float32(params.get("noise_scale", defaults["noise_scale"]))
+        length_scale = np.float32(params.get("length_scale", defaults["length_scale"]))
+        noise_w_scale = np.float32(params.get("noise_w_scale", defaults["noise_w_scale"]))
+
+        phoneme_ids_array = request.phoneme_ids          # already (1, T)
+        phoneme_ids_lengths = request.phoneme_lengths     # already (1,)
+        attention_mask = np.ones_like(phoneme_ids_array, dtype=np.int64)
+
+        # Provide every known alias — we filter to actual model inputs below
+        args: Dict[str, np.ndarray] = {
+            # piper / phoonnx style
+            "input": phoneme_ids_array,
+            "input_lengths": phoneme_ids_lengths,
+            # MMS style
+            "x": phoneme_ids_array,
+            "x_length": phoneme_ids_lengths,
+            # HuggingFace style
+            "input_ids": phoneme_ids_array,
+            "attention_mask": attention_mask,
+            # scales
+            "scales": np.array(
+                [noise_scale, length_scale, noise_w_scale], dtype=np.float32
+            ),
+            "noise_scale": np.array([noise_scale], dtype=np.float32),
+            "noise_scale_w": np.array([noise_w_scale], dtype=np.float32),
+            "length_scale": np.array([length_scale], dtype=np.float32),
+        }
+
+        # Optional speaker / language ids
+        if request.language_id is not None:
+            args["langid"] = np.array([request.language_id], dtype=np.int64)
+        if request.speaker_id is not None:
+            args["sid"] = np.array([request.speaker_id], dtype=np.int64)
+
+        return self._filter_inputs(args, session)
+
+    def parse_outputs(
+        self,
+        outputs: List[np.ndarray],
+        request: AdapterSynthesisRequest,
+    ) -> AdapterSynthesisResult:
+        """Extract audio waveform from VITS ONNX outputs."""
+        # VITS returns a single output tensor — squeeze to 1-D
+        audio = outputs[0].squeeze()
+        return AdapterSynthesisResult(audio=audio)
+
+    def default_params(self) -> Dict[str, float]:
+        return {
+            "noise_scale": 0.667,
+            "length_scale": 1.0,
+            "noise_w_scale": 0.8,
+        }
+
+    # ------------------------------------------------------------------
+    # Optional
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def detect(
+        config: Optional[Dict[str, Any]] = None,
+        session: Optional[onnxruntime.InferenceSession] = None,
+    ) -> bool:
+        # Config-based detection
+        if config is not None:
+            # Explicit engine tag
+            engine = config.get("engine", "")
+            if engine in ("vits", "piper", "mimic3", "coqui", "phoonnx"):
+                return True
+            # Piper signature
+            if "phoneme_id_map" in config and "phoneme_type" in config:
+                return True
+            # Phoonnx signature
+            if "phoonnx_version" in config or "piper_version" in config:
+                return True
+            # Coqui signature
+            if "characters" in config and isinstance(config.get("characters"), dict):
+                return True
+            # Mimic3 signature
+            if "phonemizer" in config and "phonemes" in config:
+                return True
+
+        # Session-based detection: check for "scales" input
+        if session is not None:
+            input_names = {inp.name for inp in session.get_inputs()}
+            if "scales" in input_names:
+                return True
+
+        return False
+
+    def parse_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract VITS inference parameters from a JSON config dict."""
+        inference = config.get("inference", {})
+        defaults = self.default_params()
+        return {
+            "noise_scale": inference.get("noise_scale", defaults["noise_scale"]),
+            "length_scale": inference.get("length_scale", defaults["length_scale"]),
+            "noise_w_scale": inference.get("noise_w", defaults["noise_w_scale"]),
+        }
+
+    def param_labels(self) -> Dict[str, str]:
+        """Human-readable labels for VITS synthesis parameters."""
+        return {
+            "noise_scale": "Noise",
+            "length_scale": "Speed",
+            "noise_w_scale": "Noise W",
+        }

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -1,3 +1,11 @@
+"""
+TTSVoice — architecture-agnostic TTS voice.
+
+This module is the main user-facing synthesis interface.  It delegates
+all ONNX-specific I/O to an engine adapter (``phoonnx.engines``),
+which means the same TTSVoice class works for VITS or
+any future architecture without code changes here.
+"""
 import json
 import os.path
 import re
@@ -11,6 +19,12 @@ import onnxruntime
 from langcodes import closest_match
 
 from phoonnx.config import PhonemeType, VoiceConfig, SynthesisConfig, get_phonemizer
+from phoonnx.engines import detect_engine, get_adapter
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest,
+    AdapterSynthesisResult,
+    BaseOnnxAdapter,
+)
 from phoonnx.phonemizers import Phonemizer
 from phoonnx.phonemizers.base import PhonemizedChunks
 from phoonnx.tokenizer import TTSTokenizer
@@ -102,6 +116,7 @@ class TTSVoice:
     config: VoiceConfig
     phonetic_spellings: Optional[PhoneticSpellings] = None
     phonemizer: Optional[Phonemizer] = None
+    adapter: Optional[BaseOnnxAdapter] = None
 
     def __post_init__(self):
         """
@@ -116,10 +131,28 @@ class TTSVoice:
             self.phonetic_spellings = PhoneticSpellings.from_lang(self.config.lang_code)
         except FileNotFoundError:
             pass
+
+        # Phonemizer
         if self.phonemizer is None:
-            self.phonemizer = get_phonemizer(self.config.phoneme_type,
-                                             self.config.alphabet,
-                                             self.config.phonemizer_model)
+            self.phonemizer = get_phonemizer(
+                self.config.phoneme_type,
+                self.config.alphabet,
+                self.config.phonemizer_model,
+            )
+
+        # Engine adapter — auto-detect if not explicitly provided
+        if self.adapter is None:
+            engine_name = self.config.engine.value if self.config.engine else None
+            try:
+                # Try by engine name first
+                if engine_name and engine_name not in ("piper", "mimic3", "coqui"):
+                    self.adapter = get_adapter(engine_name)
+                else:
+                    # For piper/mimic3/coqui all use the vits adapter
+                    self.adapter = get_adapter("vits")
+            except KeyError:
+                # Fall back to auto-detection
+                self.adapter = detect_engine(session=self.session)
 
     @property
     def tokenizer(self) -> TTSTokenizer:
@@ -189,19 +222,29 @@ class TTSVoice:
         else:
             providers = ["CPUExecutionProvider"]
 
+        session = onnxruntime.InferenceSession(
+            str(model_path),
+            sess_options=onnxruntime.SessionOptions(),
+            providers=providers,
+        )
+
+        # Auto-detect engine adapter from config + session
+        adapter = detect_engine(config=config_dict, session=session)
+
+        voice_config = VoiceConfig.from_dict(
+            config_dict,
+            vocab=vocab_dict,
+            tokenizer_config=tokenizer_dict,
+            alphabet=alphabet_str,
+            tokens_txt=phonemes_txt,
+            lang_code=lang_code,
+            phoneme_type=phoneme_type_str,
+        )
+
         return TTSVoice(
-            config=VoiceConfig.from_dict(config_dict,
-                                         vocab=vocab_dict,
-                                         tokenizer_config=tokenizer_dict,
-                                         alphabet=alphabet_str,
-                                         tokens_txt=phonemes_txt,
-                                         lang_code=lang_code,
-                                         phoneme_type=phoneme_type_str),
-            session=onnxruntime.InferenceSession(
-                str(model_path),
-                sess_options=onnxruntime.SessionOptions(),
-                providers=providers,
-            )
+            config=voice_config,
+            session=session,
+            adapter=adapter,
         )
 
     def phonemize(self, text: str) -> PhonemizedChunks:
@@ -232,10 +275,7 @@ class TTSVoice:
 
                 continue
 
-            # Phonemization
-            phonemes = self.phonemizer.phonemize(
-                text_part, self.config.lang_code
-            )
+            phonemes.extend(self.phonemizer.phonemize(text_part, self.config.lang_code))
 
         if phonemes and (not phonemes[-1]):
             # Remove empty phonemes
@@ -356,66 +396,67 @@ class TTSVoice:
 
             wav_file.writeframes(audio_chunk.audio_int16_bytes)
 
+
     def phoneme_ids_to_audio(
             self, phoneme_ids: list[int], syn_config: Optional[SynthesisConfig] = None
     ) -> np.ndarray:
         """
         Synthesize raw audio from phoneme ids.
 
+        Delegates all ONNX I/O to ``self.adapter`` so the same code
+        path works for VITS or any future engine.
+
         :param phoneme_ids: List of phoneme ids.
         :param syn_config: Synthesis configuration.
-        :return: Audio float numpy array from voice model (unnormalized, in range [-1, 1]).
+        :return: Audio float numpy array (unnormalized, in range [-1, 1]).
         """
         syn_config = syn_config or SynthesisConfig()
 
-        langid = syn_config.lang_id or 0
-        speaker_id = syn_config.speaker_id or 0
-        length_scale = syn_config.length_scale
-        noise_scale = syn_config.noise_scale
-        noise_w_scale = syn_config.noise_w_scale
+        # Build the architecture-agnostic request
+        phoneme_ids_array = np.expand_dims(
+            np.array(phoneme_ids, dtype=np.int64), 0
+        )
+        phoneme_ids_lengths = np.array(
+            [phoneme_ids_array.shape[1]], dtype=np.int64
+        )
 
-        expected_args = [model_input.name for model_input in self.session.get_inputs()]
-        # print("Expected ONNX Inputs:", expected_args)
-
-        # Convert phoneme_ids list[int] to ONNX inputs
-        phoneme_ids_array = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
-        phoneme_ids_lengths = np.array([phoneme_ids_array.shape[1]], dtype=np.int64)
-        attention_mask = np.ones_like(phoneme_ids_array, dtype=np.int64)
-
-        # Prepare all possible input formats for different ONNX exports
-        args = {
-            "input": phoneme_ids_array,
-            "input_lengths": phoneme_ids_lengths,
-            "x": phoneme_ids_array,          # MMS style
-            "x_length": phoneme_ids_lengths, # MMS style
-            "input_ids": phoneme_ids_array,  # HF style
-            "attention_mask": attention_mask # HF style
-        }
-
-        # Add synthesis parameters
-        if length_scale is None:
-            length_scale = self.config.length_scale
-        if noise_scale is None:
-            noise_scale = self.config.noise_scale
-        if noise_w_scale is None:
-            noise_w_scale = self.config.noise_w_scale
-
-        args.update({
-            "scales": np.array([noise_scale, length_scale, noise_w_scale], dtype=np.float32),
-            "noise_scale": np.array([noise_scale], dtype=np.float32),
-            "noise_scale_w": np.array([noise_w_scale], dtype=np.float32),
-            "length_scale": np.array([length_scale], dtype=np.float32),
-            "langid": np.array([langid], dtype=np.int64),
-            "sid": np.array([speaker_id], dtype=np.int64),
+        # Merge defaults from adapter → VoiceConfig → SynthesisConfig
+        params = dict(self.adapter.default_params())
+        # Override with voice-config level defaults
+        params.update({
+            k: v for k, v in {
+                "noise_scale": self.config.noise_scale,
+                "length_scale": self.config.length_scale,
+                "noise_w_scale": self.config.noise_w_scale,
+            }.items() if v is not None
         })
+        # Override with any engine-specific extras from voice config
+        if hasattr(self.config, 'engine_params'):
+            params.update(self.config.engine_params)
+        # Override with per-call SynthesisConfig
+        if syn_config.noise_scale is not None:
+            params["noise_scale"] = syn_config.noise_scale
+        if syn_config.length_scale is not None:
+            params["length_scale"] = syn_config.length_scale
+        if syn_config.noise_w_scale is not None:
+            params["noise_w_scale"] = syn_config.noise_w_scale
+        # Engine-specific extras from SynthesisConfig
+        params.update(syn_config.extra_params)
 
-        # Keep only ONNX model-expected inputs
-        args = {k: v for k, v in args.items() if k in expected_args}
+        request = AdapterSynthesisRequest(
+            phoneme_ids=phoneme_ids_array,
+            phoneme_lengths=phoneme_ids_lengths,
+            speaker_id=syn_config.speaker_id or 0,
+            language_id=syn_config.lang_id or 0,
+            params=params,
+        )
 
-        audio = self.session.run(None, args)[0].squeeze()
-        return audio
+        # Delegate to the adapter
+        feed_dict = self.adapter.build_feed_dict(request, self.session)
+        raw_outputs = self.session.run(None, feed_dict)
+        result = self.adapter.parse_outputs(raw_outputs, request)
 
-
+        return result.audio
 
 if __name__ == "__main__":
     from phoonnx.phonemizers.gl import CotoviaPhonemizer

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,0 +1,181 @@
+"""Tests for the pluggable multi-engine inference framework.
+
+The framework refactored TTSVoice's synthesis path from inline ONNX I/O into
+engine adapters. These tests pin the VITS adapter's behaviour so the refactor
+is provably equivalent to the previous inline logic for every ONNX input
+convention (piper / MMS / HuggingFace), plus the registry and detection.
+"""
+import numpy as np
+import pytest
+
+from phoonnx.engines import (
+    register_engine, get_adapter, detect_engine, list_engines,
+)
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter,
+)
+from phoonnx.engines.vits import VitsAdapter
+
+
+class _Named:
+    def __init__(self, name): self.name = name
+
+
+class DummySession:
+    def __init__(self, input_names, run_fn=None):
+        self._inputs = [_Named(n) for n in input_names]
+        self._run_fn = run_fn
+
+    def get_inputs(self): return self._inputs
+    def get_outputs(self): return [_Named("output")]
+    def run(self, _none, feed): return self._run_fn(feed)
+
+
+def _request(n=5, spk=0, lang=0, **params):
+    ids = np.arange(1, n + 1, dtype=np.int64)[None, :]
+    return AdapterSynthesisRequest(
+        phoneme_ids=ids, phoneme_lengths=np.array([n], dtype=np.int64),
+        speaker_id=spk, language_id=lang, params=params,
+    )
+
+
+# ---------------------------------------------------------------- registry
+def test_registry_has_vits():
+    assert "vits" in list_engines()
+    assert isinstance(get_adapter("vits"), VitsAdapter)
+
+
+def test_get_adapter_unknown_raises():
+    with pytest.raises(KeyError):
+        get_adapter("does-not-exist")
+
+
+def test_register_and_detect_priority():
+    class Dummy(VitsAdapter):
+        @staticmethod
+        def detect(config=None, session=None): return True
+    register_engine("dummy_high", Dummy, detect_priority=1)
+    # lower priority number is checked first
+    assert isinstance(detect_engine(config={"x": 1}), Dummy)
+
+
+def test_detect_falls_back_to_vits():
+    # nothing matches -> VITS fallback
+    adapter = detect_engine(config={"totally": "unknown"})
+    assert isinstance(adapter, VitsAdapter)
+
+
+# ---------------------------------------------- VitsAdapter.build_feed_dict
+def test_feed_piper_inputs():
+    """piper/phoonnx export: input / input_lengths / scales / sid."""
+    sess = DummySession(["input", "input_lengths", "scales", "sid"])
+    feed = VitsAdapter().build_feed_dict(_request(spk=3), sess)
+    assert set(feed) == {"input", "input_lengths", "scales", "sid"}
+    assert feed["input"].tolist() == [[1, 2, 3, 4, 5]]
+    assert feed["input_lengths"].tolist() == [5]
+    assert feed["scales"] == pytest.approx([0.667, 1.0, 0.8], abs=1e-4)  # noise, length, noise_w
+    assert feed["sid"].tolist() == [3]
+
+
+def test_feed_mms_inputs():
+    """MMS export: x / x_length — and the piper aliases are filtered out."""
+    sess = DummySession(["x", "x_length", "scales"])
+    feed = VitsAdapter().build_feed_dict(_request(), sess)
+    assert set(feed) == {"x", "x_length", "scales"}
+    assert "input" not in feed and "input_ids" not in feed
+
+
+def test_feed_hf_inputs():
+    """HuggingFace export: input_ids / attention_mask."""
+    sess = DummySession(["input_ids", "attention_mask"])
+    feed = VitsAdapter().build_feed_dict(_request(), sess)
+    assert set(feed) == {"input_ids", "attention_mask"}
+    assert feed["attention_mask"].tolist() == [[1, 1, 1, 1, 1]]
+
+
+def test_feed_separate_scalar_scales():
+    """exports with split scale inputs instead of a packed `scales`."""
+    sess = DummySession(["input", "input_lengths", "noise_scale",
+                         "length_scale", "noise_scale_w"])
+    feed = VitsAdapter().build_feed_dict(
+        _request(noise_scale=0.5, length_scale=1.2, noise_w_scale=0.9), sess)
+    assert feed["noise_scale"].tolist() == pytest.approx([0.5])
+    assert feed["length_scale"].tolist() == pytest.approx([1.2])
+    assert feed["noise_scale_w"].tolist() == pytest.approx([0.9])
+    assert "scales" not in feed
+
+
+def test_feed_langid_included_when_input_present():
+    sess = DummySession(["input", "input_lengths", "scales", "langid"])
+    feed = VitsAdapter().build_feed_dict(_request(lang=2), sess)
+    assert feed["langid"].tolist() == [2]
+
+
+def test_params_override_defaults():
+    sess = DummySession(["scales"])
+    feed = VitsAdapter().build_feed_dict(
+        _request(noise_scale=0.1, length_scale=2.0, noise_w_scale=0.3), sess)
+    assert feed["scales"] == pytest.approx([0.1, 2.0, 0.3], abs=1e-4)
+
+
+def test_no_regression_vs_inline_logic():
+    """Golden: the adapter feed equals what the previous inline code built."""
+    ids = np.array([[1, 2, 3]], dtype=np.int64)
+    lens = np.array([3], dtype=np.int64)
+    ns, ls, nw = 0.667, 1.0, 0.8
+    # what the old inline path produced for a piper model (then filtered):
+    expected = {
+        "input": ids, "input_lengths": lens,
+        "scales": np.array([ns, ls, nw], dtype=np.float32),
+        "sid": np.array([0], dtype=np.int64),
+    }
+    sess = DummySession(["input", "input_lengths", "scales", "sid"])
+    feed = VitsAdapter().build_feed_dict(_request(n=3), sess)
+    assert set(feed) == set(expected)
+    for k in expected:
+        assert np.array_equal(feed[k], expected[k]), k
+
+
+# ----------------------------------------------- parse_outputs / detect
+def test_parse_outputs_squeeze():
+    res = VitsAdapter().parse_outputs([np.zeros((1, 1, 2048), np.float32)], _request())
+    assert isinstance(res, AdapterSynthesisResult)
+    assert res.audio.shape == (2048,)
+
+
+@pytest.mark.parametrize("cfg", [
+    {"engine": "piper"}, {"engine": "coqui"},
+    {"phoneme_id_map": {"a": [1]}, "phoneme_type": "espeak"},
+    {"phoonnx_version": "1.0"}, {"piper_version": "1.0"},
+    {"characters": {"pad": "_"}},
+    {"phonemizer": "espeak", "phonemes": {}},
+])
+def test_detect_config_signatures(cfg):
+    assert VitsAdapter.detect(config=cfg) is True
+
+
+def test_detect_session_scales():
+    assert VitsAdapter.detect(session=DummySession(["input", "scales"])) is True
+    assert VitsAdapter.detect(session=DummySession(["mels"])) is False
+
+
+def test_default_params_and_parse_config():
+    a = VitsAdapter()
+    assert a.default_params() == {"noise_scale": 0.667, "length_scale": 1.0, "noise_w_scale": 0.8}
+    p = a.parse_config({"inference": {"noise_scale": 0.4, "length_scale": 1.5, "noise_w": 0.7}})
+    assert p == {"noise_scale": 0.4, "length_scale": 1.5, "noise_w_scale": 0.7}
+
+
+def test_full_synth_delegation():
+    """End-to-end: build_feed_dict -> session.run -> parse_outputs."""
+    captured = {}
+    def run_fn(feed):
+        captured.update(feed)
+        return [np.full((1, 1, 100), 0.25, dtype=np.float32)]
+    sess = DummySession(["input", "input_lengths", "scales", "sid"], run_fn=run_fn)
+    adapter = VitsAdapter()
+    req = _request(n=4)
+    out = sess.run(None, adapter.build_feed_dict(req, sess))
+    audio = adapter.parse_outputs(out, req).audio
+    assert captured["input"].tolist() == [[1, 2, 3, 4]]
+    assert audio.shape == (100,) and float(audio[0]) == pytest.approx(0.25)


### PR DESCRIPTION
## Summary

Adds a registry-based adapter framework so new TTS architectures can be plugged into phoonnx without touching core voice code.

### Changes
- BaseOnnxAdapter abstraction
- phoonnx.engines registry with auto-detection
- VitsAdapter: existing VITS logic refactored behind the new interface
- TTSVoice delegates ONNX I/O to adapters

### Testing
- 121 tests pass, 1 skipped

## Scope
This PR is **inference-only**. Training engine abstractions will come in a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable engine architecture for interchangeable inference/training engines and adapter-based synthesis delegation.
  * Voice/config now accept engine-specific defaults and per-call extra parameters for finer synthesis control.

* **Documentation**
  * Detailed engine architecture guide, registration/lifecycle checklist, CLI integration, config examples, and onboarding steps for new engines.

* **Tests**
  * New test suite validating registry behavior, adapter detection, input/output mappings, parameter overrides, and end-to-end synthesis delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->