### PR TITLE
feat(config): native phoonnx config round-trip

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -253,17 +253,19 @@ class VoiceConfig:
         diacritics = False
 
         if VoiceConfig.is_phoonnx(config):
-            engine =  engine or Engine.PHOONNX
+            engine = engine or config.get("engine") or Engine.PHOONNX
 
             lang_code = lang_code or config.get("lang_code")
             phoneme_type = phoneme_type or config.get("phoneme_type", PhonemeType.ESPEAK)
             alphabet = alphabet or Alphabet(config.get("alphabet", "ipa"))
             diacritics = config.get("inference", {}).get("add_diacritics", True)
 
-            config["pad"] =  DEFAULT_PAD_TOKEN
-            config["blank"] = DEFAULT_BLANK_TOKEN
-            config["bos"] = DEFAULT_BOS_TOKEN
-            config["eos"] = DEFAULT_EOS_TOKEN
+            # Preserve the model's own special tokens when present (a native
+            # config may use any pad/blank/bos/eos); fall back to phoonnx defaults.
+            config["pad"] = config.get("pad") or DEFAULT_PAD_TOKEN
+            config["blank"] = config.get("blank") or DEFAULT_BLANK_TOKEN
+            config["bos"] = config.get("bos") or DEFAULT_BOS_TOKEN
+            config["eos"] = config.get("eos") or DEFAULT_EOS_TOKEN
 
             tokenizer = TTSTokenizer.from_phoonnx_config(config)
 
@@ -403,6 +405,54 @@ class VoiceConfig:
             word_sep_token=config.get("word_sep_token") or config.get("blank_word", " "),
             engine_params=engine_params or {}
         )
+
+    def to_native_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this config to a **native phoonnx** ``config.json`` dict.
+
+        The result loads back through the ``is_phoonnx`` path in
+        :meth:`from_dict` (it carries ``phoonnx_version``), folding the
+        tokenizer vocabulary into ``phoneme_id_map`` and recording the
+        tokenizer flags + special tokens explicitly, so any model round-trips
+        without relying on the foreign-config detection heuristics.
+        """
+        try:
+            from phoonnx.version import VERSION as _v
+            version = ".".join(str(p) for p in _v) if isinstance(_v, (tuple, list)) else str(_v)
+        except Exception:
+            version = "1.0"
+
+        tok = self.tokenizer
+        voc = tok.vocabulary
+        return {
+            "phoonnx_version": version,
+            "engine": self.engine.value if self.engine else "phoonnx",
+            "phoneme_type": self.phoneme_type.value if self.phoneme_type else "graphemes",
+            "alphabet": self.alphabet.value if self.alphabet else "unicode",
+            "lang_code": self.lang_code,
+            "audio": {"sample_rate": self.sample_rate},
+            "num_symbols": self.num_symbols,
+            "num_speakers": self.num_speakers,
+            "num_langs": self.num_langs,
+            "speaker_id_map": dict(self.speaker_id_map or {}),
+            "lang_id_map": dict(self.lang_id_map or {}),
+            "phonemizer_model": self.phonemizer_model,
+            "add_diacritics": self.add_diacritics,
+            "inference": {
+                "noise_scale": self.noise_scale,
+                "length_scale": self.length_scale,
+                "noise_w": self.noise_w_scale,
+            },
+            "phoneme_id_map": dict(voc.char2idx),
+            "pad": voc.pad, "blank": voc.blank, "bos": voc.bos, "eos": voc.eos,
+            "add_blank_char": tok.add_blank_char,
+            "add_blank_word": tok.add_blank_word,
+            "use_eos_bos": tok.use_eos_bos,
+            "blank_at_start": tok.blank_at_start,
+            "blank_at_end": tok.blank_at_end,
+            "word_sep_token": self.word_sep_token,
+            "blank_between": self.blank_between.value if self.blank_between else "tokens_and_words",
+        }
 
 
 @dataclass

--- a/phoonnx/tokenizer.py
+++ b/phoonnx/tokenizer.py
@@ -617,12 +617,14 @@ class TTSTokenizer:
             blanks at start and end enabled, BOS/EOS wrapping enabled, and word-blank mapping disabled).
         """
         voc: Vocabulary = Vocabulary.from_phoonnx_config(cfg)
-        # Default settings for phoonnx
-        add_blank: bool = True
-        blank_at_end: bool = True
-        blank_at_start: bool = True
-        use_eos_bos: bool = True
-        add_blank_word: bool = False
+        # Native phoonnx configs carry the tokenizer flags explicitly so any
+        # model round-trips faithfully; the historical phoonnx defaults apply
+        # only when a flag is absent.
+        add_blank: bool = cfg.get("add_blank_char", True)
+        blank_at_end: bool = cfg.get("blank_at_end", True)
+        blank_at_start: bool = cfg.get("blank_at_start", True)
+        use_eos_bos: bool = cfg.get("use_eos_bos", True)
+        add_blank_word: bool = cfg.get("add_blank_word", False)
         return TTSTokenizer(voc, add_blank_char=add_blank, add_blank_word=add_blank_word,
                             blank_at_end=blank_at_end, blank_at_start=blank_at_start,
                             use_eos_bos=use_eos_bos)

--- a/tests/test_native_config.py
+++ b/tests/test_native_config.py
@@ -1,0 +1,59 @@
+"""Round-trip: foreign config -> VoiceConfig.to_native_dict() -> native config.
+
+Modernizing community mirrors to native phoonnx configs must reproduce the exact
+tokenization, including models that differ from the phoonnx defaults (e.g. MMS /
+matcha use no BOS/EOS). The native config must carry the tokenizer flags.
+"""
+from phoonnx.config import VoiceConfig
+
+
+def _ids(vc):
+    keys = [k for k in vc.tokenizer.vocabulary.char2idx if len(k) == 1][2:10]
+    return vc.tokenizer.tokenize(keys)
+
+
+def _roundtrip(vc):
+    native = vc.to_native_dict()
+    assert "phoonnx_version" in native
+    assert native["phoneme_id_map"]
+    vc2 = VoiceConfig.from_dict(dict(native))
+    return vc, vc2, native
+
+
+def test_piper_roundtrip():
+    cfg = {
+        "piper_version": "1.0.0", "phoneme_type": "espeak",
+        "phoneme_id_map": {"_": [0], "^": [1], "$": [2], "a": [3], "b": [4],
+                            "c": [5], "!": [6], " ": [7]},
+        "num_symbols": 8, "num_speakers": 1, "audio": {"sample_rate": 22050},
+        "espeak": {"voice": "en-us"},
+        "inference": {"noise_scale": 0.667, "length_scale": 1.0, "noise_w": 0.8},
+    }
+    vc = VoiceConfig.from_dict(cfg)
+    vc, vc2, native = _roundtrip(vc)
+    assert _ids(vc) == _ids(vc2)
+    assert native["use_eos_bos"] == vc.tokenizer.use_eos_bos
+
+
+def test_mms_style_roundtrip_no_eos_bos():
+    # transformers/MMS path: add_blank, no bos/eos
+    vocab = {"_": 0, "a": 1, "b": 2, "c": 3, "d": 4, "e": 5, " ": 6}
+    tok_cfg = {"add_blank": True, "language": "en", "pad_token": "_"}
+    vc = VoiceConfig.from_dict({}, vocab=vocab, tokenizer_config=tok_cfg,
+                               phoneme_type="graphemes", alphabet="unicode",
+                               lang_code="en")
+    assert vc.tokenizer.use_eos_bos is False  # the case the old native path broke
+    vc, vc2, native = _roundtrip(vc)
+    assert native["use_eos_bos"] is False
+    assert vc2.tokenizer.use_eos_bos is False
+    assert _ids(vc) == _ids(vc2)
+
+
+def test_native_carries_tokenizer_flags():
+    vocab = {"_": 0, "a": 1, "b": 2, "c": 3}
+    vc = VoiceConfig.from_dict({}, vocab=vocab, tokenizer_config={"add_blank": True, "language": "en", "pad_token": "_"},
+                               phoneme_type="graphemes", alphabet="unicode", lang_code="en")
+    native = vc.to_native_dict()
+    for k in ("add_blank_char", "add_blank_word", "use_eos_bos",
+              "blank_at_start", "blank_at_end", "pad", "blank", "phoneme_id_map"):
+        assert k in native, k


### PR DESCRIPTION
Lets mirrored community models ship a **well-formed native phoonnx `config.json`** instead of leaning on the foreign-config detection heuristics (piper/coqui/mimic3/transformers). Split out of the Matcha work (#138) as its own self-contained change.

## Changes
- `from_phoonnx_config` now **reads** the tokenizer flags (`add_blank_char`, `add_blank_word`, `use_eos_bos`, `blank_at_start/end`) from the config instead of hardcoding the phoonnx defaults; the `is_phoonnx` branch preserves the model's own `pad`/`blank`/`bos`/`eos` + engine when present.
- `VoiceConfig.to_native_dict()` serializes any loaded config to a native `config.json` (folds the vocab into `phoneme_id_map`, records the tokenizer flags + special tokens + audio/speakers/inference).

## Why it matters
The old native path hardcoded `use_eos_bos=True`, so it could only faithfully represent models that match phoonnx's defaults. Round-trip is now verified for piper (eos/bos **on**) **and** MMS/matcha (eos/bos **off**) — the case that previously broke silently.

Full suite: **146 passed, 1 skipped**. Independent of #138 (no overlap; `engine_params` is already in dev from #131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration can now be exported to native format for enhanced compatibility and round-tripping.

* **Bug Fixes**
  * Special token settings are now preserved during configuration processing instead of being unconditionally overwritten.
  * Tokenizer defaults are now derived from configuration when available.

* **Tests**
  * Added comprehensive test coverage for configuration serialization and tokenization consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->