### PR TITLE
feat(engines): OptiSpeech inference adapter

### DIFF
--- a/docs/optispeech.md
+++ b/docs/optispeech.md
@@ -1,0 +1,107 @@
+# OptiSpeech Engine
+
+OptiSpeech is a non-autoregressive, **FastSpeech2-style** TTS: an acoustic model
+with explicit duration / pitch / energy prediction and a GAN vocoder, exported
+as a **single ONNX file** that outputs the waveform directly (no separate
+vocoder stage).
+
+## Inference
+
+OptiSpeech uses a different ONNX I/O contract from VITS, and it embeds **all of
+its config inside the ONNX metadata** (no external config file).
+
+### ONNX Inputs
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| ``x`` | int64 | ``[B, T]`` | Phoneme IDs |
+| ``x_lengths`` | int64 | ``[B]`` | Sequence lengths |
+| ``scales`` | float32 | ``[3]`` | ``[d_factor, p_factor, e_factor]`` |
+| ``sids`` | int64 | ``[B]`` | Speaker IDs (optional, multi-speaker) |
+| ``lids`` | int64 | ``[B]`` | Language IDs (optional, multi-language) |
+
+### ONNX Outputs
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| ``wav`` | float32 | ``[B, 1, T]`` | Waveform |
+| ``wav_lengths`` | int64 | ``[B]`` | Sample counts |
+| ``durations`` | int64 | ``[B, T_text]`` | Per-phoneme durations |
+
+> Note the ``scales`` tensor differs from VITS, where it packs
+> ``[noise_scale, length_scale, noise_w_scale]``. OptiSpeech shares the
+> ``x``/``x_lengths``/``scales`` input names with Matcha-TTS, so the adapter is
+> probed **before** Matcha — it is identified by its embedded metadata and
+> ``wav``/``durations`` outputs.
+
+### Parameters
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| ``d_factor`` | 1.0 | Duration scale — speaking rate (>1 slower, <1 faster) |
+| ``p_factor`` | 1.0 | Pitch scale |
+| ``e_factor`` | 1.0 | Energy scale |
+
+Pass them per call via ``SynthesisConfig.extra_params``::
+
+    voice.synthesize("hello", SynthesisConfig(extra_params={"d_factor": 0.9}))
+
+## Config — embedded metadata → native config
+
+OptiSpeech stores its config inside the ONNX model under the ``inference``
+metadata key (a JSON blob): ``sample_rate``, ``input_symbols`` (symbol→id),
+``special_symbols``, ``text_processor`` (``add_blank`` / ``add_bos_eos`` /
+``tokenizer``), ``speakers`` and ``languages``.
+
+``phoonnx.engines.optispeech_config.voice_config_from_optispeech_meta`` converts
+that metadata into a native phoonnx ``VoiceConfig`` (folding ``input_symbols``
+into the tokenizer ``phoneme_id_map`` and honouring the ``add_blank`` /
+``add_bos_eos`` flags), e.g.::
+
+    import onnxruntime as ort
+    from phoonnx.engines.optispeech import OptiSpeechAdapter
+    from phoonnx.engines.optispeech_config import voice_config_from_optispeech_meta
+
+    sess = ort.InferenceSession("model.onnx")
+    meta = OptiSpeechAdapter().parse_onnx_meta(sess)
+    config = voice_config_from_optispeech_meta(meta)
+
+The mirrored voices (below) ship this as a **native ``config.json``** alongside
+the model, so they load through the standard path — ``engine: optispeech`` in
+the config routes to ``OptiSpeechAdapter``, with no runtime metadata extraction.
+
+## Voice index
+
+OptiSpeech voices ship in ``phoonnx/voice_index/optispeech.json``, mirrored under
+``OpenVoiceOS/phoonnx-optispeech`` (each subfolder = ``model.onnx`` + native
+``config.json``). They are loaded by the voice manager like any other voice:
+
+```python
+from phoonnx.model_manager import TTSModelManager
+
+m = TTSModelManager(); m.merge_default_voices()
+voice = m.voices["hf_community/mush42/optispeech-lightspeech-en-us-emily"].load()
+for chunk in voice.synthesize("Hello from OptiSpeech."):
+    ...   # chunk.audio_float_array
+```
+
+Current entries (mirror of [`mush42/optispeech`](https://huggingface.co/mush42/optispeech), 24 kHz, en-US):
+
+| voice_id | acoustic | speaker |
+|----------|----------|---------|
+| `…/optispeech-lightspeech-en-us-emily` | LightSpeech | emily |
+| `…/optispeech-lightspeech-en-us-mike` | LightSpeech | mike |
+| `…/optispeech-convnext-en-us-emily` | ConvNeXt-TTS | emily |
+
+## Text processing
+
+OptiSpeech's IPA tokenizer phonemizes with espeak (``phoneme_type: espeak``,
+``alphabet: ipa``). The tokenizer flags come from the model's ``text_processor``
+metadata (e.g. these LightSpeech/ConvNeXt voices use ``add_blank: false`` /
+``add_bos_eos: false``), so phoonnx feeds the exact token sequence the model was
+trained on.
+
+## References
+
+- [OptiSpeech](https://github.com/mush42/optispeech)
+- [docs/engines.md](./engines.md) — the engine adapter framework

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -21,6 +21,7 @@ class Engine(str, Enum):
     COQUI = "coqui"
     TRANSFORMERS = "transformers"
     MATCHA = "matcha"  # flow-matching mel model + separate vocoder
+    OPTISPEECH = "optispeech"  # FastSpeech2-style acoustic + GAN vocoder
 
 
 class Alphabet(str, Enum):

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -116,7 +116,11 @@ def list_engines() -> List[str]:
 def _register_builtins() -> None:
     from phoonnx.engines.vits import VitsAdapter
     from phoonnx.engines.matcha import MatchaAdapter
+    from phoonnx.engines.optispeech import OptiSpeechAdapter
 
+    # OptiSpeech shares VITS-like x/x_lengths/scales inputs with Matcha, but has
+    # a distinctive metadata + wav/durations output signature — check it first.
+    register_engine("optispeech", OptiSpeechAdapter, detect_priority=35)
     register_engine("vits", VitsAdapter, detect_priority=50)
     register_engine("matcha", MatchaAdapter, detect_priority=40)
 

--- a/phoonnx/engines/optispeech.py
+++ b/phoonnx/engines/optispeech.py
@@ -1,0 +1,202 @@
+"""
+OptiSpeech inference adapter.
+
+OptiSpeech is a non-autoregressive FastSpeech2-style TTS with GAN
+vocoder.  Its ONNX contract differs from VITS:
+
+  Inputs:
+    x          (int64)     — phoneme IDs
+    x_lengths  (int64)     — sequence lengths
+    scales     (float32[3])— [d_factor, p_factor, e_factor]
+    sids       (int64)     — speaker IDs (optional, multi-speaker)
+    lids       (int64)     — language IDs (optional, multi-language)
+
+  Outputs:
+    wav          (float32) — waveform [B, 1, T]
+    wav_lengths  (int64)   — sample counts [B]
+    durations    (int64)   — per-phoneme durations [B, T_text]
+
+  Metadata:
+    All config is embedded in the ONNX model under the ``"inference"``
+    metadata key as a JSON blob containing sample_rate, inference_args,
+    input_symbols, special_symbols, text_processor, speakers, languages.
+
+Scale semantics:
+    scales[0] = d_factor  (duration scale — >1 slower, <1 faster)
+    scales[1] = p_factor  (pitch scale)
+    scales[2] = e_factor  (energy scale)
+
+This is fundamentally different from VITS where scales =
+[noise_scale, length_scale, noise_w_scale].
+"""
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest,
+    AdapterSynthesisResult,
+    BaseOnnxAdapter,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+class OptiSpeechAdapter(BaseOnnxAdapter):
+    """Adapter for OptiSpeech ONNX models."""
+
+    def __init__(self):
+        self._onnx_meta: Optional[Dict[str, Any]] = None
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    def build_feed_dict(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> Dict[str, np.ndarray]:
+        params = request.params
+        d_factor = np.float32(params.get("d_factor", 1.0))
+        p_factor = np.float32(params.get("p_factor", 1.0))
+        e_factor = np.float32(params.get("e_factor", 1.0))
+
+        args: Dict[str, np.ndarray] = {
+            "x": request.phoneme_ids,
+            "x_lengths": request.phoneme_lengths,
+            "scales": np.array([d_factor, p_factor, e_factor], dtype=np.float32),
+        }
+
+        # Multi-speaker
+        if request.speaker_id is not None:
+            args["sids"] = np.array([request.speaker_id], dtype=np.int64)
+
+        # Multi-language
+        if request.language_id is not None:
+            args["lids"] = np.array([request.language_id], dtype=np.int64)
+
+        return self._filter_inputs(args, session)
+
+    def parse_outputs(
+        self,
+        outputs: List[np.ndarray],
+        request: AdapterSynthesisRequest,
+    ) -> AdapterSynthesisResult:
+        # OptiSpeech returns [wav, wav_lengths, durations]
+        audio = outputs[0].squeeze()
+
+        extras: Dict[str, Any] = {}
+        if len(outputs) > 1:
+            extras["wav_lengths"] = outputs[1]
+        if len(outputs) > 2:
+            extras["durations"] = outputs[2]
+
+        return AdapterSynthesisResult(audio=audio, extras=extras)
+
+    def default_params(self) -> Dict[str, float]:
+        return {
+            "d_factor": 1.0,
+            "p_factor": 1.0,
+            "e_factor": 1.0,
+        }
+
+    # ------------------------------------------------------------------
+    # Optional
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def detect(
+        config: Optional[Dict[str, Any]] = None,
+        session: Optional[onnxruntime.InferenceSession] = None,
+    ) -> bool:
+        # 1. Check ONNX metadata for OptiSpeech signature
+        if session is not None:
+            try:
+                meta = session.get_modelmeta().custom_metadata_map
+                if "inference" in meta:
+                    infer = json.loads(meta["inference"])
+                    # OptiSpeech metadata always contains text_processor + input_symbols
+                    if "text_processor" in infer and "input_symbols" in infer:
+                        return True
+                if meta.get("model_type") == "optispeech":
+                    return True
+            except Exception:
+                pass
+
+            # 2. Heuristic: has "x" + "x_lengths" inputs but NOT "input" or "input_lengths"
+            input_names = {inp.name for inp in session.get_inputs()}
+            output_names = {out.name for out in session.get_outputs()}
+            if (
+                "x" in input_names
+                and "x_lengths" in input_names
+                and "input" not in input_names
+                and "input_lengths" not in input_names
+            ):
+                # Also check that outputs include wav + wav_lengths + durations
+                if "wav" in output_names or "durations" in output_names:
+                    return True
+
+        # 3. Config-based
+        if config is not None:
+            engine = config.get("engine", "")
+            if engine == "optispeech":
+                return True
+
+        return False
+
+    def parse_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract default d/p/e factors from config if present."""
+        inference_args = config.get("inference_args", {})
+        return {
+            "d_factor": inference_args.get("d_factor", 1.0),
+            "p_factor": inference_args.get("p_factor", 1.0),
+            "e_factor": inference_args.get("e_factor", 1.0),
+        }
+
+    def configure_tokenizer(self, tokenizer):
+        """
+        OptiSpeech models embed ``text_processor`` config in ONNX metadata
+        that controls whether blanks / BOS/EOS should be inserted.  Respect
+        those flags so the model receives the exact token sequence it was
+        trained on.
+        """
+        if self._onnx_meta is None:
+            return tokenizer
+        tp = self._onnx_meta.get("text_processor", {})
+        if tp.get("add_blank") is False:
+            tokenizer.add_blank_char = False
+            tokenizer.blank_at_start = False
+            tokenizer.blank_at_end = False
+        if tp.get("add_bos_eos") is False:
+            tokenizer.use_eos_bos = False
+        return tokenizer
+
+    def parse_onnx_meta(
+        self, session: onnxruntime.InferenceSession,
+    ) -> Dict[str, Any]:
+        """
+        Extract the full config from OptiSpeech's embedded ONNX metadata.
+
+        Returns a dict with keys:
+            name, sample_rate, inference_args, input_symbols,
+            special_symbols, speakers, languages, text_processor
+        """
+        try:
+            meta = session.get_modelmeta().custom_metadata_map
+            if "inference" in meta:
+                self._onnx_meta = json.loads(meta["inference"])
+                return self._onnx_meta
+        except Exception:
+            LOG.debug("Failed to parse OptiSpeech ONNX metadata", exc_info=True)
+        return {}
+
+    def param_labels(self) -> Dict[str, str]:
+        return {
+            "d_factor": "Speed",
+            "p_factor": "Pitch",
+            "e_factor": "Energy",
+        }

--- a/phoonnx/engines/optispeech_config.py
+++ b/phoonnx/engines/optispeech_config.py
@@ -1,0 +1,108 @@
+"""
+OptiSpeech ↔ phoonnx config bridge.
+
+OptiSpeech embeds all of its config inside the ONNX model metadata (under the
+``"inference"`` key) rather than in an external JSON file. This module turns
+that embedded metadata into a phoonnx :class:`VoiceConfig` (with its tokenizer)
+so the rest of the pipeline works unchanged.
+
+Usage (from ``TTSVoice.load``)::
+
+    meta = adapter.parse_onnx_meta(session)
+    config = voice_config_from_optispeech_meta(meta)
+"""
+import logging
+from typing import Any, Dict, Optional
+
+from phoonnx.config import Alphabet, Engine, PhonemeType, VoiceConfig
+from phoonnx.tokenizer import BlankBetween, TTSTokenizer, Vocabulary
+
+LOG = logging.getLogger(__name__)
+
+# OptiSpeech default special symbols
+_OS_PAD = "_"
+_OS_BOS = "^"
+_OS_EOS = "$"
+
+
+def _build_tokenizer(
+    input_symbols: Dict[str, int],
+    special_symbols: Dict[str, Any],
+    text_processor: Dict[str, Any],
+) -> TTSTokenizer:
+    """Reproduce OptiSpeech's tokenization from the embedded metadata."""
+    voc = Vocabulary(
+        char2idx=dict(input_symbols),
+        pad=_OS_PAD,
+        blank=_OS_PAD,  # OptiSpeech uses PAD as the interspersed blank
+        bos=special_symbols.get("bos", _OS_BOS),
+        eos=special_symbols.get("eos", _OS_EOS),
+    )
+    add_blank = bool(text_processor.get("add_blank", True))
+    add_bos_eos = bool(text_processor.get("add_bos_eos", True))
+    return TTSTokenizer(
+        voc,
+        add_blank_char=add_blank,
+        add_blank_word=False,
+        use_eos_bos=add_bos_eos,
+        blank_at_start=add_blank,
+        blank_at_end=add_blank,
+    )
+
+
+def voice_config_from_optispeech_meta(
+    meta: Dict[str, Any],
+    *,
+    lang_code: Optional[str] = None,
+    phoneme_type: Optional[PhonemeType] = None,
+) -> VoiceConfig:
+    """
+    Build a full :class:`VoiceConfig` from OptiSpeech's embedded ONNX metadata
+    (the parsed ``inference`` JSON blob).
+    """
+    input_symbols = meta.get("input_symbols", {})
+    special_symbols = meta.get("special_symbols", {})
+    text_processor = meta.get("text_processor", {})
+    inference_args = meta.get("inference_args", {})
+    languages = meta.get("languages", []) or []
+    speakers = meta.get("speakers", []) or []
+    sample_rate = meta.get("sample_rate", 22050)
+
+    if not lang_code and languages:
+        lang_code = languages[0]
+
+    # OptiSpeech's IPATokenizer phonemizes with espeak/piper_phonemize.
+    if phoneme_type is None:
+        tokenizer_name = text_processor.get("tokenizer", "ipa")
+        phoneme_type = PhonemeType.GRAPHEMES if tokenizer_name == "arabic-buck" else PhonemeType.ESPEAK
+
+    add_bos_eos = bool(text_processor.get("add_bos_eos", True))
+    add_blank = bool(text_processor.get("add_blank", True))
+
+    return VoiceConfig(
+        tokenizer=_build_tokenizer(input_symbols, special_symbols, text_processor),
+        num_symbols=len(input_symbols),
+        num_speakers=max(len(speakers), 1),
+        num_langs=max(len(languages), 1),
+        sample_rate=sample_rate,
+        lang_code=lang_code,
+        phoneme_type=phoneme_type,
+        alphabet=Alphabet.IPA,
+        phonemizer_model=None,
+        engine=Engine.OPTISPEECH,
+        speaker_id_map={name: idx for idx, name in enumerate(speakers)} if speakers else {},
+        add_diacritics=False,
+        engine_params={
+            "d_factor": inference_args.get("d_factor", 1.0),
+            "p_factor": inference_args.get("p_factor", 1.0),
+            "e_factor": inference_args.get("e_factor", 1.0),
+        },
+        blank_between=BlankBetween.TOKENS_AND_WORDS,
+        blank_at_start=add_blank,
+        blank_at_end=add_blank,
+        pad_token=_OS_PAD,
+        blank_token=_OS_PAD,
+        bos_token=_OS_BOS if add_bos_eos else None,
+        eos_token=_OS_EOS if add_bos_eos else None,
+        word_sep_token=" ",
+    )

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -443,6 +443,7 @@ class TTSModelManager:
         self.cache.update(JsonStorage(str(base_path / "mimic3.json")))
         self.cache.update(JsonStorage(str(base_path / "transformers_community.json")))
         self.cache.update(JsonStorage(str(base_path / "piper_community.json")))
+        self.cache.update(JsonStorage(str(base_path / "optispeech.json")))
         self.cache.update(JsonStorage(str(base_path / "coqui_community.json")))
         self.cache.update(JsonStorage(str(base_path / "BSC.json")))
         self.voices = {}

--- a/phoonnx/voice_index/optispeech.json
+++ b/phoonnx/voice_index/optispeech.json
@@ -1,0 +1,41 @@
+{
+    "hf_community/mush42/optispeech-lightspeech-en-us-emily": {
+        "voice_id": "hf_community/mush42/optispeech-lightspeech-en-us-emily",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-optispeech/resolve/main/mush42__optispeech-lightspeech-en-us-emily/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-optispeech/resolve/main/mush42__optispeech-lightspeech-en-us-emily/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "engine": "optispeech",
+        "lang": "en-US"
+    },
+    "hf_community/mush42/optispeech-lightspeech-en-us-mike": {
+        "voice_id": "hf_community/mush42/optispeech-lightspeech-en-us-mike",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-optispeech/resolve/main/mush42__optispeech-lightspeech-en-us-mike/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-optispeech/resolve/main/mush42__optispeech-lightspeech-en-us-mike/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "engine": "optispeech",
+        "lang": "en-US"
+    },
+    "hf_community/mush42/optispeech-convnext-en-us-emily": {
+        "voice_id": "hf_community/mush42/optispeech-convnext-en-us-emily",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-optispeech/resolve/main/mush42__optispeech-convnext-en-us-emily/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-optispeech/resolve/main/mush42__optispeech-convnext-en-us-emily/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "engine": "optispeech",
+        "lang": "en-US"
+    }
+}

--- a/tests/test_optispeech.py
+++ b/tests/test_optispeech.py
@@ -1,0 +1,109 @@
+"""Tests for the OptiSpeech inference adapter + config bridge."""
+import json
+import numpy as np
+import pytest
+
+from phoonnx.engines import get_adapter, detect_engine
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.optispeech import OptiSpeechAdapter
+from phoonnx.engines.optispeech_config import voice_config_from_optispeech_meta
+from phoonnx.config import Engine, VoiceConfig
+
+
+class _Named:
+    def __init__(self, name): self.name = name
+
+
+class _Meta:
+    def __init__(self, m): self.custom_metadata_map = m
+
+
+class DummySession:
+    def __init__(self, input_names, output_names, meta=None):
+        self._inputs = [_Named(n) for n in input_names]
+        self._outputs = [_Named(n) for n in output_names]
+        self._meta = meta or {}
+    def get_inputs(self): return self._inputs
+    def get_outputs(self): return self._outputs
+    def get_modelmeta(self): return _Meta(self._meta)
+
+
+META = {
+    "name": "test", "sample_rate": 24000, "languages": ["en-us"], "speakers": [],
+    "inference_args": {"d_factor": 1.0, "p_factor": 1.0, "e_factor": 1.0},
+    "input_symbols": {"_": 0, "^": 1, "$": 2, "a": 3, "b": 4, "c": 5, " ": 6},
+    "special_symbols": {"pad": "_", "bos": "^", "eos": "$"},
+    "text_processor": {"tokenizer_name": "ipa", "add_blank": False, "add_bos_eos": False},
+}
+OPTISPEECH_SESSION = DummySession(
+    ["x", "x_lengths", "scales"], ["wav", "wav_lengths", "durations"],
+    meta={"inference": json.dumps(META)})
+
+
+def _req(n=4, spk=None, lang=None, **params):
+    return AdapterSynthesisRequest(
+        phoneme_ids=np.arange(1, n + 1, dtype=np.int64)[None, :],
+        phoneme_lengths=np.array([n], dtype=np.int64),
+        speaker_id=spk, language_id=lang, params=params)
+
+
+def test_registered():
+    assert isinstance(get_adapter("optispeech"), OptiSpeechAdapter)
+
+
+def test_detect_by_metadata():
+    assert OptiSpeechAdapter.detect(session=OPTISPEECH_SESSION) is True
+
+
+def test_detect_priority_beats_matcha():
+    # OptiSpeech shares x/x_lengths/scales with Matcha but must win via metadata
+    assert isinstance(detect_engine(session=OPTISPEECH_SESSION), OptiSpeechAdapter)
+
+
+def test_detect_does_not_match_plain_vits():
+    s = DummySession(["input", "input_lengths", "scales"], ["output"])
+    assert OptiSpeechAdapter.detect(session=s) is False
+
+
+def test_build_feed_dict_dpe_scales():
+    feed = OptiSpeechAdapter().build_feed_dict(_req(spk=2), OPTISPEECH_SESSION)
+    assert set(feed) == {"x", "x_lengths", "scales"}  # no sids input on this session
+    assert feed["scales"] == pytest.approx([1.0, 1.0, 1.0])
+
+
+def test_build_feed_dict_factors_and_speaker():
+    s = DummySession(["x", "x_lengths", "scales", "sids", "lids"], ["wav"])
+    feed = OptiSpeechAdapter().build_feed_dict(
+        _req(spk=3, lang=1, d_factor=0.8, p_factor=1.2, e_factor=0.9), s)
+    assert feed["scales"] == pytest.approx([0.8, 1.2, 0.9])
+    assert feed["sids"].tolist() == [3]
+    assert feed["lids"].tolist() == [1]
+
+
+def test_parse_outputs_wav_and_extras():
+    res = OptiSpeechAdapter().parse_outputs(
+        [np.zeros((1, 1, 512), np.float32), np.array([512]), np.array([[3, 4]])], _req())
+    assert res.audio.shape == (512,)
+    assert "durations" in res.extras and "wav_lengths" in res.extras
+
+
+def test_default_params():
+    assert OptiSpeechAdapter().default_params() == {"d_factor": 1.0, "p_factor": 1.0, "e_factor": 1.0}
+
+
+def test_config_bridge():
+    vc = voice_config_from_optispeech_meta(META)
+    assert vc.engine == Engine.OPTISPEECH
+    assert vc.sample_rate == 24000
+    assert vc.lang_code == "en-US"
+    assert vc.tokenizer.add_blank_char is False  # metadata add_blank=False
+    assert vc.tokenizer.use_eos_bos is False
+    assert len(vc.tokenizer.vocabulary.char2idx) == len(META["input_symbols"])
+
+
+def test_config_bridge_native_roundtrip():
+    vc = voice_config_from_optispeech_meta(META)
+    native = vc.to_native_dict()
+    assert native["engine"] == "optispeech"
+    vc2 = VoiceConfig.from_dict(dict(native))
+    assert vc2.engine == Engine.OPTISPEECH


### PR DESCRIPTION
Adds **OptiSpeech** (FastSpeech2-style acoustic + GAN vocoder) on the engine framework. Supersedes the stale #130, rebuilt onto current dev (the original targeted an old `Vocabulary`/`TTSTokenizer` API and left the config-from-metadata path unwired).

## What's in
- **OptiSpeechAdapter** — its own I/O contract: inputs `x`/`x_lengths`/`scales=[d_factor,p_factor,e_factor]` (+ optional `sids`/`lids`), outputs `wav`/`wav_lengths`/`durations`. Metadata-based detection.
- **`optispeech_config.py`** — `voice_config_from_optispeech_meta()` turns OptiSpeech's embedded ONNX metadata (no external config file) into a native `VoiceConfig` with the right vocab + tokenizer flags (`add_blank`/`add_bos_eos`).
- **`Engine.OPTISPEECH`** + registration. **Priority fix:** OptiSpeech shares `x/x_lengths/scales` with Matcha, so it's probed *first* (it has a distinctive metadata + `wav/durations` signature) — otherwise Matcha would grab OptiSpeech models. Matcha detection is unaffected (verified).
- **Mirror:** `mush42/optispeech` → `OpenVoiceOS/phoonnx-optispeech` with a **modernized native `config.json`** (generated from the metadata) + `voice_index/optispeech.json`. The voices load via the standard path (`engine: optispeech` → adapter) — no runtime metadata extraction needed.

## Verified
3 models mirrored; each **loads from the index (auto-download) and synthesizes** (en-US, 24kHz). 10 unit tests (detect/feed/parse/config-bridge/native-roundtrip); **full suite 177 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)