### PR TITLE
feat(train): Mixer-TTS training (Lightning)

### DIFF
--- a/docs/mixertts.md
+++ b/docs/mixertts.md
@@ -75,6 +75,33 @@ inverts the natural-log mel) as a no-model-file fallback. See
 > Do not confuse it with ``alvocat-vocos-22khz`` — that is Vocos *finetuned on
 > Catalan* (for the Matxa voices) and is a different mel domain.
 
+## Training
+
+Mixer-TTS training is a registered **training engine** (``--engine mixer``,
+alias ``mixertts``): the vendored NeMo model port lives in
+``phoonnx_train/mixertts/models`` (Apache-2.0 headers, with the
+speaker/emotion/energy conditioning and optional LSGAN mel-patch refinement
+from nipponjo/tts-arabic-pytorch), wrapped by the Lightning module in
+``phoonnx_train/mixertts/lightning.py`` — mel / duration / pitch / energy MSE
++ ForwardSum (CTC) aligner loss + delayed, ramped binarization loss, exactly
+the NeMo recipe (AdamW + Noam warmup). ``extra["train_gan"] = True`` enables
+the (non-NeMo) LSGAN ``PatchDiscriminator`` refinement.
+
+It shares the standard phoonnx pipeline and the FastPitch engine's F0
+sidecars (pyworld DIO+StoneMask at the mel hop, on the same
+trimmed/normalized cached audio the mels come from):
+
+```bash
+python -m phoonnx_train.train --dataset-dir /path/to/prep \
+    --engine mixer --quality medium     # x-low=80 / medium=128 / high=384 dims
+python -m phoonnx_train.export_onnx ckpt.ckpt -c config.json --engine mixer
+```
+
+Needs the ``train`` + ``train-mixer`` extras
+(``pip install phoonnx[train,train-mixer]``): ``pyworld`` for F0 on top of
+torch / lightning / einops / numba. Export produces the inference contract
+above (mel_fmin 0 / mel_fmax 8000 recorded in the ONNX metadata).
+
 ## References
 
 - [Mixer-TTS paper](https://arxiv.org/abs/2110.03584) · [nipponjo/mixer-tts-pytorch](https://github.com/nipponjo/mixer-tts-pytorch)

--- a/phoonnx_train/engines/__init__.py
+++ b/phoonnx_train/engines/__init__.py
@@ -98,12 +98,15 @@ def _register_builtins() -> None:
         SpeedySpeechTrainingEngine,
     )
     from phoonnx_train.engines.zipvoice import ZipVoiceTrainingEngine
+    from phoonnx_train.engines.mixer import MixerTTSTrainingEngine
 
     register_engine("vits", VitsTrainingEngine)
     register_engine("matcha", MatchaTrainingEngine)
     register_engine("fastpitch", ForwardTTSTrainingEngine)
     register_engine("speedyspeech", SpeedySpeechTrainingEngine)
     register_engine("zipvoice", ZipVoiceTrainingEngine)
+    register_engine("mixer", MixerTTSTrainingEngine)
+    register_engine("mixertts", MixerTTSTrainingEngine)
 
 
 _register_builtins()

--- a/phoonnx_train/engines/mixer.py
+++ b/phoonnx_train/engines/mixer.py
@@ -1,0 +1,240 @@
+"""
+Mixer-TTS training engine adapter.
+
+Mixer-TTS (Tatanov et al., 2021, https://arxiv.org/abs/2110.03584) is a
+non-autoregressive MLP-Mixer acoustic model: token/channel-mixing
+encoder/decoder blocks, FastPitch-style duration/pitch (and here also
+energy) predictors, and an unsupervised AlignmentEncoder trained with the
+ForwardSum + binarization losses of the one-TTS-alignment recipe
+(https://arxiv.org/abs/2108.10447).
+
+The vendored model lives in ``phoonnx_train/mixertts/models`` — a
+self-contained, pure-torch port of NVIDIA NeMo's implementation
+(Apache-2.0, nemo/collections/tts/models/mixer_tts.py @ 7256db1) with the
+speaker/emotion/energy conditioning and optional LSGAN mel-patch
+refinement from nipponjo/tts-arabic-pytorch (MIT). The LightningModule /
+dataset / collate live in ``phoonnx_train.mixertts.lightning``; heavy
+torch imports are deferred until a model is actually built so the engine
+registry stays importable in torch-free environments.
+
+Pitch (F0) preprocessing is shared with the FastPitch engine (pyworld
+DIO+StoneMask at ``frame_period = 1000 * hop / sample_rate`` ms on the
+same trimmed/normalized cached audio the mels come from, length-reconciled
+to the mel frame count) — the ``<utterance>.f0.npy`` sidecars and
+``pitch_stats.json`` are engine-compatible.
+
+ONNX export follows the contract consumed by
+``phoonnx.engines.mixertts.MixerTTSAdapter``: inputs ``token_ids``
+[B, T] int64 + ``pace``/``pitch_mul``/``pitch_add`` [1] float32 +
+``speaker``/``emotion`` [1] int32 -> output ``mel_spec`` [B, 80, T_mel].
+"""
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from phoonnx_train.engines.base import TrainingEngineConfig
+from phoonnx_train.engines.fastpitch import ForwardTTSTrainingEngine
+
+if TYPE_CHECKING:  # heavy import — only needed for type annotations
+    import pytorch_lightning as pl
+
+_LOG = logging.getLogger(__name__)
+
+# ONNX opset used for export (same floor as the FastPitch engine)
+OPSET_VERSION = 14
+
+# Quality tier -> Mixer-TTS hyper-param overrides. All encoder/decoder/
+# aligner widths derive from symbols_embedding_dim; 384 is the paper
+# configuration (~24M params), the smaller tiers shrink every Mixer block.
+_QUALITY_PRESETS: Dict[str, Dict[str, Any]] = {
+    "x-low": {"symbols_embedding_dim": 80},
+    "medium": {"symbols_embedding_dim": 128},
+    "high": {"symbols_embedding_dim": 384},
+}
+
+
+def resolve_module_kwargs(config: TrainingEngineConfig, **kwargs: Any) -> Dict[str, Any]:
+    """Merge shared config + ``extra`` bag + call-site kwargs into the
+    keyword arguments for ``MixerTTSModule``.
+
+    Torch-free (pure dict handling) so it is unit-testable without the
+    training stack. ``extra['quality']``, if present, expands to the
+    matching preset (unknown names fall back to ``medium``); explicit
+    ``extra``/kwargs keys win over preset values.
+    """
+    extra = dict(config.extra)
+    preset_name = extra.pop("quality", None)
+    merged: Dict[str, Any] = {}
+    if preset_name is not None:
+        if preset_name not in _QUALITY_PRESETS:
+            _LOG.warning("unknown quality %r — falling back to 'medium'", preset_name)
+            preset_name = "medium"
+        merged.update(_QUALITY_PRESETS[preset_name])
+    merged.update(extra)
+    merged.update(kwargs)
+    merged.update(
+        num_symbols=config.num_symbols,
+        num_speakers=config.num_speakers,
+        sample_rate=config.sample_rate,
+    )
+    return merged
+
+
+class MixerTTSTrainingEngine(ForwardTTSTrainingEngine):
+    """Training engine adapter for Mixer-TTS.
+
+    Subclasses the FastPitch engine only to reuse its shared plumbing —
+    the pyworld F0 ``extra_preprocess`` sidecar cache and the tolerant
+    ``load_checkpoint`` — the model/ONNX contract is Mixer-TTS's own.
+    """
+
+    def create_model(
+        self,
+        config: TrainingEngineConfig,
+        dataset_paths: List[Path],
+        **kwargs: Any,
+    ) -> "pl.LightningModule":
+        from phoonnx_train.mixertts.lightning import MixerTTSModule
+
+        return MixerTTSModule(
+            dataset=[str(p) for p in dataset_paths],
+            **resolve_module_kwargs(config, **kwargs),
+        )
+
+    def export_onnx(
+        self,
+        checkpoint_path: Path,
+        config_path: Path,
+        output_dir: Path,
+        **kwargs: Any,
+    ) -> Path:
+        """Export a Mixer-TTS checkpoint to ONNX.
+
+        Contract matches ``phoonnx.engines.mixertts.MixerTTSAdapter``:
+        ``token_ids`` [B,T] int64 + ``pace``/``pitch_mul``/``pitch_add``
+        [1] float32 + ``speaker``/``emotion`` [1] int32 ->
+        ``mel_spec`` [B, 80, T_mel]. The pitch controls operate in the
+        normalized (z-scored) pitch domain, applied to the predicted
+        pitch before the pitch embedding.
+        """
+        import json
+
+        # validate the inputs before touching the heavy imports so a bad
+        # path fails fast (and identically) with or without torch installed
+        with open(config_path, "r", encoding="utf-8") as f:
+            model_config: Dict[str, Any] = json.load(f)
+        checkpoint_path = Path(checkpoint_path)
+        if not checkpoint_path.is_file():
+            raise FileNotFoundError(f"checkpoint not found: {checkpoint_path}")
+
+        import torch
+
+        from phoonnx_train.mixertts.lightning import MixerTTSModule
+        from phoonnx_train.torch_compat import onnx_export_kwargs
+
+        module: MixerTTSModule = MixerTTSModule.load_from_checkpoint(
+            checkpoint_path, dataset=None, map_location="cpu",
+        )
+        model = module.model
+        model.eval()
+
+        num_symbols = module.hparams.num_symbols
+        num_speakers = module.hparams.num_speakers
+
+        class _InferWrapper(torch.nn.Module):
+            """pace / pitch_mul / pitch_add / speaker / emotion are graph
+            inputs so the MixerTTSAdapter's controls actually reach the
+            model (traced as constants they would be silent no-ops).
+            Single-speaker graphs simply never read speaker/emotion; the
+            adapter filters its feed against the session inputs."""
+
+            def __init__(self, m):
+                super().__init__()
+                self.m = m
+
+            def forward(self, token_ids, pace, speaker, emotion,
+                        pitch_mul, pitch_add):
+                text_mask = (token_ids != self.m.padding_idx).unsqueeze(2)
+
+                def pitch_transform(pitch, lens, mean, std):
+                    return pitch * pitch_mul + pitch_add
+
+                spect = self.m.infer(
+                    text=token_ids, text_mask=text_mask, pace=pace,
+                    speaker=speaker.long(), emotion=emotion.long(),
+                    pitch_transform=pitch_transform,
+                )
+                return spect.transpose(1, 2).to(torch.float)  # [B, mel, T]
+
+        wrapper = _InferWrapper(model)
+        wrapper.eval()
+
+        dummy_ids = torch.randint(low=1, high=max(2, num_symbols - 1),
+                                  size=(1, 30), dtype=torch.long)
+        # int32 to match the MixerTTSAdapter feed dtype; cast to long
+        # inside the wrapper for the embedding lookup
+        dummy_args = (
+            dummy_ids,
+            torch.ones(1),
+            torch.zeros(1, dtype=torch.int32),
+            torch.zeros(1, dtype=torch.int32),
+            torch.ones(1),
+            torch.zeros(1),
+        )
+        input_names = ["token_ids", "pace", "speaker", "emotion",
+                       "pitch_mul", "pitch_add"]
+        dynamic_axes = {
+            "token_ids": {0: "batch_size", 1: "phonemes"},
+            "mel_spec": {0: "batch_size", 2: "frame"},
+        }
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"{checkpoint_path.stem}.onnx"
+
+        with torch.no_grad():
+            torch.onnx.export(
+                wrapper,
+                dummy_args,
+                str(output_path),
+                input_names=input_names,
+                output_names=["mel_spec"],
+                dynamic_axes=dynamic_axes,
+                opset_version=OPSET_VERSION,
+                **onnx_export_kwargs(),
+            )
+
+        try:
+            import onnx as _onnx
+
+            onnx_model = _onnx.load(str(output_path))
+            del onnx_model.metadata_props[:]
+            for key, value in {
+                "model_type": "mixertts",
+                "engine": "mixertts",
+                "n_speakers": num_speakers,
+                "n_vocab": num_symbols,
+                "sample_rate": model_config.get("audio", {}).get(
+                    "sample_rate", module.hparams.sample_rate),
+                "mel_fmin": module.hparams.mel_fmin,
+                "mel_fmax": module.hparams.mel_fmax,
+                "mel_channels": module.hparams.mel_channels,
+                "pitch_mean": module.hparams.get("pitch_mean", 0.0),
+                "pitch_std": module.hparams.get("pitch_std", 1.0),
+                "alphabet": model_config.get("alphabet", ""),
+                "phoneme_type": model_config.get("phoneme_type", ""),
+                "phonemizer_model": model_config.get("phonemizer_model", ""),
+                "phoneme_id_map": json.dumps(model_config.get("phoneme_id_map", {})),
+                "has_espeak": model_config.get("phoneme_type", "") == "espeak",
+            }.items():
+                meta = onnx_model.metadata_props.add()
+                meta.key = key
+                meta.value = str(value)
+            _onnx.save(onnx_model, str(output_path))
+        except ImportError:
+            _LOG.warning("onnx package not installed — skipping metadata")
+
+        _LOG.info("Exported Mixer-TTS ONNX model to %s", output_path)
+        return output_path
+
+    def quality_presets(self) -> Dict[str, Dict[str, Any]]:
+        return _QUALITY_PRESETS

--- a/phoonnx_train/mixertts/__init__.py
+++ b/phoonnx_train/mixertts/__init__.py
@@ -1,0 +1,5 @@
+"""Mixer-TTS training (vendored model + Lightning wrapper).
+
+See ``phoonnx_train.engines.mixer`` for the training-engine adapter and
+``phoonnx_train/mixertts/models`` for the vendored model lineage/licenses.
+"""

--- a/phoonnx_train/mixertts/lightning.py
+++ b/phoonnx_train/mixertts/lightning.py
@@ -1,0 +1,449 @@
+"""LightningModule + dataset/collate wrapping the vendored Mixer-TTS model.
+
+The model (``phoonnx_train/mixertts/models``) is a self-contained port of
+NVIDIA NeMo's Mixer-TTS (Apache-2.0,
+nemo/collections/tts/models/mixer_tts.py @ 7256db1; paper: Tatanov et al.,
+2021, https://arxiv.org/abs/2110.03584) with the speaker/emotion/energy
+conditioning and optional LSGAN mel-patch refinement added by
+nipponjo/tts-arabic-pytorch (MIT).
+
+Training reuses the shared phoonnx preprocessing pipeline (same as the
+FastPitch engine): phoneme ids + linear-spectrogram caches come from
+``phoonnx_train.preprocess`` (``dataset.jsonl``), the mel target is derived
+from the linear spectrogram at load time via
+``phoonnx_train.vits.mel_processing`` (fmin/fmax pinned to the shared
+0/8000 Hz convention), and the frame-aligned F0 target is read from the
+``<utterance>.f0.npy`` sidecars written by the engine's
+``extra_preprocess`` (pyworld DIO+StoneMask at the mel hop, on the same
+trimmed/normalized cached audio the mels come from).
+
+Loss/optimizer fidelity vs upstream NeMo:
+
+- losses: masked-MSE mel/log-duration/pitch/energy + ForwardSum (CTC)
+  aligner loss + delayed, ramped binarization (bin) loss — identical
+  formulation and scales (durs 0.1 / mel 1.0 / pitch 0.1 / energy 0.1,
+  bin ramp from ``bin_loss_start_ratio * max_epochs``), computed by the
+  vendored model's ``_metrics``.
+- alignment: unsupervised AlignmentEncoder + monotonic alignment search
+  (``binarize_attention_parallel``) with the beta-binomial prior, as in
+  the one-TTS-alignment recipe (https://arxiv.org/abs/2108.10447).
+- optimizer: AdamW(lr, betas=(0.9, 0.98), weight_decay=1e-6) with a
+  Noam warmup schedule (NeMo uses NoamAnnealing, warmup 1000 steps).
+- optional (off by default, non-NeMo) LSGAN PatchDiscriminator on random
+  mel chunks + feature-matching loss, following nipponjo; this switches
+  the module to manual optimization with a second AdamW.
+"""
+import logging
+from pathlib import Path
+from typing import Any, List, Optional
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+from torch import LongTensor
+from torch.utils.data import DataLoader, Dataset, random_split
+
+from phoonnx_train.fastpitch.pitch_stats import (
+    f0_cache_path,
+    load_or_compute_pitch_stats,
+)
+from phoonnx_train.mixertts.models.common.loss import (
+    PatchDiscriminator,
+    calc_feature_match_loss,
+    extract_chunks,
+)
+from phoonnx_train.mixertts.models.mixer_tts.mixer_tts import (
+    MixerTTSModel as _MixerTTS,
+)
+from phoonnx_train.mixertts.prior import BetaBinomialPrior
+from phoonnx_train.vits.dataset import PhoonnxDataset, Utterance
+from phoonnx_train.vits.mel_processing import spec_to_mel_torch
+
+_LOG = logging.getLogger(__name__)
+
+
+class UtteranceTensors:
+    __slots__ = ("phoneme_ids", "mel", "speaker_id", "pitch", "energy", "attn_prior")
+
+    def __init__(self, phoneme_ids, mel, speaker_id, pitch, energy, attn_prior):
+        self.phoneme_ids = phoneme_ids
+        self.mel = mel
+        self.speaker_id = speaker_id
+        self.pitch = pitch
+        self.energy = energy
+        self.attn_prior = attn_prior
+
+
+class Batch:
+    __slots__ = (
+        "phoneme_ids", "phoneme_lengths", "mels", "mel_lengths",
+        "pitch", "energy", "speaker_ids", "attn_prior",
+    )
+
+    def __init__(self, phoneme_ids, phoneme_lengths, mels, mel_lengths,
+                 pitch, energy, speaker_ids, attn_prior):
+        self.phoneme_ids = phoneme_ids
+        self.phoneme_lengths = phoneme_lengths
+        self.mels = mels
+        self.mel_lengths = mel_lengths
+        self.pitch = pitch
+        self.energy = energy
+        self.speaker_ids = speaker_ids
+        self.attn_prior = attn_prior
+
+
+class MixerTTSDataset(Dataset):
+    """Wraps the shared ``PhoonnxDataset`` utterances for Mixer-TTS.
+
+    Per utterance: phoneme ids, log-mel target (from the shared linear
+    spectrogram cache), frame-aligned z-scored F0, per-frame energy
+    (L2 norm over mel bins, as in FastPitch/nipponjo), and the
+    beta-binomial alignment prior.
+    """
+
+    def __init__(self, dataset_paths: List[Path], mel_channels: int,
+                 filter_length: int, sample_rate: int,
+                 mel_fmin: float, mel_fmax: Optional[float],
+                 max_phoneme_ids: Optional[int] = None):
+        jsonl_paths = [
+            (Path(p) / "dataset.jsonl") if Path(p).is_dir() else Path(p)
+            for p in dataset_paths
+        ]
+        self._inner = PhoonnxDataset(jsonl_paths, max_phoneme_ids=max_phoneme_ids)
+        self.mel_channels = mel_channels
+        self.filter_length = filter_length
+        self.sample_rate = sample_rate
+        self.mel_fmin = mel_fmin
+        self.mel_fmax = mel_fmax
+        self.prior = BetaBinomialPrior()
+        self.pitch_mean, self.pitch_std = load_or_compute_pitch_stats(
+            dataset_paths,
+            [f0_cache_path(utt.audio_spec_path) for utt in self._inner.utterances],
+        )
+
+    def __len__(self) -> int:
+        return len(self._inner)
+
+    def __getitem__(self, idx: int) -> UtteranceTensors:
+        utt: Utterance = self._inner.utterances[idx]
+        spec = torch.load(utt.audio_spec_path)  # [n_fft//2+1, T]
+        mel = spec_to_mel_torch(
+            spec.unsqueeze(0), self.filter_length, self.mel_channels,
+            self.sample_rate, self.mel_fmin, self.mel_fmax,
+        ).squeeze(0)  # [mel_channels, T_mel]
+        t_mel = mel.size(1)
+
+        pitch = torch.zeros(t_mel)
+        f0_candidate = f0_cache_path(utt.audio_spec_path)
+        if f0_candidate.exists():
+            f0 = np.load(f0_candidate).astype("float32")
+            # length-reconcile to T_mel (extra_preprocess already keeps the
+            # drift within ±2 frames); z-score voiced frames with the corpus
+            # stats, unvoiced frames stay 0 — NeMo's pitch normalization
+            f0 = f0[:t_mel]
+            voiced = f0 > 0
+            f0[voiced] = (f0[voiced] - self.pitch_mean) / self.pitch_std
+            pitch[: len(f0)] = torch.from_numpy(f0)
+
+        # per-frame energy: L2 norm over mel bins (FastPitch recipe); the
+        # model log-compresses the duration-averaged target itself
+        energy = torch.norm(mel.float(), dim=0, p=2)  # [T_mel]
+        attn_prior = torch.from_numpy(
+            self.prior(t_mel, len(utt.phoneme_ids))
+        )  # [T_mel, T_text]
+
+        return UtteranceTensors(
+            phoneme_ids=LongTensor(utt.phoneme_ids),
+            mel=mel,
+            speaker_id=LongTensor([utt.speaker_id]) if utt.speaker_id is not None else None,
+            pitch=pitch,
+            energy=energy,
+            attn_prior=attn_prior,
+        )
+
+
+class MixerTTSCollate:
+    def __init__(self, is_multispeaker: bool):
+        self.is_multispeaker = is_multispeaker
+
+    def __call__(self, utterances: List[UtteranceTensors]) -> Batch:
+        n = len(utterances)
+        max_ph = max(u.phoneme_ids.size(0) for u in utterances)
+        max_mel = max(u.mel.size(1) for u in utterances)
+        mel_channels = utterances[0].mel.size(0)
+
+        phoneme_ids = torch.zeros(n, max_ph, dtype=torch.long)
+        phoneme_lengths = torch.zeros(n, dtype=torch.long)
+        mels = torch.zeros(n, mel_channels, max_mel)
+        mel_lengths = torch.zeros(n, dtype=torch.long)
+        pitch = torch.zeros(n, max_mel)
+        energy = torch.zeros(n, max_mel)
+        attn_prior = torch.zeros(n, max_mel, max_ph)
+        speaker_ids = torch.zeros(n, dtype=torch.long) if self.is_multispeaker else None
+
+        for i, utt in enumerate(utterances):
+            pl_ = utt.phoneme_ids.size(0)
+            ml = utt.mel.size(1)
+            phoneme_ids[i, :pl_] = utt.phoneme_ids
+            phoneme_lengths[i] = pl_
+            mels[i, :, :ml] = utt.mel
+            mel_lengths[i] = ml
+            pitch[i, :ml] = utt.pitch[:ml]
+            energy[i, :ml] = utt.energy[:ml]
+            attn_prior[i, :ml, :pl_] = utt.attn_prior
+            if speaker_ids is not None and utt.speaker_id is not None:
+                speaker_ids[i] = utt.speaker_id
+
+        return Batch(phoneme_ids, phoneme_lengths, mels, mel_lengths,
+                     pitch, energy, speaker_ids, attn_prior)
+
+
+class MixerTTSModule(pl.LightningModule):
+    """LightningModule wrapping the vendored Mixer-TTS model."""
+
+    def __init__(
+        self,
+        num_symbols: int,
+        num_speakers: int = 1,
+        sample_rate: int = 22050,
+        filter_length: int = 1024,
+        mel_channels: int = 80,
+        mel_fmin: float = 0.0,
+        # pinned to the shared phoonnx mel convention: defaulting to Nyquist
+        # would silently mismatch every shared vocoder
+        mel_fmax: Optional[float] = 8000.0,
+        symbols_embedding_dim: int = 384,
+        num_emotions: int = 1,
+        dataset: Optional[List[Path]] = None,
+        learning_rate: float = 1e-3,
+        weight_decay: float = 1e-6,
+        warmup_steps: int = 1000,
+        train_gan: bool = False,
+        gan_chunk_len: int = 128,
+        gan_learning_rate: float = 1e-4,
+        batch_size: int = 8,
+        num_workers: int = 1,
+        validation_split: float = 0.1,
+        num_test_examples: int = 5,
+        max_phoneme_ids: Optional[int] = None,
+        # bin (hard-attention) loss is delayed then ramped — hard attention
+        # against a still-random soft alignment destabilizes the aligner
+        bin_loss_start_ratio: float = 0.2,
+        bin_loss_warmup_epochs: int = 100,
+        # corpus F0 stats; filled from the dataset's pitch_stats.json at
+        # dataset load and persisted in the checkpoint hparams so export /
+        # inference know the pitch-normalization domain
+        pitch_mean: float = 0.0,
+        pitch_std: float = 1.0,
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self.save_hyperparameters()
+
+        self.model = _MixerTTS(
+            n_mel_channels=mel_channels,
+            num_tokens=num_symbols,
+            padding_idx=0,
+            symbols_embedding_dim=symbols_embedding_dim,
+            n_speakers=num_speakers,
+            n_emotions=num_emotions,
+        )
+        self.model.pitch_mean = pitch_mean
+        self.model.pitch_std = pitch_std
+        self.model.add_bin_loss = False
+        self.model.bin_loss_scale = 0.0
+        self.model.bin_loss_start_ratio = bin_loss_start_ratio
+        self.model.bin_loss_warmup_epochs = bin_loss_warmup_epochs
+
+        self.train_gan = train_gan
+        self.critic = PatchDiscriminator(1, 32) if train_gan else None
+        self.tar_len = gan_chunk_len
+        if train_gan:
+            # two optimizers (generator + critic) — upstream GAN loop style
+            self.automatic_optimization = False
+
+        self._train_dataset: Optional[Dataset] = None
+        self._val_dataset: Optional[Dataset] = None
+        self._test_dataset: Optional[Dataset] = None
+        self._load_datasets(validation_split, num_test_examples, max_phoneme_ids)
+
+    # ------------------------------------------------------------------
+    def _load_datasets(self, validation_split: float, num_test_examples: int,
+                       max_phoneme_ids: Optional[int]) -> None:
+        if not self.hparams.dataset:
+            _LOG.debug("No dataset to load")
+            return
+        full_dataset = MixerTTSDataset(
+            self.hparams.dataset,
+            mel_channels=self.hparams.mel_channels,
+            filter_length=self.hparams.filter_length,
+            sample_rate=self.hparams.sample_rate,
+            mel_fmin=self.hparams.mel_fmin,
+            mel_fmax=self.hparams.mel_fmax,
+            max_phoneme_ids=max_phoneme_ids,
+        )
+        # persist the corpus pitch stats (checkpointed via hparams) so
+        # inference-time pitch controls know the normalization domain
+        self.hparams.pitch_mean = full_dataset.pitch_mean
+        self.hparams.pitch_std = full_dataset.pitch_std
+        self.model.pitch_mean = full_dataset.pitch_mean
+        self.model.pitch_std = full_dataset.pitch_std
+        valid_size = max(0, int(len(full_dataset) * validation_split))
+        test_size = min(num_test_examples, max(0, len(full_dataset) - valid_size))
+        train_size = len(full_dataset) - valid_size - test_size
+        self._train_dataset, self._test_dataset, self._val_dataset = random_split(
+            full_dataset, [train_size, test_size, valid_size]
+        )
+
+    def _collate(self) -> MixerTTSCollate:
+        return MixerTTSCollate(is_multispeaker=self.hparams.num_speakers > 1)
+
+    def train_dataloader(self):
+        return DataLoader(self._train_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size, shuffle=True)
+
+    def val_dataloader(self):
+        return DataLoader(self._val_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size)
+
+    def test_dataloader(self):
+        return DataLoader(self._test_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size)
+
+    # ------------------------------------------------------------------
+    def forward(self, x, pace: float = 1.0, speaker: int = 0, emotion: int = 0):
+        return self.model.infer(x, pace=pace, speaker=speaker, emotion=emotion)
+
+    def on_train_epoch_start(self):
+        # the vendored model defines this schedule but is a plain nn.Module,
+        # so Lightning never calls its hook — drive it from here (mirrors
+        # NeMo MixerTTSModel.on_train_epoch_start)
+        max_epochs = max(1, self.trainer.max_epochs or 1)
+        start_epoch = int(np.ceil(self.model.bin_loss_start_ratio * max_epochs))
+        if not self.model.add_bin_loss and self.current_epoch >= start_epoch:
+            _LOG.info("Using hard attentions after epoch: %d", self.current_epoch)
+            self.model.add_bin_loss = True
+        if self.model.add_bin_loss:
+            self.model.bin_loss_scale = min(
+                (self.current_epoch - start_epoch)
+                / max(1, self.model.bin_loss_warmup_epochs), 1.0)
+
+    def _step(self, batch: Batch):
+        # no emotion labels in the shared dataset format — condition on the
+        # neutral (0) emotion when an emotion embedding is configured
+        emotion = None
+        if self.model.emotion_emb is not None:
+            emotion = torch.zeros(batch.phoneme_ids.size(0), dtype=torch.long,
+                                  device=batch.phoneme_ids.device)
+        preds = self.model(
+            text=batch.phoneme_ids,
+            text_len=batch.phoneme_lengths,
+            pitch=batch.pitch,
+            energy=batch.energy,
+            spect=batch.mels,
+            spect_len=batch.mel_lengths,
+            attn_prior=batch.attn_prior,
+            speaker=batch.speaker_ids,
+            emotion=emotion,
+        )
+        (pred_spect, _, pred_log_durs, pred_pitch, pred_energy,
+         attn_soft, attn_logprob, attn_hard, attn_hard_dur) = preds
+        (loss, durs_loss, acc, acc_dist_1, acc_dist_3, pitch_loss,
+         energy_loss, mel_loss, ctc_loss, bin_loss) = self.model._metrics(
+            pred_durs=pred_log_durs,
+            pred_pitch=pred_pitch,
+            pred_energy=pred_energy,
+            true_durs=attn_hard_dur,
+            true_text_len=batch.phoneme_lengths,
+            true_pitch=batch.pitch,
+            true_energy=batch.energy,
+            true_spect=batch.mels,
+            pred_spect=pred_spect,
+            true_spect_len=batch.mel_lengths,
+            attn_logprob=attn_logprob,
+            attn_soft=attn_soft,
+            attn_hard=attn_hard,
+            attn_hard_dur=attn_hard_dur,
+        )
+        losses = {
+            "loss": loss, "durs_loss": durs_loss, "mel_loss": mel_loss,
+            "pitch_loss": pitch_loss, "energy_loss": energy_loss,
+            "ctc_loss": ctc_loss,
+        }
+        if bin_loss is not None:
+            losses["bin_loss"] = bin_loss
+        return losses, pred_spect
+
+    def training_step(self, batch: Batch, batch_idx: int):
+        if not self.train_gan:
+            losses, _ = self._step(batch)
+            self.log_dict({f"train_{k}": v for k, v in losses.items()},
+                          batch_size=batch.phoneme_ids.size(0))
+            return losses["loss"]
+
+        # manual optimization: LSGAN critic on random mel chunks (nipponjo)
+        opt_g, opt_d = self.optimizers()
+        losses, pred_spect = self._step(batch)
+        gen_loss = losses["loss"]
+        mel, mel_len = batch.mels, batch.mel_lengths
+
+        tl = int(min(mel_len.min().item(), self.tar_len))
+        ofx = (torch.rand(mel_len.size(), device=self.device) * (mel_len + tl / 2) - tl / 2) \
+            .clamp(mel_len * 0, mel_len - tl - 1).long()
+        org = (extract_chunks(mel, ofx, mel_ids=None, chunk_len=tl).unsqueeze(1) + 4.5) / 2.5
+        gen = (extract_chunks(pred_spect.transpose(1, 2), ofx, mel_ids=None,
+                              chunk_len=tl).unsqueeze(1) + 4.5) / 2.5
+        # critic (LSGAN)
+        d_org, fmaps_org = self.critic(org)
+        d_gen, _ = self.critic(gen.detach())
+        loss_d = 0.5 * (d_org - 1).square().mean() + 0.5 * d_gen.square().mean()
+        opt_d.zero_grad()
+        self.manual_backward(loss_d)
+        torch.nn.utils.clip_grad_norm_(self.critic.parameters(), 1000.0)
+        opt_d.step()
+        # generator adversarial + feature matching
+        d_gen2, fmaps_gen = self.critic(gen)
+        loss_g_adv = 0.5 * (d_gen2 - 1).square().mean()
+        loss_fm = calc_feature_match_loss(fmaps_gen, [f.detach() for f in fmaps_org])
+        gen_loss = gen_loss + loss_g_adv + loss_fm
+
+        opt_g.zero_grad()
+        self.manual_backward(gen_loss)
+        torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1000.0)
+        opt_g.step()
+        self.log_dict({"train_loss": gen_loss, "train_loss_d": loss_d,
+                       "train_mel_loss": losses["mel_loss"]},
+                      prog_bar=True, batch_size=batch.phoneme_ids.size(0))
+        return gen_loss
+
+    def validation_step(self, batch: Batch, batch_idx: int):
+        losses, _ = self._step(batch)
+        self.log_dict({f"val_{k}": v for k, v in losses.items()},
+                      batch_size=batch.phoneme_ids.size(0))
+        return losses["loss"]
+
+    def configure_optimizers(self):
+        if self.train_gan:
+            # GAN loop: zero-momentum betas, no scheduler (nipponjo recipe)
+            opt_g = torch.optim.AdamW(
+                self.model.parameters(), lr=self.hparams.learning_rate,
+                betas=(0.0, 0.99), weight_decay=self.hparams.weight_decay)
+            opt_d = torch.optim.AdamW(
+                self.critic.parameters(), lr=self.hparams.gan_learning_rate,
+                betas=(0.0, 0.99), weight_decay=self.hparams.weight_decay)
+            return [opt_g, opt_d]
+        # NeMo: AdamW(lr=1e-3, betas=(0.9, 0.98), wd=1e-6) + NoamAnnealing
+        optimizer = torch.optim.AdamW(
+            self.model.parameters(), lr=self.hparams.learning_rate,
+            betas=(0.9, 0.98), weight_decay=self.hparams.weight_decay)
+        warmup = max(1, self.hparams.warmup_steps)
+
+        def noam(step: int) -> float:
+            step = max(1, step)
+            return min(step ** -0.5, step * warmup ** -1.5) * warmup ** 0.5
+
+        scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, noam)
+        return [optimizer], [{"scheduler": scheduler, "interval": "step"}]

--- a/phoonnx_train/mixertts/lightning.py
+++ b/phoonnx_train/mixertts/lightning.py
@@ -27,8 +27,10 @@ Loss/optimizer fidelity vs upstream NeMo:
 - alignment: unsupervised AlignmentEncoder + monotonic alignment search
   (``binarize_attention_parallel``) with the beta-binomial prior, as in
   the one-TTS-alignment recipe (https://arxiv.org/abs/2108.10447).
-- optimizer: AdamW(lr, betas=(0.9, 0.98), weight_decay=1e-6) with a
-  Noam warmup schedule (NeMo uses NoamAnnealing, warmup 1000 steps).
+- optimizer: AdamW(lr, betas=(0.9, 0.98), weight_decay=1e-6) — the betas
+  follow nipponjo's non-GAN recipe — under a Noam warmup schedule matching
+  NeMo's NoamAnnealing (warmup 1000 steps, d_model=1: peak effective LR is
+  ``lr / sqrt(warmup)``).
 - optional (off by default, non-NeMo) LSGAN PatchDiscriminator on random
   mel chunks + feature-matching loss, following nipponjo; this switches
   the module to manual optimization with a second AdamW.
@@ -318,6 +320,12 @@ class MixerTTSModule(pl.LightningModule):
         return self.model.infer(x, pace=pace, speaker=speaker, emotion=emotion)
 
     def on_train_epoch_start(self):
+        if self.train_gan:
+            # GAN refinement phase: the aligner is assumed converged — bin
+            # loss at full scale from the start, no ramp restart (nipponjo)
+            self.model.add_bin_loss = True
+            self.model.bin_loss_scale = 1.0
+            return
         # the vendored model defines this schedule but is a plain nn.Module,
         # so Lightning never calls its hook — drive it from here (mirrors
         # NeMo MixerTTSModel.on_train_epoch_start)
@@ -385,6 +393,8 @@ class MixerTTSModule(pl.LightningModule):
             return losses["loss"]
 
         # manual optimization: LSGAN critic on random mel chunks (nipponjo)
+        # — during the GAN refinement phase the aligner is assumed converged,
+        # so the binarization loss runs at full scale from step 0 (nipponjo)
         opt_g, opt_d = self.optimizers()
         losses, pred_spect = self._step(batch)
         gen_loss = losses["loss"]
@@ -406,13 +416,14 @@ class MixerTTSModule(pl.LightningModule):
         opt_d.step()
         # generator adversarial + feature matching
         d_gen2, fmaps_gen = self.critic(gen)
-        loss_g_adv = 0.5 * (d_gen2 - 1).square().mean()
+        # adversarial weight 4.0 and generator grad-clip 20, per nipponjo
+        loss_g_adv = 4.0 * 0.5 * (d_gen2 - 1).square().mean()
         loss_fm = calc_feature_match_loss(fmaps_gen, [f.detach() for f in fmaps_org])
         gen_loss = gen_loss + loss_g_adv + loss_fm
 
         opt_g.zero_grad()
         self.manual_backward(gen_loss)
-        torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1000.0)
+        torch.nn.utils.clip_grad_norm_(self.model.parameters(), 20.0)
         opt_g.step()
         self.log_dict({"train_loss": gen_loss, "train_loss_d": loss_d,
                        "train_mel_loss": losses["mel_loss"]},
@@ -427,23 +438,29 @@ class MixerTTSModule(pl.LightningModule):
 
     def configure_optimizers(self):
         if self.train_gan:
-            # GAN loop: zero-momentum betas, no scheduler (nipponjo recipe)
+            # GAN loop: zero-momentum betas, lr 1e-4 for both generator and
+            # critic, no scheduler (nipponjo recipe)
             opt_g = torch.optim.AdamW(
-                self.model.parameters(), lr=self.hparams.learning_rate,
+                self.model.parameters(), lr=self.hparams.gan_learning_rate,
                 betas=(0.0, 0.99), weight_decay=self.hparams.weight_decay)
             opt_d = torch.optim.AdamW(
                 self.critic.parameters(), lr=self.hparams.gan_learning_rate,
                 betas=(0.0, 0.99), weight_decay=self.hparams.weight_decay)
             return [opt_g, opt_d]
-        # NeMo: AdamW(lr=1e-3, betas=(0.9, 0.98), wd=1e-6) + NoamAnnealing
+        # AdamW(lr=1e-3, wd=1e-6) + Noam warmup as in NeMo's NoamAnnealing
+        # (betas (0.9, 0.98) follow nipponjo's non-GAN recipe)
         optimizer = torch.optim.AdamW(
             self.model.parameters(), lr=self.hparams.learning_rate,
             betas=(0.9, 0.98), weight_decay=self.hparams.weight_decay)
         warmup = max(1, self.hparams.warmup_steps)
 
         def noam(step: int) -> float:
+            # NeMo NoamAnnealing with d_model=1: factor = min(step^-0.5,
+            # step * warmup^-1.5), NOT renormalized to peak at lr — the
+            # effective peak LR (at step == warmup) is lr / sqrt(warmup),
+            # i.e. ~3.16e-5 for the 1e-3 / 1000-step defaults
             step = max(1, step)
-            return min(step ** -0.5, step * warmup ** -1.5) * warmup ** 0.5
+            return min(step ** -0.5, step * warmup ** -1.5)
 
         scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, noam)
         return [optimizer], [{"scheduler": scheduler, "interval": "step"}]

--- a/phoonnx_train/mixertts/models/__init__.py
+++ b/phoonnx_train/mixertts/models/__init__.py
@@ -1,0 +1,6 @@
+"""Vendored Mixer-TTS model code.
+
+Lineage: NVIDIA NeMo (Apache-2.0) via nipponjo/tts-arabic-pytorch (MIT).
+Each file carries its upstream license header and source URL.
+"""
+from .mixer_tts.mixer_tts import MixerTTSModel

--- a/phoonnx_train/mixertts/models/common/loss.py
+++ b/phoonnx_train/mixertts/models/common/loss.py
@@ -1,0 +1,200 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torch import Tensor
+from typing import Optional, List
+
+
+def extract_chunks(A: Tensor, 
+                   ofx: Tensor, 
+                   mel_ids: Optional[Tensor] = None, 
+                   chunk_len: int = 128
+                   ):
+    """
+    Args:
+        A (Tensor): spectrograms [B, F, T]
+        ofx (Tensor): offsets [num_chunks,]
+        mel_ids (Tensor): [num_chunks,]
+        
+    Returns:
+        chunks (Tensor): [num_chunks, F, chunk_len]
+        
+    Example:
+        >>> A = torch.randn((8, 128, 500))
+        >>> ofx = torch.rand(16).mul(300).long()
+        >>> mel_ids = torch.randint(0, 8, (16,))
+        >>> chunks = extract_chunks(A, ofx, mel_ids)
+    """
+    if mel_ids is None:
+        mel_ids = torch.arange(0, A.size(0), device=A.device)
+    
+    ids = torch.arange(0, chunk_len, device=A.device)[None,:].repeat(len(mel_ids), 1) + ofx[:,None]
+    ids = ids + mel_ids[:,None] * A.size(2)
+
+    chunks = A.transpose(0, 1).flatten(1)[:, ids.long()].transpose(0, 1)
+    return chunks
+
+
+def calc_feature_match_loss(fmaps_gen: List[Tensor],
+                            fmaps_org: List[Tensor]):
+    
+    loss_fmatch = 0.
+    for (fmap_gen, fmap_org) in zip(fmaps_gen, fmaps_org):
+        fmap_org.detach_()
+        loss_fmatch += (fmap_gen - fmap_org).abs().mean()
+
+    loss_fmatch = loss_fmatch / len(fmaps_gen)
+    return loss_fmatch
+
+
+class Conv2DSpectralNorm(nn.Conv2d):
+    """Convolution layer that applies Spectral Normalization before every call."""
+
+    def __init__(self, 
+                 cnum_in: int, 
+                 cnum_out: int, 
+                 kernel_size: int, 
+                 stride: int, 
+                 padding: int = 0, 
+                 n_iter: int = 1, 
+                 eps: float = 1e-12, 
+                 bias: bool = True
+                 ):
+        super().__init__(cnum_in,
+                         cnum_out, kernel_size=kernel_size,
+                         stride=stride, padding=padding, bias=bias)
+        self.register_buffer("weight_u", torch.empty(self.weight.size(0), 1))
+        nn.init.trunc_normal_(self.weight_u)
+        self.n_iter = n_iter
+        self.eps = eps
+
+    def l2_norm(self, x):
+        return F.normalize(x, p=2, dim=0, eps=self.eps)
+
+    def forward(self, x):
+
+        weight_orig = self.weight.flatten(1).detach()
+
+        for _ in range(self.n_iter):
+            v = self.l2_norm(weight_orig.t() @ self.weight_u)
+            self.weight_u = self.l2_norm(weight_orig @ v)
+
+        sigma = self.weight_u.t() @ weight_orig @ v
+        self.weight.data.div_(sigma)
+
+        x = super().forward(x)
+
+        return x
+
+
+class LinearSN(nn.Linear):
+    """Linear layer that applies Spectral Normalization before every call."""
+
+    def __init__(self, 
+                 cnum_in,
+                 cnum_out, 
+                 n_iter=1, 
+                 eps=1e-12, 
+                 bias=True):
+        super().__init__(cnum_in, cnum_out, bias=bias)
+        self.register_buffer("weight_u", torch.empty(self.weight.size(0), 1))
+        nn.init.trunc_normal_(self.weight_u)
+        self.n_iter = n_iter
+        self.eps = eps
+
+    def l2_norm(self, x):
+        return torch.nn.functional.normalize(x, p=2, dim=0, eps=self.eps)
+
+    def forward(self, x):
+        weight_orig = self.weight.detach()
+
+        for _ in range(self.n_iter):
+            v = self.l2_norm(weight_orig.t() @ self.weight_u)
+            self.weight_u = self.l2_norm(weight_orig @ v)
+
+        sigma = self.weight_u.t() @ weight_orig @ v
+        self.weight.data.div_(sigma)
+
+        x = super().forward(x)
+
+        return x
+
+class DConv(nn.Module):
+    def __init__(self, 
+                 cnum_in,
+                 cnum_out, 
+                 ksize=5, 
+                 stride=2, 
+                 padding='auto'):
+        super().__init__()
+        padding = (ksize-1)//2 if padding == 'auto' else padding
+        self.conv_sn = Conv2DSpectralNorm(
+            cnum_in, cnum_out, ksize, stride, padding)
+        #self.conv_sn = spectral_norm(nn.Conv2d(cnum_in, cnum_out, ksize, stride, padding))
+        self.leaky = nn.LeakyReLU(negative_slope=0.2)
+
+    def forward(self, x):
+        x = self.conv_sn(x)
+        x = self.leaky(x)
+        return x
+
+
+class PatchDiscriminator(nn.Module):
+    def __init__(self, cnum_in, cnum):
+        super().__init__()
+        self.conv1 = DConv(cnum_in, cnum)
+        self.conv2 = DConv(cnum, 2*cnum)
+        self.conv3 = DConv(2*cnum, 4*cnum)
+        self.conv4 = DConv(4*cnum, 4*cnum)
+        self.conv5 = DConv(4*cnum, 4*cnum)
+
+    def forward(self, x):
+        x1 = self.conv1(x)
+        x2 = self.conv2(x1)
+        x3 = self.conv3(x2)
+        x4 = self.conv4(x3)
+        x5 = self.conv5(x4)
+        x = nn.Flatten()(x5)
+
+        return x, [x1, x2, x3, x4]
+    
+    
+class Discriminator3S(nn.Module):
+    def __init__(self, 
+                 cnum_in, 
+                 cnum, 
+                 d_mel=80, 
+                 d_emb=384):
+        super().__init__()
+        self.conv1 = DConv(cnum_in, cnum)
+        self.conv2 = DConv(cnum, 2*cnum)
+        self.conv3 = DConv(2*cnum, 4*cnum)
+        self.conv4 = DConv(4*cnum, 4*cnum)
+        self.conv5 = DConv(4*cnum, 4*cnum)
+        
+        self.lin1 = LinearSN(d_emb, 256)
+        self.lin2 = LinearSN(256, d_mel)
+        self.act = nn.LeakyReLU(0.2)
+
+
+    def forward(self, x, s):
+        """
+            x: [B, 1, d_mel, T]
+            s: [B, d_emb]
+        """
+        xl1 = self.act(self.lin1(s))
+        xl2 = self.act(self.lin2(xl1))
+
+        x_rep = xl2.unsqueeze(2).repeat(1,1,x.size(-1)).unsqueeze(1)
+        x_cat = torch.cat((x, x_rep), dim=1)
+
+        x1 = self.conv1(x_cat)
+        x2 = self.conv2(x1)
+        x3 = self.conv3(x2)
+        x4 = self.conv4(x3)
+        x5 = self.conv5(x4)
+        # x = self.conv6(x5)
+        x = nn.Flatten()(x5)
+
+        return x, [x1, x2, x3, x4]#, x5]

--- a/phoonnx_train/mixertts/models/mixer_tts/__init__.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/__init__.py
@@ -1,0 +1,2 @@
+"""Vendored Mixer-TTS model (NVIDIA NeMo port, Apache-2.0 — see mixer_tts.py)."""
+from .mixer_tts import MixerTTSModel

--- a/phoonnx_train/mixertts/models/mixer_tts/mixer_tts.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/mixer_tts.py
@@ -1,0 +1,988 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/models/mixer_tts.py
+
+import contextlib
+from typing import List, Optional
+
+import numpy as np
+import torch
+# import wandb
+# from pytorch_lightning.loggers import WandbLogger
+from torch import nn
+from torch.nn import functional as F
+# from transformers import AlbertTokenizer
+from .modules.aligner import AlignmentEncoder
+from .modules.mixer_tts import MixerTTSModule
+
+# from nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers import (
+#     EnglishCharsTokenizer,
+#     EnglishPhonemesTokenizer,
+# )
+
+from .modules.aligner_loss import BinLoss, ForwardSumLoss
+
+from .modules.fastpitch import average_features, TemporalPredictor
+from .modules.helpers import (
+    binarize_attention_parallel,
+    get_mask_from_lengths,
+    regulate_len,
+)
+
+# from nemo.collections.tts.models.base import SpectrogramGenerator
+# from nemo.core import Exportable
+# from nemo.core.classes.common import PretrainedModelInfo, typecheck
+# from nemo.core.neural_types.elements import (
+#     LengthsType,
+#     LogprobsType,
+#     MelSpectrogramType,
+#     ProbsType,
+#     RegressionValuesType,
+#     TokenDurationType,
+#     TokenIndex,
+#     TokenLogDurationType,
+# )
+# from nemo.core.neural_types.neural_type import NeuralType
+# from nemo.utils import logging, model_utils
+
+
+# class MixerTTSModel(SpectrogramGenerator, Exportable):
+class MixerTTSModel(nn.Module):
+    """Mixer-TTS and Mixer-TTS-X models (https://arxiv.org/abs/2110.03584) that is used to generate mel spectrogram from text."""
+
+    def __init__(self,
+                n_mel_channels=80,
+                num_tokens=178,
+                padding_idx=0,
+                symbols_embedding_dim = 384,
+                # encoder
+                encoder_feature_dim=None,
+                encoder_kernel_sizes=[11, 13, 15, 17, 19, 21],
+                encoder_num_layers=6,
+                encoder_expansion_factor=4,
+                encoder_dropout=0.15,
+                # decoder
+                decoder_num_tokens=-1,
+                decoder_feature_dim=None,
+                decoder_kernel_sizes=[15, 17, 19, 21, 23, 25, 27, 29, 31],
+                decoder_num_layers=9,
+                decoder_expansion_factor=4,
+                decoder_dropout=0.15,
+                # duration predictor
+                # duration_predictor_input_size=384,
+                duration_predictor_kernel_size=3,
+                duration_predictor_filter_size=256,
+                duration_predictor_dropout=0.15,
+                duration_predictor_n_layers=2,
+                # pitch predictor
+                # pitch_predictor_input_size=384,
+                pitch_predictor_kernel_size=3,
+                pitch_predictor_filter_size=256,
+                pitch_predictor_dropout=0.15,
+                pitch_predictor_n_layers=2,
+                pitch_emb_in_channels=1,
+                # pitch_emb_out_channels=384,
+                pitch_emb_kernel_size=3,
+                # energy predictor
+                energy_conditioning=True,
+                energy_predictor_kernel_size=3, 
+                energy_predictor_filter_size=256,
+                energy_predictor_dropout=0.15, 
+                energy_predictor_n_layers=2,                 
+                energy_embedding_kernel_size=3,
+                # speaker / emotion embedding
+                n_speakers=8,
+                n_emotions=8,     
+                # aligner
+                aligner_n_text_channels=None,
+                ):
+        
+        if encoder_feature_dim is None: encoder_feature_dim = symbols_embedding_dim
+        if decoder_feature_dim is None: decoder_feature_dim = symbols_embedding_dim
+        if aligner_n_text_channels is None: aligner_n_text_channels = symbols_embedding_dim
+        
+        # Convert to Hydra 1.0 compatible DictConfig
+        # cfg = model_utils.convert_model_config_to_dict_config(cfg)
+        # cfg = model_utils.maybe_update_config_version(cfg)
+
+        # Setup normalizer
+        self.normalizer = None
+        self.text_normalizer_call = None
+        self.text_normalizer_call_kwargs = {}
+        # try:
+        #     self._setup_normalizer(cfg)
+        # except: pass
+
+        # Setup tokenizer
+        self.tokenizer = None
+        # the export path masks padding by id; the phoonnx pipeline always
+        # uses padding_idx (0)
+        self.tokenizer_pad = padding_idx
+        
+        self.padding_idx = padding_idx
+
+        super().__init__()
+
+        self.pitch_loss_scale = 0.1
+        self.durs_loss_scale = 0.1
+        self.energy_loss_scale = 0.1
+        self.mel_loss_scale = 1.0
+
+        # self.aligner = instantiate(cfg.alignment_module)
+        self.aligner = AlignmentEncoder(
+            n_text_channels=aligner_n_text_channels,
+        )
+        self.forward_sum_loss = ForwardSumLoss()
+        self.bin_loss = BinLoss()
+        self.add_bin_loss = False
+        self.bin_loss_scale = 0.0
+        self.bin_loss_start_ratio = 0.2
+        self.bin_loss_warmup_epochs = 100
+
+        self.cond_on_lm_embeddings = False
+
+        # if self.cond_on_lm_embeddings:
+        #     self.lm_padding_value = (
+        #         self._train_dl.dataset.lm_padding_value
+        #         if self._train_dl is not None
+        #         else self._get_lm_padding_value(cfg.lm_model)
+        #     )
+        #     self.lm_embeddings = self._get_lm_embeddings(cfg.lm_model)
+        #     self.lm_embeddings.weight.requires_grad = False
+
+        #     self.self_attention_module = instantiate(
+        #         cfg.self_attention_module, 
+        #         n_lm_tokens_channels=self.lm_embeddings.weight.shape[1]
+        #     )
+
+        # TODO:
+        # self.encoder = instantiate(cfg.encoder, num_tokens=114, padding_idx=112)
+        self.encoder = MixerTTSModule(num_tokens=num_tokens,
+                                      feature_dim=encoder_feature_dim,
+                                      num_layers=encoder_num_layers,
+                                      kernel_sizes=encoder_kernel_sizes,
+                                      padding_idx=padding_idx,
+                                      expansion_factor=encoder_expansion_factor,
+                                      dropout=encoder_dropout,
+                                      )
+        self.symbol_emb = self.encoder.to_embed
+        
+        if n_speakers > 1:
+            self.speaker_emb = nn.Embedding(n_speakers, symbols_embedding_dim)
+        else: self.speaker_emb = None
+        if n_emotions > 1:
+            self.emotion_emb = nn.Embedding(n_emotions, symbols_embedding_dim)
+        else: self.emotion_emb = None
+
+        # self.duration_predictor = instantiate(cfg.duration_predictor)
+        self.duration_predictor = TemporalPredictor(
+            input_size=encoder_feature_dim,
+            kernel_size=duration_predictor_kernel_size,
+            filter_size=duration_predictor_filter_size,
+            dropout=duration_predictor_dropout,
+            n_layers=duration_predictor_n_layers
+            )
+        
+        pitch_mean=212.35853576660156
+        pitch_std=68.52803802490234
+
+        # pitch predictor
+        self.pitch_mean, self.pitch_std = float(pitch_mean), float(pitch_std)
+        self.pitch_predictor = TemporalPredictor(
+            input_size=encoder_feature_dim,
+            kernel_size=pitch_predictor_kernel_size,
+            filter_size=pitch_predictor_filter_size,
+            dropout=pitch_predictor_dropout,
+            n_layers=pitch_predictor_n_layers
+        )
+        self.pitch_emb = nn.Conv1d(
+            in_channels=pitch_emb_in_channels,
+            out_channels=symbols_embedding_dim,
+            kernel_size=pitch_emb_kernel_size,
+            padding=(pitch_emb_kernel_size-1)//2
+        )
+        
+        # energy embedding
+        self.energy_conditioning = energy_conditioning
+        if energy_conditioning:
+            self.energy_predictor = TemporalPredictor(
+                input_size=encoder_feature_dim,
+                filter_size=energy_predictor_filter_size,
+                kernel_size=energy_predictor_kernel_size,
+                dropout=energy_predictor_dropout,
+                n_layers=energy_predictor_n_layers,               
+            )
+
+            self.energy_emb = nn.Conv1d(
+                1, symbols_embedding_dim,
+                kernel_size=energy_embedding_kernel_size,
+                padding=int((energy_embedding_kernel_size - 1) / 2))
+
+
+        # TODO: 
+        # self.preprocessor = instantiate(cfg.preprocessor)
+
+        # decoder
+        self.decoder = MixerTTSModule(num_tokens=decoder_num_tokens,
+                                      feature_dim=decoder_feature_dim,
+                                      num_layers=decoder_num_layers,
+                                      kernel_sizes=decoder_kernel_sizes,                                     
+                                      expansion_factor=decoder_expansion_factor,
+                                      dropout=decoder_dropout,)
+        self.proj = nn.Linear(self.decoder.d_model, n_mel_channels)
+
+    # def _setup_normalizer(self, cfg):
+    #     if "text_normalizer" in cfg:
+    #         normalizer_kwargs = {}
+
+    #         if "whitelist" in cfg.text_normalizer:
+    #             normalizer_kwargs["whitelist"] = self.register_artifact(
+    #                 'text_normalizer.whitelist', cfg.text_normalizer.whitelist
+    #             )
+
+    #         try:
+    #             import nemo_text_processing
+
+    #             self.normalizer = instantiate(cfg.text_normalizer, **normalizer_kwargs)
+    #         except Exception as e:
+    #             logging.error(e)
+    #             raise ImportError(
+    #                 "`nemo_text_processing` not installed, see https://github.com/NVIDIA/NeMo-text-processing for more details"
+    #             )
+
+    #         self.text_normalizer_call = self.normalizer.normalize
+    #         if "text_normalizer_call_kwargs" in cfg:
+    #             self.text_normalizer_call_kwargs = cfg.text_normalizer_call_kwargs
+
+    # def _setup_tokenizer(self, cfg):
+        # text_tokenizer_kwargs = {}
+        # if "g2p" in cfg.text_tokenizer:
+        #     # for backward compatibility
+        #     if (
+        #         self._is_model_being_restored()
+        #         and (cfg.text_tokenizer.g2p.get('_target_', None) is not None)
+        #         and cfg.text_tokenizer.g2p["_target_"].startswith("nemo_text_processing.g2p")
+        #     ):
+        #         cfg.text_tokenizer.g2p["_target_"] = g2p_backward_compatible_support(
+        #             cfg.text_tokenizer.g2p["_target_"]
+        #         )
+
+        #     g2p_kwargs = {}
+
+        #     if "phoneme_dict" in cfg.text_tokenizer.g2p:
+        #         g2p_kwargs["phoneme_dict"] = self.register_artifact(
+        #             'text_tokenizer.g2p.phoneme_dict', cfg.text_tokenizer.g2p.phoneme_dict,
+        #         )
+
+        #     if "heteronyms" in cfg.text_tokenizer.g2p:
+        #         g2p_kwargs["heteronyms"] = self.register_artifact(
+        #             'text_tokenizer.g2p.heteronyms', cfg.text_tokenizer.g2p.heteronyms,
+        #         )
+
+        #     text_tokenizer_kwargs["g2p"] = instantiate(cfg.text_tokenizer.g2p, **g2p_kwargs)
+
+        # self.tokenizer = instantiate(cfg.text_tokenizer, **text_tokenizer_kwargs)
+
+    # def _get_lm_model_tokenizer(self, lm_model="albert"):
+    #     if getattr(self, "_lm_model_tokenizer", None) is not None:
+    #         return self._lm_model_tokenizer
+
+    #     if self._train_dl is not None and self._train_dl.dataset is not None:
+    #         self._lm_model_tokenizer = self._train_dl.dataset.lm_model_tokenizer
+
+    #     if lm_model == "albert":
+    #         self._lm_model_tokenizer = AlbertTokenizer.from_pretrained('albert-base-v2')
+    #     else:
+    #         raise NotImplementedError(
+    #             f"{lm_model} lm model is not supported. Only albert is supported at this moment."
+    #         )
+
+    #     return self._lm_model_tokenizer
+
+    def _metrics(
+        self,
+        true_durs,
+        true_text_len,
+        pred_durs,
+        true_pitch,
+        pred_pitch,
+        true_energy,
+        pred_energy,
+        true_spect=None,
+        pred_spect=None,
+        true_spect_len=None,
+        attn_logprob=None,
+        attn_soft=None,
+        attn_hard=None,
+        attn_hard_dur=None,
+    ):
+        text_mask = get_mask_from_lengths(true_text_len)
+        mel_mask = get_mask_from_lengths(true_spect_len)
+        loss = 0.0
+
+        # Dur loss and metrics
+        durs_loss = F.mse_loss(pred_durs, (true_durs + 1).float().log(), reduction='none')
+        durs_loss = durs_loss * text_mask.float()
+        durs_loss = durs_loss.sum() / text_mask.sum()
+
+        durs_pred = pred_durs.exp() - 1
+        durs_pred = torch.clamp_min(durs_pred, min=0)
+        durs_pred = durs_pred.round().long()
+
+        acc = ((true_durs == durs_pred) * text_mask).sum().float() / text_mask.sum() * 100
+        acc_dist_1 = (((true_durs - durs_pred).abs() <= 1) * text_mask).sum().float() / text_mask.sum() * 100
+        acc_dist_3 = (((true_durs - durs_pred).abs() <= 3) * text_mask).sum().float() / text_mask.sum() * 100
+
+        pred_spect = pred_spect.transpose(1, 2)
+
+        # Mel loss
+        mel_loss = F.mse_loss(pred_spect, true_spect, reduction='none').mean(dim=-2)
+        mel_loss = mel_loss * mel_mask.float()
+        mel_loss = mel_loss.sum() / mel_mask.sum()
+
+        loss = loss + self.durs_loss_scale * durs_loss + self.mel_loss_scale * mel_loss
+
+        # Aligner loss
+        bin_loss, ctc_loss = None, None
+        ctc_loss = self.forward_sum_loss(attn_logprob=attn_logprob, in_lens=true_text_len, out_lens=true_spect_len)
+        loss = loss + ctc_loss
+        if self.add_bin_loss:
+            bin_loss = self.bin_loss(hard_attention=attn_hard, soft_attention=attn_soft)
+            loss = loss + self.bin_loss_scale * bin_loss
+        true_avg_pitch = average_features(true_pitch.unsqueeze(1), attn_hard_dur).squeeze(1)
+
+        # Pitch loss
+        pitch_loss = F.mse_loss(pred_pitch, true_avg_pitch, reduction='none')  # noqa
+        pitch_loss = (pitch_loss * text_mask).sum() / text_mask.sum()
+        
+        if pred_energy is not None:
+            true_avg_energy = average_features(true_energy.unsqueeze(1), attn_hard_dur).squeeze(1)
+            # energy_pred = F.pad(energy_pred, (0, ldiff, 0, 0), value=0.0)
+            true_avg_energy = torch.log(1.0 + true_avg_energy)
+            energy_loss = F.mse_loss(pred_energy, true_avg_energy, reduction='none')
+            energy_loss = (energy_loss * text_mask).sum() / text_mask.sum()
+        else:
+            energy_loss = 0
+                
+
+        loss = (loss 
+                + self.pitch_loss_scale * pitch_loss 
+                + self.energy_loss_scale * energy_loss)
+
+        return (loss, durs_loss, 
+                acc, acc_dist_1, acc_dist_3, 
+                pitch_loss, energy_loss,
+                mel_loss, ctc_loss, bin_loss)
+
+    @torch.jit.unused
+    def run_aligner(self, text, text_len, text_mask, spect, spect_len, attn_prior):
+        text_emb = self.symbol_emb(text)
+        attn_soft, attn_logprob = self.aligner(
+            spect, text_emb.permute(0, 2, 1), mask=text_mask == 0, attn_prior=attn_prior,
+        )
+        attn_hard = binarize_attention_parallel(attn_soft, text_len, spect_len)
+        attn_hard_dur = attn_hard.sum(2)[:, 0, :]
+        assert torch.all(torch.eq(attn_hard_dur.sum(dim=1), spect_len))
+        return attn_soft, attn_logprob, attn_hard, attn_hard_dur
+
+    # @typecheck(
+    #     input_types={
+    #         "text": NeuralType(('B', 'T_text'), TokenIndex()),
+    #         "text_len": NeuralType(('B',), LengthsType()),
+    #         "pitch": NeuralType(('B', 'T_audio'), RegressionValuesType(), optional=True),
+    #         "spect": NeuralType(('B', 'D', 'T_spec'), MelSpectrogramType(), optional=True),
+    #         "spect_len": NeuralType(('B',), LengthsType(), optional=True),
+    #         "attn_prior": NeuralType(('B', 'T_spec', 'T_text'), ProbsType(), optional=True),
+    #         "lm_tokens": NeuralType(('B', 'T_lm_tokens'), TokenIndex(), optional=True),
+    #     },
+    #     output_types={
+    #         "pred_spect": NeuralType(('B', 'D', 'T_spec'), MelSpectrogramType()),
+    #         "durs_predicted": NeuralType(('B', 'T_text'), TokenDurationType()),
+    #         "log_durs_predicted": NeuralType(('B', 'T_text'), TokenLogDurationType()),
+    #         "pitch_predicted": NeuralType(('B', 'T_text'), RegressionValuesType()),
+    #         "attn_soft": NeuralType(('B', 'S', 'T_spec', 'T_text'), ProbsType()),
+    #         "attn_logprob": NeuralType(('B', 'S', 'T_spec', 'T_text'), LogprobsType()),
+    #         "attn_hard": NeuralType(('B', 'S', 'T_spec', 'T_text'), ProbsType()),
+    #         "attn_hard_dur": NeuralType(('B', 'T_text'), TokenDurationType()),
+    #     },
+    # )
+    def forward(self,
+                text,
+                text_len,
+                pitch=None,
+                energy=None,
+                spect=None,
+                spect_len=None,
+                attn_prior=None,
+                speaker=None,
+                emotion=None,
+                pace=1.0,
+                lm_tokens=None,
+                ):
+        if self.training:
+            assert pitch is not None
+
+        text_mask = get_mask_from_lengths(text_len).unsqueeze(2)
+        
+        # Calculate speaker embedding
+        if self.speaker_emb is None: spk_emb = 0
+        else: spk_emb = self.speaker_emb(speaker).unsqueeze(1)
+        # Calculate emotion embedding
+        if self.emotion_emb is None: emo_emb = 0
+        else: emo_emb = self.emotion_emb(emotion).unsqueeze(1)
+ 
+        # Input encoder
+        enc_out, enc_mask = self.encoder(text, text_mask, 
+                                         conditioning=spk_emb+emo_emb)
+
+        # Aligner
+        attn_soft, attn_logprob, attn_hard, attn_hard_dur = None, None, None, None
+        if spect is not None:
+            attn_soft, attn_logprob, attn_hard, attn_hard_dur = self.run_aligner(
+                text, text_len, text_mask, spect, spect_len, attn_prior
+            )
+
+        if self.cond_on_lm_embeddings:
+            lm_emb = self.lm_embeddings(lm_tokens)
+            lm_features = self.self_attention_module(
+                enc_out, lm_emb, lm_emb, q_mask=enc_mask.squeeze(2), kv_mask=lm_tokens != self.lm_padding_value
+            )
+
+        # Duration predictor
+        log_durs_predicted = self.duration_predictor(enc_out, enc_mask)
+        durs_predicted = torch.clamp(log_durs_predicted.exp() - 1, 0)
+
+        # Pitch predictor
+        pitch_predicted = self.pitch_predictor(enc_out, enc_mask)
+
+        # Avg pitch, add pitch_emb
+        if not self.training:
+            if pitch is not None:
+                pitch = average_features(pitch.unsqueeze(1), attn_hard_dur).squeeze(1)
+                pitch_emb = self.pitch_emb(pitch.unsqueeze(1))
+            else:
+                pitch_emb = self.pitch_emb(pitch_predicted.unsqueeze(1))
+        else:
+            pitch = average_features(pitch.unsqueeze(1), attn_hard_dur).squeeze(1)
+            pitch_emb = self.pitch_emb(pitch.unsqueeze(1))
+
+        enc_out = enc_out + pitch_emb.transpose(1, 2)
+        
+        
+        # Predict energy
+        if self.energy_conditioning:
+            energy_pred = self.energy_predictor(enc_out, enc_mask).squeeze(-1)
+
+            # Average energy over characters
+            energy_tgt = average_features(energy.unsqueeze(1), attn_hard_dur)
+            energy_tgt = torch.log(1.0 + energy_tgt)
+
+            energy_emb = self.energy_emb(energy_tgt)
+            energy_tgt = energy_tgt.squeeze(1)
+            enc_out = enc_out + energy_emb.transpose(1, 2)
+        else:
+            energy_pred = None
+            energy_tgt = None
+
+        if self.cond_on_lm_embeddings:
+            enc_out = enc_out + lm_features
+
+        # Regulate length
+        len_regulated_enc_out, dec_lens = regulate_len(attn_hard_dur, enc_out, pace=pace)
+
+        # Decoder
+        dec_out, dec_lens = self.decoder(len_regulated_enc_out, get_mask_from_lengths(dec_lens).unsqueeze(2))
+        
+        # Project to mel spec
+        pred_spect = self.proj(dec_out)
+
+        return (
+            pred_spect,
+            durs_predicted,
+            log_durs_predicted,
+            pitch_predicted,
+            energy_pred,
+            attn_soft,
+            attn_logprob,
+            attn_hard,
+            attn_hard_dur,
+        )
+
+    @torch.inference_mode()
+    def infer(
+        self,
+        text,
+        text_len=None,
+        text_mask=None,
+        spect=None,
+        spect_len=None,
+        attn_prior=None,
+        use_gt_durs=False,
+        pace=1.0,
+        speaker=0,
+        emotion=0,
+        lm_tokens=None,
+        pitch=None,        
+        pitch_transform=None,
+        energy_tgt = None,
+        energy_transform = None,
+    ):
+        if text_len is None and text_mask is None:
+            text_mask = (text != self.padding_idx).unsqueeze(2)
+        if text_mask is None:
+            text_mask = get_mask_from_lengths(text_len).unsqueeze(2)
+        # if speaker is None: speaker = torch.LongTensor([0]).to(text.device)
+        # if emotion is None: emotion = torch.LongTensor([0]).to(text.device)
+            
+        if self.speaker_emb is None: spk_emb = 0
+        else:
+            speaker = (torch.ones(text.size(0)).long().to(text.device) * speaker)
+            spk_emb = self.speaker_emb(speaker).unsqueeze(1)
+        if self.emotion_emb is None: emo_emb = 0
+        else:
+            emotion = (torch.ones(text.size(0)).long().to(text.device) * emotion)
+            emo_emb = self.emotion_emb(emotion).unsqueeze(1)
+
+        enc_out, enc_mask = self.encoder(text, text_mask, 
+                                         conditioning=spk_emb+emo_emb)
+
+        # Aligner
+        attn_hard_dur = None
+        if use_gt_durs:
+            attn_soft, attn_logprob, attn_hard, attn_hard_dur = self.run_aligner(
+                text, text_len, text_mask, spect, spect_len, attn_prior
+            )
+
+        if self.cond_on_lm_embeddings:
+            lm_emb = self.lm_embeddings(lm_tokens)
+            lm_features = self.self_attention_module(
+                enc_out, lm_emb, lm_emb, q_mask=enc_mask.squeeze(2), kv_mask=lm_tokens != self.lm_padding_value
+            )
+
+        # Duration predictor
+        log_durs_predicted = self.duration_predictor(enc_out, enc_mask)
+        durs_predicted = torch.clamp(log_durs_predicted.exp() - 1, 0)
+
+
+        # Avg pitch, pitch predictor
+        if use_gt_durs and pitch is not None:
+            pitch = average_features(pitch.unsqueeze(1), attn_hard_dur).squeeze(1)
+            pitch_emb = self.pitch_emb(pitch.unsqueeze(1))
+        else:
+            pitch_predicted = self.pitch_predictor(enc_out, enc_mask)
+            
+            if pitch_transform is not None:
+                if self.pitch_std == 0.0:
+                    # XXX LJSpeech-1.1 defaults
+                    mean, std = 218.14, 67.24
+                else:
+                    mean, std = self.pitch_mean, self.pitch_std
+                pitch_predicted = pitch_transform(
+                    pitch_predicted, enc_mask.sum(dim=(1,2)),
+                    mean, std)
+            
+            pitch_emb = self.pitch_emb(pitch_predicted.unsqueeze(1))
+
+        # Add pitch emb
+        enc_out = enc_out + pitch_emb.transpose(1, 2)
+        
+        # Predict energy
+        if self.energy_conditioning:
+            if energy_tgt is None:
+                energy_predicted = self.energy_predictor(enc_out, enc_mask).squeeze(-1)
+                if energy_transform is not None:
+                    energy_predicted = energy_transform(
+                        energy_predicted, enc_mask.sum(dim=(1,2)))
+                
+                energy_emb = self.energy_emb(energy_predicted.unsqueeze(1)).transpose(1, 2)
+            
+            else:
+                energy_emb = self.energy_emb(energy_tgt).transpose(1, 2)
+
+            enc_out = enc_out + energy_emb
+        else:
+            energy_pred = None
+                
+
+        if self.cond_on_lm_embeddings:
+            enc_out = enc_out + lm_features
+
+        if use_gt_durs:
+            if attn_hard_dur is not None:
+                len_regulated_enc_out, dec_lens = regulate_len(attn_hard_dur, enc_out)
+            else:
+                raise NotImplementedError
+        else:
+            len_regulated_enc_out, dec_lens = regulate_len(durs_predicted, enc_out, pace=pace)
+
+        dec_out, _ = self.decoder(len_regulated_enc_out, get_mask_from_lengths(dec_lens).unsqueeze(2))
+        pred_spect = self.proj(dec_out)
+
+        return pred_spect
+
+    def on_train_epoch_start(self):
+        bin_loss_start_epoch = np.ceil(self.bin_loss_start_ratio * self._trainer.max_epochs)
+
+        # Add bin loss when current_epoch >= bin_start_epoch
+        if not self.add_bin_loss and self.current_epoch >= bin_loss_start_epoch:
+            # logging.info(f"Using hard attentions after epoch: {self.current_epoch}")
+            print(f"Using hard attentions after epoch: {self.current_epoch}")
+            self.add_bin_loss = True
+
+        if self.add_bin_loss:
+            self.bin_loss_scale = min((self.current_epoch - bin_loss_start_epoch) / self.bin_loss_warmup_epochs, 1.0)
+
+    def training_step(self, batch, batch_idx):
+        attn_prior, lm_tokens = None, None
+        if self.cond_on_lm_embeddings:
+            audio, audio_len, text, text_len, attn_prior, pitch, _, lm_tokens = batch
+        else:
+            audio, audio_len, text, text_len, attn_prior, pitch, _ = batch
+
+        spect, spect_len = self.preprocessor(input_signal=audio, length=audio_len)
+
+        # pitch normalization
+        zero_pitch_idx = pitch == 0
+        pitch = (pitch - self.pitch_mean) / self.pitch_std
+        pitch[zero_pitch_idx] = 0.0
+
+        (pred_spect, _, pred_log_durs, pred_pitch, attn_soft, attn_logprob, attn_hard, attn_hard_dur,) = self(
+            text=text,
+            text_len=text_len,
+            pitch=pitch,
+            spect=spect,
+            spect_len=spect_len,
+            attn_prior=attn_prior,
+            lm_tokens=lm_tokens,
+        )
+
+        (loss, durs_loss, acc, acc_dist_1, acc_dist_3, pitch_loss, mel_loss, ctc_loss, bin_loss,) = self._metrics(
+            pred_durs=pred_log_durs,
+            pred_pitch=pred_pitch,
+            true_durs=attn_hard_dur,
+            true_text_len=text_len,
+            true_pitch=pitch,
+            true_spect=spect,
+            pred_spect=pred_spect,
+            true_spect_len=spect_len,
+            attn_logprob=attn_logprob,
+            attn_soft=attn_soft,
+            attn_hard=attn_hard,
+            attn_hard_dur=attn_hard_dur,
+        )
+
+        train_log = {
+            'train_loss': loss,
+            'train_durs_loss': durs_loss,
+            'train_pitch_loss': torch.tensor(1.0).to(durs_loss.device) if pitch_loss is None else pitch_loss,
+            'train_mel_loss': mel_loss,
+            'train_durs_acc': acc,
+            'train_durs_acc_dist_3': acc_dist_3,
+            'train_ctc_loss': torch.tensor(1.0).to(durs_loss.device) if ctc_loss is None else ctc_loss,
+            'train_bin_loss': torch.tensor(1.0).to(durs_loss.device) if bin_loss is None else bin_loss,
+        }
+
+        return {'loss': loss, 'progress_bar': {k: v.detach() for k, v in train_log.items()}, 'log': train_log}
+
+    def validation_step(self, batch, batch_idx):
+        attn_prior, lm_tokens = None, None
+        if self.cond_on_lm_embeddings:
+            audio, audio_len, text, text_len, attn_prior, pitch, _, lm_tokens = batch
+        else:
+            audio, audio_len, text, text_len, attn_prior, pitch, _ = batch
+
+        spect, spect_len = self.preprocessor(input_signal=audio, length=audio_len)
+
+        # pitch normalization
+        zero_pitch_idx = pitch == 0
+        pitch = (pitch - self.pitch_mean) / self.pitch_std
+        pitch[zero_pitch_idx] = 0.0
+
+        (pred_spect, _, pred_log_durs, pred_pitch, attn_soft, attn_logprob, attn_hard, attn_hard_dur,) = self(
+            text=text,
+            text_len=text_len,
+            pitch=pitch,
+            spect=spect,
+            spect_len=spect_len,
+            attn_prior=attn_prior,
+            lm_tokens=lm_tokens,
+        )
+
+        (loss, durs_loss, acc, acc_dist_1, acc_dist_3, pitch_loss, mel_loss, ctc_loss, bin_loss,) = self._metrics(
+            pred_durs=pred_log_durs,
+            pred_pitch=pred_pitch,
+            true_durs=attn_hard_dur,
+            true_text_len=text_len,
+            true_pitch=pitch,
+            true_spect=spect,
+            pred_spect=pred_spect,
+            true_spect_len=spect_len,
+            attn_logprob=attn_logprob,
+            attn_soft=attn_soft,
+            attn_hard=attn_hard,
+            attn_hard_dur=attn_hard_dur,
+        )
+
+        # without ground truth internal features except for durations
+        pred_spect, _, pred_log_durs, pred_pitch, attn_soft, attn_logprob, attn_hard, attn_hard_dur = self(
+            text=text,
+            text_len=text_len,
+            pitch=None,
+            spect=spect,
+            spect_len=spect_len,
+            attn_prior=attn_prior,
+            lm_tokens=lm_tokens,
+        )
+
+        *_, with_pred_features_mel_loss, _, _ = self._metrics(
+            pred_durs=pred_log_durs,
+            pred_pitch=pred_pitch,
+            true_durs=attn_hard_dur,
+            true_text_len=text_len,
+            true_pitch=pitch,
+            true_spect=spect,
+            pred_spect=pred_spect,
+            true_spect_len=spect_len,
+            attn_logprob=attn_logprob,
+            attn_soft=attn_soft,
+            attn_hard=attn_hard,
+            attn_hard_dur=attn_hard_dur,
+        )
+
+        val_log = {
+            'val_loss': loss,
+            'val_durs_loss': durs_loss,
+            'val_pitch_loss': torch.tensor(1.0).to(durs_loss.device) if pitch_loss is None else pitch_loss,
+            'val_mel_loss': mel_loss,
+            'val_with_pred_features_mel_loss': with_pred_features_mel_loss,
+            'val_durs_acc': acc,
+            'val_durs_acc_dist_3': acc_dist_3,
+            'val_ctc_loss': torch.tensor(1.0).to(durs_loss.device) if ctc_loss is None else ctc_loss,
+            'val_bin_loss': torch.tensor(1.0).to(durs_loss.device) if bin_loss is None else bin_loss,
+        }
+        self.log_dict(val_log, prog_bar=False, on_epoch=True, logger=True, sync_dist=True)
+
+        # if batch_idx == 0 and self.current_epoch % 5 == 0 and isinstance(self.logger, WandbLogger):
+        #     specs = []
+        #     pitches = []
+        #     for i in range(min(3, spect.shape[0])):
+        #         specs += [
+        #             wandb.Image(
+        #                 plot_spectrogram_to_numpy(spect[i, :, : spect_len[i]].data.cpu().numpy()),
+        #                 caption=f"gt mel {i}",
+        #             ),
+        #             wandb.Image(
+        #                 plot_spectrogram_to_numpy(pred_spect.transpose(1, 2)[i, :, : spect_len[i]].data.cpu().numpy()),
+        #                 caption=f"pred mel {i}",
+        #             ),
+        #         ]
+
+        #         pitches += [
+        #             wandb.Image(
+        #                 plot_pitch_to_numpy(
+        #                     average_features(pitch.unsqueeze(1), attn_hard_dur)
+        #                     .squeeze(1)[i, : text_len[i]]
+        #                     .data.cpu()
+        #                     .numpy(),
+        #                     ylim_range=[-2.5, 2.5],
+        #                 ),
+        #                 caption=f"gt pitch {i}",
+        #             ),
+        #         ]
+
+        #         pitches += [
+        #             wandb.Image(
+        #                 plot_pitch_to_numpy(pred_pitch[i, : text_len[i]].data.cpu().numpy(), ylim_range=[-2.5, 2.5]),
+        #                 caption=f"pred pitch {i}",
+        #             ),
+        #         ]
+
+        #     self.logger.experiment.log({"specs": specs, "pitches": pitches})
+
+    # @typecheck(
+    #     input_types={
+    #         "tokens": NeuralType(('B', 'T_text'), TokenIndex(), optional=True),
+    #         "tokens_len": NeuralType(('B'), LengthsType(), optional=True),
+    #         "lm_tokens": NeuralType(('B', 'T_lm_tokens'), TokenIndex(), optional=True),
+    #         "raw_texts": [NeuralType(optional=True)],
+    #         "lm_model": NeuralType(optional=True),
+    #     },
+    #     output_types={"spect": NeuralType(('B', 'D', 'T_spec'), MelSpectrogramType()),},
+    # )
+    def generate_spectrogram(
+        self,
+        tokens: Optional[torch.Tensor] = None,
+        tokens_len: Optional[torch.Tensor] = None,
+        lm_tokens: Optional[torch.Tensor] = None,
+        raw_texts: Optional[List[str]] = None,
+        norm_text_for_lm_model: bool = True,
+        lm_model: str = "albert",
+    ):
+        if tokens is not None:
+            if tokens_len is None:
+                # It is assumed that padding is consecutive and only at the end
+                tokens_len = (tokens != self.tokenizer.pad).sum(dim=-1)
+        else:
+            if raw_texts is None:
+                raise ValueError("raw_texts must be specified if tokens is None")
+
+            t_seqs = [self.tokenizer(t) for t in raw_texts]
+            tokens = torch.nn.utils.rnn.pad_sequence(
+                sequences=[torch.tensor(t, dtype=torch.long, device=self.device) for t in t_seqs],
+                batch_first=True,
+                padding_value=self.tokenizer.pad,
+            )
+            tokens_len = torch.tensor([len(t) for t in t_seqs], dtype=torch.long, device=tokens.device)
+
+        # if self.cond_on_lm_embeddings and lm_tokens is None:
+        #     if raw_texts is None:
+        #         raise ValueError("raw_texts must be specified if lm_tokens is None")
+
+        #     lm_model_tokenizer = self._get_lm_model_tokenizer(lm_model)
+        #     lm_padding_value = lm_model_tokenizer._convert_token_to_id('<pad>')
+        #     lm_space_value = lm_model_tokenizer._convert_token_to_id('▁')
+
+        #     assert isinstance(self.tokenizer, EnglishCharsTokenizer) or isinstance(
+        #         self.tokenizer, EnglishPhonemesTokenizer
+        #     )
+
+        #     if norm_text_for_lm_model and self.text_normalizer_call is not None:
+        #         raw_texts = [self.text_normalizer_call(t, **self.text_normalizer_call_kwargs) for t in raw_texts]
+
+        #     preprocess_texts_as_tts_input = [self.tokenizer.text_preprocessing_func(t) for t in raw_texts]
+        #     lm_tokens_as_ids_list = [
+        #         lm_model_tokenizer.encode(t, add_special_tokens=False) for t in preprocess_texts_as_tts_input
+        #     ]
+
+        #     if self.tokenizer.pad_with_space:
+        #         lm_tokens_as_ids_list = [[lm_space_value] + t + [lm_space_value] for t in lm_tokens_as_ids_list]
+
+        #     lm_tokens = torch.full(
+        #         (len(lm_tokens_as_ids_list), max([len(t) for t in lm_tokens_as_ids_list])),
+        #         fill_value=lm_padding_value,
+        #         device=tokens.device,
+        #     )
+        #     for i, lm_tokens_i in enumerate(lm_tokens_as_ids_list):
+        #         lm_tokens[i, : len(lm_tokens_i)] = torch.tensor(lm_tokens_i, device=tokens.device)
+
+        pred_spect = self.infer(tokens, tokens_len, lm_tokens=lm_tokens).transpose(1, 2)
+        return pred_spect
+
+    def parse(self, text: str, normalize=True) -> torch.Tensor:
+        if self.training:
+            # logging.warning("parse() is meant to be called in eval mode.")
+            print("parse() is meant to be called in eval mode.")
+        if normalize and self.text_normalizer_call is not None:
+            text = self.text_normalizer_call(text, **self.text_normalizer_call_kwargs)
+
+        eval_phon_mode = contextlib.nullcontext()
+        if hasattr(self.tokenizer, "set_phone_prob"):
+            eval_phon_mode = self.tokenizer.set_phone_prob(prob=1.0)
+
+        with eval_phon_mode:
+            tokens = self.tokenizer.encode(text)
+        return torch.tensor(tokens).long().unsqueeze(0).to(self.device)
+
+    # def _loader(self, cfg):
+    #     try:
+    #         _ = cfg.dataset.manifest_filepath
+    #     except omegaconf.errors.MissingMandatoryValue:
+    #         logging.warning("manifest_filepath was skipped. No dataset for this model.")
+    #         return None
+
+    #     dataset = instantiate(
+    #         cfg.dataset,
+    #         text_normalizer=self.normalizer,
+    #         text_normalizer_call_kwargs=self.text_normalizer_call_kwargs,
+    #         text_tokenizer=self.tokenizer,
+    #     )
+    #     return torch.utils.data.DataLoader(  # noqa
+    #         dataset=dataset, collate_fn=dataset.collate_fn, **cfg.dataloader_params,
+    #     )
+
+    # def setup_training_data(self, cfg):
+    #     self._train_dl = self._loader(cfg)
+
+    # def setup_validation_data(self, cfg):
+    #     self._validation_dl = self._loader(cfg)
+
+    # def setup_test_data(self, cfg):
+    #     """Omitted."""
+    #     pass
+
+    # @classmethod
+    # def list_available_models(cls) -> 'List[PretrainedModelInfo]':
+    #     """
+    #     This method returns a list of pre-trained model which can be instantiated directly from NVIDIA's NGC cloud.
+    #     Returns:
+    #         List of available pre-trained models.
+    #     """
+    #     list_of_models = []
+    #     model = PretrainedModelInfo(
+    #         pretrained_model_name="tts_en_lj_mixertts",
+    #         location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/tts_en_lj_mixertts/versions/1.6.0/files/tts_en_lj_mixertts.nemo",
+    #         description="This model is trained on LJSpeech sampled at 22050Hz with and can be used to generate female English voices with an American accent.",
+    #         class_=cls,  # noqa
+    #     )
+    #     list_of_models.append(model)
+
+    #     model = PretrainedModelInfo(
+    #         pretrained_model_name="tts_en_lj_mixerttsx",
+    #         location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/tts_en_lj_mixerttsx/versions/1.6.0/files/tts_en_lj_mixerttsx.nemo",
+    #         description="This model is trained on LJSpeech sampled at 22050Hz with and can be used to generate female English voices with an American accent.",
+    #         class_=cls,  # noqa
+    #     )
+    #     list_of_models.append(model)
+
+    #     return list_of_models
+
+    # Methods for model exportability
+    # @property
+    # def input_types(self):
+    #     return {
+    #         "text": NeuralType(('B', 'T_text'), TokenIndex()),
+    #         "lm_tokens": NeuralType(('B', 'T_lm_tokens'), TokenIndex(), optional=True),
+    #     }
+
+    # @property
+    # def output_types(self):
+    #     return {
+    #         "spect": NeuralType(('B', 'D', 'T_spec'), MelSpectrogramType()),
+    #     }
+
+    def input_example(self, max_text_len=10, max_lm_tokens_len=10, device='cpu'):
+        text = torch.randint(
+            low=0, high=self.encoder.to_embed.num_embeddings, 
+            size=(1, max_text_len), device=device, dtype=torch.long,
+        )
+
+        inputs = {'text': text}
+
+        # if self.cond_on_lm_embeddings:
+        #     inputs['lm_tokens'] = torch.randint(
+        #         low=0,
+        #         high=self.lm_embeddings.weight.shape[0],
+        #         size=(1, max_lm_tokens_len),
+        #         device=self.device,
+        #         dtype=torch.long,
+        #     )
+
+        return (inputs,)
+
+    def forward_for_export(self, text, lm_tokens=None):
+        text_mask = (text != self.tokenizer_pad).unsqueeze(2)
+        spect = self.infer(text=text, text_mask=text_mask, lm_tokens=lm_tokens).transpose(1, 2)
+        return spect.to(torch.float)

--- a/phoonnx_train/mixertts/models/mixer_tts/modules/aligner.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/modules/aligner.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/modules/aligner.py
+
+import torch
+from einops import rearrange
+from torch import nn
+
+from .submodules import ConditionalInput, ConvNorm
+from .helpers import binarize_attention_parallel
+
+
+class AlignmentEncoder(torch.nn.Module):
+    """
+    Module for alignment text and mel spectrogram.
+
+    Args:
+        n_mel_channels: Dimension of mel spectrogram.
+        n_text_channels: Dimension of text embeddings.
+        n_att_channels: Dimension of model
+        temperature: Temperature to scale distance by.
+            Suggested to be 0.0005 when using dist_type "l2" and 15.0 when using "cosine".
+        condition_types: List of types for nemo.collections.tts.modules.submodules.ConditionalInput.
+        dist_type: Distance type to use for similarity measurement. Supports "l2" and "cosine" distance.
+    """
+
+    def __init__(
+        self,
+        n_mel_channels=80,
+        n_text_channels=512,
+        n_att_channels=80,
+        temperature=0.0005,
+        condition_types=[],
+        dist_type="l2",
+    ):
+        super().__init__()
+        self.temperature = temperature
+        self.cond_input = ConditionalInput(n_text_channels, n_text_channels, condition_types)
+        self.softmax = torch.nn.Softmax(dim=3)
+        self.log_softmax = torch.nn.LogSoftmax(dim=3)
+
+        self.key_proj = nn.Sequential(
+            ConvNorm(n_text_channels, n_text_channels * 2, kernel_size=3, bias=True, w_init_gain='relu'),
+            torch.nn.ReLU(),
+            ConvNorm(n_text_channels * 2, n_att_channels, kernel_size=1, bias=True),
+        )
+
+        self.query_proj = nn.Sequential(
+            ConvNorm(n_mel_channels, n_mel_channels * 2, kernel_size=3, bias=True, w_init_gain='relu'),
+            torch.nn.ReLU(),
+            ConvNorm(n_mel_channels * 2, n_mel_channels, kernel_size=1, bias=True),
+            torch.nn.ReLU(),
+            ConvNorm(n_mel_channels, n_att_channels, kernel_size=1, bias=True),
+        )
+        if dist_type == "l2":
+            self.dist_fn = self.get_euclidean_dist
+        elif dist_type == "cosine":
+            self.dist_fn = self.get_cosine_dist
+        else:
+            raise ValueError(f"Unknown distance type '{dist_type}'")
+
+    @staticmethod
+    def _apply_mask(inputs, mask, mask_value):
+        if mask is None:
+            return
+
+        mask = rearrange(mask, "B T2 1 -> B 1 1 T2")
+        inputs.data.masked_fill_(mask, mask_value)
+
+    def get_dist(self, keys, queries, mask=None):
+        """Calculation of distance matrix.
+
+        Args:
+            queries (torch.tensor): B x C1 x T1 tensor (probably going to be mel data).
+            keys (torch.tensor): B x C2 x T2 tensor (text data).
+            mask (torch.tensor): B x T2 x 1 tensor, binary mask for variable length entries and also can be used
+                for ignoring unnecessary elements from keys in the resulting distance matrix (True = mask element, False = leave unchanged).
+        Output:
+            dist (torch.tensor): B x T1 x T2 tensor.
+        """
+        # B x C x T1
+        queries_enc = self.query_proj(queries)
+        # B x C x T2
+        keys_enc = self.key_proj(keys)
+        # B x 1 x T1 x T2
+        dist = self.dist_fn(queries_enc=queries_enc, keys_enc=keys_enc)
+
+        self._apply_mask(dist, mask, float("inf"))
+
+        return dist.squeeze(1)  # B x T1 x T2, as get_mean_dist_by_durations expects
+
+    @staticmethod
+    def get_euclidean_dist(queries_enc, keys_enc):
+        queries_enc = rearrange(queries_enc, "B C T1 -> B C T1 1")
+        keys_enc = rearrange(keys_enc, "B C T2 -> B C 1 T2")
+        # B x C x T1 x T2
+        distance = (queries_enc - keys_enc) ** 2
+        # B x 1 x T1 x T2
+        l2_dist = distance.sum(axis=1, keepdim=True)
+        return l2_dist
+
+    @staticmethod
+    def get_cosine_dist(queries_enc, keys_enc):
+        queries_enc = rearrange(queries_enc, "B C T1 -> B C T1 1")
+        keys_enc = rearrange(keys_enc, "B C T2 -> B C 1 T2")
+        cosine_dist = -torch.nn.functional.cosine_similarity(queries_enc, keys_enc, dim=1)
+        cosine_dist = rearrange(cosine_dist, "B T1 T2 -> B 1 T1 T2")
+        return cosine_dist
+
+    @staticmethod
+    def get_durations(attn_soft, text_len, spect_len):
+        """Calculation of durations.
+
+        Args:
+            attn_soft (torch.tensor): B x 1 x T1 x T2 tensor.
+            text_len (torch.tensor): B tensor, lengths of text.
+            spect_len (torch.tensor): B tensor, lengths of mel spectrogram.
+        """
+        attn_hard = binarize_attention_parallel(attn_soft, text_len, spect_len)
+        durations = attn_hard.sum(2)[:, 0, :]
+        assert torch.all(torch.eq(durations.sum(dim=1), spect_len))
+        return durations
+
+    @staticmethod
+    def get_mean_dist_by_durations(dist, durations, mask=None):
+        """Select elements from the distance matrix for the given durations and mask and return mean distance.
+
+        Args:
+            dist (torch.tensor): B x T1 x T2 tensor.
+            durations (torch.tensor): B x T2 tensor. Dim T2 should sum to T1.
+            mask (torch.tensor): B x T2 x 1 binary mask for variable length entries and also can be used
+                for ignoring unnecessary elements in dist by T2 dim (True = mask element, False = leave unchanged).
+        Output:
+            mean_dist (torch.tensor): B x 1 tensor.
+        """
+        batch_size, t1_size, t2_size = dist.size()
+        assert torch.all(torch.eq(durations.sum(dim=1), t1_size))
+
+        AlignmentEncoder._apply_mask(dist, mask, 0)
+
+        # TODO(oktai15): make it more efficient
+        mean_dist_by_durations = []
+        for dist_idx in range(batch_size):
+            mean_dist_by_durations.append(
+                torch.mean(
+                    dist[
+                        dist_idx,
+                        torch.arange(t1_size),
+                        torch.repeat_interleave(torch.arange(t2_size), repeats=durations[dist_idx]),
+                    ]
+                )
+            )
+
+        return torch.tensor(mean_dist_by_durations, dtype=dist.dtype, device=dist.device)
+
+    @staticmethod
+    def get_mean_distance_for_word(l2_dists, durs, start_token, num_tokens):
+        """Calculates the mean distance between text and audio embeddings given a range of text tokens.
+
+        Args:
+            l2_dists (torch.tensor): L2 distance matrix from Aligner inference. T1 x T2 tensor.
+            durs (torch.tensor): List of durations corresponding to each text token. T2 tensor. Should sum to T1.
+            start_token (int): Index of the starting token for the word of interest.
+            num_tokens (int): Length (in tokens) of the word of interest.
+        Output:
+            mean_dist_for_word (float): Mean embedding distance between the word indicated and its predicted audio frames.
+        """
+        # Need to calculate which audio frame we start on by summing all durations up to the start token's duration
+        start_frame = torch.sum(durs[:start_token]).data
+
+        total_frames = 0
+        dist_sum = 0
+
+        # Loop through each text token
+        for token_ind in range(start_token, start_token + num_tokens):
+            # Loop through each frame for the given text token
+            for frame_ind in range(start_frame, start_frame + durs[token_ind]):
+                # Recall that the L2 distance matrix is shape [spec_len, text_len]
+                dist_sum += l2_dists[frame_ind, token_ind]
+
+            # Update total frames so far & the starting frame for the next token
+            total_frames += durs[token_ind]
+            start_frame += durs[token_ind]
+
+        return dist_sum / total_frames
+
+    def forward(self, queries, keys, mask=None, attn_prior=None, conditioning=None):
+        """Forward pass of the aligner encoder.
+
+        Args:
+            queries (torch.tensor): B x C1 x T1 tensor (probably going to be mel data).
+            keys (torch.tensor): B x C2 x T2 tensor (text data).
+            mask (torch.tensor): B x T2 x 1 tensor, binary mask for variable length entries (True = mask element, False = leave unchanged).
+            attn_prior (torch.tensor): prior for attention matrix.
+            conditioning (torch.tensor): B x 1 x C2 conditioning embedding
+        Output:
+            attn (torch.tensor): B x 1 x T1 x T2 attention mask. Final dim T2 should sum to 1.
+            attn_logprob (torch.tensor): B x 1 x T1 x T2 log-prob attention mask.
+        """
+        keys = self.cond_input(keys.transpose(1, 2), conditioning).transpose(1, 2)
+        # B x C x T1
+        queries_enc = self.query_proj(queries)
+        # B x C x T2
+        keys_enc = self.key_proj(keys)
+        # B x 1 x T1 x T2
+        distance = self.dist_fn(queries_enc=queries_enc, keys_enc=keys_enc)
+        attn = -self.temperature * distance
+
+        if attn_prior is not None:
+            attn = self.log_softmax(attn) + torch.log(attn_prior[:, None] + 1e-8)
+
+        attn_logprob = attn.clone()
+
+        self._apply_mask(attn, mask, -float("inf"))
+
+        attn = self.softmax(attn)  # softmax along T2
+        return attn, attn_logprob

--- a/phoonnx_train/mixertts/models/mixer_tts/modules/aligner_loss.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/modules/aligner_loss.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/losses/aligner_loss.py
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# from nemo.core.classes import Loss, typecheck
+# from nemo.core.neural_types.elements import LengthsType, LogprobsType, LossType, ProbsType
+# from nemo.core.neural_types.neural_type import NeuralType
+
+
+class ForwardSumLoss(nn.Module):
+    def __init__(self, blank_logprob=-1, loss_scale=1.0):
+        super().__init__()
+        self.log_softmax = torch.nn.LogSoftmax(dim=-1)
+        self.ctc_loss = torch.nn.CTCLoss(zero_infinity=True)
+        self.blank_logprob = blank_logprob
+        self.loss_scale = loss_scale
+
+    # @property
+    # def input_types(self):
+    #     return {
+    #         "attn_logprob": NeuralType(('B', 'S', 'T_spec', 'T_text'), LogprobsType()),
+    #         "in_lens": NeuralType(tuple('B'), LengthsType()),
+    #         "out_lens": NeuralType(tuple('B'), LengthsType()),
+    #     }
+
+    # @property
+    # def output_types(self):
+    #     return {
+    #         "forward_sum_loss": NeuralType(elements_type=LossType()),
+    #     }
+
+    # @typecheck()
+    def forward(self, attn_logprob, in_lens, out_lens):
+        key_lens = in_lens
+        query_lens = out_lens
+        max_key_len = attn_logprob.size(-1)
+
+        # Reorder input to [query_len, batch_size, key_len]
+        attn_logprob = attn_logprob.squeeze(1)
+        attn_logprob = attn_logprob.permute(1, 0, 2)
+
+        # Add blank label
+        attn_logprob = F.pad(input=attn_logprob, pad=(1, 0, 0, 0, 0, 0), value=self.blank_logprob)
+
+        # Convert to log probabilities
+        # Note: Mask out probs beyond key_len
+        key_inds = torch.arange(max_key_len + 1, device=attn_logprob.device, dtype=torch.long)
+        attn_logprob.masked_fill_(key_inds.view(1, 1, -1) > key_lens.view(1, -1, 1), -1e15)  # key_inds >= key_lens+1
+        attn_logprob = self.log_softmax(attn_logprob)
+
+        # Target sequences
+        target_seqs = key_inds[1:].unsqueeze(0)
+        target_seqs = target_seqs.repeat(key_lens.numel(), 1)
+
+        # Evaluate CTC loss
+        cost = self.ctc_loss(attn_logprob, target_seqs, input_lengths=query_lens, target_lengths=key_lens)
+        cost *= self.loss_scale
+
+        return cost
+
+
+class BinLoss(nn.Module):
+    def __init__(self, loss_scale=1.0):
+        super().__init__()
+        self.loss_scale = loss_scale
+
+    # @property
+    # def input_types(self):
+    #     return {
+    #         "hard_attention": NeuralType(('B', 'S', 'T_spec', 'T_text'), ProbsType()),
+    #         "soft_attention": NeuralType(('B', 'S', 'T_spec', 'T_text'), ProbsType()),
+    #     }
+
+    # @property
+    # def output_types(self):
+    #     return {
+    #         "bin_loss": NeuralType(elements_type=LossType()),
+    #     }
+
+    # @typecheck()
+    def forward(self, hard_attention, soft_attention):
+        log_sum = torch.log(torch.clamp(soft_attention[hard_attention == 1], min=1e-12)).sum()
+        loss = -log_sum / hard_attention.sum()
+        loss *= self.loss_scale
+        return loss

--- a/phoonnx_train/mixertts/models/mixer_tts/modules/fastpitch.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/modules/fastpitch.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2021, NVIDIA Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/modules/fastpitch.py
+
+import torch
+import torch.nn as nn
+
+from .submodules import ConditionalInput, ConditionalLayerNorm
+# from nemo.core.classes import NeuralModule, adapter_mixins, typecheck
+# from nemo.core.neural_types.elements import (
+#     EncodedRepresentation,
+#     Index,
+#     LengthsType,
+#     LogprobsType,
+#     MelSpectrogramType,
+#     ProbsType,
+#     RegressionValuesType,
+#     TokenDurationType,
+#     TokenIndex,
+#     TokenLogDurationType,
+# )
+# from nemo.core.neural_types.neural_type import NeuralType
+
+
+def average_features(pitch, durs):
+    durs_cums_ends = torch.cumsum(durs, dim=1).long()
+    durs_cums_starts = torch.nn.functional.pad(durs_cums_ends[:, :-1], (1, 0))
+    pitch_nonzero_cums = torch.nn.functional.pad(torch.cumsum(pitch != 0.0, dim=2), (1, 0))
+    pitch_cums = torch.nn.functional.pad(torch.cumsum(pitch, dim=2), (1, 0))
+
+    bs, l = durs_cums_ends.size()
+    n_formants = pitch.size(1)
+    dcs = durs_cums_starts[:, None, :].expand(bs, n_formants, l)
+    dce = durs_cums_ends[:, None, :].expand(bs, n_formants, l)
+
+    pitch_sums = (torch.gather(pitch_cums, 2, dce) - torch.gather(pitch_cums, 2, dcs)).float()
+    pitch_nelems = (torch.gather(pitch_nonzero_cums, 2, dce) - torch.gather(pitch_nonzero_cums, 2, dcs)).float()
+
+    pitch_avg = torch.where(pitch_nelems == 0.0, pitch_nelems, pitch_sums / pitch_nelems)
+    return pitch_avg
+
+
+def log_to_duration(log_dur, min_dur, max_dur, mask):
+    dur = torch.clamp(torch.exp(log_dur) - 1.0, min_dur, max_dur)
+    dur *= mask.squeeze(2)
+    return dur
+
+
+class ConvReLUNorm(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size=1, dropout=0.0, condition_dim=384, condition_types=[]):
+        super(ConvReLUNorm, self).__init__()
+        self.conv = torch.nn.Conv1d(in_channels, out_channels, kernel_size=kernel_size, padding=(kernel_size // 2))
+        self.norm = ConditionalLayerNorm(out_channels, condition_dim=condition_dim, condition_types=condition_types)
+        self.dropout = torch.nn.Dropout(dropout)
+
+    def forward(self, signal, conditioning=None):
+        out = torch.nn.functional.relu(self.conv(signal))
+        out = self.norm(out.transpose(1, 2), conditioning).transpose(1, 2)
+        out = self.dropout(out)
+
+        # if self.is_adapter_available():
+        #     out = self.forward_enabled_adapters(out.transpose(1, 2)).transpose(1, 2)
+
+        return out
+
+
+class TemporalPredictor(nn.Module):
+    """Predicts a single float per each temporal location"""
+
+    def __init__(self, input_size, filter_size, kernel_size, dropout, n_layers=2, condition_types=[]):
+        super(TemporalPredictor, self).__init__()
+        self.cond_input = ConditionalInput(input_size, input_size, condition_types)
+        self.layers = torch.nn.ModuleList()
+        for i in range(n_layers):
+            self.layers.append(
+                ConvReLUNorm(
+                    input_size if i == 0 else filter_size,
+                    filter_size,
+                    kernel_size=kernel_size,
+                    dropout=dropout,
+                    condition_dim=input_size,
+                    condition_types=condition_types,
+                )
+            )
+        self.fc = torch.nn.Linear(filter_size, 1, bias=True)
+
+        # Use for adapter input dimension
+        self.filter_size = filter_size
+
+    # @property
+    # def input_types(self):
+    #     return {
+    #         "enc": NeuralType(('B', 'T', 'D'), EncodedRepresentation()),
+    #         "enc_mask": NeuralType(('B', 'T', 1), TokenDurationType()),
+    #         "conditioning": NeuralType(('B', 'T', 'D'), EncodedRepresentation(), optional=True),
+    #     }
+
+    # @property
+    # def output_types(self):
+    #     return {
+    #         "out": NeuralType(('B', 'T'), EncodedRepresentation()),
+    #     }
+
+    def forward(self, enc, enc_mask, conditioning=None):
+        enc = self.cond_input(enc, conditioning)
+        out = enc * enc_mask
+        out = out.transpose(1, 2)
+
+        for layer in self.layers:
+            out = layer(out, conditioning=conditioning)
+
+        out = out.transpose(1, 2)
+        out = self.fc(out) * enc_mask
+        return out.squeeze(-1)
+
+

--- a/phoonnx_train/mixertts/models/mixer_tts/modules/helpers.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/modules/helpers.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2021, NVIDIA Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/parts/utils/helpers.py
+
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from numba import jit, prange
+
+# from nemo.collections.tts.torch.tts_data_types import DATA_STR2DATA_CLASS, MAIN_DATA_TYPES, WithLens
+# from nemo.utils import logging
+# from nemo.utils.decorators import deprecated
+
+HAVE_WANDB = False
+# try:
+#     import wandb
+# except ModuleNotFoundError:
+#     HAVE_WANDB = False
+
+# try:
+#     from pytorch_lightning.utilities import rank_zero_only
+# except ModuleNotFoundError:
+#     from functools import wraps
+
+    # def rank_zero_only(fn):
+    #     @wraps(fn)
+    #     def wrapped_fn(*args, **kwargs):
+    #         logging.error(
+    #             f"Function {fn} requires lighting to be installed, but it was not found. Please install lightning first"
+    #         )
+    #         exit(1)
+
+def binarize_attention(attn, in_len, out_len):
+    """Convert soft attention matrix to hard attention matrix.
+
+    Args:
+        attn (torch.Tensor): B x 1 x max_mel_len x max_text_len. Soft attention matrix.
+        in_len (torch.Tensor): B. Lengths of texts.
+        out_len (torch.Tensor): B. Lengths of spectrograms.
+
+    Output:
+        attn_out (torch.Tensor): B x 1 x max_mel_len x max_text_len. Hard attention matrix, final dim max_text_len should sum to 1.
+    """
+    b_size = attn.shape[0]
+    with torch.no_grad():
+        attn_cpu = attn.data.cpu().numpy()
+        attn_out = torch.zeros_like(attn)
+        for ind in range(b_size):
+            hard_attn = mas(attn_cpu[ind, 0, : out_len[ind], : in_len[ind]])
+            attn_out[ind, 0, : out_len[ind], : in_len[ind]] = torch.tensor(hard_attn, device=attn.device)
+    return attn_out
+
+
+def binarize_attention_parallel(attn, in_lens, out_lens):
+    """For training purposes only. Binarizes attention with MAS.
+           These will no longer receive a gradient.
+
+        Args:
+            attn: B x 1 x max_mel_len x max_text_len
+        """
+    with torch.no_grad():
+        log_attn_cpu = torch.log(attn.data).cpu().numpy()
+        attn_out = b_mas(log_attn_cpu, in_lens.cpu().numpy(), out_lens.cpu().numpy(), width=1)
+    return torch.from_numpy(attn_out).to(attn.device)
+
+
+def get_mask_from_lengths(lengths: Optional[torch.Tensor] = None, x: Optional[torch.Tensor] = None,) -> torch.Tensor:
+    """Constructs binary mask from a 1D torch tensor of input lengths
+
+    Args:
+        lengths: Optional[torch.tensor] (torch.tensor): 1D tensor with lengths
+        x: Optional[torch.tensor] = tensor to be used on, last dimension is for mask 
+    Returns:
+        mask (torch.tensor): num_sequences x max_length x 1 binary tensor
+    """
+    if lengths is None:
+        assert x is not None
+        return torch.ones(x.shape[-1], dtype=torch.bool, device=x.device)
+    else:
+        if x is None:
+            max_len = torch.max(lengths)
+        else:
+            max_len = x.shape[-1]
+    ids = torch.arange(0, max_len, device=lengths.device, dtype=lengths.dtype)
+    mask = ids < lengths.unsqueeze(1)
+    return mask
+
+
+def sort_tensor(
+    context: torch.Tensor, lens: torch.Tensor, dim: Optional[int] = 0, descending: Optional[bool] = True
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Sorts elements in context by the dim lengths specified in lens
+    Args:
+        context:  source tensor, sorted by lens
+        lens: lengths of elements of context along the dimension dim
+        dim: Optional[int] : dimension to sort by
+    Returns:
+        context: tensor sorted by lens along dimension dim
+        lens_sorted: lens tensor, sorted
+        ids_sorted: reorder ids to be used to restore original order
+    
+    """
+    lens_sorted, ids_sorted = torch.sort(lens, descending=descending)
+    context = torch.index_select(context, dim, ids_sorted)
+    return context, lens_sorted, ids_sorted
+
+
+def unsort_tensor(ordered: torch.Tensor, indices: torch.Tensor, dim: Optional[int] = 0) -> torch.Tensor:
+    """Reverses the result of sort_tensor function:
+       o, _, ids = sort_tensor(x,l) 
+       assert unsort_tensor(o,ids) == x
+    Args:
+        ordered: context tensor, sorted by lengths
+        indices: torch.tensor: 1D tensor with 're-order' indices returned by sort_tensor
+    Returns:
+        ordered tensor in original order (before calling sort_tensor)  
+    """
+    return torch.index_select(ordered, dim, indices.argsort(0))
+
+
+@jit(nopython=True)
+def mas(attn_map, width=1):
+    # assumes mel x text
+    opt = np.zeros_like(attn_map)
+    attn_map = np.log(attn_map)
+    attn_map[0, 1:] = -np.inf
+    log_p = np.zeros_like(attn_map)
+    log_p[0, :] = attn_map[0, :]
+    prev_ind = np.zeros_like(attn_map, dtype=np.int64)
+    for i in range(1, attn_map.shape[0]):
+        for j in range(attn_map.shape[1]):  # for each text dim
+            prev_j = np.arange(max(0, j - width), j + 1)
+            prev_log = np.array([log_p[i - 1, prev_idx] for prev_idx in prev_j])
+
+            ind = np.argmax(prev_log)
+            log_p[i, j] = attn_map[i, j] + prev_log[ind]
+            prev_ind[i, j] = prev_j[ind]
+
+    # now backtrack
+    curr_text_idx = attn_map.shape[1] - 1
+    for i in range(attn_map.shape[0] - 1, -1, -1):
+        opt[i, curr_text_idx] = 1
+        curr_text_idx = prev_ind[i, curr_text_idx]
+    opt[0, curr_text_idx] = 1
+
+    assert opt.sum(0).all()
+    assert opt.sum(1).all()
+
+    return opt
+
+
+@jit(nopython=True)
+def mas_width1(log_attn_map):
+    """mas with hardcoded width=1"""
+    # assumes mel x text
+    neg_inf = log_attn_map.dtype.type(-np.inf)
+    log_p = log_attn_map.copy()
+    log_p[0, 1:] = neg_inf
+    for i in range(1, log_p.shape[0]):
+        prev_log1 = neg_inf
+        for j in range(log_p.shape[1]):
+            prev_log2 = log_p[i - 1, j]
+            log_p[i, j] += max(prev_log1, prev_log2)
+            prev_log1 = prev_log2
+
+    # now backtrack
+    opt = np.zeros_like(log_p)
+    one = opt.dtype.type(1)
+    j = log_p.shape[1] - 1
+    for i in range(log_p.shape[0] - 1, 0, -1):
+        opt[i, j] = one
+        if log_p[i - 1, j - 1] >= log_p[i - 1, j]:
+            j -= 1
+            if j == 0:
+                opt[1:i, j] = one
+                break
+    opt[0, j] = one
+    return opt
+
+
+@jit(nopython=True, parallel=True)
+def b_mas(b_log_attn_map, in_lens, out_lens, width=1):
+    assert width == 1
+    attn_out = np.zeros_like(b_log_attn_map)
+
+    for b in prange(b_log_attn_map.shape[0]):
+        out = mas_width1(b_log_attn_map[b, 0, : out_lens[b], : in_lens[b]])
+        attn_out[b, 0, : out_lens[b], : in_lens[b]] = out
+    return attn_out
+
+
+
+def regulate_len(
+    durations, enc_out, pace=1.0, mel_max_len=None, group_size=1, dur_lens: torch.tensor = None,
+):
+    """A function that takes predicted durations per encoded token, and repeats enc_out according to the duration.
+    NOTE: durations.shape[1] == enc_out.shape[1]
+
+    Args:
+        durations (torch.tensor): A tensor of shape (batch x enc_length) that represents how many times to repeat each
+            token in enc_out.
+        enc_out (torch.tensor): A tensor of shape (batch x enc_length x enc_hidden) that represents the encoded tokens.
+        pace (float): The pace of speaker. Higher values result in faster speaking pace. Defaults to 1.0.        max_mel_len (int): The maximum length above which the output will be removed. If sum(durations, dim=1) >
+            max_mel_len, the values after max_mel_len will be removed. Defaults to None, which has no max length.
+        group_size (int): replicate the last element specified by durations[i, in_lens[i] - 1] until the
+            full length of the sequence is the next nearest multiple of group_size
+        in_lens (torch.tensor): input sequence length specifying valid values in the durations input tensor (only needed if group_size >1)
+    """
+
+    dtype = enc_out.dtype
+    reps = durations.float() / pace
+    reps = (reps + 0.5).floor().long()
+    dec_lens = reps.sum(dim=1)
+    if group_size > 1:
+        to_pad = group_size * (torch.div(dec_lens + 1, group_size, rounding_mode='floor')) - dec_lens
+        reps.index_put_(
+            indices=[torch.arange(dur_lens.shape[0], dtype=torch.long), dur_lens - 1], values=to_pad, accumulate=True
+        )
+        dec_lens = reps.sum(dim=1)
+
+    max_len = dec_lens.max()
+    reps_cumsum = torch.cumsum(torch.nn.functional.pad(reps, (1, 0, 0, 0), value=0.0), dim=1)[:, None, :]
+    reps_cumsum = reps_cumsum.to(dtype=dtype, device=enc_out.device)
+
+    range_ = torch.arange(max_len).to(enc_out.device)[None, :, None]
+    mult = (reps_cumsum[:, :, :-1] <= range_) & (reps_cumsum[:, :, 1:] > range_)
+    mult = mult.to(dtype)
+    enc_rep = torch.matmul(mult, enc_out)
+
+    if mel_max_len is not None:
+        enc_rep = enc_rep[:, :mel_max_len]
+        dec_lens = torch.clamp_max(dec_lens, mel_max_len)
+
+    return enc_rep, dec_lens
+
+

--- a/phoonnx_train/mixertts/models/mixer_tts/modules/mixer_tts.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/modules/mixer_tts.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/modules/mixer_tts.py
+
+import math
+
+import torch
+from torch import nn
+
+from .submodules import ConvNorm
+from .transformer import PositionalEmbedding
+
+
+def get_same_padding(kernel_size, stride, dilation) -> int:
+    if stride > 1 and dilation > 1:
+        raise ValueError("Only stride OR dilation may be greater than 1")
+    return (dilation * (kernel_size - 1)) // 2
+
+
+class SameLensMaskedConv1d(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, stride, dilation, padding, groups):
+        super().__init__()
+
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            dilation=dilation,
+            padding=padding,
+            groups=groups,
+        )
+
+    def forward(self, x, mask):
+        x = self.conv(x.transpose(1, 2)).transpose(1, 2) * mask
+        return x, mask
+
+
+class SameLensMaskedLinear(nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.linear = nn.Linear(in_channels, out_channels)
+
+    def forward(self, x, mask):
+        x = self.linear(x) * mask
+        return x, mask
+
+
+def create_channel_mix_layer(in_feat, out_feat):
+    return SameLensMaskedLinear(in_feat, out_feat)
+
+
+def create_time_mix_layer(in_feat, out_feat, kernel_size=3, stride=1, conv_type="depth-wise", dilation=1):
+    padding = get_same_padding(kernel_size, stride=stride, dilation=dilation)
+
+    if conv_type == "original":
+        groups = 1
+    elif conv_type == "depth-wise":
+        groups = in_feat
+    else:
+        raise NotImplementedError
+
+    conv = SameLensMaskedConv1d(
+        in_feat, out_feat, kernel_size=kernel_size, stride=stride, dilation=dilation, padding=padding, groups=groups
+    )
+
+    return conv
+
+
+class Mix(nn.Module):
+    def __init__(self, first_mix_layer, second_mix_layer, dropout):
+        super().__init__()
+
+        self.first_mix_layer = first_mix_layer
+        self.act = nn.GELU()
+        self.drop_1 = nn.Dropout(dropout)
+        self.second_mix_layer = second_mix_layer
+        self.drop_2 = nn.Dropout(dropout)
+
+    def forward(self, x, mask=None):
+        x, mask = self.first_mix_layer(x, mask)
+        x = self.act(x)
+        x = self.drop_1(x)
+        x, mask = self.second_mix_layer(x, mask)
+        x = self.drop_2(x)
+        return x, mask
+
+
+class PreNormResidual(nn.Module):
+    def __init__(self, fn, feature_dim):
+        super().__init__()
+        self.fn = fn
+        self.norm = nn.LayerNorm(feature_dim)
+
+    def forward(self, x, mask):
+        new_x, mask = self.fn(self.norm(x), mask)
+        x = x + new_x
+        return x, mask
+
+
+class MixerTTSBlock(nn.Module):
+    def __init__(self, in_feat, expansion_factor, kernel_size, conv_type, dropout):
+        super().__init__()
+
+        self.time_mix = PreNormResidual(
+            fn=Mix(
+                first_mix_layer=create_time_mix_layer(
+                    in_feat=in_feat, out_feat=in_feat, kernel_size=kernel_size, conv_type=conv_type,
+                ),
+                second_mix_layer=create_time_mix_layer(
+                    in_feat=in_feat, out_feat=in_feat, kernel_size=kernel_size, conv_type=conv_type,
+                ),
+                dropout=dropout,
+            ),
+            feature_dim=in_feat,
+        )
+
+        self.channel_mix = PreNormResidual(
+            fn=Mix(
+                first_mix_layer=create_channel_mix_layer(in_feat=in_feat, out_feat=expansion_factor * in_feat,),
+                second_mix_layer=create_channel_mix_layer(in_feat=expansion_factor * in_feat, out_feat=in_feat,),
+                dropout=dropout,
+            ),
+            feature_dim=in_feat,
+        )
+
+    def forward(self, x, mask):
+        x, mask = self.time_mix(x, mask)
+        x, mask = self.channel_mix(x, mask)
+        return x, mask
+
+
+class MixerTTSModule(nn.Module):
+    def __init__(
+        self,
+        num_tokens,
+        feature_dim,
+        num_layers,
+        kernel_sizes,
+        padding_idx=0,
+        conv_type="depth-wise",
+        expansion_factor=4,
+        dropout=0.0,
+    ):
+        super().__init__()
+
+        if len(kernel_sizes) != num_layers:
+            raise ValueError
+
+        self.d_model = feature_dim
+        self.to_embed = (
+            nn.Embedding(num_tokens, feature_dim, padding_idx=padding_idx) if num_tokens != -1 else nn.Identity()
+        )
+        self.mixer_blocks = nn.Sequential(
+            *[
+                MixerTTSBlock(feature_dim, expansion_factor, kernel_size, conv_type, dropout)
+                for kernel_size in kernel_sizes
+            ],
+        )
+        self.norm = nn.LayerNorm(feature_dim)
+
+    def forward(self, x, mask, conditioning=0):
+        x = self.to_embed(x)
+        x = x + conditioning
+
+        x = x * mask
+        for block in self.mixer_blocks:
+            x, lens = block(x, mask)
+
+        x = self.norm(x)
+
+        return x, mask
+
+
+class SelfAttentionModule(nn.Module):
+    """Self-attention for lm tokens and text. """
+
+    def __init__(self, n_text_channels=384, n_lm_tokens_channels=128):
+        super().__init__()
+
+        self.text_pos_emb = PositionalEmbedding(n_text_channels)
+        self.lm_pos_emb = PositionalEmbedding(n_lm_tokens_channels)
+
+        self.query_proj = nn.Sequential(
+            ConvNorm(n_text_channels, n_text_channels, kernel_size=3, bias=True, w_init_gain='relu'),
+            torch.nn.ReLU(),
+            ConvNorm(n_text_channels, n_text_channels, kernel_size=1, bias=True),
+        )
+
+        self.key_proj = nn.Sequential(
+            ConvNorm(n_lm_tokens_channels, n_text_channels, kernel_size=3, bias=True, w_init_gain='relu'),
+            torch.nn.ReLU(),
+            ConvNorm(n_text_channels, n_text_channels, kernel_size=1, bias=True),
+        )
+
+        self.value_proj = nn.Sequential(
+            ConvNorm(n_lm_tokens_channels, n_text_channels, kernel_size=3, bias=True, w_init_gain='relu'),
+            torch.nn.ReLU(),
+            ConvNorm(n_text_channels, n_text_channels, kernel_size=1, bias=True),
+        )
+
+        self.scale = math.sqrt(n_text_channels)
+
+    def forward(self, queries, keys, values, q_mask=None, kv_mask=None):
+        """Forward pass of self-attention.
+
+        Args:
+            queries (torch.tensor): B x T1 x C1 tensor
+            keys (torch.tensor): B x T2 x C2 tensor
+            values (torch.tensor): B x T2 x C2 tensor
+            q_mask (torch.tensor): B x T1 tensor, bool mask for variable length entries
+            kv_mask (torch.tensor): B x T2 tensor, bool mask for variable length entries
+        Output:
+            attn_out (torch.tensor): B x T1 x C1 tensor
+        """
+        pos_q_seq = torch.arange(queries.size(-2), device=queries.device).to(queries.dtype)
+        pos_kv_seq = torch.arange(keys.size(-2), device=queries.device).to(queries.dtype)
+
+        pos_q_emb = self.text_pos_emb(pos_q_seq)
+        pos_kv_emb = self.lm_pos_emb(pos_kv_seq)
+
+        if q_mask is not None:
+            pos_q_emb = pos_q_emb * q_mask.unsqueeze(2)
+
+        if kv_mask is not None:
+            pos_kv_emb = pos_kv_emb * kv_mask.unsqueeze(2)
+
+        queries = (queries + pos_q_emb).transpose(1, 2)
+        keys = (keys + pos_kv_emb).transpose(1, 2)
+        values = (values + pos_kv_emb).transpose(1, 2)
+
+        queries_enc = self.query_proj(queries).transpose(-2, -1)  # B x T1 x C1
+        keys_enc = self.key_proj(keys)  # B x C1 x T2
+        values_enc = self.value_proj(values).transpose(-2, -1)  # B x T2 x C1
+
+        scores = torch.matmul(queries_enc, keys_enc) / self.scale  # B x T1 x T2
+
+        if kv_mask is not None:
+            scores.masked_fill_(~kv_mask.unsqueeze(-2), -float("inf"))
+
+        return torch.matmul(torch.softmax(scores, dim=-1), values_enc)  # B x T1 x C1

--- a/phoonnx_train/mixertts/models/mixer_tts/modules/submodules.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/modules/submodules.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/modules/submodules.py
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.nn import functional as F
+
+# from nemo.core.classes import NeuralModule, adapter_mixins
+# from nemo.core.neural_types.elements import EncodedRepresentation, Index, LengthsType, MelSpectrogramType
+# from nemo.core.neural_types.neural_type import NeuralType
+# from nemo.utils import logging
+
+
+SUPPORTED_CONDITION_TYPES = ["add", "concat", "layernorm"]
+
+
+def check_support_condition_types(condition_types):
+    for tp in condition_types:
+        if tp not in SUPPORTED_CONDITION_TYPES:
+            raise ValueError(f"Unknown conditioning type {tp}")
+
+
+def masked_instance_norm(
+    input: Tensor, mask: Tensor, weight: Tensor, bias: Tensor, momentum: float, eps: float = 1e-5,
+) -> Tensor:
+    r"""Applies Masked Instance Normalization for each channel in each data sample in a batch.
+
+    See :class:`~MaskedInstanceNorm1d` for details.
+    """
+    lengths = mask.sum((-1,))
+    mean = (input * mask).sum((-1,)) / lengths  # (N, C)
+    var = (((input - mean[(..., None)]) * mask) ** 2).sum((-1,)) / lengths  # (N, C)
+    out = (input - mean[(..., None)]) / torch.sqrt(var[(..., None)] + eps)  # (N, C, ...)
+    out = out * weight[None, :][(..., None)] + bias[None, :][(..., None)]
+
+    return out
+
+
+class MaskedInstanceNorm1d(torch.nn.InstanceNorm1d):
+    r"""Applies Instance Normalization over a masked 3D input
+    (a mini-batch of 1D inputs with additional channel dimension)..
+
+    See documentation of :class:`~torch.nn.InstanceNorm1d` for details.
+
+    Shape:
+        - Input: :math:`(N, C, L)`
+        - Mask: :math:`(N, 1, L)`
+        - Output: :math:`(N, C, L)` (same shape as input)
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        eps: float = 1e-5,
+        momentum: float = 0.1,
+        affine: bool = False,
+        track_running_stats: bool = False,
+    ) -> None:
+        super(MaskedInstanceNorm1d, self).__init__(num_features, eps, momentum, affine, track_running_stats)
+
+    def forward(self, input: Tensor, mask: Tensor) -> Tensor:
+        return masked_instance_norm(input, mask, self.weight, self.bias, self.momentum, self.eps,)
+
+
+class PartialConv1d(torch.nn.Conv1d):
+    """
+    Zero padding creates a unique identifier for where the edge of the data is, such that the model can almost always identify
+    exactly where it is relative to either edge given a sufficient receptive field. Partial padding goes to some lengths to remove 
+    this affect.
+    """
+
+    __constants__ = ['slide_winsize']
+    slide_winsize: float
+
+    def __init__(self, *args, **kwargs):
+        super(PartialConv1d, self).__init__(*args, **kwargs)
+        weight_maskUpdater = torch.ones(1, 1, self.kernel_size[0])
+        self.register_buffer("weight_maskUpdater", weight_maskUpdater, persistent=False)
+        self.slide_winsize = self.weight_maskUpdater.shape[1] * self.weight_maskUpdater.shape[2]
+
+    def forward(self, input, mask_in):
+        if mask_in is None:
+            mask = torch.ones(1, 1, input.shape[2], dtype=input.dtype, device=input.device)
+        else:
+            mask = mask_in
+            input = torch.mul(input, mask)
+        with torch.no_grad():
+            update_mask = F.conv1d(
+                mask,
+                self.weight_maskUpdater,
+                bias=None,
+                stride=self.stride,
+                padding=self.padding,
+                dilation=self.dilation,
+                groups=1,
+            )
+            update_mask_filled = torch.masked_fill(update_mask, update_mask == 0, self.slide_winsize)
+            mask_ratio = self.slide_winsize / update_mask_filled
+            update_mask = torch.clamp(update_mask, 0, 1)
+            mask_ratio = torch.mul(mask_ratio, update_mask)
+
+        raw_out = self._conv_forward(input, self.weight, self.bias)
+
+        if self.bias is not None:
+            bias_view = self.bias.view(1, self.out_channels, 1)
+            output = torch.mul(raw_out - bias_view, mask_ratio) + bias_view
+            output = torch.mul(output, update_mask)
+        else:
+            output = torch.mul(raw_out, mask_ratio)
+
+        return output
+
+
+class LinearNorm(torch.nn.Module):
+    def __init__(self, in_dim, out_dim, bias=True, w_init_gain='linear'):
+        super().__init__()
+        self.linear_layer = torch.nn.Linear(in_dim, out_dim, bias=bias)
+
+        torch.nn.init.xavier_uniform_(self.linear_layer.weight, gain=torch.nn.init.calculate_gain(w_init_gain))
+
+    def forward(self, x):
+        return self.linear_layer(x)
+
+
+class ConvNorm(nn.Module):
+    __constants__ = ['use_partial_padding']
+    use_partial_padding: bool
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size=1,
+        stride=1,
+        padding=None,
+        dilation=1,
+        bias=True,
+        w_init_gain='linear',
+        use_partial_padding=False,
+        use_weight_norm=False,
+        norm_fn=None,
+    ):
+        super(ConvNorm, self).__init__()
+        if padding is None:
+            assert kernel_size % 2 == 1
+            padding = int(dilation * (kernel_size - 1) / 2)
+        self.use_partial_padding = use_partial_padding
+        conv_fn = torch.nn.Conv1d
+        if use_partial_padding:
+            conv_fn = PartialConv1d
+        self.conv = conv_fn(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias,
+        )
+        torch.nn.init.xavier_uniform_(self.conv.weight, gain=torch.nn.init.calculate_gain(w_init_gain))
+        if use_weight_norm:
+            self.conv = torch.nn.utils.weight_norm(self.conv)
+        if norm_fn is not None:
+            self.norm = norm_fn(out_channels, affine=True)
+        else:
+            self.norm = None
+
+    def forward(self, signal, mask=None):
+        if self.use_partial_padding:
+            ret = self.conv(signal, mask)
+            if self.norm is not None:
+                ret = self.norm(ret, mask)
+        else:
+            if mask is not None:
+                signal = signal.mul(mask)
+            ret = self.conv(signal)
+            if self.norm is not None:
+                ret = self.norm(ret)
+
+        # if self.is_adapter_available():
+        #     ret = self.forward_enabled_adapters(ret.transpose(1, 2)).transpose(1, 2)
+
+        return ret
+
+
+
+class ConditionalLayerNorm(torch.nn.LayerNorm):
+    """
+    This module is used to condition torch.nn.LayerNorm.
+    If we don't have any conditions, this will be a normal LayerNorm.
+    """
+
+    def __init__(self, hidden_dim, condition_dim=None, condition_types=[]):
+        check_support_condition_types(condition_types)
+        self.condition = "layernorm" in condition_types
+        super().__init__(hidden_dim, elementwise_affine=not self.condition)
+
+        if self.condition:
+            self.cond_weight = torch.nn.Linear(condition_dim, hidden_dim)
+            self.cond_bias = torch.nn.Linear(condition_dim, hidden_dim)
+            self.init_parameters()
+
+    def init_parameters(self):
+        torch.nn.init.constant_(self.cond_weight.weight, 0.0)
+        torch.nn.init.constant_(self.cond_weight.bias, 1.0)
+        torch.nn.init.constant_(self.cond_bias.weight, 0.0)
+        torch.nn.init.constant_(self.cond_bias.bias, 0.0)
+
+    def forward(self, inputs, conditioning=None):
+        inputs = super().forward(inputs)
+
+        # Normalize along channel
+        if self.condition:
+            if conditioning is None:
+                raise ValueError(
+                    """You should add additional data types as conditions (e.g. speaker id or reference audio) 
+                                 and define speaker_encoder in your config."""
+                )
+
+            inputs = inputs * self.cond_weight(conditioning)
+            inputs = inputs + self.cond_bias(conditioning)
+
+        return inputs
+
+
+class ConditionalInput(torch.nn.Module):
+    """
+    This module is used to condition any model inputs.
+    If we don't have any conditions, this will be a normal pass.
+    """
+
+    def __init__(self, hidden_dim, condition_dim, condition_types=[]):
+        check_support_condition_types(condition_types)
+        super().__init__()
+        self.support_types = ["add", "concat"]
+        self.condition_types = [tp for tp in condition_types if tp in self.support_types]
+        self.hidden_dim = hidden_dim
+        self.condition_dim = condition_dim
+
+        if "add" in self.condition_types and condition_dim != hidden_dim:
+            self.add_proj = torch.nn.Linear(condition_dim, hidden_dim)
+
+        if "concat" in self.condition_types:
+            self.concat_proj = torch.nn.Linear(hidden_dim + condition_dim, hidden_dim)
+
+    def forward(self, inputs, conditioning=None):
+        """
+        Args:
+            inputs (torch.tensor): B x T x C tensor.
+            conditioning (torch.tensor): B x 1 x C conditioning embedding.
+        """
+        if len(self.condition_types) > 0:
+            if conditioning is None:
+                raise ValueError(
+                    """You should add additional data types as conditions (e.g. speaker id or reference audio) 
+                                 and define speaker_encoder in your config."""
+                )
+
+            if "add" in self.condition_types:
+                if self.condition_dim != self.hidden_dim:
+                    conditioning = self.add_proj(conditioning)
+                inputs = inputs + conditioning
+
+            if "concat" in self.condition_types:
+                conditioning = conditioning.repeat(1, inputs.shape[1], 1)
+                inputs = torch.cat([inputs, conditioning])
+                inputs = self.concat_proj(inputs)
+
+        return inputs
+

--- a/phoonnx_train/mixertts/models/mixer_tts/modules/transformer.py
+++ b/phoonnx_train/mixertts/models/mixer_tts/modules/transformer.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# adapted from:
+# https://github.com/NVIDIA/NeMo/blob/7256db10771aa1d213d9b49640667efaa14f89c9/nemo/collections/tts/modules/transformer.py
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# from nemo.core.classes import NeuralModule, adapter_mixins, typecheck
+# from nemo.core.neural_types.elements import EncodedRepresentation, LengthsType, MaskType, TokenIndex
+# from nemo.core.neural_types.neural_type import NeuralType
+
+
+class PositionalEmbedding(nn.Module):
+    def __init__(self, demb):
+        super(PositionalEmbedding, self).__init__()
+        self.demb = demb
+        inv_freq = 1 / (10000 ** (torch.arange(0.0, demb, 2.0) / demb))
+        self.register_buffer('inv_freq', inv_freq)
+
+    def forward(self, pos_seq, bsz=None):
+        #        sinusoid_inp = torch.ger(pos_seq, self.inv_freq)
+        sinusoid_inp = torch.matmul(torch.unsqueeze(pos_seq, -1), torch.unsqueeze(self.inv_freq, 0))
+
+        pos_emb = torch.cat([sinusoid_inp.sin(), sinusoid_inp.cos()], dim=1)
+        if bsz is not None:
+            return pos_emb[None, :, :].repeat(bsz, 1, 1)
+        else:
+            return pos_emb[None, :, :]
+
+

--- a/phoonnx_train/mixertts/prior.py
+++ b/phoonnx_train/mixertts/prior.py
@@ -1,0 +1,71 @@
+"""Beta-binomial alignment prior for the Mixer-TTS aligner.
+
+Torch/scipy-free (numpy + math.lgamma) so it can be unit-tested without
+the training stack. Equivalent to NVIDIA NeMo's
+``beta_binomial_prior_distribution`` (Apache-2.0,
+nemo/collections/tts/torch/helpers.py), which computes the same
+``scipy.stats.betabinom`` pmf: for mel frame ``i`` (1-based, of M), the
+prior over the P phoneme positions is ``BetaBinom(P - 1, a=i,
+b=M + 1 - i)`` — the "cigar along the diagonal" prior of the RAD-TTS /
+one-TTS-alignment recipe (Badlani et al., 2021,
+https://arxiv.org/abs/2108.10447; Mixer-TTS: Tatanov et al., 2021,
+https://arxiv.org/abs/2110.03584).
+
+NeMo interpolates cached priors of rounded sizes for speed
+(``BetaBinomialInterpolator``); here the exact prior is computed and
+LRU-cached per (mel_len, text_len) instead — exact, and free of the
+scipy/ndimage dependency.
+"""
+from functools import lru_cache
+from math import lgamma
+
+import numpy as np
+
+
+def _log_betabinom_pmf(k: np.ndarray, n: int, a: float, b: float) -> np.ndarray:
+    """log pmf of BetaBinomial(n, a, b) at integer support ``k``."""
+    # log C(n, k) + betaln(k + a, n - k + b) - betaln(a, b)
+    lg = np.vectorize(lgamma)
+    log_comb = lg(n + 1) - lg(k + 1) - lg(n - k + 1)
+    betaln_num = lg(k + a) + lg(n - k + b) - lg(n + a + b)
+    betaln_den = lgamma(a) + lgamma(b) - lgamma(a + b)
+    return log_comb + betaln_num - betaln_den
+
+
+def beta_binomial_prior_distribution(
+    phoneme_count: int, mel_count: int, scaling: float = 1.0
+) -> np.ndarray:
+    """Return the [mel_count, phoneme_count] alignment prior matrix.
+
+    Row ``i`` (0-based) is the BetaBinomial(P-1, scaling*(i+1),
+    scaling*(M-i)) pmf over phoneme positions, matching NeMo/FastPitch's
+    ``beta_binomial_prior_distribution`` exactly.
+    """
+    if phoneme_count < 1 or mel_count < 1:
+        raise ValueError(
+            f"phoneme_count and mel_count must be >= 1, "
+            f"got {phoneme_count} and {mel_count}"
+        )
+    P, M = phoneme_count, mel_count
+    x = np.arange(P)
+    rows = []
+    for i in range(1, M + 1):
+        a, b = scaling * i, scaling * (M + 1 - i)
+        rows.append(np.exp(_log_betabinom_pmf(x, P - 1, a, b)))
+    return np.asarray(rows, dtype=np.float32)
+
+
+@lru_cache(maxsize=256)
+def _cached_prior(mel_count: int, phoneme_count: int) -> np.ndarray:
+    return beta_binomial_prior_distribution(phoneme_count, mel_count)
+
+
+class BetaBinomialPrior:
+    """Callable returning the exact [mel_len, text_len] prior, LRU-cached.
+
+    Drop-in for NeMo's ``BetaBinomialInterpolator`` minus the lossy
+    zoom-interpolation approximation.
+    """
+
+    def __call__(self, mel_len: int, text_len: int) -> np.ndarray:
+        return _cached_prior(int(mel_len), int(text_len))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,13 @@ train-eval = [
 train-fastpitch = [
     "pyworld>=0.3.2",
 ]
+# extra deps for the Mixer-TTS training engine (phoonnx_train/engines/mixer.py)
+# on top of [train]: pyworld for the shared F0 (pitch) sidecar cache. einops
+# (Mixer blocks / aligner) and numba (monotonic alignment search) are already
+# pulled in via [train] (numba transitively through librosa on <3.13).
+train-mixer = [
+    "pyworld>=0.3.2",
+]
 ar = ["epitran", "arbtok"]
 ca = ["epitran"]
 gl = ["pycotovia>=0.1.0"]

--- a/tests/test_mixertts_training.py
+++ b/tests/test_mixertts_training.py
@@ -1,0 +1,193 @@
+"""Tests for the Mixer-TTS training engine (phoonnx_train.engines.mixer).
+
+Torch is not part of the test environment: the engine registry, config
+handling and quality presets are all importable without torch (heavy
+imports are deferred until a model is actually built), and the
+beta-binomial alignment-prior math lives in the torch/scipy-free
+``phoonnx_train.mixertts.prior`` module, loaded here by file path so the
+mixertts package models (which need torch) are never imported.
+"""
+import copy
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from phoonnx_train.engines import get_engine, list_engines
+from phoonnx_train.engines.base import TrainingEngineConfig
+from phoonnx_train.engines.mixer import (
+    _QUALITY_PRESETS,
+    MixerTTSTrainingEngine,
+    resolve_module_kwargs,
+)
+
+_PRIOR = Path(__file__).parent.parent / "phoonnx_train" / "mixertts" / "prior.py"
+spec = importlib.util.spec_from_file_location("mixer_prior", _PRIOR)
+prior = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(prior)
+
+
+# ---------------------------------------------------------------- registry
+def test_engine_registered_with_alias():
+    assert "mixer" in list_engines()
+    assert "mixertts" in list_engines()
+    assert isinstance(get_engine("mixer"), MixerTTSTrainingEngine)
+    assert isinstance(get_engine("mixertts"), MixerTTSTrainingEngine)
+
+
+def test_quality_presets():
+    presets = MixerTTSTrainingEngine().quality_presets()
+    assert set(presets) == {"x-low", "medium", "high"}
+    # every Mixer block width derives from the symbol embedding dim
+    dims = [presets[t]["symbols_embedding_dim"] for t in ("x-low", "medium", "high")]
+    assert dims == sorted(dims) and all(d > 0 for d in dims)
+    assert presets["high"]["symbols_embedding_dim"] == 384  # paper config
+
+
+# ----------------------------------------------------------- config handling
+def test_kwargs_accept_train_cli_extra_bag():
+    # train.py merges preset kwargs + batch_size/validation_split/num_workers
+    # into extra — the engine must accept the full bag
+    eng = get_engine("mixer")
+    cfg = TrainingEngineConfig(
+        num_symbols=90,
+        num_speakers=3,
+        sample_rate=16000,
+        extra={**eng.quality_presets()["x-low"], "batch_size": 4,
+               "validation_split": 0.1, "num_workers": 0},
+    )
+    kw = resolve_module_kwargs(cfg)
+    assert kw["num_symbols"] == 90
+    assert kw["num_speakers"] == 3
+    assert kw["sample_rate"] == 16000
+    assert kw["symbols_embedding_dim"] == _QUALITY_PRESETS["x-low"]["symbols_embedding_dim"]
+    assert kw["batch_size"] == 4
+
+
+def test_kwargs_do_not_mutate_presets():
+    before = copy.deepcopy(_QUALITY_PRESETS)
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"quality": "x-low", "batch_size": 2})
+    kw = resolve_module_kwargs(cfg)
+    kw["symbols_embedding_dim"] = -1
+    assert _QUALITY_PRESETS == before
+
+
+def test_kwargs_unknown_quality_falls_back_to_medium():
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"quality": "nonsense"})
+    kw = resolve_module_kwargs(cfg)
+    assert kw["symbols_embedding_dim"] == _QUALITY_PRESETS["medium"]["symbols_embedding_dim"]
+
+
+def test_kwargs_extra_overrides_preset():
+    cfg = TrainingEngineConfig(
+        num_symbols=90, extra={"quality": "medium", "symbols_embedding_dim": 64},
+    )
+    assert resolve_module_kwargs(cfg)["symbols_embedding_dim"] == 64
+
+
+def test_kwargs_config_wins_over_extra_symbol_count():
+    # num_symbols/num_speakers/sample_rate come from the shared config,
+    # not from a stray extra key
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"num_symbols": 5})
+    assert resolve_module_kwargs(cfg)["num_symbols"] == 90
+
+
+def test_kwargs_gan_flag_passes_through():
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"train_gan": True})
+    assert resolve_module_kwargs(cfg)["train_gan"] is True
+
+
+# --------------------------------------------------------- extra_preprocess
+def test_extra_preprocess_missing_deps_returns_empty(monkeypatch, tmp_path):
+    """Shared with the FastPitch engine: without pyworld/librosa it
+    degrades to {} instead of crashing preprocessing."""
+    engine = MixerTTSTrainingEngine()
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name in ("pyworld", "librosa"):
+            raise ImportError(name)
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    result = engine.extra_preprocess(tmp_path / "a.wav", tmp_path / "cache", 22050)
+    assert result == {}
+    assert not (tmp_path / "cache").exists()  # nothing written
+
+
+# ------------------------------------------------------------- export guard
+def test_export_onnx_missing_config_raises(tmp_path):
+    engine = MixerTTSTrainingEngine()
+    (tmp_path / "model.ckpt").write_bytes(b"not a checkpoint")
+    with pytest.raises((FileNotFoundError, OSError)):
+        engine.export_onnx(tmp_path / "model.ckpt", tmp_path / "missing.json", tmp_path)
+
+
+def test_export_onnx_missing_checkpoint_raises(tmp_path):
+    engine = MixerTTSTrainingEngine()
+    (tmp_path / "config.json").write_text("{}")
+    with pytest.raises(FileNotFoundError):
+        engine.export_onnx(tmp_path / "nope.ckpt", tmp_path / "config.json", tmp_path)
+
+
+def test_export_onnx_malformed_config_raises(tmp_path):
+    engine = MixerTTSTrainingEngine()
+    (tmp_path / "model.ckpt").write_bytes(b"x")
+    (tmp_path / "config.json").write_text("{not json")
+    import json as _json
+    with pytest.raises(_json.JSONDecodeError):
+        engine.export_onnx(tmp_path / "model.ckpt", tmp_path / "config.json", tmp_path)
+
+
+# ------------------------------------------------------- beta-binomial prior
+def test_prior_shape_and_rows_sum_to_one():
+    p = prior.beta_binomial_prior_distribution(11, 37)
+    assert p.shape == (37, 11)
+    assert np.allclose(p.sum(axis=1), 1.0, atol=1e-4)  # each row is a pmf
+    assert (p >= 0).all()
+
+
+def test_prior_is_diagonal_cigar():
+    # the argmax phoneme index must be monotonically non-decreasing over
+    # mel frames — first frames attend to first phonemes, last to last
+    p = prior.beta_binomial_prior_distribution(23, 200)
+    peaks = p.argmax(axis=1)
+    assert peaks[0] == 0 and peaks[-1] == 22
+    assert (np.diff(peaks) >= 0).all()
+
+
+def test_prior_matches_betabinom_pmf_exactly():
+    # spot-check against the closed-form BetaBinomial pmf for tiny numbers:
+    # M=1 frame, P=2 phonemes -> BetaBinom(n=1, a=1, b=1) = uniform
+    p = prior.beta_binomial_prior_distribution(2, 1)
+    assert np.allclose(p, [[0.5, 0.5]], atol=1e-6)
+
+
+def test_prior_single_phoneme_and_single_frame():
+    # degenerate boundaries must not divide by zero or return empties
+    assert prior.beta_binomial_prior_distribution(1, 5).shape == (5, 1)
+    assert np.allclose(prior.beta_binomial_prior_distribution(1, 5), 1.0)
+    assert prior.beta_binomial_prior_distribution(7, 1).shape == (1, 7)
+
+
+@pytest.mark.parametrize("P,M", [(0, 10), (10, 0), (-1, 5), (5, -1)])
+def test_prior_rejects_nonpositive_sizes(P, M):
+    with pytest.raises(ValueError):
+        prior.beta_binomial_prior_distribution(P, M)
+
+
+def test_prior_large_sizes_stay_finite():
+    # long utterances: lgamma-space math must not overflow to inf/nan
+    p = prior.beta_binomial_prior_distribution(400, 2000)
+    assert np.isfinite(p).all()
+    assert np.allclose(p.sum(axis=1), 1.0, atol=1e-3)
+
+
+def test_prior_callable_cache_returns_same_array():
+    bb = prior.BetaBinomialPrior()
+    a = bb(50, 10)
+    b = bb(50, 10)
+    assert a.shape == (50, 10)
+    assert a is b  # LRU-cached exact prior, no recompute


### PR DESCRIPTION
Adds a Mixer-TTS training engine (`--engine mixer`, alias `mixertts`) to the training-engine registry.

## Model
- Vendored, self-contained pure-torch port of NVIDIA NeMo's Mixer-TTS (Apache-2.0 headers + source URLs in every file; paper: https://arxiv.org/abs/2110.03584) with the speaker/emotion/energy conditioning and optional LSGAN mel-patch refinement from nipponjo/tts-arabic-pytorch (MIT), under `phoonnx_train/mixertts/models/`.
- Lightning wrapper (`phoonnx_train/mixertts/lightning.py`) keeps the NeMo recipe: masked-MSE mel/log-duration/pitch/energy losses + ForwardSum (CTC) aligner loss + delayed, ramped binarization loss; unsupervised AlignmentEncoder + monotonic alignment search with a beta-binomial prior; AdamW(betas 0.9/0.98, wd 1e-6) + Noam warmup. `extra["train_gan"]=true` enables the (non-NeMo) LSGAN PatchDiscriminator refinement via manual optimization.
- The beta-binomial prior is computed exactly in lgamma space (`phoonnx_train/mixertts/prior.py`, torch/scipy-free) instead of NeMo's zoom-interpolated cache.

## Pipeline integration
- Registered in `phoonnx_train/engines` — works with the shared `preprocess.py` / `train.py --engine mixer` / `export_onnx.py --engine mixer` CLIs, quality tiers `x-low`/`medium`/`high` (symbol-embedding dim 80/128/384).
- Reuses the FastPitch engine's F0 sidecar cache (pyworld DIO+StoneMask at `frame_period = 1000*hop/sr`, computed on the same trimmed/normalized cached audio the mels come from, length-reconciled to the mel frame count) and its `pitch_stats.json` z-scoring; mel target derives from the shared linear-spectrogram cache with fmin 0 / fmax 8000 pinned.
- Corpus pitch stats are persisted in checkpoint hparams and recorded in the ONNX metadata together with mel fmin/fmax.

## ONNX export
Matches the existing `phoonnx.engines.mixertts.MixerTTSAdapter` contract: `token_ids` (int64) + `pace`/`pitch_mul`/`pitch_add` (float32) + `speaker`/`emotion` (int32, present when the corresponding embedding exists) -> `mel_spec [B, 80, T]`, dynamic batch/sequence axes, opset 14.

## Tests
Torch-free tests in `tests/test_mixertts_training.py` (registry, presets, config-bag handling, export input validation, prior math incl. boundary/adversarial cases). Verified locally: 1-epoch CPU train on a synthetic dataset (finite losses), resume-from-checkpoint, `load_checkpoint` fine-tune path, ONNX export + onnxruntime inference at multiple sequence lengths for single-speaker, multi-speaker and GAN-mode checkpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)