### PR TITLE
feat(voices): add ca-custom (257-spk) + fa-custom coqui VITS

### DIFF
--- a/phoonnx/voice_index/coqui_vits.json
+++ b/phoonnx/voice_index/coqui_vits.json
@@ -440,5 +440,31 @@
         "alphabet": "unicode",
         "engine": "coqui",
         "lang": "yo"
+    },
+    "coqui/ca-custom-vits": {
+        "voice_id": "coqui/ca-custom-vits",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-coqui-vits/resolve/main/ca-custom-vits/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-coqui-vits/resolve/main/ca-custom-vits/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "engine": "coqui",
+        "lang": "ca"
+    },
+    "coqui/fa-custom-vits-female": {
+        "voice_id": "coqui/fa-custom-vits-female",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-coqui-vits/resolve/main/fa-custom-vits-female/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-coqui-vits/resolve/main/fa-custom-vits-female/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "engine": "coqui",
+        "lang": "fa"
     }
 }


### PR DESCRIPTION
Follow-up to the merged coqui VITS PR (#149) for the last two zoo voices, which were packaging quirks rather than architecture problems:

- **`coqui/ca-custom-vits`** — 257-speaker Catalan VITS (944 MB). The batch's `*.pth` glob had grabbed `speaker_ids.pth` instead of `model_file.pth`; with the right checkpoint it loads clean (0 missing/unexpected) and synthesizes multi-speaker Catalan.
- **`coqui/fa-custom-vits-female`** — Persian female VITS, HF-hosted as loose files (`Kamtera/persian-tts-female-vits`) rather than a github zip, so the zip-based batch couldn't fetch it.

Both already mirrored to `OpenVoiceOS/phoonnx-coqui-vits`; this PR just adds the two `coqui_vits.json` index entries (34 → 36 voices, +Catalan). Both load from the index and synthesize; **suite 221 passed**.

This completes the entire coqui zoo VITS set (minus the 2 Neon models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Catalan and Farsi text-to-speech voice support
  * Includes a female variant for Farsi voice

<!-- end of auto-generated comment: release notes by coderabbit.ai -->