### PR TITLE
feat(voices): coqui SpeedySpeech + en/vctk FastPitch (108-spk)

### DIFF
--- a/phoonnx/engines/coqui_config.py
+++ b/phoonnx/engines/coqui_config.py
@@ -26,7 +26,7 @@ _PHONEMIZER = {"gruut": PhonemeType.GRUUT, "espeak": PhonemeType.ESPEAK,
 
 
 def voice_config_from_coqui(config: Dict[str, Any], *, lang_code: str,
-                            engine: Engine = Engine.GLOWTTS) -> VoiceConfig:
+                            engine: Engine = Engine.GLOWTTS, num_speakers: int = 0) -> VoiceConfig:
     """Build a :class:`VoiceConfig` from a Coqui-TTS ``config.json``."""
     ch = config.get("characters", {})
     audio = config.get("audio", {})
@@ -45,7 +45,7 @@ def voice_config_from_coqui(config: Dict[str, Any], *, lang_code: str,
         combined = list(ch.get("characters") or "") + list(ch.get("phonemes") or "")
         full = [pad] + list(ch.get("punctuations") or "") + combined + [blank]
         char2idx = {c: i for i, c in enumerate(full)}
-        n_spk = config.get("num_speakers") or config.get("model_args", {}).get("num_speakers") or 1
+        n_spk = num_speakers or config.get("num_speakers") or config.get("model_args", {}).get("num_speakers") or 1
         tok = TTSTokenizer(
             Vocabulary(char2idx=char2idx, pad=pad, blank=blank),
             add_blank_char=True, add_blank_word=False, use_eos_bos=False,
@@ -81,7 +81,7 @@ def voice_config_from_coqui(config: Dict[str, Any], *, lang_code: str,
         add_blank_char=add_blank, add_blank_word=False, use_eos_bos=use_eos_bos,
         blank_at_start=add_blank, blank_at_end=add_blank)
     return VoiceConfig(
-        tokenizer=tok, num_symbols=len(char2idx), num_speakers=1, num_langs=1,
+        tokenizer=tok, num_symbols=len(char2idx), num_speakers=max(num_speakers, 1), num_langs=1,
         sample_rate=audio.get("sample_rate", 22050), lang_code=lang_code,
         phoneme_type=_phon if use_phonemes else PhonemeType.GRAPHEMES,
         alphabet=Alphabet.IPA if use_phonemes else Alphabet.UNICODE,

--- a/phoonnx/voice_index/fastpitch.json
+++ b/phoonnx/voice_index/fastpitch.json
@@ -46,5 +46,21 @@
         "vocoder_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/vocos-mel-22khz-univ/model.onnx",
         "vocoder_config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/vocos-mel-22khz-univ/vocoder.json",
         "vocoder_type": "vocos"
+    },
+    "coqui/en-vctk-fast_pitch": {
+        "voice_id": "coqui/en-vctk-fast_pitch",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-fastpitch/resolve/main/coqui-vctk-fastpitch/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-fastpitch/resolve/main/coqui-vctk-fastpitch/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "gruut",
+        "alphabet": "ipa",
+        "engine": "fastpitch",
+        "lang": "en-us",
+        "vocoder_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/vocos-mel-22khz-univ/model.onnx",
+        "vocoder_config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/vocos-mel-22khz-univ/vocoder.json",
+        "vocoder_type": "vocos"
     }
 }

--- a/phoonnx/voice_index/fastpitch.json
+++ b/phoonnx/voice_index/fastpitch.json
@@ -30,5 +30,21 @@
         "vocoder_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/coqui-ljspeech-hifigan-v2/model.onnx",
         "vocoder_config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/coqui-ljspeech-hifigan-v2/vocoder.json",
         "vocoder_type": "hifigan"
+    },
+    "coqui/en-ljspeech-speedy-speech": {
+        "voice_id": "coqui/en-ljspeech-speedy-speech",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-fastpitch/resolve/main/coqui-ljspeech-speedyspeech/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-fastpitch/resolve/main/coqui-ljspeech-speedyspeech/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "gruut",
+        "alphabet": "ipa",
+        "engine": "fastpitch",
+        "lang": "en-us",
+        "vocoder_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/vocos-mel-22khz-univ/model.onnx",
+        "vocoder_config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vocoders/resolve/main/vocos-mel-22khz-univ/vocoder.json",
+        "vocoder_type": "vocos"
     }
 }

--- a/scripts/conversion/coqui_fastpitch_export/export_fp.py
+++ b/scripts/conversion/coqui_fastpitch_export/export_fp.py
@@ -5,22 +5,32 @@ from types import SimpleNamespace
 from forward_tts import ForwardTTS, ForwardTTSArgs
 
 class FPWrap(torch.nn.Module):
-    def __init__(self, m): super().__init__(); self.m = m
-    def forward(self, token_ids):
-        return self.m.inference(token_ids)["model_outputs"].transpose(1, 2)  # [B,80,T]
+    def __init__(self, m, multispk=False): super().__init__(); self.m = m; self.multispk = multispk
+    def forward(self, token_ids, speaker=None):
+        aux = {"d_vectors": None, "speaker_ids": speaker if self.multispk else None}
+        return self.m.inference(token_ids, aux_input=aux)["model_outputs"].transpose(1, 2)  # [B,80,T]
 
 cfgp = sys.argv[1]; ck = sys.argv[2]; out = sys.argv[3]
 cfg = json5.load(open(cfgp, encoding="utf-8"))
 sd = torch.load(ck, map_location="cpu", weights_only=False)["model"]
 ma = cfg.get("model_args", {}); emb = [k for k in sd if k.endswith("emb.weight")][0]; ma["num_chars"] = sd[emb].shape[0]
 d = ForwardTTSArgs().__dict__; args = ForwardTTSArgs(**{k: v for k, v in ma.items() if k in d})
-conf = SimpleNamespace(model_args=args, num_chars=args.num_chars, num_speakers=1,
-                       use_speaker_embedding=False, use_d_vector_file=False, d_vector_dim=0)
-model = ForwardTTS(conf); model.load_state_dict(sd, strict=False); model.eval()
-w = FPWrap(model)
+nspk = sd["emb_g.weight"].shape[0] if "emb_g.weight" in sd else 1
+multispk = nspk > 1
+spk_mgr = SimpleNamespace(num_speakers=nspk) if multispk else None
+conf = SimpleNamespace(model_args=args, num_chars=args.num_chars, num_speakers=nspk,
+                       use_speaker_embedding=multispk, use_d_vector_file=False, d_vector_dim=0)
+model = ForwardTTS(conf, None, None, spk_mgr); model.load_state_dict(sd, strict=False); model.eval()
+w = FPWrap(model, multispk)
 x = torch.randint(1, ma["num_chars"] - 1, (1, 30))
-with torch.no_grad(): print("mel", tuple(w(x).shape))
-torch.onnx.export(w, (x,), out, input_names=["token_ids"], output_names=["mel_spec"],
-                  dynamic_axes={"token_ids": {0: "b", 1: "t"}, "mel_spec": {0: "b", 2: "frame"}},
-                  opset_version=14, dynamo=False)
+if multispk:
+    sid = torch.zeros(1, dtype=torch.int32)
+    eargs = (x, sid); names = ["token_ids", "speaker"]
+    dyn = {"token_ids": {0: "b", 1: "t"}, "speaker": {0: "b"}, "mel_spec": {0: "b", 2: "frame"}}
+else:
+    eargs = (x,); names = ["token_ids"]
+    dyn = {"token_ids": {0: "b", 1: "t"}, "mel_spec": {0: "b", 2: "frame"}}
+with torch.no_grad(): print("mel", tuple(w(*eargs).shape), "| speakers:", nspk)
+torch.onnx.export(w, eargs, out, input_names=names, output_names=["mel_spec"],
+                  dynamic_axes=dyn, opset_version=14, dynamo=False)
 print("exported", out)


### PR DESCRIPTION
Adds two more coqui FastPitch-family voices + multi-speaker FastPitch export.

## What's in
- **`coqui/en-vctk-fast_pitch`** — **108-speaker** English FastPitch. Added multi-speaker support to the FastPitch (`ForwardTTS`) exporter: detects `emb_g` in the checkpoint, builds with a speaker_manager + `use_speaker_embedding`, and exports an **int32 `speaker` input** (matching the adapter). Speakers verified distinct (spk0 ≠ spk77); gruut.
- **`coqui/en-ljspeech-speedy-speech`** — SpeedySpeech is `ForwardTTS` with a `residual_conv_bn` encoder + `use_pitch=False`, so it runs on the FastPitch engine unchanged.
- `voice_config_from_coqui` gains a `num_speakers` override (coqui stores multi-speaker counts in a separate file; same change as PR #150, reconciles on merge).

Both load + synthesize from the index (vctk multi-speaker confirmed); **suite 221 passed**.

## Coqui coverage now
Every non-autoregressive, ONNX-exportable coqui acoustic model is covered: **VITS, GlowTTS, FastPitch (single + multi-speaker), SpeedySpeech**. Remaining zoo models are autoregressive (Tacotron2), GPT/diffusion (XTTS/Bark/Tortoise — not ONNX-able), or the YourTTS voice-cloning feature (needs a speaker encoder + d-vector plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multi-speaker voice models in FastPitch exports
  * Added new voice definitions for FastPitch and Speedy Speech models

* **Improvements**
  * Enhanced speaker count configuration handling with explicit parameter support and intelligent fallback logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->