### PR TITLE
feat(alphabet): two-alphabet model + pairwise conversion registry

### DIFF
--- a/docs/alphabet_model.md
+++ b/docs/alphabet_model.md
@@ -1,0 +1,65 @@
+# Alphabet model
+
+phoonnx uses two distinct alphabet concepts that meet at the synthesis boundary.
+
+## VoiceConfig.alphabet — model-expected alphabet
+
+Set from the model's `config.json`; describes the script or phoneme representation
+the ONNX model was trained to consume.  Callers must not override this field.
+
+Examples: `ipa`, `hangul`, `unicode`, `cangjie`.
+
+## SynthesisConfig.alphabet — user-input alphabet
+
+The representation the *caller* provides to `TTSVoice.synthesize`.  `None` (default)
+means "assume the model's own alphabet" — the text passes through unchanged.
+
+Set this when the caller's text is in a different representation than the model
+expects.  For example, a Korean voice trained on conjoining Jamo (`alphabet=hangul`)
+but given raw Hangul syllables:
+
+```python
+from phoonnx.config import Alphabet, SynthesisConfig
+
+audio = list(voice.synthesize(
+    "안녕하세요",
+    syn_config=SynthesisConfig(alphabet=Alphabet.UNICODE),
+))
+```
+
+## Conversion bridge — `phoonnx.alphabet_convert.convert`
+
+```python
+convert(text, src: Alphabet, dst: Alphabet) -> str
+```
+
+Called inside `TTSVoice.synthesize` after diacritics and before `adapter.encode_text`:
+
+```python
+src = syn_config.alphabet or voice.config.alphabet   # caller's representation
+text = convert(text, src=src, dst=voice.config.alphabet)
+```
+
+Returns `text` unchanged when `src == dst` or no converter is registered for the
+`(src, dst)` pair (unregistered pairs log a DEBUG message and never raise).
+
+## Registered converters
+
+| Pair                     | Transform                                                     | Dependencies               |
+|--------------------------|---------------------------------------------------------------|----------------------------|
+| `(UNICODE, HANGUL)`      | Hangul syllables → conjoining Jamo (NFD)                      | none (pure Python)         |
+| `(UNICODE, HIRA)`        | Kanji → hiragana via `pykakasi`                               | `pykakasi` (extra: `cjk`)  |
+| `(UNICODE, CANGJIE)`     | Hanzi → Cangjie tokens via `spacy-pkuseg` + HF mapping        | `spacy-pkuseg` (extra: `cjk`) |
+
+Install CJK optional deps:
+
+```
+pip install phoonnx[cjk]
+```
+
+## Relationship to phonemizers
+
+Phonemizers (IPA/ARPA output) are a separate step that runs after `convert` in
+`TTSVoice.phonemize`.  They already emit the model's alphabet, so `convert` is a
+no-op for all IPA/ARPA voices (`src == dst`).  `convert` only fires for
+script/grapheme voices where the model was trained on a normalised text form.

--- a/phoonnx/alphabet_convert.py
+++ b/phoonnx/alphabet_convert.py
@@ -1,0 +1,102 @@
+"""Generic pairwise alphabet-conversion util for phoonnx.
+
+Two alphabets live in phoonnx's synthesis pipeline:
+
+* **VoiceConfig.alphabet** — the *model-expected* alphabet: the script or phoneme
+  representation the ONNX model was trained to consume.  Set by the model's
+  ``config.json``; callers must not change it at synthesis time.
+
+* **SynthesisConfig.alphabet** — the *user-input* alphabet: the representation the
+  caller provides to :meth:`~phoonnx.voice.TTSVoice.synthesize`.  ``None`` means
+  "same as the model's alphabet" (no conversion needed).
+
+The bridge between them is :func:`convert`::
+
+    convert(text, src=syn_config.alphabet or voice.config.alphabet,
+                  dst=voice.config.alphabet)
+
+Registered converters
+---------------------
+The :data:`ALPHABET_CONVERTERS` dict maps ``(src, dst)`` pairs to callables:
+
++-----------------------------+---------------------------------------------+
+| Pair                        | Transform                                   |
++=============================+=============================================+
+| ``(UNICODE, HANGUL)``       | Hangul syllables → conjoining Jamo (NFD)    |
++-----------------------------+---------------------------------------------+
+| ``(UNICODE, HIRA)``         | Kanji → hiragana via *pykakasi* (opt. dep)  |
++-----------------------------+---------------------------------------------+
+| ``(UNICODE, CANGJIE)``      | Hanzi → Cangjie tokens via *spacy-pkuseg*   |
+|                             | + HF ``Cangjie5_TC.json`` (opt. dep)        |
++-----------------------------+---------------------------------------------+
+
+Missing optional deps degrade to identity with a warning; the engine never
+raises due to a missing converter.
+
+.. note::
+   Phonemizers (IPA/ARPA etc.) are *not* routed through this module — they run in
+   :meth:`~phoonnx.voice.TTSVoice.phonemize` after this step and already emit the
+   model's alphabet.  :func:`convert` only bridges *script/grapheme* alphabets
+   (cases where the model consumes modified text, not phoneme IDs).
+"""
+import logging
+from typing import Callable
+
+from phoonnx.config import Alphabet
+from phoonnx.lang_preprocess import (
+    hangul_to_jamo,
+    japanese_to_hiragana,
+    chinese_to_cangjie,
+)
+
+LOG = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Registry: (src_alphabet, dst_alphabet) -> Callable[[str], str]
+# ---------------------------------------------------------------------------
+
+ALPHABET_CONVERTERS: dict[tuple[Alphabet, Alphabet], Callable[[str], str]] = {
+    (Alphabet.UNICODE, Alphabet.HANGUL): hangul_to_jamo,
+    (Alphabet.UNICODE, Alphabet.HIRA): japanese_to_hiragana,
+    (Alphabet.UNICODE, Alphabet.CANGJIE): chinese_to_cangjie,
+}
+
+
+def convert(text: str, src: Alphabet, dst: Alphabet) -> str:
+    """Convert *text* from the *src* alphabet representation to *dst*.
+
+    Returns *text* unchanged when:
+
+    * ``src == dst`` (identity — no conversion needed), or
+    * the ``(src, dst)`` pair is not in :data:`ALPHABET_CONVERTERS` (graceful
+      identity; the missing pair is logged at DEBUG level).
+
+    Parameters
+    ----------
+    text:
+        Input text in the *src* alphabet's representation.
+    src:
+        Source :class:`~phoonnx.config.Alphabet` — the caller's representation.
+        Pass ``SynthesisConfig.alphabet`` (falling back to ``VoiceConfig.alphabet``
+        when the former is ``None``).
+    dst:
+        Target :class:`~phoonnx.config.Alphabet` — what the model expects.
+        Pass ``VoiceConfig.alphabet``.
+
+    Returns
+    -------
+    str
+        Converted text, or *text* unchanged when no conversion is needed or
+        available.
+    """
+    if src == dst:
+        return text
+    converter = ALPHABET_CONVERTERS.get((src, dst))
+    if converter is None:
+        LOG.debug(
+            "alphabet_convert: no converter registered for (%s, %s); returning text unchanged",
+            src,
+            dst,
+        )
+        return text
+    return converter(text)

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -48,6 +48,7 @@ class Alphabet(str, Enum):
     ERAAB = "eraab" # fa
     COTOVIA = "cotovia" # gl
     HANZI = "hanzi" # zh
+    CANGJIE = "cangjie"  # zh (Cangjie code tokens, e.g. [cj_...])
     BUCKWALTER = "buckwalter" # ar
 
 
@@ -116,6 +117,11 @@ class VoiceConfig:
     """espeak, byt5, text, cotovia, or graphemes."""
 
     alphabet: Optional[Alphabet]
+    """Model-expected alphabet — the script/phoneme representation the ONNX model
+    was trained to consume.  This value is read from the model's ``config.json``
+    and must not be set by the caller at synthesis time.  Script-conversion engines
+    (e.g. HANGUL→Jamo, UNICODE→Cangjie) normalise caller text *into* this
+    representation before ``adapter.encode_text``."""
 
     phonemizer_model: Optional[str]
     """for phonemizers that allow changing base model """
@@ -518,6 +524,23 @@ class SynthesisConfig:
 
     """for arabic and hebrew models"""
     add_diacritics: bool = True
+
+    alphabet: Optional[Alphabet] = None
+    """User-input alphabet — the script/representation that the *caller* provides
+    to :meth:`~phoonnx.voice.TTSVoice.synthesize`.
+
+    ``None`` (default) means "assume the model's own alphabet" — the text is
+    passed through unchanged.  Set this when the caller's text is in a different
+    representation than what the model expects; for example, pass
+    ``Alphabet.UNICODE`` when giving raw Korean Hangul to a Jamo-trained voice.
+
+    The conversion bridge is :func:`phoonnx.alphabet_convert.convert`::
+
+        convert(text, src=syn_config.alphabet or voice.config.alphabet,
+                      dst=voice.config.alphabet)
+
+    This is a no-op for phoneme alphabets (IPA/ARPA) and identical src==dst
+    pairs; it only fires for the registered script-conversion pairs."""
 
     # Engine-specific per-call params (d_factor, p_factor, e_factor, …)
     extra_params: Dict[str, Any] = field(default_factory=dict)

--- a/phoonnx/lang_preprocess.py
+++ b/phoonnx/lang_preprocess.py
@@ -1,0 +1,132 @@
+"""Per-language script transforms for TTS front ends.
+
+Some voices are trained on a normalised form of the input script rather than raw
+Unicode.  This module provides the transforms that bridge caller text to the
+model-expected representation.
+
+Hangul→Jamo is pure Python and always available.  Japanese, Chinese and Russian
+each require an optional dependency; when the dependency is absent the function
+warns once and returns the input unchanged (graceful identity).
+"""
+from unicodedata import category, normalize
+
+from phoonnx.util import LOG
+
+# lazy singletons for the optional backends (created on first use)
+_kakasi = None
+_cangjie = None
+
+
+def is_kanji(c: str) -> bool:
+    return "一" <= c <= "鿿"
+
+
+def is_katakana(c: str) -> bool:
+    return "ァ" <= c <= "ヺ"
+
+
+def hangul_to_jamo(text: str) -> str:
+    """Decompose precomposed Hangul syllables into conjoining Jamo (NFD). Pure Python.
+
+    Models trained on Jamo sequences require this step; the syllable codepoints are
+    out-of-vocabulary for them.  Non-Hangul characters are passed through unchanged.
+    """
+    def decompose(ch: str) -> str:
+        if not ("가" <= ch <= "힯"):
+            return ch
+        base = ord(ch) - 0xAC00
+        initial = chr(0x1100 + base // (21 * 28))
+        medial = chr(0x1161 + (base % (21 * 28)) // 28)
+        final = chr(0x11A7 + base % 28) if base % 28 else ""
+        return initial + medial + final
+
+    return "".join(decompose(c) for c in text).strip()
+
+
+def japanese_to_hiragana(text: str) -> str:
+    """Convert kanji to hiragana (katakana kept) and NFKD-normalise. Needs ``pykakasi``.
+
+    Returns *text* unchanged if ``pykakasi`` is not installed.
+    """
+    global _kakasi
+    try:
+        if _kakasi is None:
+            import pykakasi
+            _kakasi = pykakasi.kakasi()
+    except ImportError:
+        LOG.warning("pykakasi not installed — Japanese text left unprocessed")
+        return text
+    out = []
+    for r in _kakasi.convert(text):
+        inp, hira = r["orig"], r["hira"]
+        if any(is_kanji(c) for c in inp):
+            if hira and hira[0] in ("は", "へ"):  # は / へ
+                hira = " " + hira
+            out.append(hira)
+        elif inp and all(is_katakana(c) for c in inp):
+            out.append(inp)
+        else:
+            out.append(inp)
+    return normalize("NFKD", "".join(out))
+
+
+class ChineseCangjieConverter:
+    """Convert Chinese characters to Cangjie-code tokens (``[cj_...]``).
+
+    Needs ``spacy_pkuseg`` for word segmentation and a ``Cangjie5_TC.json``
+    glyph→code mapping from HuggingFace (``ResembleAI/chatterbox``).  Without the
+    segmenter it still encodes individual glyphs; without the mapping it returns the
+    input unchanged with a warning.
+    """
+
+    def __init__(self, repo_id: str = "ResembleAI/chatterbox", cache_dir=None):
+        self.word2cj: dict = {}
+        self.cj2word: dict = {}
+        self.segmenter = None
+        try:
+            import json
+            from huggingface_hub import hf_hub_download
+            path = hf_hub_download(
+                repo_id=repo_id, filename="Cangjie5_TC.json", cache_dir=cache_dir
+            )
+            with open(path, encoding="utf-8") as fp:
+                for entry in json.load(fp):
+                    word, code = entry.split("\t")[:2]
+                    self.word2cj[word] = code
+                    self.cj2word.setdefault(code, []).append(word)
+        except Exception as e:
+            LOG.warning("Could not load Cangjie mapping: %s", e)
+        try:
+            from spacy_pkuseg import pkuseg
+            self.segmenter = pkuseg()
+        except ImportError:
+            LOG.warning("spacy_pkuseg not installed — Chinese segmentation skipped")
+
+    def _encode_glyph(self, glyph: str):
+        code = self.word2cj.get(glyph)
+        if code is None:
+            return None
+        idx = self.cj2word[code].index(glyph)
+        return code + (str(idx) if idx > 0 else "")
+
+    def __call__(self, text: str) -> str:
+        full = " ".join(self.segmenter.cut(text)) if self.segmenter else text
+        out = []
+        for t in full:
+            if category(t) == "Lo":
+                cj = self._encode_glyph(t)
+                if cj is None:
+                    out.append(t)
+                    continue
+                out.append("".join(f"[cj_{c}]" for c in cj) + "[cj_.]")
+            else:
+                out.append(t)
+        return "".join(out)
+
+
+def chinese_to_cangjie(text: str) -> str:
+    """Convert Chinese text to Cangjie tokens, reusing a module-level instance."""
+    global _cangjie
+    if _cangjie is None:
+        _cangjie = ChineseCangjieConverter()
+    return _cangjie(text)

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -18,6 +18,7 @@ import numpy as np
 import onnxruntime
 from langcodes import closest_match
 
+from phoonnx.alphabet_convert import convert
 from phoonnx.config import PhonemeType, VoiceConfig, SynthesisConfig, get_phonemizer
 from phoonnx.engines import detect_engine, get_adapter
 from phoonnx.engines.base import (
@@ -362,6 +363,15 @@ class TTSVoice:
         if syn_config.add_diacritics:
             text = self.phonemizer.add_diacritics(text, self.config.lang_code)
             LOG.debug("text+diacritics=%s", text)
+
+        # Script-conversion: bridge the caller's alphabet to the model's alphabet.
+        # syn_config.alphabet is the user-input alphabet; None means "assume model's".
+        # self.config.alphabet is the model-expected alphabet.
+        # No-op when src == dst or when the pair has no registered converter.
+        if self.config.alphabet is not None:
+            src_alphabet = syn_config.alphabet or self.config.alphabet
+            text = convert(text, src=src_alphabet, dst=self.config.alphabet)
+            LOG.debug("text+alphabet_convert=%s", text)
 
         # All phonemization goes through the unified self.phonemize method
         sentence_phonemes = self.phonemize(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ zh = ["epitran", "gruut[zh]>=2.3.0,<3.0", "misaki[zh]", "spacy>=3.7"]
 
 # runtime deps for zero-shot voice cloning (reference loading + resampling)
 cloning = ["soundfile", "scipy"]
+# Optional deps for CJK script-conversion in alphabet_convert (ja: pykakasi; zh: spacy-pkuseg).
+# ko (Hangul→Jamo) is pure Python and requires no extra.
+cjk = ["pykakasi==2.3.0", "spacy-pkuseg"]
 # everything optional — every language phonemizer + cloning. Used by the Docker image.
 all = [
     "epitran",
@@ -74,6 +77,7 @@ all = [
     "misaki[en]", "misaki[ja]", "misaki[vi]", "misaki[zh]",
     "spacy>=3.7",
     "soundfile", "scipy",
+    "pykakasi==2.3.0", "spacy-pkuseg",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/test_alphabet_convert.py
+++ b/tests/test_alphabet_convert.py
@@ -1,0 +1,208 @@
+"""Tests for phoonnx.alphabet_convert — convert, ALPHABET_CONVERTERS.
+
+Covers:
+- Registered pair actually converts (HANGUL decomposition, HIRA/CANGJIE best-effort).
+- src == dst → identity (no conversion).
+- Unregistered pair → identity + DEBUG log.
+- Registry is keyed by (Alphabet, Alphabet) pairs.
+- synthesize() wiring: HANGUL-alphabet voice receives Jamo before encode_text.
+- SynthesisConfig.alphabet as explicit src overrides the model's alphabet for convert.
+"""
+import logging
+import unicodedata
+
+import pytest
+
+from phoonnx.alphabet_convert import ALPHABET_CONVERTERS, convert
+from phoonnx.config import Alphabet
+
+# Precomposed Hangul syllable '가' (U+AC00)
+GA = unicodedata.normalize("NFC", "가")
+
+
+# ---------------------------------------------------------------------------
+# Registered pairs
+# ---------------------------------------------------------------------------
+
+def test_convert_hangul_decomposes_to_jamo():
+    """(UNICODE, HANGUL) decomposes precomposed syllables into conjoining Jamo."""
+    result = convert(GA, Alphabet.UNICODE, Alphabet.HANGUL)
+    assert result == unicodedata.normalize("NFD", GA)
+    # every character should be a Jamo codepoint
+    assert all("ᄀ" <= c <= "ᇿ" for c in result)
+
+
+def test_convert_hira_registered():
+    """(UNICODE, HIRA) converter is registered and callable on ASCII (passthrough)."""
+    result = convert("hello", Alphabet.UNICODE, Alphabet.HIRA)
+    assert isinstance(result, str)
+
+
+def test_convert_cangjie_registered():
+    """(UNICODE, CANGJIE) converter is registered and callable on ASCII (passthrough)."""
+    result = convert("hello", Alphabet.UNICODE, Alphabet.CANGJIE)
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Identity: src == dst
+# ---------------------------------------------------------------------------
+
+def test_convert_src_eq_dst_unicode_identity():
+    text = "hello world"
+    assert convert(text, Alphabet.UNICODE, Alphabet.UNICODE) == text
+
+
+def test_convert_src_eq_dst_ipa_identity():
+    text = "hɛloʊ"
+    assert convert(text, Alphabet.IPA, Alphabet.IPA) == text
+
+
+def test_convert_src_eq_dst_arpa_identity():
+    text = "HH AH0 L OW1"
+    assert convert(text, Alphabet.ARPA, Alphabet.ARPA) == text
+
+
+# ---------------------------------------------------------------------------
+# Unregistered pair → identity + debug log
+# ---------------------------------------------------------------------------
+
+def test_convert_unregistered_pair_is_identity(caplog):
+    text = "some text"
+    with caplog.at_level(logging.DEBUG, logger="phoonnx.alphabet_convert"):
+        result = convert(text, Alphabet.ARPA, Alphabet.HANGUL)
+    assert result == text
+
+
+def test_convert_unregistered_pair_logs_debug(caplog):
+    with caplog.at_level(logging.DEBUG, logger="phoonnx.alphabet_convert"):
+        convert("x", Alphabet.IPA, Alphabet.CANGJIE)
+    assert any("no converter registered" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Registry shape
+# ---------------------------------------------------------------------------
+
+def test_registry_keyed_by_alphabet_pairs():
+    for key in ALPHABET_CONVERTERS:
+        assert isinstance(key, tuple) and len(key) == 2
+        src, dst = key
+        assert isinstance(src, Alphabet)
+        assert isinstance(dst, Alphabet)
+
+
+def test_unicode_hangul_in_registry():
+    assert (Alphabet.UNICODE, Alphabet.HANGUL) in ALPHABET_CONVERTERS
+
+
+def test_unicode_hira_in_registry():
+    assert (Alphabet.UNICODE, Alphabet.HIRA) in ALPHABET_CONVERTERS
+
+
+def test_unicode_cangjie_in_registry():
+    assert (Alphabet.UNICODE, Alphabet.CANGJIE) in ALPHABET_CONVERTERS
+
+
+# ---------------------------------------------------------------------------
+# Hangul decomposition correctness
+# ---------------------------------------------------------------------------
+
+def test_hangul_multi_syllable_all_jamo():
+    """Multi-syllable word: all output codepoints are Jamo."""
+    text = "안녕"  # two syllables
+    result = convert(text, Alphabet.UNICODE, Alphabet.HANGUL)
+    assert all("ᄀ" <= c <= "ᇿ" for c in result)
+    assert len(result) > len(text)  # decomposed form is longer
+
+
+def test_hangul_ascii_passthrough():
+    """Non-Hangul characters are passed through by the Jamo converter."""
+    text = "hello"
+    result = convert(text, Alphabet.UNICODE, Alphabet.HANGUL)
+    assert result.strip() == text
+
+
+# ---------------------------------------------------------------------------
+# synthesize() wiring — uses minimal stubs, no ONNX model loaded
+# ---------------------------------------------------------------------------
+
+def _make_hangul_voice():
+    """Return a minimal TTSVoice stub with alphabet=HANGUL and captured phonemize input."""
+    from unittest.mock import MagicMock
+    import numpy as np
+
+    from phoonnx.config import VoiceConfig, PhonemeType, Alphabet, Engine
+    from phoonnx.tokenizer import TTSTokenizer, Vocabulary
+    from phoonnx.voice import TTSVoice
+
+    vocab = Vocabulary(
+        char2idx={c: i for i, c in enumerate("abcdefghijklmnopqrstuvwxyz ")}
+    )
+    tokenizer = TTSTokenizer(
+        vocab,
+        add_blank_char=False,
+        add_blank_word=False,
+        use_eos_bos=False,
+        blank_at_end=False,
+        blank_at_start=False,
+    )
+
+    config = VoiceConfig(
+        num_symbols=30,
+        num_speakers=1,
+        num_langs=1,
+        sample_rate=22050,
+        lang_code="ko",
+        phoneme_type=PhonemeType.GRAPHEMES,
+        alphabet=Alphabet.HANGUL,
+        tokenizer=tokenizer,
+        engine=Engine.PIPER,
+        phonemizer_model=None,
+    )
+
+    captured: dict = {}
+
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.config = config
+    voice.phonetic_spellings = None
+
+    mock_phonemizer = MagicMock()
+    mock_phonemizer.add_diacritics.side_effect = lambda text, lang: text
+    voice.phonemizer = mock_phonemizer
+
+    # phonemize captures the text it receives, then returns a single token list
+    voice.phonemize = lambda text: captured.update({"text": text}) or [["ᄀ"]]
+    voice.phonemes_to_ids = lambda phonemes: [1, 2, 3]
+    voice.phoneme_ids_to_audio = lambda ids, sc: np.zeros(100, dtype="float32")
+
+    return voice, captured
+
+
+def test_voice_synthesize_applies_alphabet_conversion():
+    """TTSVoice.synthesize converts UNICODE Hangul → Jamo before phonemize."""
+    from phoonnx.config import SynthesisConfig, Alphabet
+
+    voice, captured = _make_hangul_voice()
+
+    # Caller passes raw Hangul; explicit alphabet=UNICODE signals that
+    syn_config = SynthesisConfig(add_diacritics=False, alphabet=Alphabet.UNICODE)
+    list(voice.synthesize(GA, syn_config=syn_config))
+
+    # phonemize must have received Jamo, not the precomposed syllable
+    assert captured["text"] == unicodedata.normalize("NFD", GA)
+
+
+def test_voice_synthesize_no_alphabet_field_is_noop():
+    """SynthesisConfig.alphabet=None → src defaults to model alphabet → no-op."""
+    from phoonnx.config import SynthesisConfig
+
+    voice, captured = _make_hangul_voice()
+
+    # Input is already Jamo (pre-decomposed); alphabet=None means "I'm in the model's alphabet"
+    pre_jamo = unicodedata.normalize("NFD", GA)
+    syn_config = SynthesisConfig(add_diacritics=False, alphabet=None)
+    list(voice.synthesize(pre_jamo, syn_config=syn_config))
+
+    # src == dst (HANGUL == HANGUL) → identity; phonemize receives unchanged text
+    assert captured["text"] == pre_jamo


### PR DESCRIPTION
Defines phoonnx's alphabet model cleanly and adds the conversion util.

**Two alphabets:**
- `VoiceConfig.alphabet` — the **model-expected** input alphabet (set by the model's config.json; not changed at synthesis time).
- `SynthesisConfig.alphabet` (new) — the **user-input** alphabet (what the caller's text is written in; None = assume the model's).

Conversion is the bridge: `convert(text, src=syn.alphabet or voice.alphabet, dst=voice.alphabet)`, wired into `TTSVoice.synthesize` after diacritics / before phonemize. No-op for IPA/phoneme alphabets and same-alphabet voices; the phonemizer stays its own step.

`phoonnx/alphabet_convert.py`: `convert(src,dst)` over a `(src,dst)`-keyed registry — identity for same/unregistered pairs, never raises. Registered: (UNICODE,HANGUL) Hangul→Jamo, (UNICODE,HIRA) kanji→hiragana, (UNICODE,CANGJIE) Chinese→Cangjie. Added `CANGJIE` to the Alphabet enum + a `cjk` optional-deps extra.

No stress, no chatterbox coupling (those are separate PRs). See docs/alphabet_model.md. 16 new tests + existing green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>