### PR TITLE
feat: AhoTTS (pyahotts) Basque phonemizer

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -618,7 +618,9 @@ def get_phonemizer(phoneme_type: PhonemeType,
     elif phoneme_type == PhonemeType.COTOVIA:
         phonemizer = CotoviaPhonemizer(alphabet=alphabet)
     elif phoneme_type == PhonemeType.AHOTTS:
-        phonemizer = AhoTTSPhonemizer()
+        # `model` is the voice's phonemizer_model: the AhoTTS engine variant
+        # ("classic" | "modern" | "northern"); defaults to "modern".
+        phonemizer = AhoTTSPhonemizer(model)
     elif phoneme_type == PhonemeType.UNICODE:
         phonemizer = UnicodeCodepointPhonemizer()
     elif phoneme_type == PhonemeType.GRAPHEMES:

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -81,6 +81,7 @@ class PhonemeType(str, Enum):
     CUTLET = "cutlet" # ja
     PYKAKASI = "pykakasi" # ja
     COTOVIA = "cotovia"  # galician  (no ipa!)
+    AHOTTS = "ahotts"  # basque
     PHONIKUD = "phonikud"  # hebrew
     MANTOQ = "mantoq"  # arabic
     VIPHONEME = "viphoneme" # vietnamese
@@ -548,8 +549,8 @@ def get_phonemizer(phoneme_type: PhonemeType,
                        MisakiEnPhonemizer, MisakiJaPhonemizer, MisakiZhPhonemizer,
                        MisakiKoPhonemizer, MisakiViPhonemizer,
                        KoG2PPhonemizer, PypinyinPhonemizer, PyKakasiPhonemizer, CotoviaPhonemizer,
-                       CutletPhonemizer, PhonikudPhonemizer, VIPhonemePhonemizer, XpinyinPhonemizer,
-                       UnicodeCodepointPhonemizer, JiebaPhonemizer)
+                       AhoTTSPhonemizer, CutletPhonemizer, PhonikudPhonemizer, VIPhonemePhonemizer,
+                       XpinyinPhonemizer, UnicodeCodepointPhonemizer, JiebaPhonemizer)
     if phoneme_type == PhonemeType.ESPEAK:
         phonemizer = EspeakPhonemizer()
     elif phoneme_type == PhonemeType.BYT5:
@@ -616,6 +617,8 @@ def get_phonemizer(phoneme_type: PhonemeType,
         phonemizer = G2pMPhonemizer(alphabet=alphabet)
     elif phoneme_type == PhonemeType.COTOVIA:
         phonemizer = CotoviaPhonemizer(alphabet=alphabet)
+    elif phoneme_type == PhonemeType.AHOTTS:
+        phonemizer = AhoTTSPhonemizer()
     elif phoneme_type == PhonemeType.UNICODE:
         phonemizer = UnicodeCodepointPhonemizer()
     elif phoneme_type == PhonemeType.GRAPHEMES:

--- a/phoonnx/phonemizers/__init__.py
+++ b/phoonnx/phonemizers/__init__.py
@@ -3,6 +3,7 @@ from typing import Union
 from phoonnx.phonemizers.base import BasePhonemizer, UnicodeCodepointPhonemizer, GraphemePhonemizer, TextChunks, RawPhonemizedChunks
 from phoonnx.phonemizers.en import DeepPhonemizer, OpenPhonemizer, G2PEnPhonemizer
 from phoonnx.phonemizers.gl import CotoviaPhonemizer
+from phoonnx.phonemizers.eu import AhoTTSPhonemizer
 from phoonnx.phonemizers.vi import VIPhonemePhonemizer
 from phoonnx.phonemizers.he import PhonikudPhonemizer
 from phoonnx.phonemizers.ar import MantoqPhonemizer
@@ -44,6 +45,7 @@ Phonemizer = Union[
     JiebaPhonemizer,
     PhonikudPhonemizer,
     CotoviaPhonemizer,
+    AhoTTSPhonemizer,
     MantoqPhonemizer,
     GraphemePhonemizer,
     OpenPhonemizer,

--- a/phoonnx/phonemizers/eu.py
+++ b/phoonnx/phonemizers/eu.py
@@ -1,77 +1,76 @@
-from typing import List, Optional
+from typing import Optional
 
 from phoonnx.phonemizers.base import BasePhonemizer
 from phoonnx.config import Alphabet
 
 
-# Collapse multi-char IPA tokens emitted by AhoTTS into the single-char
-# symbols used by the StyleTTS2-eu / VITS-eu phoneme_id_map. Stressed vowels
-# carry a leading "'" in the AhoTTS output and become uppercase ASCII letters;
-# the affricates / aspirated stops collapse to single ASCII placeholders.
-MULTICHAR = {
-    "tʃ": "C",
-    "ts": "V",
-    "tʂ": "P",
-    "'i": "I",
-    "'e": "E",
-    "'a": "A",
-    "'o": "O",
-    "'u": "U",
-    "pʰ": "H",
-    "kʰ": "K",
-    "tʰ": "T",
+# AhoTTS engine variant, selected per-voice via ``phonemizer_model`` in the
+# voice config.  Each maps to an ``ahotts_g2p.phonemize`` call.
+ENGINES = {
+    "classic": {"version": "classic"},    # original AhoTTS engine (HiTZ VITS voices)
+    "modern": {"version": "modern"},      # StyleTTS-era build (HiTZ/StyleTTS2-eu)
+    "northern": {"dialect": "northern"},  # Northern (Iparralde / Iparrahotsa) dialect
 }
+DEFAULT_ENGINE = "modern"
 
 
 class AhoTTSPhonemizer(BasePhonemizer):
     """
-    A phonemizer for Basque (eu) backed by the ``pyahotts`` package, which wraps
-    the AhoTTS engine.
+    Basque (eu) phonemizer backed by ``ahotts-g2p``, a pure-Python port of the
+    AhoTTS engine (no C build, no runtime dependencies).
 
-    This is the **V1** AhoTTS engine, a close approximation (~96%) of the
-    StyleTTS2-eu V3 phonemizer. It powers the ``hitz-eu-styletts2`` and
-    ``hitz-eu_*`` mirror voices, whose configs set ``phoneme_type: ahotts``.
+    The engine variant is chosen per-voice with ``phonemizer_model`` in the
+    voice config (passed to the constructor as ``engine``):
 
-    ``pyahotts`` is imported lazily so that importing ``phoonnx`` does not
-    hard-require it; a clear error is raised on first use if it is missing.
+      * ``classic``  -- the original AhoTTS engine; the HiTZ VITS voices.
+      * ``modern``   -- the StyleTTS-era build; HiTZ/StyleTTS2-eu.  The default.
+      * ``northern`` -- the Northern (Iparralde / Iparrahotsa) dialect: pronounced
+        /h/, French vowels (ü -> /y/), uvular /ʁ/, a remapped sibilant system.
+
+    ``ahotts_g2p.phonemize`` already returns the collapsed single-char training
+    string, so no further token folding is needed.  It is imported lazily so
+    importing ``phoonnx`` does not hard-require it.
     """
 
-    def __init__(self, alphabet: Alphabet = Alphabet.IPA):
+    def __init__(self, engine: Optional[str] = None,
+                 alphabet: Alphabet = Alphabet.IPA):
         """
-        Initialize the AhoTTS phonemizer.
-
         Args:
-            alphabet (Alphabet): Accepted for signature parity with the other
-                phonemizers; AhoTTS always produces IPA-derived tokens.
+            engine (Optional[str]): AhoTTS variant -- ``"classic"``, ``"modern"``
+                or ``"northern"`` (from the voice's ``phonemizer_model``).
+                Defaults to ``"modern"``.
+            alphabet (Alphabet): Accepted for signature parity; AhoTTS always
+                produces IPA-derived single-char tokens.
         """
-        self._ahotts = None
+        engine = (engine or DEFAULT_ENGINE).lower()
+        if engine not in ENGINES:
+            raise ValueError(
+                f"unknown AhoTTS engine {engine!r} "
+                f"(supported: {', '.join(ENGINES)})"
+            )
+        self.engine = engine
+        self._phonemize = None
         super().__init__(alphabet)
 
     @property
-    def ahotts(self):
-        """Lazily create and cache the underlying ``pyahotts.AhoTTS`` engine."""
-        if self._ahotts is None:
+    def phonemize_fn(self):
+        """Lazily import and cache ``ahotts_g2p.phonemize``."""
+        if self._phonemize is None:
             try:
-                from pyahotts import AhoTTS
+                from ahotts_g2p import phonemize
             except ImportError as e:
                 raise ImportError(
-                    "pyahotts is required for the AhoTTS Basque phonemizer. "
-                    "Install it with 'pip install pyahotts>=0.1.0a1' "
+                    "ahotts-g2p is required for the AhoTTS Basque phonemizer. "
+                    "Install it with 'pip install ahotts-g2p' "
                     "(or 'pip install phoonnx[eu]')."
                 ) from e
-            self._ahotts = AhoTTS()
-        return self._ahotts
+            self._phonemize = phonemize
+        return self._phonemize
 
     @classmethod
     def get_lang(cls, target_lang: str) -> str:
         """
         Validate and return the closest supported language code.
-
-        Args:
-            target_lang (str): The language code to validate.
-
-        Returns:
-            str: The validated language code.
 
         Raises:
             ValueError: If the language code is unsupported.
@@ -80,30 +79,22 @@ class AhoTTSPhonemizer(BasePhonemizer):
 
     def phonemize_string(self, text: str, lang: str) -> str:
         """
-        Convert Basque text into a StyleTTS2-eu tokenizable phoneme string.
+        Convert Basque text into the AhoTTS single-char IPA training string.
 
-        Calls ``pyahotts.AhoTTS.get_phonemes`` to obtain per-word lists of IPA
-        phone tokens, collapses multi-char IPA tokens to their single-char
-        StyleTTS2 symbols (see :data:`MULTICHAR`), joins each word's phones with
-        no separator, and joins words with a single space.
-
-        Parameters:
+        Args:
             text (str): The input text to phonemize.
             lang (str): The language code (validated; AhoTTS only supports eu).
 
         Returns:
-            str: The collapsed phoneme string (one char per StyleTTS2 symbol).
+            str: Space-separated single-char phoneme tokens.
         """
         self.get_lang(lang)
-        words: List[List[str]] = self.ahotts.get_phonemes(text, lang="eu", ipa=True)
-        return " ".join(
-            "".join(MULTICHAR.get(phone, phone) for phone in word)
-            for word in words
-        )
+        return self.phonemize_fn(text, lang="eu", **ENGINES[self.engine])
 
 
 if __name__ == "__main__":
-    eu = AhoTTSPhonemizer()
-    for sentence in ["Kaixo, mundua.", "Euskara hizkuntza zaharra eta ederra da."]:
-        print(f"\n--- Getting phonemes for '{sentence}' (AhoTTS) ---")
-        print(f"  AhoTTS Phonemes: {eu.phonemize_string(sentence, 'eu')}")
+    for eng in ("classic", "modern", "northern"):
+        eu = AhoTTSPhonemizer(eng)
+        print(f"\n--- AhoTTS '{eng}' ---")
+        for sentence in ["Kaixo, mundua.", "Euskara hizkuntza zaharra eta ederra da."]:
+            print(f"  {sentence!r}: {eu.phonemize_string(sentence, 'eu')}")

--- a/phoonnx/phonemizers/eu.py
+++ b/phoonnx/phonemizers/eu.py
@@ -1,0 +1,109 @@
+from typing import List, Optional
+
+from phoonnx.phonemizers.base import BasePhonemizer
+from phoonnx.config import Alphabet
+
+
+# Collapse multi-char IPA tokens emitted by AhoTTS into the single-char
+# symbols used by the StyleTTS2-eu / VITS-eu phoneme_id_map. Stressed vowels
+# carry a leading "'" in the AhoTTS output and become uppercase ASCII letters;
+# the affricates / aspirated stops collapse to single ASCII placeholders.
+MULTICHAR = {
+    "tʃ": "C",
+    "ts": "V",
+    "tʂ": "P",
+    "'i": "I",
+    "'e": "E",
+    "'a": "A",
+    "'o": "O",
+    "'u": "U",
+    "pʰ": "H",
+    "kʰ": "K",
+    "tʰ": "T",
+}
+
+
+class AhoTTSPhonemizer(BasePhonemizer):
+    """
+    A phonemizer for Basque (eu) backed by the ``pyahotts`` package, which wraps
+    the AhoTTS engine.
+
+    This is the **V1** AhoTTS engine, a close approximation (~96%) of the
+    StyleTTS2-eu V3 phonemizer. It powers the ``hitz-eu-styletts2`` and
+    ``hitz-eu_*`` mirror voices, whose configs set ``phoneme_type: ahotts``.
+
+    ``pyahotts`` is imported lazily so that importing ``phoonnx`` does not
+    hard-require it; a clear error is raised on first use if it is missing.
+    """
+
+    def __init__(self, alphabet: Alphabet = Alphabet.IPA):
+        """
+        Initialize the AhoTTS phonemizer.
+
+        Args:
+            alphabet (Alphabet): Accepted for signature parity with the other
+                phonemizers; AhoTTS always produces IPA-derived tokens.
+        """
+        self._ahotts = None
+        super().__init__(alphabet)
+
+    @property
+    def ahotts(self):
+        """Lazily create and cache the underlying ``pyahotts.AhoTTS`` engine."""
+        if self._ahotts is None:
+            try:
+                from pyahotts import AhoTTS
+            except ImportError as e:
+                raise ImportError(
+                    "pyahotts is required for the AhoTTS Basque phonemizer. "
+                    "Install it with 'pip install pyahotts>=0.1.0a1' "
+                    "(or 'pip install phoonnx[eu]')."
+                ) from e
+            self._ahotts = AhoTTS()
+        return self._ahotts
+
+    @classmethod
+    def get_lang(cls, target_lang: str) -> str:
+        """
+        Validate and return the closest supported language code.
+
+        Args:
+            target_lang (str): The language code to validate.
+
+        Returns:
+            str: The validated language code.
+
+        Raises:
+            ValueError: If the language code is unsupported.
+        """
+        return cls.match_lang(target_lang, ["eu-ES"])
+
+    def phonemize_string(self, text: str, lang: str) -> str:
+        """
+        Convert Basque text into a StyleTTS2-eu tokenizable phoneme string.
+
+        Calls ``pyahotts.AhoTTS.get_phonemes`` to obtain per-word lists of IPA
+        phone tokens, collapses multi-char IPA tokens to their single-char
+        StyleTTS2 symbols (see :data:`MULTICHAR`), joins each word's phones with
+        no separator, and joins words with a single space.
+
+        Parameters:
+            text (str): The input text to phonemize.
+            lang (str): The language code (validated; AhoTTS only supports eu).
+
+        Returns:
+            str: The collapsed phoneme string (one char per StyleTTS2 symbol).
+        """
+        self.get_lang(lang)
+        words: List[List[str]] = self.ahotts.get_phonemes(text, lang="eu", ipa=True)
+        return " ".join(
+            "".join(MULTICHAR.get(phone, phone) for phone in word)
+            for word in words
+        )
+
+
+if __name__ == "__main__":
+    eu = AhoTTSPhonemizer()
+    for sentence in ["Kaixo, mundua.", "Euskara hizkuntza zaharra eta ederra da."]:
+        print(f"\n--- Getting phonemes for '{sentence}' (AhoTTS) ---")
+        print(f"  AhoTTS Phonemes: {eu.phonemize_string(sentence, 'eu')}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Homepage = "https://github.com/TigreGotico/phoonnx"
 test = [
     "pytest",
     "ovos-plugin-manager",
+    "pyahotts>=0.1.0a1",
 ]
 train = [
     "cython>=0.29.0,<1",
@@ -51,6 +52,7 @@ cs = ["epitran"]
 de = ["epitran", "gruut[de]>=2.3.0,<3.0"]
 en = ["epitran", "gruut[en]>=2.3.0,<3.0", "misaki[en]", "spacy>=3.7"]
 es = ["epitran"]
+eu = ["pyahotts>=0.1.0a1"]
 fa = ["epitran"]
 fr = ["epitran"]
 he = ["epitran"]
@@ -72,6 +74,7 @@ all = [
     "gruut[de]>=2.3.0,<3.0", "gruut[en]>=2.3.0,<3.0", "gruut[ja]>=2.3.0,<3.0",
     "gruut[vi]>=2.3.0,<3.0", "gruut[zh]>=2.3.0,<3.0",
     "misaki[en]", "misaki[ja]", "misaki[vi]", "misaki[zh]",
+    "pyahotts>=0.1.0a1",
     "spacy>=3.7",
     "soundfile", "scipy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Homepage = "https://github.com/TigreGotico/phoonnx"
 test = [
     "pytest",
     "ovos-plugin-manager",
-    "pyahotts>=0.1.0a1",
+    "ahotts-g2p>=0.1.0",
 ]
 train = [
     "cython>=0.29.0,<1",
@@ -52,7 +52,7 @@ cs = ["epitran"]
 de = ["epitran", "gruut[de]>=2.3.0,<3.0"]
 en = ["epitran", "gruut[en]>=2.3.0,<3.0", "misaki[en]", "spacy>=3.7"]
 es = ["epitran"]
-eu = ["pyahotts>=0.1.0a1"]
+eu = ["ahotts-g2p>=0.1.0"]
 fa = ["epitran"]
 fr = ["epitran"]
 he = ["epitran"]
@@ -74,7 +74,7 @@ all = [
     "gruut[de]>=2.3.0,<3.0", "gruut[en]>=2.3.0,<3.0", "gruut[ja]>=2.3.0,<3.0",
     "gruut[vi]>=2.3.0,<3.0", "gruut[zh]>=2.3.0,<3.0",
     "misaki[en]", "misaki[ja]", "misaki[vi]", "misaki[zh]",
-    "pyahotts>=0.1.0a1",
+    "ahotts-g2p>=0.1.0",
     "spacy>=3.7",
     "soundfile", "scipy",
 ]

--- a/tests/test_eu_phonemizer.py
+++ b/tests/test_eu_phonemizer.py
@@ -1,9 +1,14 @@
-"""Tests for the AhoTTS (pyahotts) Basque phonemizer.
+"""Tests for the AhoTTS (ahotts-g2p) Basque phonemizer.
 
-pyahotts is a real dependency (declared in the ``eu`` and ``test`` extras),
+ahotts-g2p is a real dependency (declared in the ``eu`` and ``test`` extras),
 so it is imported unconditionally — no importorskip. The phonemizer output is
 asserted to be fully tokenizable by the StyleTTS2-eu 178-symbol phoneme map.
+The engine variant is chosen by ``phonemizer_model`` (passed to the factory as
+``model``): ``classic`` (VITS voices), ``modern`` (StyleTTS2-eu, default) or
+``northern`` (Iparralde dialect).
 """
+import pytest
+
 from phoonnx.config import PhonemeType, get_phonemizer
 
 
@@ -55,3 +60,35 @@ def test_ahotts_phonemize_chunks_are_tokenizable():
         for sentence_phones in chunks:
             for ch in sentence_phones:
                 assert ch in SYMBOLS, f"untokenizable phoneme {ch!r} in {sentence!r}"
+
+
+# --- engine selection (phonemizer_model) ----------------------------------
+
+def test_default_engine_is_modern():
+    # no phonemizer_model -> the StyleTTS2-eu "modern" engine
+    assert get_phonemizer(PhonemeType.AHOTTS).engine == "modern"
+
+
+@pytest.mark.parametrize("engine", ["classic", "modern", "northern"])
+def test_each_engine_is_tokenizable(engine):
+    phonemizer = get_phonemizer(PhonemeType.AHOTTS, model=engine)
+    assert phonemizer.engine == engine
+    for sentence in SENTENCES:
+        out = phonemizer.phonemize_string(sentence, "eu")
+        assert out.strip()
+        unknown = sorted({ch for ch in out if ch not in SYMBOLS})
+        assert not unknown, f"{engine}: untokenizable {unknown} in {sentence!r}"
+
+
+def test_engines_differ():
+    s = "Euskara hizkuntza zaharra da."
+    classic = get_phonemizer(PhonemeType.AHOTTS, model="classic").phonemize_string(s, "eu")
+    modern = get_phonemizer(PhonemeType.AHOTTS, model="modern").phonemize_string(s, "eu")
+    northern = get_phonemizer(PhonemeType.AHOTTS, model="northern").phonemize_string(s, "eu")
+    assert classic != modern        # modern adds punctuation tokens + dict stress
+    assert northern != classic      # Northern pronounces /h/, uvular ʁ, remapped sibilants
+
+
+def test_unknown_engine_raises():
+    with pytest.raises(ValueError):
+        get_phonemizer(PhonemeType.AHOTTS, model="v2")

--- a/tests/test_eu_phonemizer.py
+++ b/tests/test_eu_phonemizer.py
@@ -1,0 +1,57 @@
+"""Tests for the AhoTTS (pyahotts) Basque phonemizer.
+
+pyahotts is a real dependency (declared in the ``eu`` and ``test`` extras),
+so it is imported unconditionally — no importorskip. The phonemizer output is
+asserted to be fully tokenizable by the StyleTTS2-eu 178-symbol phoneme map.
+"""
+from phoonnx.config import PhonemeType, get_phonemizer
+
+
+# --- StyleTTS2-eu symbol set (single-char-collapsed IPA) -------------------
+# Built inline from the StyleTTS2 symbol set, matching the phoneme_id_map of
+# the OpenVoiceOS/phoonnx-styletts2/hitz-eu-styletts2 voice. The phonemizer
+# output must be tokenizable by this map (every output char is a key here).
+_pad = "$"
+_punctuation = ';:,.!?¡¿—…"<>“” '
+_letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_letters_ipa = (
+    "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧ"
+    "ʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩ᵻ"
+)
+
+# the full set of tokenizable symbols (the StyleTTS2-eu phoneme_id_map keys)
+SYMBOLS = set(_pad + _punctuation + _letters + _letters_ipa)
+
+
+SENTENCES = [
+    "Kaixo, mundua.",
+    "Euskara hizkuntza zaharra eta ederra da.",
+    "Bilbo Euskal Herriko hiri handiena da.",
+    "Nik liburu bat irakurri dut atzo arratsaldean.",
+    "Etxean txakur bat eta katu bi ditugu.",
+]
+
+
+def test_ahotts_phonemizer_output_is_tokenizable():
+    phonemizer = get_phonemizer(PhonemeType.AHOTTS)
+    for sentence in SENTENCES:
+        out = phonemizer.phonemize_string(sentence, "eu")
+        # non-empty string per sentence
+        assert isinstance(out, str)
+        assert out.strip(), f"empty phonemization for {sentence!r}"
+        # every char of the output must be a key in the StyleTTS2-eu map
+        unknown = sorted({ch for ch in out if ch not in SYMBOLS})
+        assert not unknown, (
+            f"phonemes not in StyleTTS2-eu map for {sentence!r}: {unknown}"
+        )
+
+
+def test_ahotts_phonemize_chunks_are_tokenizable():
+    """The full phonemize() pipeline (chunking + per-char lists) is tokenizable."""
+    phonemizer = get_phonemizer(PhonemeType.AHOTTS)
+    for sentence in SENTENCES:
+        chunks = phonemizer.phonemize(sentence, "eu")
+        assert chunks and any(chunks), f"no phonemes for {sentence!r}"
+        for sentence_phones in chunks:
+            for ch in sentence_phones:
+                assert ch in SYMBOLS, f"untokenizable phoneme {ch!r} in {sentence!r}"


### PR DESCRIPTION
Adds `PhonemeType.AHOTTS` — a Basque (eu) phonemizer backed by **pyahotts** (the public AhoTTS Python bindings).

## What
- `phoonnx/phonemizers/eu.py` — `AhoTTSPhonemizer`: lazy `pyahotts.AhoTTS()`, `phonemize_string` calls `get_phonemes(text, lang="eu", ipa=True)` and collapses multi-char IPA → the StyleTTS2-eu single-char set (`tʃ→C`, `ts→V`, `tʂ→P`, `'a→A`, …).
- `config.py`: `AHOTTS = "ahotts"` + `get_phonemizer` dispatch.
- `pyproject.toml`: `eu = ["pyahotts>=0.1.0a1"]` (+ test/all extras).
- `tests/test_eu_phonemizer.py`: asserts output is tokenizable by the StyleTTS2-eu symbol map (no importorskip).

## Powers
The mirror voices `OpenVoiceOS/phoonnx-styletts2/hitz-eu-styletts2` and `OpenVoiceOS/phoonnx-vits/hitz-eu_*` (which set `phoneme_type: ahotts`).

## Note
This is the **V1 pyahotts** path — a ~96% approximation of the StyleTTS2-eu V3 phonemizer (across the test sentences there was **zero** out-of-map drift). A version-accurate pure-Python AhoTTS port (V1/V2/V3, eu+es) will follow in a later PR.

Validation: `pytest` → 243 passed, 7 (pre-existing) skipped; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AHOTTS phonemizer option for Basque language support with three configurable engine variants (classic, modern, northern)

* **Tests**
  * Added comprehensive test suite validating phonemizer output, tokenization, and engine variant behavior

* **Chores**
  * Added ahotts-g2p dependency for Basque language support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->