### PR TITLE
feat: alphacep vosk-tts (Russian) voice support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `shami` | Levantine Arabic / English (HamsVITS) | [Shami](training/engines/shami.md) |
 | `f5tts` | DiT flow-matching (F5-TTS / Habibi) | [F5-TTS](training/engines/f5tts.md) |
 | `chatterbox` | Autoregressive codec-LM cloning | [Chatterbox](training/engines/chatterbox.md) |
+| `vosk` | VITS (shared adapter), vosk-tts Russian front-end | [Engines](engines.md) |
 | `supertonic` | Flow-matching, fixed per-speaker style | [Engines](engines.md) |
 | `neutts` | Autoregressive NeuCodec LM, preset cloning @24 kHz | [Cloning](cloning.md) |
 | `pockettts` | Flow-matching codec LM with explicit stream state, raw-text (no phonemizer) | [Pocket TTS](pockettts.md) |

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -89,6 +89,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | [F5-TTS](training/engines/f5tts.md) | `phoonnx/engines/f5tts.py` | `engine == "f5tts"` — multi-graph engine (auxiliary ONNX graphs via `aux_model_urls`) |
 | Shami / HamsVITS | `phoonnx/engines/shami.py` | `engine in ("shami", "hams")` — VITS variant with per-phoneme `language_ids` for Levantine Arabic / English code-switching |
 | [Chatterbox](training/engines/chatterbox.md) | `phoonnx/engines/chatterbox.py` | `engine == "chatterbox"` — first **autoregressive** engine (codec-LM), d-vector [cloning](cloning.md) + exaggeration |
+| Vosk | `phoonnx/engines/vits.py` (shared) | `engine == "vosk"` — alphacep vosk-tts Russian voices: plain VITS exports whose front-end is scriptconv's dictionary/rule `VoskPhonemizer` |
 | SuperTonic | `phoonnx/engines/supertonic.py` | `engine == "supertonic"` — multi-graph flow-matching engine (4 ONNX graphs via `aux_model_urls`), raw-text (no phonemizer), fixed per-speaker style instead of cloning |
 | NeuTTS (NeuTTS Air / VieNeu / Akiti) | `phoonnx/engines/neutts.py` | `engine == "neutts"` — autoregressive single-codebook codec-LM (Qwen3 backbone + NeuCodec decoder), raw text phonemized with espeak-ng, in-context [cloning](cloning.md) from pre-encoded voice presets, 24 kHz |
 | [Pocket TTS](pockettts.md) | `phoonnx/engines/pockettts.py` | `engine == "pockettts"` — 5-graph flow-matching codec LM with explicit stream state, raw-text (no phonemizer), state-based voices and reference [cloning](cloning.md) |

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -12,7 +12,8 @@ The catalog is not fetched from a handful of live endpoints. `merge_default_voic
 `transformers_community`, `piper_community`, `optispeech`, `glowtts`, `mixertts`,
 `fastpitch`, `coqui_community`, `vits2`, `styletts2`, `f5tts`, `coqui_vits`, `BSC`,
 `shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`, `qwen3tts`,
-`outetts`, `arktts`, `omnivoice`, `indic_parler`, `llasa`, `orpheus`, `mosstts`.
+`outetts`, `arktts`, `omnivoice`, `indic_parler`, `llasa`, `orpheus`, `mosstts`,
+`vosk`.
 
 Each JSON entry becomes a `TTSModelInfo`. Model/config/vocoder files are only fetched from their URLs when a voice is actually downloaded or loaded.
 
@@ -174,6 +175,7 @@ relevant to specific engine families (see [engines.md](engines.md), [cloning.md]
 | `vocoder_config_url` | `str` \| `None` | Vocoder `vocoder.json` parameters |
 | `vocoder_type` | `str` \| `None` | Vocoder implementation (`vocos`, `wavenext`, `hifigan`, `melgan`, `raw`, `griffinlim`) |
 | `style_url` | `str` \| `None` | Per-voice StyleTTS2/Kokoro style embedding |
+| `dictionary_url` | `str` \| `None` | Vosk pronunciation dictionary (word → phonemes); downloaded as the voice's `phonemizer_model` |
 | `speaker_encoder_url` / `speaker_encoder_type` | `str` \| `None` | Cloning speaker-encoder ONNX (reference audio → d-vector) |
 | `aux_model_urls` | `dict` \| `None` | Extra ONNX graphs/files for multi-graph engines (F5-TTS; SuperTonic's `duration_predictor`/`text_encoder`/`vocoder` graphs plus its `tts.json` config, `unicode_indexer.json` and per-speaker `style.json`; NeuTTS's NeuCodec decoder graph plus its `tokenizer.json` and `voices.json`; Indic Parler's `text_encoder`/`decoder_decode`/`dac_decoder` graphs plus its two tokenizers; MOSS-TTS-Nano's decode-step / local-decoder / codec graphs plus its SentencePiece `tokenizer.model` and the `.data` external-weight blobs those graphs reference by filename), keyed by engine-param name |
 | `engine_options` | `dict` \| `None` | Plain per-voice engine settings that are not downloadable files, merged into `engine_params` as-is (e.g. NeuTTS's `voice` preset name) |

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -45,6 +45,7 @@ class Engine(str, Enum):
     ORPHEUS = "orpheus"  # Orpheus (Canopy Labs): Llama codec-LM + SNAC decoder, emotive tags
     MAGPIE = "magpie"  # NVIDIA Magpie-TTS: encoder-decoder codec LM, 8 codebooks, 12 languages
     MOSSTTS = "mosstts"  # MOSS-TTS-Nano: autoregressive RVQ-16 codec-LM, zero-shot cloning @48kHz
+    VOSK = "vosk"  # alphacep vosk-tts: VITS + dictionary/rule Russian g2p
 
 
 # Alphabet and PhonemeType are wire-format enums shared with scriptconv;
@@ -213,6 +214,12 @@ class VoiceConfig:
         return PiperLoader.detect(LoadRequest(config=config))
 
     @staticmethod
+    def is_vosk(config: dict[str, Any]) -> bool:
+        """Whether *config* is an alphacep vosk-tts voice."""
+        from phoonnx.config_loaders import LoadRequest, VoskLoader
+        return VoskLoader.detect(LoadRequest(config=config))
+
+    @staticmethod
     def is_coqui_vits(config: dict[str, Any]) -> bool:
         """Whether *config* is a Coqui VITS grapheme voice."""
         from phoonnx.config_loaders import CoquiLoader, LoadRequest
@@ -362,6 +369,7 @@ class VoiceConfig:
             "use_eos_bos": tok.use_eos_bos,
             "blank_at_start": tok.blank_at_start,
             "blank_at_end": tok.blank_at_end,
+            "fold_compounds": tok.fold_compounds,
             "word_sep_token": self.word_sep_token,
             "blank_between": self.blank_between.value if self.blank_between else "tokens_and_words",
             "engine_params": dict(self.engine_params or {}),

--- a/phoonnx/config_loaders.py
+++ b/phoonnx/config_loaders.py
@@ -17,6 +17,13 @@ mirrors the historical detection ladder:
 * ``phoonnx`` precedes ``piper`` because a native config that phonemizes with
   espeak carries a piper-shaped ``phoneme_id_map`` and would otherwise be
   claimed by the piper loader;
+* ``vosk`` precedes ``piper``, but for a different reason than ``phoonnx``
+  does: :class:`PiperLoader` already rejects a config with no ``phoneme_type``
+  (unless it carries ``piper_version``), and a genuine vosk config has
+  neither. Ordering only guards the engine-declared branch — a config naming
+  ``engine: vosk`` that also happens to carry ``piper_version`` — from being
+  claimed by :class:`PiperLoader`'s unconditional ``piper_version`` check
+  first;
 * ``vocab`` (transformers) and ``tokens_txt`` (sherpa) come last because they
   are decided by what the caller passed alongside the config, not by the config
   itself, and any real config shape should win over them.
@@ -250,6 +257,70 @@ class PhoonnxLoader(ConfigLoader):
             alphabet=alphabet,
             add_diacritics=inference.get("add_diacritics", True),
             diacritizer_model=inference.get("diacritizer_model", None),
+        )
+
+
+class VoskLoader(ConfigLoader):
+    """alphacep vosk-tts voices: piper-shaped VITS with a dictionary/rule
+    Russian g2p.
+
+    Indexed voices name ``engine: vosk``, resolved by the engine-declared
+    branch below; this loader also recognises a *local* vosk model directory
+    with no declared engine, whose ``config.json`` is piper-shaped
+    (list-valued ``phoneme_id_map``, an ``espeak`` stanza) but — unlike a real
+    piper config — carries no ``phoneme_type``. :class:`PiperLoader` already
+    rejects a config with no ``phoneme_type`` (its own ``piper_version`` fast
+    path aside), so the missing key is what keeps a genuine vosk config out of
+    :class:`PiperLoader`'s hands regardless of probing order; the
+    romanised-Russian phoneme inventory (``a0``/``a1``/``bj``/``sch`` …) is
+    the second signal that keeps a piper-shaped config with some *other*,
+    unrelated vocabulary from being mistaken for vosk.
+    """
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        config = request.config
+        # an explicitly declared engine is authoritative in both directions:
+        # a config naming vosk is trusted even without the tell-tale
+        # inventory, and one naming anything else is never claimed by it.
+        engine = config.get("engine")
+        if engine in ("vosk", Engine.VOSK, Engine.VOSK.value):
+            pid = config.get("phoneme_id_map")
+            return isinstance(pid, dict) and bool(pid)
+        if engine:
+            return False
+        pid = config.get("phoneme_id_map")
+        if not isinstance(pid, dict) or not pid:
+            return False
+        # a real vosk config carries no phoneme_type of its own - piper does.
+        # Without this, a piper (or piper-shaped) config that merely happens
+        # to also define "a0"/"sch" phonemes (a custom vocabulary, a fixture)
+        # would be stolen from PiperLoader by the inventory check alone.
+        if config.get("phoneme_type"):
+            return False
+        return "a0" in pid and "sch" in pid
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        config = request.config
+
+        # fixed special tokens (ids 0/1/2 in every vosk phoneme_id_map)
+        config["pad"] = DEFAULT_PAD_TOKEN
+        config["blank"] = DEFAULT_BLANK_TOKEN
+        config["bos"] = DEFAULT_BOS_TOKEN
+        config["eos"] = DEFAULT_EOS_TOKEN
+
+        # the config's own phoneme_type/espeak stanza describes how the
+        # dictionary/rule g2p was *derived*, not how this loader tokenizes;
+        # the vocabulary is the fixed romanised-Russian phoneme set, so both
+        # are pinned rather than inherited from the config or the caller.
+        return LoadedFields(
+            tokenizer=TTSTokenizer.from_vosk_config(config),
+            engine=Engine.VOSK,
+            lang_code=request.lang_code or config.get("lang_code") or "ru",
+            phoneme_type=PhonemeType.VOSK,
+            alphabet=Alphabet.VOSK,
+            pinned=frozenset({"phoneme_type", "alphabet"}),
         )
 
 
@@ -544,6 +615,7 @@ LOADERS: List[Type[ConfigLoader]] = [
     _raw_text_loader(Engine.QWEN3TTS, 24000),
     _raw_text_loader(Engine.OUTETTS, 24000),
     PhoonnxLoader,
+    VoskLoader,
     PiperLoader,
     Mimic3Loader,
     CoquiLoader,

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -166,6 +166,13 @@ def _register_builtins() -> None:
     # probed before the plain single-graph vits adapter.
     register_engine("vits_prior_split", VitsPriorSplitAdapter, detect_priority=49)
     register_engine("vits", VitsAdapter, detect_priority=50)
+    # alphacep vosk-tts voices are plain VITS exports (input/input_lengths/
+    # scales[/sid]) - VitsAdapter.detect() matches them the same as any other
+    # VITS graph. The config loader always names the engine explicitly, so in
+    # practice this entry is reached through the named-engine lookup; the
+    # priority is still set *after* "vits" (not tied with it) so an anonymous
+    # VITS voice's auto-detect is never claimed under the "vosk" name instead.
+    register_engine("vosk", VitsAdapter, detect_priority=51)
     register_engine("matcha", MatchaAdapter, detect_priority=40)
     register_engine("glowtts", GlowTTSAdapter, detect_priority=42)
     register_engine("mixertts", MixerTTSAdapter, detect_priority=36)

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -255,6 +255,7 @@ class TTSModelInfo:
     tokenizer_config_url: Optional[str] = None  # transformers provides tokenizer_config.json with metadata
     tokens_url: Optional[str] = None  # mimic3/sherpa provide phoneme_map in this format
     phoneme_map_url: Optional[str] = None  # json lookup table for phoneme replacement
+    dictionary_url: Optional[str] = None  # vosk: word -> phonemes pronunciation dictionary
     phoneme_type: Optional[PhonemeType] = None
     phonemizer_model: Optional[str] = None  # per-phonemizer variant (e.g. AhoTTS classic/modern/northern)
     alphabet: Optional[Alphabet] = None
@@ -354,6 +355,13 @@ class TTSModelInfo:
                     config["phoneme_type"] = "espeak"
             else:
                 config = {"phoneme_type": "graphemes", "alphabet": "unicode"}
+            # vosk voices ship a pronunciation dictionary; its local path is the
+            # phonemizer_model the VoskPhonemizer loads. A failed fetch leaves
+            # phonemizer_model unset rather than pointing at nothing.
+            if self.dictionary_url and not self.phonemizer_model:
+                dict_path = self.download_dictionary()
+                if dict_path:
+                    self.phonemizer_model = str(dict_path)
             if self.phoneme_type:
                 config["phoneme_type"] = self.phoneme_type
             if self.phonemizer_model:
@@ -492,6 +500,25 @@ class TTSModelInfo:
         path = self.hub_path(self.tokens_url)
         return path.read_text(encoding="utf-8") if path else ""
 
+    def download_dictionary(self) -> Optional[Path]:
+        """Give the vosk pronunciation ``dictionary`` (word -> phonemes) path,
+        from the hub cache, if any.
+
+        The file is large (tens of MB) but optional: a failed fetch (offline,
+        a dropped connection, a pruned hub revision) degrades to rule-based
+        g2p for every word rather than failing the whole voice load, the same
+        way the phonemizer already degrades per out-of-dictionary word.
+        """
+        if not self.dictionary_url:
+            return None
+        try:
+            return self.hub_path(self.dictionary_url)
+        except Exception as exc:
+            LOG.warning(f"Could not fetch vosk pronunciation dictionary for "
+                        f"{self.voice_id} ({exc}); falling back to "
+                        f"rule-based g2p for every word")
+            return None
+
     def _fetch_onnx(self, url: str) -> Path:
         """Give the local path of an ONNX graph, with its sidecar alongside.
 
@@ -628,6 +655,9 @@ class TTSModelInfo:
         elif self.tokens_url:
             self.download_tokens_txt()
 
+        # vosk pronunciation dictionary (the phonemizer's model)
+        self.download_dictionary()
+
         # vocoder / style / speaker-encoder / aux graphs
         self.engine_params()
         return model_path
@@ -642,7 +672,8 @@ class TTSModelInfo:
         """
         urls = [self.model_url, self.vocoder_url, self.style_url,
                 self.speaker_encoder_url, self.speech_encoder_url,
-                self.embed_tokens_url, self.conditional_decoder_url]
+                self.embed_tokens_url, self.conditional_decoder_url,
+                self.dictionary_url]
         urls += [u for u in (self.aux_model_urls or {}).values() if u]
         return list(dict.fromkeys(u for u in urls if u))
 
@@ -739,6 +770,14 @@ class TTSModelInfo:
                               engine_params=self.engine_params() or None,
                               providers=providers,
                               phonemes_txt=str(tokens_path) if self.tokens_url else None)
+        # A phonemizer_model resolved from the index (the vosk pronunciation
+        # dictionary) is an index-level artifact: the published config.json never
+        # references it, so the config loaded from disk cannot carry it.
+        if self.phonemizer_model and not voice.config.phonemizer_model:
+            voice.config.phonemizer_model = self.phonemizer_model
+            voice.phonemizer = get_phonemizer(voice.config.phoneme_type,
+                                              alphabet=voice.config.alphabet,
+                                              model=self.phonemizer_model)
         # override phoneme_type, if config.json is wrong
         if self.phoneme_type != voice.config.phoneme_type or self.alphabet != voice.config.alphabet:
             voice.config.phoneme_type = self.phoneme_type
@@ -771,7 +810,7 @@ class TTSModelManager:
         # last touched; indic_parler.json, llasa.json, orpheus.json and
         # mosstts.json are new to this change.
         "outetts.json", "arktts.json", "omnivoice.json", "indic_parler.json",
-        "llasa.json", "orpheus.json", "mosstts.json",
+        "llasa.json", "orpheus.json", "mosstts.json", "vosk.json",
     )
 
     @classmethod

--- a/phoonnx/tokenizer.py
+++ b/phoonnx/tokenizer.py
@@ -496,6 +496,11 @@ class TTSTokenizer:
     use_eos_bos: bool
     blank_at_end: bool
     blank_at_start: bool
+    fold_compounds: bool = True
+    """Greedily merge adjacent characters into multi-char vocabulary keys
+    (mimic3 diphthongs). Must be ``False`` when the input is already a list of
+    complete phoneme tokens (e.g. vosk), where merging would corrupt genuine
+    consonant clusters like ``s h`` -> ``sh``."""
     not_found_characters: Set[str] = field(default_factory=set)
 
     @property
@@ -543,7 +548,7 @@ class TTSTokenizer:
         # first pre-process phoneme_map to check for dipthongs having their own phoneme_id
         # common in mimic3 models
         compound_toks = sorted((k for k in self.vocabulary.char2idx
-                                if len(k) > 1), key=len, reverse=True)
+                                if len(k) > 1), key=len, reverse=True) if self.fold_compounds else []
 
         token_ids: List[Optional[int]] = []
 
@@ -684,9 +689,10 @@ class TTSTokenizer:
         blank_at_start: bool = cfg.get("blank_at_start", True)
         use_eos_bos: bool = cfg.get("use_eos_bos", True)
         add_blank_word: bool = cfg.get("add_blank_word", False)
+        fold_compounds: bool = cfg.get("fold_compounds", True)
         return TTSTokenizer(voc, add_blank_char=add_blank, add_blank_word=add_blank_word,
                             blank_at_end=blank_at_end, blank_at_start=blank_at_start,
-                            use_eos_bos=use_eos_bos)
+                            use_eos_bos=use_eos_bos, fold_compounds=fold_compounds)
 
     @staticmethod
     def from_piper_config(cfg: Dict[str, Any]) -> 'TTSTokenizer':
@@ -709,6 +715,22 @@ class TTSTokenizer:
         return TTSTokenizer(voc, add_blank_char=add_blank, add_blank_word=add_blank_word,
                             blank_at_end=blank_at_end, blank_at_start=blank_at_start,
                             use_eos_bos=use_eos_bos)
+
+    @staticmethod
+    def from_vosk_config(cfg: Dict[str, Any]) -> 'TTSTokenizer':
+        """
+        Create a TTSTokenizer for an alphacep vosk-tts voice.
+
+        Tokenization matches piper (blank id 0 interspersed between every token
+        with leading/trailing blanks, BOS/EOS wrapping) — which reproduces
+        vosk_tts's own ``^ 0 p 0 p … 0 $`` id stream exactly. Compound folding
+        is disabled because the phonemizer already emits complete phoneme
+        tokens, so merging neighbours (``s`` + ``h`` -> ``sh``) would be wrong.
+        """
+        voc: Vocabulary = Vocabulary.from_piper_config(cfg)
+        return TTSTokenizer(voc, add_blank_char=True, add_blank_word=False,
+                            blank_at_end=True, blank_at_start=True,
+                            use_eos_bos=True, fold_compounds=False)
 
     @staticmethod
     def from_mimic3_config(cfg: Dict[str, Any], tokens_txt: str) -> 'TTSTokenizer':

--- a/phoonnx/voice_index/vosk.json
+++ b/phoonnx/voice_index/vosk.json
@@ -1,0 +1,44 @@
+{
+    "vosk/tamara": {
+        "voice_id": "vosk/tamara",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__tamara/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__tamara/config.json",
+        "dictionary_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__tamara/dictionary",
+        "phoneme_type": "vosk",
+        "lang": "ru-RU",
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "vocab_url": null,
+        "phoneme_map_url": null,
+        "alphabet": "vosk",
+        "engine": "vosk"
+    },
+    "vosk/irina": {
+        "voice_id": "vosk/irina",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__irina/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__irina/config.json",
+        "dictionary_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__irina/dictionary",
+        "phoneme_type": "vosk",
+        "lang": "ru-RU",
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "vocab_url": null,
+        "phoneme_map_url": null,
+        "alphabet": "vosk",
+        "engine": "vosk"
+    },
+    "vosk/natasha": {
+        "voice_id": "vosk/natasha",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__natasha/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__natasha/config.json",
+        "dictionary_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/vosk__natasha/dictionary",
+        "phoneme_type": "vosk",
+        "lang": "ru-RU",
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "vocab_url": null,
+        "phoneme_map_url": null,
+        "alphabet": "vosk",
+        "engine": "vosk"
+    }
+}

--- a/tests/differential/corpus.py
+++ b/tests/differential/corpus.py
@@ -67,6 +67,22 @@ CANONICAL = {"engine": "matcha", "phoneme_type": "gruut", "alphabet": "ipa",
 CANONICAL_BARE = {"phoneme_id_map": {"a": 1, "_": 0}}
 CANONICAL_BAD_ALPHABET = {"engine": "matcha", "alphabet": "not-an-alphabet",
                           "phoneme_id_map": {"a": 1, "_": 0}}
+# alphacep vosk-tts: piper-shaped, but - unlike a real piper config - carries
+# no phoneme_type of its own; that absence (which PiperLoader's own detect()
+# already requires) plus the romanised-Russian phoneme inventory ("a0",
+# "sch") is what routes it to VoskLoader
+VOSK = {"espeak": {"voice": "ru"},
+        "phoneme_id_map": {"a0": [1], "sch": [2], "_": [0]},
+        "audio": {"sample_rate": 22050}}
+# a real piper config that happens to define the same phonemes: the inventory
+# alone is not the signature, a declared phoneme_type keeps it as piper
+VOSK_LOOKALIKE_PIPER = {"phoneme_type": "espeak", "espeak": {"voice": "ru"},
+                        "phoneme_id_map": {"a0": [1], "sch": [2], "_": [0]},
+                        "audio": {"sample_rate": 22050}}
+# an explicitly named vosk engine without the tell-tale inventory: the
+# declared name must still win over the shape-sniffer
+VOSK_EXPLICIT_ENGINE = {"engine": "vosk", "phoneme_id_map": {"p": [1], "_": [0]},
+                        "audio": {"sample_rate": 22050}}
 
 # (engine name, its codec's sample rate); the loaders differ in nothing else
 CODEC_ENGINES = [("llasa", 16000), ("neutts", 24000), ("orpheus", 24000),
@@ -104,6 +120,9 @@ def build(tmpdir: str) -> List[Tuple[str, Dict[str, Any], Dict[str, Any]]]:
         ("canonical", CANONICAL, {}),
         ("canonical-bare", CANONICAL_BARE, {}),
         ("canonical-bad-alphabet", CANONICAL_BAD_ALPHABET, {}),
+        ("vosk", VOSK, {}),
+        ("vosk-lookalike-piper", VOSK_LOOKALIKE_PIPER, {}),
+        ("vosk-explicit-engine", VOSK_EXPLICIT_ENGINE, {}),
         ("transformers", {"num_symbols": 5}, {"vocab": {"a": 1, "b": 2, "_": 0}}),
         ("transformers-tokcfg", {"num_symbols": 5},
          {"vocab": {"a": 1, "_": 0},

--- a/tests/differential/golden.json
+++ b/tests/differential/golden.json
@@ -17686,5 +17686,1459 @@
    },
    "word_sep_token": " "
   }
+ },
+ "vosk-explicit-engine|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vosk",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "p": [
+     1
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "p": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-explicit-engine|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vosk",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "p": [
+     1
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "p": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-explicit-engine|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vosk",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "p": [
+     1
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "p": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-explicit-engine|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vosk",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "p": [
+     1
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "p": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-explicit-engine|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vosk",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "p": [
+     1
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "p": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-explicit-engine|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vosk",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "p": [
+     1
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "p": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-explicit-engine|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vosk",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "p": [
+     1
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "p": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-lookalike-piper|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-lookalike-piper|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-lookalike-piper|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-lookalike-piper|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-lookalike-piper|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-lookalike-piper|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk-lookalike-piper|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "vosk|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "espeak": {
+    "voice": "ru"
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a0": [
+     1
+    ],
+    "sch": [
+     2
+    ]
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "vosk",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "vosk",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "ru",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "vosk",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a0": 1,
+     "sch": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
  }
 }

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -7,7 +7,7 @@ from phoonnx.config import Alphabet, Engine, PhonemeType, VoiceConfig
 from phoonnx.config_loaders import (LOADERS, CanonicalLoader, ChatterboxLoader, CoquiLoader,
                                     LoadedFields, LoadRequest, Mimic3Loader, PhoonnxLoader,
                                     PiperLoader, RawTextLoader, TokensTxtLoader,
-                                    TransformersLoader, resolve_overrides)
+                                    TransformersLoader, VoskLoader, resolve_overrides)
 from phoonnx.util import normalize_lang
 
 
@@ -33,6 +33,28 @@ class TestRegistryOrder(unittest.TestCase):
 
     def test_phoonnx_is_probed_before_piper(self):
         self.assertLess(_index(PhoonnxLoader), _index(PiperLoader))
+
+    def test_vosk_is_probed_before_piper(self):
+        self.assertLess(_index(VoskLoader), _index(PiperLoader))
+
+    def test_a_vosk_config_is_never_claimed_by_the_piper_loader(self):
+        # a real alphacep vosk-tts config.json is piper-shaped (espeak
+        # stanza, list-valued phoneme_id_map) but - unlike a real piper
+        # config - carries no phoneme_type; PiperLoader already rejects that,
+        # so it never reaches PiperLoader regardless of probing order
+        cfg = {"espeak": {"voice": "ru"},
+               "phoneme_id_map": {"a0": [10], "sch": [20], "_": [0]}}
+        self.assertFalse(PiperLoader.detect(LoadRequest(config=dict(cfg))))
+        self.assertEqual(VoiceConfig.from_dict(dict(cfg)).engine, Engine.VOSK)
+
+    def test_a_piper_config_with_the_vosk_inventory_is_not_stolen(self):
+        # the romanised-Russian inventory alone is not the signature: a real
+        # piper config (declares phoneme_type) that happens to also define
+        # "a0"/"sch" phonemes must still load as piper, not vosk
+        cfg = {"phoneme_type": "espeak", "espeak": {"voice": "ru"},
+               "phoneme_id_map": {"a0": [10], "sch": [20], "_": [0]}}
+        self.assertFalse(VoskLoader.detect(LoadRequest(config=dict(cfg))))
+        self.assertEqual(VoiceConfig.from_dict(dict(cfg)).engine, Engine.PIPER)
 
     def test_companion_file_loaders_are_probed_last(self):
         shape = max(_index(c) for c in (PhoonnxLoader, PiperLoader, Mimic3Loader, CoquiLoader))
@@ -183,6 +205,48 @@ class TestRawTextLoaderDefaults(unittest.TestCase):
     def test_a_config_sample_rate_is_never_overwritten(self):
         voice = VoiceConfig.from_dict({"engine": "llasa", "audio": {"sample_rate": 48000}})
         self.assertEqual(voice.sample_rate, 48000)
+
+
+def _vosk_cfg():
+    # a real vosk config: piper-shaped, but no phoneme_type of its own
+    return {"espeak": {"voice": "ru"},
+            "phoneme_id_map": {"a0": [10], "a1": [11], "bj": [12], "sch": [20], "_": [0]}}
+
+
+class TestVoskLoader(unittest.TestCase):
+    def test_detects_by_phoneme_inventory(self):
+        self.assertTrue(VoskLoader.detect(LoadRequest(config=_vosk_cfg())))
+
+    def test_rejects_configs_without_the_vosk_phoneme_set(self):
+        cfg = {"phoneme_id_map": {"a": [1], "_": [0]}}
+        self.assertFalse(VoskLoader.detect(LoadRequest(config=cfg)))
+
+    def test_rejects_configs_that_declare_a_phoneme_type(self):
+        # the inventory alone is not the signature - a real piper config that
+        # happens to also define "a0"/"sch" phonemes must not be stolen
+        cfg = dict(_vosk_cfg(), phoneme_type="espeak")
+        self.assertFalse(VoskLoader.detect(LoadRequest(config=cfg)))
+
+    def test_an_explicit_non_vosk_engine_beats_shape_sniffing(self):
+        cfg = dict(_vosk_cfg(), engine="piper")
+        self.assertFalse(VoskLoader.detect(LoadRequest(config=cfg)))
+
+    def test_load_defaults_lang_to_russian(self):
+        voice = VoiceConfig.from_dict(_vosk_cfg())
+        self.assertEqual(voice.engine, Engine.VOSK)
+        self.assertEqual(voice.phoneme_type, PhonemeType.VOSK)
+        self.assertEqual(voice.alphabet, Alphabet.VOSK)
+        self.assertEqual(voice.lang_code, normalize_lang("ru"))
+
+    def test_a_caller_lang_code_overrides_the_russian_default(self):
+        voice = VoiceConfig.from_dict(_vosk_cfg(), lang_code="ru-RU")
+        self.assertEqual(voice.lang_code, normalize_lang("ru-RU"))
+
+    def test_tokenizer_does_not_fold_compound_phonemes(self):
+        # the phonemizer already emits complete tokens; folding would merge
+        # unrelated neighbours into a spurious compound key
+        voice = VoiceConfig.from_dict(_vosk_cfg())
+        self.assertFalse(voice.tokenizer.fold_compounds)
 
 
 if __name__ == "__main__":

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -572,6 +572,42 @@ class TestDownloadAll(HubTestCase):
                               "tokenizer_config.json"}, pulled)
 
 
+class TestVoskDictionary(HubTestCase):
+    """The vosk pronunciation dictionary is an optional, large (tens of MB)
+    artifact: a failed fetch must degrade to rule-based g2p, not fail voice
+    construction."""
+
+    def test_dictionary_is_fetched_alongside_the_model(self):
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
+        self.hub.stage(f"{HUB}/dictionary", b"word phonemes\n")
+        info = self.make_info(dictionary_url=f"{HUB}/dictionary")
+        info.download_all()
+        pulled = {name for _, name, _ in self.hub.downloads}
+        self.assertIn("dictionary", pulled)
+
+    def test_dictionary_becomes_the_phonemizer_model(self):
+        self.hub.stage(f"{HUB}/dictionary", b"word phonemes\n")
+        info = self.make_info(dictionary_url=f"{HUB}/dictionary")
+        self.assertTrue(info.config.phonemizer_model)
+        self.assertTrue(os.path.exists(info.config.phonemizer_model))
+
+    def test_a_failed_fetch_degrades_instead_of_raising(self):
+        self.hub.errors["dictionary"] = ConnectionError("offline")
+        info = self.make_info(dictionary_url=f"{HUB}/dictionary")
+        with patch("phoonnx.model_manager.LOG") as mock_log:
+            self.assertIsNone(info.download_dictionary())
+            self.assertTrue(mock_log.warning.called)
+        # the config still builds - no phonemizer_model, rule-based g2p only
+        self.assertFalse(info.config.phonemizer_model)
+
+    def test_download_all_does_not_raise_when_the_dictionary_is_unreachable(self):
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
+        self.hub.errors["dictionary"] = ConnectionError("offline")
+        info = self.make_info(dictionary_url=f"{HUB}/dictionary")
+        model_path = info.download_all()
+        self.assertEqual(model_path.read_bytes(), b"onnxdata")
+
+
 class TestLoadProviders(HubTestCase):
     @patch("phoonnx.model_manager.VoiceConfig")
     @patch("phoonnx.model_manager.make_session")

--- a/tests/test_ru.py
+++ b/tests/test_ru.py
@@ -1,0 +1,139 @@
+"""Tests for the alphacep vosk-tts Russian voices (config + tokenizer).
+
+The Russian G2P itself lives in scriptconv (``VoskPhonemizer``); what phoonnx
+owns — and what is tested here — is recognising a vosk voice and turning its
+phoneme tokens into the exact id stream the model was trained on.
+"""
+from phoonnx.config import VoiceConfig, Engine, Alphabet, PhonemeType
+from phoonnx.tokenizer import TTSTokenizer
+
+# A minimal vosk phoneme inventory (piper-shaped: id is a 1-element list).
+# Order/ids only need to be internally consistent for the tests.
+_VOSK_PHONES = [
+    "_", "^", "$", " ", ",", ".", "-",
+    "a0", "a1", "e0", "e1", "i0", "i1", "o0", "o1", "u0", "u1", "y0", "y1",
+    "b", "bj", "c", "ch", "d", "dj", "f", "g", "h", "j", "k", "l", "lj",
+    "m", "mj", "n", "nj", "p", "r", "rj", "s", "sch", "sh", "sj", "t", "tj",
+    "v", "vj", "z", "zh",
+]
+
+
+def _vosk_config():
+    return {
+        "audio": {"sample_rate": 22050},
+        "espeak": {"voice": "ru"},
+        "inference": {"noise_scale": 0.667, "length_scale": 1.0, "noise_w": 0.8},
+        "num_speakers": 1,
+        "phoneme_id_map": {p: [i] for i, p in enumerate(_VOSK_PHONES)},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# config detection / construction
+# --------------------------------------------------------------------------- #
+def test_is_vosk_detects_inventory():
+    assert VoiceConfig.is_vosk(_vosk_config()) is True
+
+
+def test_is_vosk_rejects_non_vosk():
+    # piper espeak config: no a0/sch markers
+    assert VoiceConfig.is_vosk({"phoneme_id_map": {"a": [0], "b": [1]}}) is False
+    assert VoiceConfig.is_vosk({}) is False
+
+
+def test_from_dict_builds_vosk_voice():
+    cfg = VoiceConfig.from_dict(_vosk_config())
+    assert cfg.engine == Engine.VOSK
+    assert cfg.phoneme_type == PhonemeType.VOSK
+    assert cfg.alphabet == Alphabet.VOSK
+    assert cfg.sample_rate == 22050
+    # tokenizer must not greedily fold neighbouring single-char tokens
+    assert cfg.tokenizer.fold_compounds is False
+
+
+def test_explicit_engine_selects_vosk_without_sniffing():
+    # a voice that names its engine is authoritative, even with an inventory
+    # the shape-sniffer would not recognise
+    cfg = VoiceConfig.from_dict({"engine": "vosk",
+                                 "audio": {"sample_rate": 22050},
+                                 "phoneme_id_map": {"_": [0], "^": [1], "$": [2],
+                                                    "p": [3]}})
+    assert cfg.engine == Engine.VOSK
+    assert cfg.phoneme_type == PhonemeType.VOSK
+    assert cfg.alphabet == Alphabet.VOSK
+
+
+def test_explicit_non_vosk_engine_is_not_stolen():
+    cfg = _vosk_config()
+    cfg["engine"] = "piper"
+    cfg["phoneme_type"] = "espeak"
+    assert VoiceConfig.from_dict(cfg).engine != Engine.VOSK
+
+
+# --------------------------------------------------------------------------- #
+# tokenizer parity: phoonnx must reproduce vosk's id stream exactly
+# --------------------------------------------------------------------------- #
+def _vosk_reference_ids(tokens, char2idx):
+    """Replicate vosk_tts g2p_noembed: ^ 0 p 0 p ... 0 $ (blank id 0)."""
+    phones = ["^"] + tokens + ["$"]
+    ids = [char2idx[phones[0]]]
+    for p in phones[1:]:
+        ids += [0, char2idx[p]]
+    return ids
+
+
+def test_tokenizer_matches_vosk_id_stream():
+    cfg = VoiceConfig.from_dict(_vosk_config())
+    char2idx = {p: i for i, p in enumerate(_VOSK_PHONES)}
+    # the cluster case that compound-folding would corrupt
+    tokens = ["s", "h", "o0", "dj", "i1", "tj", " ", "s", "ch", "a1"]
+    expected = _vosk_reference_ids(tokens, char2idx)
+    assert cfg.tokenizer.tokenize(tokens) == expected
+    # explicitly: 's' 'h' did not collapse into the 'sh' id
+    assert char2idx["sh"] not in cfg.tokenizer.tokenize(tokens)
+
+
+def test_multi_char_phonemes_still_resolve():
+    # folding off must not stop genuine multi-char tokens ('sch', 'a1') from
+    # being looked up — they arrive as whole tokens
+    cfg = VoiceConfig.from_dict(_vosk_config())
+    char2idx = {p: i for i, p in enumerate(_VOSK_PHONES)}
+    ids = cfg.tokenizer.tokenize(["sch", "a1"])
+    assert char2idx["sch"] in ids and char2idx["a1"] in ids
+
+
+def test_fold_compounds_flag_changes_behaviour():
+    # guard: with folding on (default), adjacent s+h WOULD merge to 'sh'
+    folding = TTSTokenizer.from_piper_config(_vosk_config())
+    assert folding.fold_compounds is True
+    char2idx = {p: i for i, p in enumerate(_VOSK_PHONES)}
+    assert char2idx["sh"] in folding.tokenize(["s", "h"])
+
+
+def test_fold_compounds_round_trips_through_phoonnx_config():
+    # a vosk voice exported to a native phoonnx config must not silently
+    # regain compound folding when reloaded
+    cfg = VoiceConfig.from_dict(_vosk_config())
+    native = cfg.to_native_dict()
+    assert native["fold_compounds"] is False
+    assert TTSTokenizer.from_phoonnx_config(native).fold_compounds is False
+
+
+# --------------------------------------------------------------------------- #
+# bundled voice index
+# --------------------------------------------------------------------------- #
+def test_voice_index_entries_construct():
+    import json
+    from phoonnx.model_manager import TTSModelInfo, TTSModelManager
+
+    index = TTSModelManager.voice_index_path() / "vosk.json"
+    entries = json.loads(index.read_text(encoding="utf-8"))
+    assert entries
+    for voice_id, entry in entries.items():
+        info = TTSModelInfo(**entry)
+        assert info.voice_id == voice_id
+        assert info.engine == Engine.VOSK
+        assert info.alphabet == Alphabet.VOSK
+        assert info.phoneme_type == PhonemeType.VOSK
+        assert info.dictionary_url
+        assert info.lang.startswith("ru")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

alphacep vosk-tts voices are plain VITS exports whose `config.json` is piper-shaped — a list-valued `phoneme_id_map`, an `espeak` stanza — but, unlike a real piper config, carries no `phoneme_type` and no engine name. Its dictionary/rule Russian g2p lives in scriptconv's `VoskPhonemizer`, already registered under `Phonemizer.VOSK`.

This adds `VoskLoader` to the `phoonnx/config_loaders.py` registry, probed right before `PiperLoader`. The absence of `phoneme_type` is what actually keeps a genuine vosk config out of `PiperLoader`'s hands — its `detect()` already rejects a config with no `phoneme_type` (its `piper_version` fast path aside) — so ordering mainly guards the engine-declared branch: a config naming `engine: vosk` that also happens to carry `piper_version` must not be claimed by that fast path first. The no-engine shape-sniffing branch requires both the absence of `phoneme_type` and the romanised-Russian phoneme inventory (`a0`/`a1`/`bj`/`sch`/…), so a real piper config that happens to also define those phonemes is never mistaken for vosk. An explicitly declared `engine: vosk` is authoritative in both directions, matching every other loader's convention.

Tokenization reproduces vosk_tts's own id stream: piper-style blank interspersion, but with a new `fold_compounds` flag on `TTSTokenizer` turned off, because the phonemizer already emits complete phoneme tokens and the existing compound-folding pass would otherwise merge neighbours like `s`+`h` into a spurious `sh`. Every other tokenizer keeps folding (the flag defaults to `True`), and it round-trips through the native phoonnx config format.

`TTSModelInfo` gained a `dictionary_url` field: the voice's pronunciation dictionary downloads through the ordinary hub-cache path and becomes the phonemizer's `phonemizer_model`, patched onto the loaded voice's config since a published `config.json` has no way to reference an index-level artifact. The dictionary is a large (tens of MB) but optional file — a failed fetch (offline, a dropped connection, a pruned hub revision) is logged and degrades to rule-based g2p for every word rather than failing the whole voice load. The engine adapter registration (`vosk` → the shared `VitsAdapter`) sits strictly after `vits` in detection priority, not tied with it, so an anonymous VITS voice's auto-detect is never hijacked into the `vosk` name; in practice the config loader always names the engine explicitly, so this entry is reached through the named-engine lookup. Three voices are indexed in `phoonnx/voice_index/vosk.json` and merged into the catalog like every other bundled index.

`tests/test_ru.py` and the `VoskLoader`/dictionary-degrade cases in `tests/test_config_loaders.py` and `tests/test_model_manager.py` were verified to fail against the code without each corresponding fix and pass with it. Corpus cases were added to the differential suite and the golden snapshot regenerated; the only case whose recorded output changed is the corrected vosk fixture itself (a real vosk config carries no `phoneme_type`), every other case is unchanged.

## Model usage
Re-sited onto current `dev`'s config-loader registry and hardened against review by Claude Sonnet 5 via Claude Code.
