### PR TITLE
feat(opm): speaker selection for multi-speaker voices

### DIFF
--- a/docs/ovos_plugin.md
+++ b/docs/ovos_plugin.md
@@ -21,6 +21,31 @@ In your OpenVoiceOS `mycroft.conf` or skills config, set:
 
 If `voice` is omitted or set to `"default"`, the plugin selects a default voice for the configured language.
 
+### Multi-speaker voices
+
+Some models bundle several speakers in one voice (e.g. the Catalan multiaccent
+matxa model `OpenVoiceOS/matxa-cat-multiaccent-wavenext`, which carries the four
+dialects × two genders). Pick a speaker with `speaker_id` (an integer index) or
+`speaker` (a name resolved against the model's `speaker_id_map`, given bare or
+accent-qualified). `speaker_id` wins if both are set; single-speaker voices
+ignore both.
+
+```json
+{
+  "tts": {
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
+      "speaker_id": 3
+    }
+  }
+}
+```
+
+For the Catalan multiaccent model the indices are: `quim` 0 / `olga` 1 (balear),
+`grau` 2 / `elia` 3 (central), `pere` 4 / `emma` 5 (nord-occidental),
+`lluc` 6 / `gina` 7 (valencià).
+
 ## How It Works
 
 `PhoonnxTTSPlugin` extends the `ovos-plugin-manager` `TTS` base class. On initialization, it:

--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 import wave
-from typing import Dict
+from typing import Dict, Optional
 from ovos_utils.log import LOG
 from ovos_plugin_manager.templates.tts import TTS
 
@@ -65,6 +65,39 @@ class PhoonnxTTSPlugin(TTS):
             if key in self.config:
                 return self.config[key]
         return default
+
+    def _resolve_speaker(self, voice_info) -> Optional[int]:
+        """
+        Resolve the speaker index for multi-speaker voices from the plugin config.
+
+        Accepts either ``speaker_id`` (an integer index, or its digit string) or
+        ``speaker`` (a name resolved against the voice's ``speaker_id_map``). The
+        name may be given bare (``"elia"``) or accent-qualified
+        (``"central/elia"``); the trailing segment is tried when the full string
+        is not a map key.
+
+        Returns:
+            int | None: The speaker index, or None for single-speaker voices /
+            when nothing is configured (the engine then defaults to speaker 0).
+        """
+        spk = self._cfg_opt(None, "speaker_id", "speaker")
+        if spk is None or isinstance(spk, bool):  # bools are ints in python
+            return None
+        if isinstance(spk, int):
+            return spk
+        if isinstance(spk, str):
+            if spk.lstrip("-").isdigit():
+                return int(spk)
+            smap = getattr(voice_info.config, "speaker_id_map", None) or {}
+            if spk in smap:
+                return smap[spk]
+            bare = spk.split("/")[-1]
+            if bare in smap:
+                return smap[bare]
+            LOG.warning(f"Unknown speaker '{spk}' for voice "
+                        f"{voice_info.voice_id}; known speakers: "
+                        f"{sorted(smap.keys())}")
+        return None
 
     def refresh_voices(self, force=False):
         """
@@ -149,6 +182,11 @@ class PhoonnxTTSPlugin(TTS):
             model = self.get_model(voice_info.voice_id)
 
         synth_params = SynthesisConfig(
+            # speaker selection for multi-speaker voices (e.g. the Catalan
+            # multiaccent matxa model). ``speaker_id`` (int) or ``speaker``
+            # (name via the voice's speaker_id_map); ignored by single-speaker
+            # voices, which only have speaker 0.
+            speaker_id=self._resolve_speaker(voice_info),
             enable_phonetic_spellings=self._cfg_opt(
                 voice_info.config.enable_phonetic_spellings
                 if hasattr(voice_info.config, "enable_phonetic_spellings") else True,

--- a/tests/test_opm.py
+++ b/tests/test_opm.py
@@ -15,20 +15,21 @@ from phoonnx.voice import SynthesisConfig
 class _FakeVoiceConfig:
     """Stand-in for ``VoiceConfig`` carrying the synthesis defaults."""
 
-    def __init__(self):
+    def __init__(self, speaker_id_map=None):
         self.noise_scale = 0.667
         self.length_scale = 1.0
         self.noise_w_scale = 0.8
         self.add_diacritics = False
+        self.speaker_id_map = speaker_id_map or {}
 
 
 class _FakeVoiceInfo:
     """Stand-in for ``TTSModelInfo``; ``load()`` yields a mock ``TTSVoice``."""
 
-    def __init__(self, voice_id, lang="en-US"):
+    def __init__(self, voice_id, lang="en-US", speaker_id_map=None):
         self.voice_id = voice_id
         self.lang = lang
-        self.config = _FakeVoiceConfig()
+        self.config = _FakeVoiceConfig(speaker_id_map=speaker_id_map)
         self.tts_voice = MagicMock(name=f"TTSVoice[{voice_id}]")
 
     def load(self):
@@ -208,6 +209,51 @@ class TestGetTts(unittest.TestCase):
             out = plugin.get_tts("hi", "/tmp/out.wav", voice=lazy.voice_id)
         self.assertEqual(out, ("/tmp/out.wav", None))
         self.assertTrue(lazy.tts_voice.synthesize_wav.called)
+
+
+class TestSpeakerSelection(unittest.TestCase):
+    """``speaker_id`` / ``speaker`` config -> SynthesisConfig.speaker_id."""
+
+    # the Catalan multiaccent matxa model: accent/name -> id
+    CAT_MAP = {"quim": 0, "olga": 1, "grau": 2, "elia": 3,
+               "pere": 4, "emma": 5, "lluc": 6, "gina": 7}
+
+    def _speaker_id_for(self, config, speaker_id_map=None):
+        v = _FakeVoiceInfo("OpenVoiceOS/v", speaker_id_map=speaker_id_map)
+        plugin, _ = _make_plugin(config=config, voices=[v])
+        with patch.object(opm, "wave"):
+            plugin.get_tts("hi", "/tmp/out.wav")
+        args, kwargs = v.tts_voice.synthesize_wav.call_args
+        for cand in (*args, *kwargs.values()):
+            if isinstance(cand, SynthesisConfig):
+                return cand.speaker_id
+        self.fail("no SynthesisConfig passed to synthesize_wav")
+
+    def test_no_speaker_config_is_none(self):
+        self.assertIsNone(self._speaker_id_for({}))
+
+    def test_integer_speaker_id_passthrough(self):
+        self.assertEqual(self._speaker_id_for({"speaker_id": 3}), 3)
+
+    def test_digit_string_speaker_id(self):
+        self.assertEqual(self._speaker_id_for({"speaker_id": "5"}), 5)
+
+    def test_speaker_name_resolved_via_map(self):
+        self.assertEqual(
+            self._speaker_id_for({"speaker": "elia"}, self.CAT_MAP), 3)
+
+    def test_accent_qualified_speaker_name(self):
+        self.assertEqual(
+            self._speaker_id_for({"speaker": "central/elia"}, self.CAT_MAP), 3)
+
+    def test_unknown_speaker_name_is_none(self):
+        self.assertIsNone(
+            self._speaker_id_for({"speaker": "nope"}, self.CAT_MAP))
+
+    def test_speaker_id_takes_priority_over_name(self):
+        self.assertEqual(
+            self._speaker_id_for({"speaker_id": 6, "speaker": "elia"},
+                                 self.CAT_MAP), 6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds a `speaker_id` / `speaker` config option to `ovos-tts-plugin-phoonnx` so multi-speaker models can expose their speakers through `mycroft.conf`.

Until now `PhoonnxTTSPlugin.get_tts` never set `SynthesisConfig.speaker_id`, so every multi-speaker model collapsed to speaker 0. This blocks using models like the Catalan multiaccent matxa model (`OpenVoiceOS/matxa-cat-multiaccent-wavenext`), which packs the four Catalan dialects × two genders (8 speakers) into one ONNX.

## How

`get_tts` now resolves a speaker via a new `_resolve_speaker` helper:

- `speaker_id` — an integer index (or its digit string), passed straight through.
- `speaker` — a name looked up in the voice's `speaker_id_map`, accepted bare (`"elia"`) or accent-qualified (`"central/elia"`, trailing segment tried).
- `speaker_id` wins when both are present; single-speaker voices are unaffected (engine still defaults to speaker 0).

```json
{
  "tts": {
    "module": "ovos-tts-plugin-phoonnx",
    "ovos-tts-plugin-phoonnx": {
      "voice": "OpenVoiceOS/matxa-cat-multiaccent-wavenext",
      "speaker_id": 3
    }
  }
}
```

Catalan multiaccent indices (matches the upstream `projecte-aina/matxa-tts-cat-multiaccent` card and the legacy `ovos-tts-plugin-matxa-multispeaker-cat`): quim 0 / olga 1 (balear), grau 2 / elia 3 (central), pere 4 / emma 5 (nord-occidental), lluc 6 / gina 7 (valencià).

## Tests

`tests/test_opm.py` gains a `TestSpeakerSelection` class (int, digit-string, name-via-map, accent-qualified, unknown-name, priority). Full `test_opm.py` suite green (20 passed).

## Why

Prerequisite for the OpenVoiceOS/ovos-config `autoconfigure` recommends switching offline TTS to phoonnx — the Catalan dialect/gender defaults need per-speaker selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-speaker voice selection is now supported. Users can configure which speaker to use from multi-speaker voice models by specifying either a speaker ID or speaker name. Speaker ID takes precedence when both are provided.

* **Documentation**
  * Added comprehensive documentation for multi-speaker voice configuration, including JSON examples and speaker mapping details for compatible models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->