### PR TITLE
fix: unbreak CI — drop py3.10 leg, exclude self from license check

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -10,6 +10,6 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     secrets: inherit
     with:
-      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python_versions: '["3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
       test_path: 'tests'

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -17,4 +17,8 @@ jobs:
       # NOTE: pilosus matches the resolved requirement, so an anchored
       # `^pycotovia$` never matches `pycotovia==0.1.0` / `pycotovia:0.1.0`.
       # Allow either separator (the colon gotcha).
-      exclude_packages: '^pycotovia([=<>!~ @;:]|$)'
+      # phoonnx itself is excluded: the checker resolves it against the last
+      # setup.py-era PyPI upload (1.3.3), which carries no license metadata and
+      # is scored "Error". The check is about third-party dependencies; the
+      # repo's own license is Apache-2.0 in pyproject.toml.
+      exclude_packages: '^(pycotovia|phoonnx)([=<>!~ @;:]|$)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 authors = [{name = "JarbasAI", email = "jarbasai@mailfence.com"}]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "numpy",
     "onnxruntime",


### PR DESCRIPTION
Two CI-wide failures currently red-flag every open PR:

1. **build_tests (3.10)** — the hard dependency \`pycotovia\` requires Python>=3.11, so the 3.10 matrix leg can never resolve \`phoonnx[test]\` and fails unconditionally. Dropped 3.10 from the matrix and floored \`requires-python\` at 3.11 to match reality.
2. **license_check** — the pilosus checker resolves \`phoonnx\` itself against the last setup.py-era PyPI upload (1.3.3), which carries no license metadata and is scored \`Error\`, failing the job on every branch. Excluded phoonnx from the scan (the check is about third-party dependencies; the repo's own license is Apache-2.0 in pyproject.toml). Once a post-pyproject stable release is published the exclusion can be revisited.

With these two fixes, most open PRs' single red check should go green on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)