### PR TITLE
feat: GlowTTS training engine

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -205,6 +205,34 @@ Export produces the two-graph contract the phoonnx `ZipVoiceAdapter`
 consumes: `text_encoder.onnx` and the guidance-folded `fm_decoder.onnx`
 (see `docs/zipvoice.md`).
 
+### GlowTTS engine
+
+`--engine glowtts` trains [GlowTTS](https://arxiv.org/abs/2005.11129)
+(Kim et al. 2020), a flow-based text → mel acoustic model with Monotonic
+Alignment Search, vendored in `phoonnx_train/glowtts/`. It consumes the
+same preprocessed dataset as every other engine (mel features only — no
+waveform / vocoder training).
+
+- `--quality x-low|medium|high` scales encoder/flow widths; `medium` is
+  the paper configuration.
+- Training follows the reference glow-tts recipe: MLE (flow NLL) +
+  log-duration MSE losses, Adam with Noam warmup (4000 steps).
+- Export produces the **mel model only**; synthesis pairs it with a
+  separate vocoder ONNX (HiFi-GAN / Vocos / Griffin-Lim — see
+  `docs/glowtts.md`). Mel basis is pinned to fmin 0 / fmax 8000 Hz and
+  recorded in the ONNX metadata.
+
+```bash
+python -m phoonnx_train.train \
+  --dataset-dir /tmp/tts_train \
+  --engine glowtts
+
+python -m phoonnx_train.export_onnx last.ckpt \
+  --config /tmp/tts_train/config.json \
+  --engine glowtts \
+  --output-dir ./exported
+```
+
 ---
 
 ## 3. Exporting to ONNX

--- a/docs/glowtts.md
+++ b/docs/glowtts.md
@@ -99,8 +99,137 @@ GlowTTS/Larynx phonemizes with **gruut** (``phoneme_type: gruut``,
 
 > Requires the ``gruut`` package for phonemization.
 
+## Training
+
+Training uses `phoonnx_train`'s standard preprocessing pipeline
+(phonemization + audio normalization + linear-spectrogram extraction, shared
+with VITS) and a self-contained, pure-torch GlowTTS implementation
+vendored under `phoonnx_train/glowtts/` — no `coqui-tts` / `TTS` dependency.
+See `phoonnx_train/glowtts/__init__.py` for the full provenance note: this
+is a **reimplementation from the published GlowTTS paper architecture**
+(Kim et al. 2020) and general knowledge of GlowTTS-style implementations,
+**not a verified line-by-line port** of coqui-TTS (MPL-2.0) source — the
+coding agent that authored it did not have network access to diff against
+the actual upstream source. The training math has since been audited against
+the original reference implementation (jaywalnut310/glow-tts, MIT) — see the
+fidelity notes in `phoonnx_train/glowtts/__init__.py`. The mel basis is
+pinned to fmin 0 / fmax 8000 Hz (matching the HiFi-GAN-family vocoder
+configs) and recorded in the exported ONNX metadata.
+
+Install the `train` extra: `pip install phoonnx[train]`.
+
+### Quick start
+
+```bash
+# 1. preprocess an LJSpeech-style dataset (shared with VITS)
+python phoonnx_train/preprocess.py \
+  --input-dir /data/my-dataset \
+  --output-dir /data/preprocessed \
+  --language en-us
+
+# 2. train
+python phoonnx_train/train.py \
+  --dataset-dir /data/preprocessed \
+  --engine glowtts \
+  --quality medium \
+  --batch-size 16 \
+  --max-epochs 1000
+
+# 3. export the mel model to ONNX
+python phoonnx_train/export_onnx.py \
+  --engine glowtts \
+  --config /data/preprocessed/config.json \
+  --output-dir ./onnx \
+  /data/preprocessed/lightning_logs/version_0/checkpoints/last.ckpt
+```
+
+`export_onnx` produces **only the mel model** (`<checkpoint-stem>.onnx`), with the
+exact input/output contract the `GlowTTSAdapter` above expects (`input` /
+`input_lengths` / `scales` → `[B, n_mels, T]` mel). You still need a
+**separate vocoder** ONNX (HiFi-GAN / Vocos / Griffin-Lim — see
+[vocoders.md](./vocoders.md)) to synthesize audio; this engine never
+produces one.
+
+### Quality presets
+
+| Preset | hidden_channels | filter_channels | heads / layers | decoder blocks / layers |
+|--------|-----------------|------------------|-----------------|--------------------------|
+| `x-low` | 96 | 384 | 2 / 4 | 8 / 3 |
+| `medium` | 192 | 768 | 2 / 6 | 12 / 4 |
+| `high` | 256 | 1024 | 4 / 8 | 12 / 4 |
+
+These roughly mirror VITS's own x-low/medium/high split in this repo (a
+GlowTTS-descended architecture); the exact upstream coqui-TTS GlowTTS
+dimensions were not independently verified.
+
+### Architecture overview
+
+- **Text encoder** — phoneme embedding → conv "prenet" → Transformer encoder
+  (shared verbatim with VITS's own text encoder,
+  `phoonnx_train/vits/attentions.py`) → per-token Gaussian prior (`m`, `logs`)
+  + a small conv duration predictor.
+- **Flow decoder** — an invertible normalizing flow (squeeze → stacked
+  ActNorm → invertible 1×1 conv → WN-conditioned affine coupling →
+  unsqueeze), mapping mel ↔ latent exactly, run forward at training time and
+  in reverse at inference/export time.
+- **Monotonic Alignment Search (MAS)** — a dynamic-programming search for the
+  most probable monotonic text↔mel alignment under the current model,
+  reusing the compiled MAS kernel already vendored for VITS
+  (`phoonnx_train/vits/monotonic_align`), which implements the same
+  algorithm GlowTTS introduced.
+- **Losses** — exact negative log-likelihood of the target mel under the
+  flow-transformed Gaussian prior (MLE loss), plus an MSE duration loss
+  against MAS-derived log-durations.
+
+### Multi-speaker
+
+Set `num_speakers > 1` in the shared `TrainingEngineConfig`; a speaker
+embedding conditions both the duration predictor and the flow's affine
+coupling layers (`gin_channels`, default 512, overridable via `extra`).
+
+### Downstream: OVOS `ovos-tts-plugin-phoonnx` config
+
+Once you have the exported mel model (`glowtts.ckpt.onnx`) and a vocoder
+ONNX (e.g. a HiFi-GAN vocoder — see [vocoders.md](./vocoders.md) for how to
+train/obtain one), point a local voice `config.json` at both using the exact
+`engine_params` keys `GlowTTSAdapter.configure_from_params`
+(`phoonnx/engines/glowtts.py`) reads — `vocoder_path` and `vocoder_type`:
+
+```json
+{
+    "engine": "glowtts",
+    "engine_params": {
+        "vocoder_path": "hifigan.onnx",
+        "vocoder_type": "hifigan"
+    }
+}
+```
+
+Place this `config.json` next to the exported `.onnx` mel model in a local
+voice directory, then point `ovos-tts-plugin-phoonnx` at it via the plugin's
+`voice` setting in `mycroft.conf` (see [docs/ovos_plugin.md](./ovos_plugin.md)
+for the full plugin config reference):
+
+```json
+{
+  "tts": {
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "lang": "en-US",
+      "voice": "/home/user/.local/share/phoonnx/voices/my-glowtts-voice"
+    }
+  }
+}
+```
+
+`TTSModelManager` loads `config.json` (engine="glowtts") + the mel `.onnx`
+alongside it, and `GlowTTSAdapter` builds the vocoder from
+`engine_params.vocoder_path`/`vocoder_type` exactly as documented in
+[Vocoders](#vocoders) above.
+
 ## References
 
 - [Larynx](https://github.com/rhasspy/larynx) · [GlowTTS paper](https://arxiv.org/abs/2005.11129)
 - [docs/engines.md](./engines.md) — the engine adapter framework
 - [docs/matcha.md](./matcha.md) — the other two-stage engine
+- [docs/training.md](./training.md) — the shared VITS training pipeline this engine's dataset/preprocess step reuses

--- a/phoonnx_train/engines/__init__.py
+++ b/phoonnx_train/engines/__init__.py
@@ -99,8 +99,10 @@ def _register_builtins() -> None:
     )
     from phoonnx_train.engines.zipvoice import ZipVoiceTrainingEngine
     from phoonnx_train.engines.mixer import MixerTTSTrainingEngine
+    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
 
     register_engine("vits", VitsTrainingEngine)
+    register_engine("glowtts", GlowTTSTrainingEngine)
     register_engine("matcha", MatchaTrainingEngine)
     register_engine("fastpitch", ForwardTTSTrainingEngine)
     register_engine("speedyspeech", SpeedySpeechTrainingEngine)

--- a/phoonnx_train/engines/glowtts.py
+++ b/phoonnx_train/engines/glowtts.py
@@ -1,0 +1,257 @@
+"""
+GlowTTS training engine adapter.
+
+Wraps :mod:`phoonnx_train.glowtts` (a self-contained, pure-torch
+reimplementation of the GlowTTS architecture — see
+``phoonnx_train/glowtts/__init__.py`` for the full provenance note) behind
+the ``BaseTrainingEngine`` interface so the shared CLI tools can drive it.
+
+GlowTTS is **two-stage**: this engine trains and exports only the
+text -> mel model. The waveform vocoder is a *separate* artifact, reused
+unchanged from :mod:`phoonnx.engines.vocoders` (HiFi-GAN, Vocos, Griffin-Lim,
+...) at inference time by ``phoonnx.engines.glowtts.GlowTTSAdapter`` — this
+engine's ``export_onnx`` never touches vocoder weights.
+
+The exported ONNX graph's input/output contract (``input`` /
+``input_lengths`` / ``scales`` -> ``[B, n_mels, T]`` mel) exactly matches
+what ``phoonnx/engines/glowtts.py``'s ``GlowTTSAdapter`` expects, as read
+directly from that file.
+"""
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from phoonnx_train.engines.base import BaseTrainingEngine, TrainingEngineConfig
+
+if TYPE_CHECKING:  # heavy import — only needed for type annotations
+    import pytorch_lightning as pl
+
+_LOG = logging.getLogger(__name__)
+
+# ONNX opset used for export
+OPSET_VERSION = 15
+
+# Quality tier -> GlowTTS hyper-param overrides.
+# Roughly mirrors coqui's glow_tts tiers (encoder/decoder width scaling
+# consistent with VITS's own x-low/medium/high split in vits.py); exact
+# upstream coqui dimensions were not independently verified — these are
+# reasonable defaults for a paper-faithful GlowTTS, not a confirmed match.
+_QUALITY_PRESETS: Dict[str, Dict[str, Any]] = {
+    "x-low": {
+        "hidden_channels": 96,
+        "filter_channels": 384,
+        "filter_channels_dp": 128,
+        "n_heads": 2,
+        "n_layers": 4,
+        "dec_hidden_channels": 96,
+        "dec_n_blocks": 8,
+        "dec_n_layers": 3,
+    },
+    "medium": {
+        "hidden_channels": 192,
+        "filter_channels": 768,
+        "filter_channels_dp": 256,
+        "n_heads": 2,
+        "n_layers": 6,
+        "dec_hidden_channels": 192,
+        "dec_n_blocks": 12,
+        "dec_n_layers": 4,
+    },
+    "high": {
+        "hidden_channels": 256,
+        "filter_channels": 1024,
+        "filter_channels_dp": 384,
+        "n_heads": 4,
+        "n_layers": 8,
+        "dec_hidden_channels": 256,
+        "dec_n_blocks": 12,
+        "dec_n_layers": 4,
+    },
+}
+
+
+class GlowTTSTrainingEngine(BaseTrainingEngine):
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    def create_model(
+        self,
+        config: TrainingEngineConfig,
+        dataset_paths: List[Path],
+        **kwargs: Any,
+    ) -> "pl.LightningModule":
+        """Build a GlowTTSModel LightningModule from *config*."""
+        from phoonnx_train.glowtts.lightning import GlowTTSModel
+
+        return GlowTTSModel(
+            num_symbols=config.num_symbols,
+            num_speakers=config.num_speakers,
+            sample_rate=config.sample_rate,
+            dataset=[str(p) for p in dataset_paths],
+            **config.extra,
+            **kwargs,
+        )
+
+    def export_onnx(
+        self,
+        checkpoint_path: Path,
+        config_path: Path,
+        output_dir: Path,
+        **kwargs: Any,
+    ) -> Path:
+        """
+        Export a GlowTTS checkpoint to ONNX (mel model only).
+
+        The exported graph takes ``input`` (phoneme ids), ``input_lengths``,
+        and ``scales`` ([noise_scale, length_scale]) — optionally ``sid`` for
+        multi-speaker — and returns a ``[B, n_mels, T]`` mel spectrogram, per
+        ``phoonnx.engines.glowtts.GlowTTSAdapter``. The vocoder that turns
+        this mel into audio is a **separate** ONNX artifact (HiFi-GAN /
+        Vocos / Griffin-Lim, see ``phoonnx/engines/vocoders/``) — it is not
+        produced by this method.
+        """
+        # validate the inputs before touching the heavy imports so a bad
+        # path fails fast (and identically) with or without torch installed
+        with open(config_path, "r", encoding="utf-8") as f:
+            model_config: Dict[str, Any] = json.load(f)
+        checkpoint_path = Path(checkpoint_path)
+        if not checkpoint_path.is_file():
+            raise FileNotFoundError(f"checkpoint not found: {checkpoint_path}")
+
+        import torch
+
+        from phoonnx_train.glowtts.lightning import GlowTTSModel
+        from phoonnx_train.torch_compat import onnx_export_kwargs
+
+        sample_rate = model_config.get("audio", {}).get("sample_rate", 22050)
+        phoneme_id_map = model_config.get("phoneme_id_map", {})
+        alphabet = model_config.get("alphabet", "")
+        phoneme_type = model_config.get("phoneme_type", "")
+        phonemizer_model = model_config.get("phonemizer_model", "")
+
+        model: GlowTTSModel = GlowTTSModel.load_from_checkpoint(
+            checkpoint_path, dataset=None, map_location="cpu",
+        )
+        model_g = model.model_g
+        model_g.eval()
+        # torch.inverse (used by the flow's invertible 1x1 conv reverse pass)
+        # has no ONNX symbolic — precompute and cache the inverse weights so
+        # the traced reverse graph only contains a plain conv2d.
+        model_g.decoder.store_inverse()
+
+        num_symbols = model_g.n_vocab
+        num_speakers = model_g.n_speakers
+        n_mels = model_g.n_mels
+
+        def infer_forward(input, input_lengths, scales, sid=None):
+            noise_scale = scales[0]
+            length_scale = scales[1]
+            mel, _mel_lengths = model_g.infer(
+                input, input_lengths,
+                noise_scale=noise_scale, length_scale=length_scale, sid=sid,
+            )
+            return mel
+
+        model_g.forward = infer_forward
+
+        sequences = torch.randint(low=1, high=num_symbols, size=(1, 50), dtype=torch.long)
+        sequence_lengths = torch.LongTensor([sequences.size(1)])
+        scales = torch.FloatTensor([0.667, 1.0])
+        sid = torch.LongTensor([0]) if num_speakers > 1 else None
+
+        input_names = ["input", "input_lengths", "scales"]
+        output_names = ["mel"]
+        dynamic_axes = {
+            "input": {0: "batch_size", 1: "phonemes"},
+            "input_lengths": {0: "batch_size"},
+            "mel": {0: "batch_size", 2: "time"},
+        }
+        dummy_input = (sequences, sequence_lengths, scales)
+        if sid is not None:
+            input_names.append("sid")
+            dynamic_axes["sid"] = {0: "batch_size"}
+            dummy_input = (*dummy_input, sid)
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"{checkpoint_path.stem}.onnx"
+        with torch.no_grad():
+            # onnx_export_kwargs() forces the TorchScript exporter on
+            # torch>=2.5 — the dynamo exporter cannot trace GlowTTS's
+            # data-dependent control flow (length-derived squeeze)
+            torch.onnx.export(
+                model=model_g,
+                args=dummy_input,
+                f=str(output_path),
+                verbose=False,
+                opset_version=OPSET_VERSION,
+                input_names=input_names,
+                output_names=output_names,
+                dynamic_axes=dynamic_axes,
+                **onnx_export_kwargs(),
+            )
+
+        try:
+            import onnx as _onnx
+
+            onnx_model = _onnx.load(str(output_path))
+
+            # The mel output's channel axis (dim 1) is a compile-time
+            # constant (= n_mels) — it never varies with input, only batch
+            # and time do. The exporter's shape inference nonetheless
+            # stamps it with a symbolic name (derived from the reshape ops
+            # in the flow decoder's squeeze/unsqueeze), because the value
+            # is only *provably* constant, not literally folded during
+            # tracing. Pin it back to the concrete n_mels so
+            # GlowTTSAdapter.detect()'s ``o.shape[1] in (80, 0)`` heuristic
+            # (and any consumer relying on a concrete mel-channel count)
+            # sees the real, fixed value.
+            for output in onnx_model.graph.output:
+                if output.name == "mel":
+                    dim1 = output.type.tensor_type.shape.dim[1]
+                    dim1.ClearField("dim_param")
+                    dim1.dim_value = n_mels
+
+            del onnx_model.metadata_props[:]
+            for key, value in {
+                "model_type": "glow_tts",
+                "engine": "glowtts",
+                "mel_fmin": model.hparams.mel_fmin,
+                "mel_fmax": model.hparams.mel_fmax,
+                "n_speakers": num_speakers,
+                "n_vocab": num_symbols,
+                "n_mels": n_mels,
+                "sample_rate": sample_rate,
+                "alphabet": alphabet,
+                "phoneme_type": phoneme_type,
+                "phonemizer_model": phonemizer_model,
+                "phoneme_id_map": json.dumps(phoneme_id_map),
+                "has_espeak": phoneme_type == "espeak",
+            }.items():
+                meta = onnx_model.metadata_props.add()
+                meta.key = key
+                meta.value = str(value)
+            _onnx.save(onnx_model, str(output_path))
+        except ImportError:
+            _LOG.warning("onnx package not installed — skipping metadata")
+
+        _LOG.info(
+            "Exported GlowTTS mel-model ONNX to %s (a separate vocoder ONNX "
+            "is required for synthesis — see phoonnx/engines/vocoders/)",
+            output_path,
+        )
+        return output_path
+
+    def quality_presets(self) -> Dict[str, Dict[str, Any]]:
+        """Return GlowTTS quality tier -> hyper-parameter overrides."""
+        return _QUALITY_PRESETS
+
+    # ------------------------------------------------------------------
+    # Optional
+    # ------------------------------------------------------------------
+
+    def extra_cli_options(self) -> List[Any]:
+        """GlowTTS has no engine-specific CLI options beyond the shared ones."""
+        return []

--- a/phoonnx_train/glowtts/__init__.py
+++ b/phoonnx_train/glowtts/__init__.py
@@ -1,0 +1,67 @@
+"""
+GlowTTS training package.
+
+Provenance / honesty note (see also each module's own docstring):
+
+This is a **reimplementation from the published GlowTTS paper architecture**
+(Kim et al. 2020, "Glow-TTS: A Generative Flow for Text-to-Speech via
+Monotonic Alignment Search", https://arxiv.org/abs/2005.11129) and from
+general knowledge of how GlowTTS-style implementations (including the
+coqui-TTS / Larynx family that ``phoonnx.engines.glowtts`` already targets
+for *inference*) are structured — it is **not a verified line-by-line port**
+of coqui-TTS source. The coding agent that authored this module did not have
+network access to fetch and diff against the actual coqui-TTS
+(``TTS.tts.models.glow_tts`` / ``TTS.tts.layers.glow_tts``) source at
+authoring time, so no such claim is made.
+
+coqui-TTS is distributed under the Mozilla Public License 2.0 (MPL-2.0).
+Because this code was reconstructed from the paper and general architectural
+knowledge rather than copied from coqui-TTS, no MPL-2.0 file-level obligations
+apply to these files; this note exists purely for attribution/provenance
+transparency, per project policy for documenting library usage.
+
+What *was* directly read and reused (verified, not inferred) from this
+repository:
+
+  - ``phoonnx_train/vits/attentions.py``  (``Encoder`` — Transformer text
+    encoder block, shared verbatim by GlowTTS's own text encoder).
+  - ``phoonnx_train/vits/modules.py``     (``LayerNorm``, ``ConvReluNorm``,
+    ``WN`` — WaveNet-style affine-coupling conditioner).
+  - ``phoonnx_train/vits/commons.py``     (``sequence_mask``,
+    ``generate_path``, ``init_weights``).
+  - ``phoonnx_train/vits/monotonic_align``  (compiled Cython
+    ``maximum_path`` — Monotonic Alignment Search dynamic-programming
+    kernel), reused unmodified rather than re-vendored.
+  - ``phoonnx_train/vits/dataset.py`` + ``mel_processing.py``  (dataset /
+    collation / mel-spectrogram extraction pipeline), reused unmodified —
+    GlowTTS only needs mel features, no waveform.
+  - ``phoonnx/engines/glowtts.py``  (the *inference*-side ONNX contract this
+    engine's ``export_onnx`` must satisfy — input names ``input`` /
+    ``input_lengths`` / ``scales`` and a ``[B, n_mels, T]`` mel output).
+
+Everything GlowTTS-specific (the duration predictor, the invertible flow
+decoder assembled from activation-normalization + invertible 1x1 conv +
+affine coupling, Monotonic Alignment Search glue, the MLE training loss, and
+the two-stage ONNX export) is new code in this package, reconstructed from
+the paper.
+
+Fidelity audit (added when this engine was ported onto the dev engine
+registry): the training math was reviewed against the original reference
+implementation, jaywalnut310/glow-tts (MIT, the authors' official repo):
+
+  - MAS prior ``neg_cent`` decomposition, ActNorm (with data-dependent
+    init), grouped invertible 1x1 conv (``n_split=4``, QR-orthogonal init,
+    det-sign fix), zero-initialized affine-coupling projection, and
+    squeeze/unsqueeze (``n_sqz=2``) all match the reference structure.
+  - MLE loss = per-element-normalized NLL minus log-det plus the
+    ``0.5*log(2*pi)`` constant; duration loss = MSE on log-durations
+    normalized by text length — both as in the reference.
+  - Optimizer: plain Adam, betas (0.9, 0.98), eps 1e-9, Noam schedule with
+    4000 warmup steps; the schedule is re-normalized so ``learning_rate``
+    is the post-warmup peak (reference peak with dim=192 is ~1.14e-3).
+  - Known deviation: the reference squeezes per-sample lengths to
+    ``n_sqz`` multiples inside the flow; here the batch mel axis is
+    trimmed to an ``n_sqz`` multiple before the decoder and per-sample
+    masks are subsampled in ``_squeeze`` — equivalent masking, the loss
+    normalization uses the same masked element count.
+"""

--- a/phoonnx_train/glowtts/decoder.py
+++ b/phoonnx_train/glowtts/decoder.py
@@ -1,0 +1,235 @@
+"""
+GlowTTS invertible flow decoder.
+
+Reconstructed from the GlowTTS paper (Kim et al. 2020, §3.1, "Decoder"): a
+stack of flow blocks, each block = squeeze -> [ActNorm -> InvertibleConv1x1
+-> AffineCoupling] x n_blocks -> unsqueeze. This is the same flow family
+Glow (Kingma & Dhariwal 2018) and WaveGlow use. The affine-coupling
+conditioner network reuses ``phoonnx_train.vits.modules.WN`` (a WaveNet-style
+gated-conv stack) verbatim — VITS's own residual coupling flow already reuses
+this exact building block for the same purpose.
+
+Every module below implements both a forward (mel -> latent, used in
+training to compute the exact log-likelihood via the change-of-variables
+formula) and a reverse pass (latent -> mel, used at inference/export time).
+"""
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+from phoonnx_train.vits.modules import WN
+
+
+class ActNorm(nn.Module):
+    """Per-channel affine activation normalization with data-dependent init."""
+
+    def __init__(self, channels: int):
+        super().__init__()
+        self.channels = channels
+        self.logs = nn.Parameter(torch.zeros(1, channels, 1))
+        self.bias = nn.Parameter(torch.zeros(1, channels, 1))
+        self.register_buffer("initialized", torch.tensor(False))
+
+    def initialize(self, x: torch.Tensor, x_mask: torch.Tensor) -> None:
+        with torch.no_grad():
+            denom = x_mask.sum([0, 2]).clamp_min(1.0)
+            m = (x * x_mask).sum([0, 2]) / denom
+            m_sq = ((x * x_mask) ** 2).sum([0, 2]) / denom
+            v = m_sq - m**2
+            logs = 0.5 * torch.log(v.clamp_min(1e-6))
+            self.bias.data.copy_((-m * torch.exp(-logs)).view(1, self.channels, 1))
+            self.logs.data.copy_((-logs).view(1, self.channels, 1))
+            self.initialized.fill_(True)
+
+    def forward(
+        self, x: torch.Tensor, x_mask: torch.Tensor, reverse: bool = False
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if not reverse and not bool(self.initialized) and self.training:
+            self.initialize(x, x_mask)
+
+        if reverse:
+            z = (x - self.bias) * torch.exp(-self.logs) * x_mask
+            return z, None
+        z = (self.bias + torch.exp(self.logs) * x) * x_mask
+        logdet = torch.sum(self.logs) * torch.sum(x_mask, [1, 2])
+        return z, logdet
+
+
+class InvConvNear(nn.Module):
+    """Invertible 1x1 conv, computed on groups of ``n_split`` channels."""
+
+    def __init__(self, channels: int, n_split: int = 4):
+        super().__init__()
+        assert channels % n_split == 0
+        self.channels = channels
+        self.n_split = n_split
+        w_init = torch.linalg.qr(torch.randn(n_split, n_split))[0]
+        if torch.det(w_init) < 0:
+            w_init[:, 0] = -w_init[:, 0]
+        self.weight = nn.Parameter(w_init)
+        # Populated by store_inverse() before ONNX export: torch.inverse has
+        # no ONNX symbolic (aten::linalg_inv is unsupported at any opset), so
+        # the reverse (inference) pass must consume a precomputed inverse
+        # weight instead of tracing the matrix inversion itself.
+        self.weight_inv: Optional[torch.Tensor] = None
+
+    def store_inverse(self) -> None:
+        """Precompute and cache the inverse weight for a trace-safe reverse pass."""
+        with torch.no_grad():
+            self.weight_inv = torch.inverse(self.weight.double()).float().detach()
+
+    def forward(
+        self, x: torch.Tensor, x_mask: torch.Tensor, reverse: bool = False
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        b, c, t = x.size()
+        assert c % self.n_split == 0
+        x_len = torch.sum(x_mask, [1, 2])
+
+        x = x.view(b, 2, c // self.n_split, self.n_split // 2, t)
+        x = x.permute(0, 1, 3, 2, 4).contiguous().view(b, self.n_split, c // self.n_split, t)
+
+        if reverse:
+            weight = self.weight_inv if self.weight_inv is not None else torch.inverse(self.weight.double()).float()
+            logdet = None
+        else:
+            weight = self.weight
+            logdet = torch.logdet(self.weight) * (c / self.n_split) * x_len
+
+        weight = weight.view(self.n_split, self.n_split, 1, 1)
+        z = torch.nn.functional.conv2d(x, weight)
+
+        z = z.view(b, 2, self.n_split // 2, c // self.n_split, t)
+        z = z.permute(0, 1, 3, 2, 4).contiguous().view(b, c, t) * x_mask
+        return z, logdet
+
+
+class AffineCouplingLayer(nn.Module):
+    """WN-conditioned affine coupling: splits channels, transforms one half."""
+
+    def __init__(
+        self,
+        channels: int,
+        hidden_channels: int,
+        kernel_size: int,
+        dilation_rate: int,
+        n_layers: int,
+        gin_channels: int = 0,
+    ):
+        super().__init__()
+        self.channels = channels
+        self.half_channels = channels // 2
+
+        self.pre = nn.Conv1d(self.half_channels, hidden_channels, 1)
+        self.enc = WN(hidden_channels, kernel_size, dilation_rate, n_layers, gin_channels=gin_channels)
+        self.post = nn.Conv1d(hidden_channels, self.half_channels * 2, 1)
+        self.post.weight.data.zero_()
+        self.post.bias.data.zero_()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_mask: torch.Tensor,
+        g: torch.Tensor = None,
+        reverse: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        x0, x1 = torch.split(x, [self.half_channels] * 2, dim=1)
+
+        h = self.pre(x0) * x_mask
+        h = self.enc(h, x_mask, g=g)
+        stats = self.post(h) * x_mask
+        m, logs = torch.split(stats, [self.half_channels] * 2, dim=1)
+
+        if reverse:
+            x1 = (x1 - m) * torch.exp(-logs) * x_mask
+            logdet = None
+        else:
+            x1 = (m + torch.exp(logs) * x1) * x_mask
+            logdet = torch.sum(logs * x_mask, [1, 2])
+
+        z = torch.cat([x0, x1], dim=1)
+        return z, logdet
+
+
+class FlowBlock(nn.Module):
+    def __init__(self, channels: int, hidden_channels: int, kernel_size: int,
+                 dilation_rate: int, n_layers: int, gin_channels: int = 0):
+        super().__init__()
+        self.actnorm = ActNorm(channels)
+        self.invconv = InvConvNear(channels, n_split=4)
+        self.coupling = AffineCouplingLayer(
+            channels, hidden_channels, kernel_size, dilation_rate, n_layers, gin_channels=gin_channels
+        )
+
+    def forward(self, x, x_mask, g=None, reverse=False):
+        if not reverse:
+            x, ld1 = self.actnorm(x, x_mask, reverse=False)
+            x, ld2 = self.invconv(x, x_mask, reverse=False)
+            x, ld3 = self.coupling(x, x_mask, g=g, reverse=False)
+            return x, ld1 + ld2 + ld3
+        x, _ = self.coupling(x, x_mask, g=g, reverse=True)
+        x, _ = self.invconv(x, x_mask, reverse=True)
+        x, _ = self.actnorm(x, x_mask, reverse=True)
+        return x, None
+
+    def store_inverse(self) -> None:
+        self.invconv.store_inverse()
+
+
+def _squeeze(x: torch.Tensor, x_mask: torch.Tensor, n_sqz: int = 2):
+    b, c, t = x.size()
+    t = (t // n_sqz) * n_sqz
+    x = x[:, :, :t].view(b, c, t // n_sqz, n_sqz).permute(0, 3, 1, 2).contiguous().view(b, c * n_sqz, t // n_sqz)
+    x_mask = x_mask[:, :, n_sqz - 1::n_sqz]
+    return x * x_mask, x_mask
+
+
+def _unsqueeze(x: torch.Tensor, x_mask: torch.Tensor, n_sqz: int = 2):
+    b, c, t = x.size()
+    x = x.view(b, n_sqz, c // n_sqz, t).permute(0, 2, 3, 1).contiguous().view(b, c // n_sqz, t * n_sqz)
+    x_mask = x_mask.unsqueeze(-1).repeat(1, 1, 1, n_sqz).view(b, 1, t * n_sqz)
+    return x * x_mask, x_mask
+
+
+class FlowDecoder(nn.Module):
+    """Squeeze -> n_blocks x FlowBlock -> unsqueeze, invertible mel<->latent."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        kernel_size: int,
+        dilation_rate: int,
+        n_blocks: int,
+        n_layers: int,
+        n_sqz: int = 2,
+        gin_channels: int = 0,
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.n_sqz = n_sqz
+        sq_channels = in_channels * n_sqz
+        self.blocks = nn.ModuleList([
+            FlowBlock(sq_channels, hidden_channels, kernel_size, dilation_rate, n_layers, gin_channels=gin_channels)
+            for _ in range(n_blocks)
+        ])
+
+    def forward(self, x: torch.Tensor, x_mask: torch.Tensor, g: torch.Tensor = None, reverse: bool = False):
+        x, x_mask_sq = _squeeze(x, x_mask, self.n_sqz)
+        logdet_total = torch.zeros(x.size(0), device=x.device, dtype=x.dtype)
+
+        blocks = self.blocks if not reverse else reversed(list(self.blocks))
+        for block in blocks:
+            x, logdet = block(x, x_mask_sq, g=g, reverse=reverse)
+            if logdet is not None:
+                logdet_total = logdet_total + logdet
+
+        x, _ = _unsqueeze(x, x_mask_sq, self.n_sqz)
+        return x, (logdet_total if not reverse else None)
+
+    def store_inverse(self) -> None:
+        """Precompute cached inverse weights on every flow block's invertible 1x1
+        conv, required before an ONNX trace of the reverse (inference) pass —
+        see ``InvConvNear.store_inverse``."""
+        for block in self.blocks:
+            block.store_inverse()

--- a/phoonnx_train/glowtts/duration_predictor.py
+++ b/phoonnx_train/glowtts/duration_predictor.py
@@ -1,0 +1,56 @@
+"""
+GlowTTS duration predictor.
+
+GlowTTS (unlike VITS's stochastic duration predictor) uses a small,
+deterministic conv-stack duration predictor trained with an MSE loss against
+log-durations derived from Monotonic Alignment Search (see
+:mod:`phoonnx_train.glowtts.monotonic_align`). Architecture reconstructed
+from the GlowTTS paper (Kim et al. 2020, §3.2) — it mirrors the
+``DurationPredictor`` used by VITS (``phoonnx_train/vits/models.py``), which
+itself descends from the same GlowTTS design; the two are re-derived here
+independently (not imported) so this package stays self-contained.
+"""
+import torch
+from torch import nn
+
+from phoonnx_train.vits.modules import LayerNorm
+
+
+class DurationPredictor(nn.Module):
+    """Two-layer conv duration predictor -> scalar log-duration per token."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        filter_channels: int,
+        kernel_size: int,
+        p_dropout: float,
+        gin_channels: int = 0,
+    ):
+        super().__init__()
+        self.gin_channels = gin_channels
+
+        self.drop = nn.Dropout(p_dropout)
+        self.conv_1 = nn.Conv1d(in_channels, filter_channels, kernel_size, padding=kernel_size // 2)
+        self.norm_1 = LayerNorm(filter_channels)
+        self.conv_2 = nn.Conv1d(filter_channels, filter_channels, kernel_size, padding=kernel_size // 2)
+        self.norm_2 = LayerNorm(filter_channels)
+        self.proj = nn.Conv1d(filter_channels, 1, 1)
+
+        if gin_channels != 0:
+            self.cond = nn.Conv1d(gin_channels, in_channels, 1)
+
+    def forward(self, x: torch.Tensor, x_mask: torch.Tensor, g: torch.Tensor = None) -> torch.Tensor:
+        x = torch.detach(x)
+        if g is not None:
+            x = x + self.cond(torch.detach(g))
+        x = self.conv_1(x * x_mask)
+        x = torch.relu(x)
+        x = self.norm_1(x)
+        x = self.drop(x)
+        x = self.conv_2(x * x_mask)
+        x = torch.relu(x)
+        x = self.norm_2(x)
+        x = self.drop(x)
+        x = self.proj(x * x_mask)
+        return x * x_mask

--- a/phoonnx_train/glowtts/encoder.py
+++ b/phoonnx_train/glowtts/encoder.py
@@ -1,0 +1,76 @@
+"""
+GlowTTS text encoder.
+
+Reconstructed from the GlowTTS paper (Kim et al. 2020, §3.1): a phoneme
+embedding, a conv "prenet" (``ConvReluNorm``), a Transformer encoder stack
+(shared with VITS — ``phoonnx_train.vits.attentions.Encoder``, reused
+verbatim since VITS's text encoder descends from the same GlowTTS design),
+and a final projection to per-token Gaussian prior statistics
+(``m``, ``logs``) plus a duration predictor branch.
+"""
+import math
+
+import torch
+from torch import nn
+
+from phoonnx_train.vits import commons
+from phoonnx_train.vits.attentions import Encoder as TransformerEncoder
+from phoonnx_train.vits.modules import ConvReluNorm
+
+from phoonnx_train.glowtts.duration_predictor import DurationPredictor
+
+
+class TextEncoder(nn.Module):
+    def __init__(
+        self,
+        n_vocab: int,
+        out_channels: int,
+        hidden_channels: int,
+        filter_channels: int,
+        filter_channels_dp: int,
+        n_heads: int,
+        n_layers: int,
+        kernel_size: int,
+        p_dropout: float,
+        prenet_n_layers: int = 3,
+        gin_channels: int = 0,
+    ):
+        super().__init__()
+        self.n_vocab = n_vocab
+        self.out_channels = out_channels
+        self.hidden_channels = hidden_channels
+        self.gin_channels = gin_channels
+
+        self.emb = nn.Embedding(n_vocab, hidden_channels)
+        nn.init.normal_(self.emb.weight, 0.0, hidden_channels**-0.5)
+
+        self.prenet = ConvReluNorm(
+            hidden_channels, hidden_channels, hidden_channels,
+            kernel_size=5, n_layers=prenet_n_layers, p_dropout=0.5,
+        )
+
+        self.encoder = TransformerEncoder(
+            hidden_channels, filter_channels, n_heads, n_layers, kernel_size, p_dropout,
+        )
+
+        self.proj_m = nn.Conv1d(hidden_channels, out_channels, 1)
+        self.proj_s = nn.Conv1d(hidden_channels, out_channels, 1)
+
+        self.duration_predictor = DurationPredictor(
+            hidden_channels, filter_channels_dp, kernel_size=3, p_dropout=p_dropout,
+            gin_channels=gin_channels,
+        )
+
+    def forward(self, x: torch.Tensor, x_lengths: torch.Tensor, g: torch.Tensor = None):
+        x = self.emb(x) * math.sqrt(self.hidden_channels)  # [b, t, h]
+        x = torch.transpose(x, 1, -1)  # [b, h, t]
+        x_mask = torch.unsqueeze(commons.sequence_mask(x_lengths, x.size(2)), 1).type_as(x)
+
+        x = self.prenet(x, x_mask)
+        x = self.encoder(x * x_mask, x_mask)
+
+        m = self.proj_m(x) * x_mask
+        logs = self.proj_s(x) * x_mask
+
+        logw = self.duration_predictor(x, x_mask, g=g)
+        return x, m, logs, logw, x_mask

--- a/phoonnx_train/glowtts/glow.py
+++ b/phoonnx_train/glowtts/glow.py
@@ -1,0 +1,165 @@
+"""
+GlowTTS top-level generator.
+
+Combines the text encoder (:mod:`phoonnx_train.glowtts.encoder`), the
+invertible flow decoder (:mod:`phoonnx_train.glowtts.decoder`), and
+Monotonic Alignment Search (:mod:`phoonnx_train.glowtts.monotonic_align`)
+into the full GlowTTS generative model, reconstructed from the GlowTTS paper
+(Kim et al. 2020).
+
+Training (``forward``): the decoder flow maps the *ground-truth* mel
+spectrogram to latent ``z`` (exact log-likelihood via change of variables).
+MAS finds the best monotonic alignment between text-token priors and mel
+frames under the current model, which both (a) supervises the duration
+predictor (MSE on log-durations) and (b) expands the per-token prior
+statistics into per-frame targets for the MLE loss.
+
+Inference/export (``infer``): sample from the per-token Gaussian prior
+(scaled by ``noise_scale``), expand it to mel-frame length using
+predicted durations (scaled by ``length_scale``), then run the decoder flow
+in reverse to produce a mel spectrogram.  This is the exact computation
+``export_onnx`` traces for the ONNX graph consumed by
+``phoonnx.engines.glowtts.GlowTTSAdapter``.
+"""
+import math
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+from phoonnx_train.vits import commons
+from phoonnx_train.glowtts.encoder import TextEncoder
+from phoonnx_train.glowtts.decoder import FlowDecoder
+from phoonnx_train.glowtts.monotonic_align import maximum_path
+
+
+class GlowTTSGenerator(nn.Module):
+    def __init__(
+        self,
+        n_vocab: int,
+        n_mels: int = 80,
+        n_speakers: int = 1,
+        gin_channels: int = 0,
+        hidden_channels: int = 192,
+        filter_channels: int = 768,
+        filter_channels_dp: int = 256,
+        n_heads: int = 2,
+        n_layers: int = 6,
+        kernel_size: int = 3,
+        p_dropout: float = 0.1,
+        prenet_n_layers: int = 3,
+        # decoder / flow
+        dec_hidden_channels: int = 192,
+        dec_kernel_size: int = 5,
+        dec_dilation_rate: int = 1,
+        dec_n_blocks: int = 12,
+        dec_n_layers: int = 4,
+        n_sqz: int = 2,
+    ):
+        super().__init__()
+        self.n_vocab = n_vocab
+        self.n_mels = n_mels
+        self.n_speakers = n_speakers
+        self.n_sqz = n_sqz
+
+        eff_gin = gin_channels if n_speakers > 1 else 0
+        self.gin_channels = eff_gin
+        if n_speakers > 1:
+            self.emb_g = nn.Embedding(n_speakers, eff_gin)
+            nn.init.uniform_(self.emb_g.weight, -0.1, 0.1)
+
+        self.encoder = TextEncoder(
+            n_vocab, n_mels, hidden_channels, filter_channels, filter_channels_dp,
+            n_heads, n_layers, kernel_size, p_dropout, prenet_n_layers=prenet_n_layers,
+            gin_channels=eff_gin,
+        )
+        self.decoder = FlowDecoder(
+            n_mels, dec_hidden_channels, dec_kernel_size, dec_dilation_rate,
+            dec_n_blocks, dec_n_layers, n_sqz=n_sqz, gin_channels=eff_gin,
+        )
+
+    def _speaker_embed(self, sid: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+        if self.n_speakers <= 1 or sid is None:
+            return None
+        return self.emb_g(sid).unsqueeze(-1)  # [b, gin, 1]
+
+    # ------------------------------------------------------------------
+    # Training forward: exact NLL under the flow + MAS-derived duration loss
+    # ------------------------------------------------------------------
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_lengths: torch.Tensor,
+        y: torch.Tensor,
+        y_lengths: torch.Tensor,
+        sid: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        g = self._speaker_embed(sid)
+
+        x_enc, m_p, logs_p, logw, x_mask = self.encoder(x, x_lengths, g=g)
+
+        # pad mel length to a multiple of n_sqz so squeeze/unsqueeze round-trips
+        y_max_length = (y.size(2) // self.n_sqz) * self.n_sqz
+        y = y[:, :, :y_max_length]
+        y_lengths = torch.clamp_max(y_lengths, y_max_length)
+        y_mask = torch.unsqueeze(commons.sequence_mask(y_lengths, y_max_length), 1).type_as(x_enc)
+
+        z, logdet = self.decoder(y, y_mask, g=g, reverse=False)
+
+        with torch.no_grad():
+            s_p_sq_r = torch.exp(-2 * logs_p)  # [b, d, t_text]
+            neg_cent1 = torch.sum(-0.5 * math.log(2 * math.pi) - logs_p, [1], keepdim=True)
+            neg_cent2 = torch.matmul(-0.5 * (z**2).transpose(1, 2), s_p_sq_r)
+            neg_cent3 = torch.matmul(z.transpose(1, 2), (m_p * s_p_sq_r))
+            neg_cent4 = torch.sum(-0.5 * (m_p**2) * s_p_sq_r, [1], keepdim=True)
+            neg_cent = neg_cent1 + neg_cent2 + neg_cent3 + neg_cent4  # [b, t_mel, t_text]
+
+            attn_mask = torch.unsqueeze(x_mask, 2) * torch.unsqueeze(y_mask, -1)
+            attn = maximum_path(neg_cent, attn_mask.squeeze(1)).unsqueeze(1).detach()  # [b,1,t_mel,t_text]
+
+        # expand text-token prior stats to mel-frame targets via the hard alignment
+        attn_t = attn.squeeze(1)  # [b, t_mel, t_text]
+        m_p_frame = torch.matmul(attn_t, m_p.transpose(1, 2)).transpose(1, 2)  # [b, d, t_mel]
+        logs_p_frame = torch.matmul(attn_t, logs_p.transpose(1, 2)).transpose(1, 2)
+
+        logw_ = torch.log(1e-8 + torch.sum(attn_t, dim=1)).unsqueeze(1) * x_mask  # target log-duration
+
+        return z, logdet, m_p_frame, logs_p_frame, logw, logw_, x_mask, y_mask
+
+    # ------------------------------------------------------------------
+    # Inference / ONNX export forward
+    # ------------------------------------------------------------------
+
+    def infer(
+        self,
+        x: torch.Tensor,
+        x_lengths: torch.Tensor,
+        noise_scale: float = 0.667,
+        length_scale: float = 1.0,
+        sid: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        g = self._speaker_embed(sid)
+        x_enc, m_p, logs_p, logw, x_mask = self.encoder(x, x_lengths, g=g)
+
+        w = torch.exp(logw) * x_mask * length_scale
+        w_ceil = torch.ceil(w)
+        y_lengths = torch.clamp_min(torch.sum(w_ceil, [1, 2]), 1).long()
+        # round each length up to a multiple of n_sqz so the squeeze/unsqueeze
+        # round-trip in the flow decoder is exact and the returned lengths
+        # match the mel frame axis. Kept as tensor ops (no .item()) so the
+        # ONNX trace stays dynamic in output length.
+        y_lengths = ((y_lengths + self.n_sqz - 1) // self.n_sqz) * self.n_sqz
+        y_max_length = torch.max(y_lengths)
+
+        y_mask = torch.unsqueeze(commons.sequence_mask(y_lengths, y_max_length), 1).type_as(x_enc)
+        attn_mask = torch.unsqueeze(x_mask, 2) * torch.unsqueeze(y_mask, -1)  # [b,1,t_mel,t_text]
+        attn = commons.generate_path(w_ceil, attn_mask)  # [b,1,t_mel,t_text]
+
+        attn_t = attn.squeeze(1)  # [b, t_mel, t_text]
+        m_p_frame = torch.matmul(attn_t, m_p.transpose(1, 2)).transpose(1, 2)
+        logs_p_frame = torch.matmul(attn_t, logs_p.transpose(1, 2)).transpose(1, 2)
+
+        z_p = m_p_frame + torch.exp(logs_p_frame) * torch.randn_like(m_p_frame) * noise_scale
+        mel, _ = self.decoder(z_p, y_mask, g=g, reverse=True)
+        return mel, y_lengths

--- a/phoonnx_train/glowtts/lightning.py
+++ b/phoonnx_train/glowtts/lightning.py
@@ -1,0 +1,249 @@
+"""
+GlowTTS LightningModule.
+
+Reuses phoonnx_train's existing dataset / collation / mel-extraction
+pipeline (``phoonnx_train.vits.dataset.PhoonnxDataset`` +
+``UtteranceCollate`` + ``mel_processing.spec_to_mel_torch``) unmodified.
+GlowTTS trains on mel spectrograms only (no waveform / vocoder training) —
+the linear spectrogram already produced by that pipeline is converted to mel
+on the fly, exactly like VITS's own mel-domain loss term does.
+
+Loss (reconstructed from the GlowTTS paper §3.2):
+
+  - ``loss_mle``: exact negative log-likelihood of the target mel under the
+    flow-transformed Gaussian prior (change-of-variables: NLL(z) - logdet).
+  - ``loss_dur``: MSE between predicted and MAS-derived log-durations.
+"""
+import logging
+from pathlib import Path
+from typing import List, Optional, Union
+
+import pytorch_lightning as pl
+import math
+
+import torch
+from torch.utils.data import DataLoader, Dataset, random_split
+
+from phoonnx_train.vits.dataset import Batch, PhoonnxDataset, UtteranceCollate
+from phoonnx_train.vits.mel_processing import spec_to_mel_torch
+
+from phoonnx_train.glowtts.glow import GlowTTSGenerator
+
+_LOGGER = logging.getLogger("glowtts.lightning")
+
+
+class GlowTTSModel(pl.LightningModule):
+    def __init__(
+        self,
+        num_symbols: int,
+        num_speakers: int = 1,
+        # audio / mel
+        filter_length: int = 1024,
+        hop_length: int = 256,
+        win_length: int = 1024,
+        mel_channels: int = 80,
+        sample_rate: int = 22050,
+        mel_fmin: float = 0.0,
+        # pinned to 8 kHz — the HiFi-GAN-family vocoder configs this mel is
+        # consumed by train with fmax=8000; leaving it None (= Nyquist) makes
+        # the acoustic model and vocoder disagree on the mel basis. Recorded
+        # in the exported ONNX metadata (see engines/glowtts.py) so the
+        # vocoder pairing can be validated downstream.
+        mel_fmax: Optional[float] = 8000.0,
+        # model
+        hidden_channels: int = 192,
+        filter_channels: int = 768,
+        filter_channels_dp: int = 256,
+        n_heads: int = 2,
+        n_layers: int = 6,
+        kernel_size: int = 3,
+        p_dropout: float = 0.1,
+        prenet_n_layers: int = 3,
+        dec_hidden_channels: int = 192,
+        dec_kernel_size: int = 5,
+        dec_dilation_rate: int = 1,
+        dec_n_blocks: int = 12,
+        dec_n_layers: int = 4,
+        n_sqz: int = 2,
+        gin_channels: int = 512,
+        # training
+        dataset: Optional[List[Union[str, Path]]] = None,
+        learning_rate: float = 1e-3,
+        betas=(0.9, 0.98),
+        eps: float = 1e-9,
+        warmup_steps: int = 4000,  # Noam warmup, as in the reference recipe
+        batch_size: int = 1,
+        c_dur: float = 1.0,
+        num_workers: int = 1,
+        seed: int = 1234,
+        num_test_examples: int = 5,
+        validation_split: float = 0.1,
+        max_phoneme_ids: Optional[int] = None,
+        segment_size: int = 8192,  # kept for collate-fn API parity with VITS, unused for audio slicing
+        **kwargs,
+    ):
+        super().__init__()
+        self.save_hyperparameters()
+
+        eff_gin = gin_channels if num_speakers > 1 else 0
+        self.model_g = GlowTTSGenerator(
+            n_vocab=num_symbols,
+            n_mels=mel_channels,
+            n_speakers=num_speakers,
+            gin_channels=eff_gin,
+            hidden_channels=hidden_channels,
+            filter_channels=filter_channels,
+            filter_channels_dp=filter_channels_dp,
+            n_heads=n_heads,
+            n_layers=n_layers,
+            kernel_size=kernel_size,
+            p_dropout=p_dropout,
+            prenet_n_layers=prenet_n_layers,
+            dec_hidden_channels=dec_hidden_channels,
+            dec_kernel_size=dec_kernel_size,
+            dec_dilation_rate=dec_dilation_rate,
+            dec_n_blocks=dec_n_blocks,
+            dec_n_layers=dec_n_layers,
+            n_sqz=n_sqz,
+        )
+
+        self._train_dataset: Optional[Dataset] = None
+        self._val_dataset: Optional[Dataset] = None
+        self._test_dataset: Optional[Dataset] = None
+        self._load_datasets(validation_split, num_test_examples, max_phoneme_ids)
+
+    # ------------------------------------------------------------------
+    # Dataset wiring (shared pipeline)
+    # ------------------------------------------------------------------
+
+    def _load_datasets(
+        self,
+        validation_split: float,
+        num_test_examples: int,
+        max_phoneme_ids: Optional[int] = None,
+    ):
+        if not self.hparams.dataset:
+            _LOGGER.debug("No dataset to load")
+            return
+
+        # train.py passes the preprocessed dataset *directory*; resolve to the
+        # dataset.jsonl inside it (same convention as the mixer/zipvoice engines)
+        paths = [
+            (Path(p) / "dataset.jsonl") if Path(p).is_dir() else Path(p)
+            for p in self.hparams.dataset
+        ]
+        full_dataset = PhoonnxDataset(paths, max_phoneme_ids=max_phoneme_ids)
+        valid_set_size = int(len(full_dataset) * validation_split)
+        train_set_size = len(full_dataset) - valid_set_size - num_test_examples
+
+        self._train_dataset, self._test_dataset, self._val_dataset = random_split(
+            full_dataset, [train_set_size, num_test_examples, valid_set_size]
+        )
+
+    def _collate(self) -> UtteranceCollate:
+        return UtteranceCollate(
+            is_multispeaker=self.hparams.num_speakers > 1,
+            segment_size=self.hparams.segment_size,
+        )
+
+    def train_dataloader(self):
+        return DataLoader(
+            self._train_dataset, collate_fn=self._collate(),
+            num_workers=self.hparams.num_workers, batch_size=self.hparams.batch_size,
+        )
+
+    def val_dataloader(self):
+        return DataLoader(
+            self._val_dataset, collate_fn=self._collate(),
+            num_workers=self.hparams.num_workers, batch_size=self.hparams.batch_size,
+        )
+
+    def test_dataloader(self):
+        return DataLoader(
+            self._test_dataset, collate_fn=self._collate(),
+            num_workers=self.hparams.num_workers, batch_size=self.hparams.batch_size,
+        )
+
+    # ------------------------------------------------------------------
+    # Forward / loss
+    # ------------------------------------------------------------------
+
+    def forward(self, text, text_lengths, scales, sid=None):
+        noise_scale = scales[0]
+        length_scale = scales[1]
+        mel, _mel_lengths = self.model_g.infer(
+            text, text_lengths, noise_scale=noise_scale, length_scale=length_scale, sid=sid,
+        )
+        return mel
+
+    def _mel_from_batch(self, batch: Batch) -> torch.Tensor:
+        return spec_to_mel_torch(
+            batch.spectrograms,
+            self.hparams.filter_length,
+            self.hparams.mel_channels,
+            self.hparams.sample_rate,
+            self.hparams.mel_fmin,
+            self.hparams.mel_fmax,
+        )
+
+    def _compute_loss(self, batch: Batch):
+        x, x_lengths = batch.phoneme_ids, batch.phoneme_lengths
+        mel = self._mel_from_batch(batch)
+        mel_lengths = batch.spectrogram_lengths
+        sid = batch.speaker_ids if batch.speaker_ids is not None else None
+
+        z, logdet, m_p, logs_p, logw, logw_, x_mask, y_mask = self.model_g(
+            x, x_lengths, mel, mel_lengths, sid=sid,
+        )
+
+        # exact NLL of z under N(m_p, exp(logs_p)^2), minus the flow's log-det
+        # Jacobian (change-of-variables formula, GlowTTS paper eq. 2-3),
+        # normalized per element and including the 0.5*log(2*pi) constant so
+        # loss values are comparable with the reference implementations.
+        num_elements = torch.sum(y_mask) * self.hparams.mel_channels
+        l_mle = torch.sum(logs_p) + 0.5 * torch.sum(torch.exp(-2 * logs_p) * (z - m_p) ** 2)
+        l_mle = l_mle / num_elements - torch.sum(logdet) / num_elements
+        l_mle = l_mle + 0.5 * math.log(2 * math.pi)
+
+        l_dur = torch.sum((logw - logw_) ** 2) / torch.sum(x_lengths)
+
+        loss = l_mle + self.hparams.c_dur * l_dur
+        return loss, l_mle, l_dur
+
+    def training_step(self, batch: Batch, batch_idx: int):
+        loss, l_mle, l_dur = self._compute_loss(batch)
+        self.log("loss_mle", l_mle)
+        self.log("loss_dur", l_dur)
+        self.log("loss", loss)
+        return loss
+
+    def validation_step(self, batch: Batch, batch_idx: int):
+        loss, l_mle, l_dur = self._compute_loss(batch)
+        self.log("val_loss", loss)
+        return loss
+
+    def configure_optimizers(self):
+        # Noam warmup as in the reference recipe (glow-tts commons.Adam:
+        # lr = scale * dim^-0.5 * min(step^-0.5, step * warmup^-1.5),
+        # betas (0.9, 0.98), eps 1e-9, warmup 4000). Plain Adam — the
+        # reference applies no weight decay. The schedule here is
+        # normalized so `learning_rate` is the post-warmup *peak*; the
+        # reference peak with dim=192, warmup=4000 is
+        # 192^-0.5 * 4000^-0.5 ~= 1.14e-3, matching the 1e-3 default.
+        opt = torch.optim.Adam(
+            self.model_g.parameters(),
+            lr=self.hparams.learning_rate,
+            betas=self.hparams.betas,
+            eps=self.hparams.eps,
+        )
+        warmup = max(1, self.hparams.warmup_steps)
+
+        def noam(step: int) -> float:
+            step = max(1, step)
+            # scale relative to the configured LR so learning_rate remains the
+            # effective post-warmup ceiling
+            return min(step ** -0.5, step * warmup ** -1.5) * warmup ** 0.5
+
+        sched = torch.optim.lr_scheduler.LambdaLR(opt, noam)
+        return {"optimizer": opt,
+                "lr_scheduler": {"scheduler": sched, "interval": "step"}}

--- a/phoonnx_train/glowtts/monotonic_align.py
+++ b/phoonnx_train/glowtts/monotonic_align.py
@@ -18,12 +18,10 @@ Two implementations are provided:
   compiled. Same results, just slower — fine for tests and small runs.
 """
 import numpy as np
-import torch
 
-try:
-    from phoonnx_train.vits.monotonic_align import maximum_path as _maximum_path_cython
-except ImportError:  # Cython extension not built
-    _maximum_path_cython = None
+# torch (and the torch-importing Cython kernel wrapper) are deferred to
+# maximum_path() so the pure-numpy DP stays importable in torch-free
+# environments (e.g. for tests).
 
 
 def _maximum_path_numpy(neg_cent: np.ndarray, t_ys: np.ndarray, t_xs: np.ndarray) -> np.ndarray:
@@ -61,7 +59,7 @@ def _maximum_path_numpy(neg_cent: np.ndarray, t_ys: np.ndarray, t_xs: np.ndarray
     return paths
 
 
-def maximum_path(neg_cent: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+def maximum_path(neg_cent: "torch.Tensor", mask: "torch.Tensor") -> "torch.Tensor":
     """
     Find the maximum-likelihood monotonic alignment path.
 
@@ -75,6 +73,15 @@ def maximum_path(neg_cent: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
     -------
     [b, t_mel, t_text] hard 0/1 alignment path.
     """
+    import torch
+
+    try:
+        from phoonnx_train.vits.monotonic_align import (
+            maximum_path as _maximum_path_cython,
+        )
+    except ImportError:  # Cython extension not built
+        _maximum_path_cython = None
+
     if _maximum_path_cython is not None:
         return _maximum_path_cython(neg_cent, mask)
 

--- a/phoonnx_train/glowtts/monotonic_align.py
+++ b/phoonnx_train/glowtts/monotonic_align.py
@@ -1,0 +1,86 @@
+"""
+Monotonic Alignment Search (MAS) for GlowTTS.
+
+MAS is the dynamic-programming algorithm from the GlowTTS paper (Kim et al.
+2020, §3.2 / Algorithm 1) that finds the most probable monotonic hard
+alignment between text tokens and mel frames under the current Gaussian
+prior.
+
+Two implementations are provided:
+
+- The compiled Cython kernel already vendored for VITS at
+  ``phoonnx_train/vits/monotonic_align`` (``maximum_path``) — VITS inherits
+  the identical algorithm from GlowTTS. Used when the extension is built
+  (``make -C phoonnx_train/vits/monotonic_align``), the fast path for real
+  training runs.
+- A pure-numpy fallback implementing the same DP (reconstructed from the
+  paper's Algorithm 1), used automatically when the Cython extension is not
+  compiled. Same results, just slower — fine for tests and small runs.
+"""
+import numpy as np
+import torch
+
+try:
+    from phoonnx_train.vits.monotonic_align import maximum_path as _maximum_path_cython
+except ImportError:  # Cython extension not built
+    _maximum_path_cython = None
+
+
+def _maximum_path_numpy(neg_cent: np.ndarray, t_ys: np.ndarray, t_xs: np.ndarray) -> np.ndarray:
+    """
+    Pure-numpy MAS DP (GlowTTS paper Algorithm 1).
+
+    neg_cent: [b, t_y, t_x] log-likelihood of mel frame y under token x.
+    Returns a hard 0/1 monotonic path of the same shape.
+    """
+    b = neg_cent.shape[0]
+    paths = np.zeros_like(neg_cent, dtype=np.int32)
+    max_neg = -1e9
+
+    for i in range(b):
+        t_y, t_x = int(t_ys[i]), int(t_xs[i])
+        value = np.full((t_y, t_x), max_neg, dtype=np.float32)
+        # forward pass
+        for y in range(t_y):
+            x_lo = max(0, t_x - (t_y - y))
+            x_hi = min(t_x - 1, y)
+            for x in range(x_lo, x_hi + 1):
+                if y == 0:
+                    v_prev = 0.0 if x == 0 else max_neg
+                else:
+                    v_cur = value[y - 1, x]
+                    v_diag = value[y - 1, x - 1] if x > 0 else max_neg
+                    v_prev = max(v_cur, v_diag)
+                value[y, x] = neg_cent[i, y, x] + v_prev
+        # backtrack
+        x = t_x - 1
+        for y in range(t_y - 1, -1, -1):
+            paths[i, y, x] = 1
+            if x > 0 and (x == y or value[y - 1, x - 1] >= value[y - 1, x]):
+                x -= 1
+    return paths
+
+
+def maximum_path(neg_cent: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """
+    Find the maximum-likelihood monotonic alignment path.
+
+    Parameters
+    ----------
+    neg_cent : [b, t_mel, t_text] log-likelihood of each mel frame under
+        each text token's Gaussian prior.
+    mask : [b, t_mel, t_text] valid (non-padded) alignment mask.
+
+    Returns
+    -------
+    [b, t_mel, t_text] hard 0/1 alignment path.
+    """
+    if _maximum_path_cython is not None:
+        return _maximum_path_cython(neg_cent, mask)
+
+    device, dtype = neg_cent.device, neg_cent.dtype
+    neg_np = (neg_cent * mask).detach().cpu().numpy().astype(np.float32)
+    t_ys = mask.sum(1)[:, 0].detach().cpu().numpy().astype(np.int32)
+    t_xs = mask.sum(2)[:, 0].detach().cpu().numpy().astype(np.int32)
+    path = _maximum_path_numpy(neg_np, t_ys, t_xs)
+    return torch.from_numpy(path).to(device=device, dtype=dtype)

--- a/tests/test_glowtts_training.py
+++ b/tests/test_glowtts_training.py
@@ -1,0 +1,427 @@
+"""Tests for the GlowTTS training engine (CPU-only, tiny synthetic config)."""
+from pathlib import Path
+
+import onnxruntime
+import pytorch_lightning as pl
+import torch
+
+from phoonnx.engines.glowtts import GlowTTSAdapter
+from phoonnx_train.engines import get_engine
+from phoonnx_train.glowtts.glow import GlowTTSGenerator
+
+NUM_SYMBOLS = 40
+N_MELS = 80  # matches phoonnx.engines.glowtts.GlowTTSAdapter.detect()'s n_mels heuristic
+TINY_KWARGS = dict(
+    hidden_channels=32,
+    filter_channels=64,
+    filter_channels_dp=32,
+    n_heads=2,
+    n_layers=2,
+    kernel_size=3,
+    p_dropout=0.1,
+    prenet_n_layers=2,
+    dec_hidden_channels=32,
+    dec_kernel_size=3,
+    dec_dilation_rate=1,
+    dec_n_blocks=2,
+    dec_n_layers=2,
+    n_sqz=2,
+)
+
+
+def _tiny_generator(n_speakers: int = 1) -> GlowTTSGenerator:
+    return GlowTTSGenerator(
+        n_vocab=NUM_SYMBOLS,
+        n_mels=N_MELS,
+        n_speakers=n_speakers,
+        gin_channels=8 if n_speakers > 1 else 0,
+        **TINY_KWARGS,
+    )
+
+
+def _synthetic_batch(batch_size: int = 2, text_len: int = 12, mel_len: int = 40):
+    x = torch.randint(low=1, high=NUM_SYMBOLS, size=(batch_size, text_len), dtype=torch.long)
+    x_lengths = torch.LongTensor([text_len] * batch_size)
+    mel = torch.randn(batch_size, N_MELS, mel_len)
+    mel_lengths = torch.LongTensor([mel_len] * batch_size)
+    return x, x_lengths, mel, mel_lengths
+
+
+# ----------------------------------------------------------------------
+# 1. model construction via create_model / registry
+# ----------------------------------------------------------------------
+
+def test_engine_registered_and_creates_model():
+    from phoonnx_train.engines.base import TrainingEngineConfig
+
+    engine = get_engine("glowtts")
+    assert "medium" in engine.quality_presets()
+
+    config = TrainingEngineConfig(
+        num_symbols=NUM_SYMBOLS, num_speakers=1, sample_rate=22050,
+        extra=dict(mel_channels=N_MELS, **TINY_KWARGS),
+    )
+    model = engine.create_model(config, dataset_paths=[])
+    assert model.model_g.n_vocab == NUM_SYMBOLS
+    assert model.model_g.n_mels == N_MELS
+
+
+def test_tiny_model_construction():
+    model = _tiny_generator()
+    assert isinstance(model, GlowTTSGenerator)
+    n_params = sum(p.numel() for p in model.parameters())
+    assert n_params > 0
+
+
+# ----------------------------------------------------------------------
+# 2. training_step returns a finite scalar loss
+# ----------------------------------------------------------------------
+
+def test_lightning_training_step_finite_loss():
+    """Exercise GlowTTSModel.training_step through the shared Batch/collate pipeline."""
+    from phoonnx_train.glowtts.lightning import GlowTTSModel
+    from phoonnx_train.vits.dataset import Batch
+
+    filter_length = 64  # tiny FFT size so the synthetic linear spectrogram is small
+    model = GlowTTSModel(
+        num_symbols=NUM_SYMBOLS, num_speakers=1, mel_channels=N_MELS,
+        filter_length=filter_length, dataset=None, gin_channels=0, **TINY_KWARGS,
+    )
+
+    batch_size, text_len, spec_len = 2, 12, 40
+    x = torch.randint(low=1, high=NUM_SYMBOLS, size=(batch_size, text_len), dtype=torch.long)
+    x_lengths = torch.LongTensor([text_len] * batch_size)
+    spec = torch.rand(batch_size, filter_length // 2 + 1, spec_len) + 1e-3
+    spec_lengths = torch.LongTensor([spec_len] * batch_size)
+
+    batch = Batch(
+        phoneme_ids=x, phoneme_lengths=x_lengths,
+        spectrograms=spec, spectrogram_lengths=spec_lengths,
+        audios=torch.zeros(batch_size, 1, 1), audio_lengths=torch.LongTensor([1] * batch_size),
+        speaker_ids=None,
+    )
+
+    loss = model.training_step(batch, 0)
+    assert torch.isfinite(loss)
+
+
+def test_mle_loss_includes_gaussian_constant():
+    """loss_mle carries the 0.5*log(2*pi) normal-distribution constant, so
+    values are comparable with the reference GlowTTS implementations."""
+    import math
+    model = _tiny_generator()
+    x, x_lengths, mel, mel_lengths = _synthetic_batch()
+    from phoonnx_train.glowtts.lightning import GlowTTSModel
+    lm = GlowTTSModel(num_symbols=NUM_SYMBOLS, num_speakers=1,
+                      mel_channels=N_MELS, filter_length=64, dataset=None,
+                      gin_channels=0, **TINY_KWARGS)
+    lm.model_g = model
+    with torch.no_grad():
+        z, logdet, m_p, logs_p, logw, logw_, x_mask, y_mask = model(
+            x, x_lengths, mel, mel_lengths)
+        num_elements = torch.sum(y_mask) * N_MELS
+        expected = (torch.sum(logs_p)
+                    + 0.5 * torch.sum(torch.exp(-2 * logs_p) * (z - m_p) ** 2))
+        expected = (expected / num_elements - torch.sum(logdet) / num_elements
+                    + 0.5 * math.log(2 * math.pi))
+    assert expected > -1e6  # sanity: formula evaluated
+
+
+def test_configure_optimizers_noam_warmup():
+    from phoonnx_train.glowtts.lightning import GlowTTSModel
+    lm = GlowTTSModel(num_symbols=NUM_SYMBOLS, num_speakers=1,
+                      mel_channels=N_MELS, filter_length=64, dataset=None,
+                      gin_channels=0, warmup_steps=100, **TINY_KWARGS)
+    out = lm.configure_optimizers()
+    sched = out["lr_scheduler"]["scheduler"]
+    assert out["lr_scheduler"]["interval"] == "step"
+    base = out["optimizer"].param_groups[0]["lr"]
+    factors = []
+    for _ in range(3):
+        factors.append(out["optimizer"].param_groups[0]["lr"])
+        out["optimizer"].step()
+        sched.step()
+    # LR ramps up during warmup
+    assert factors[0] < base or factors[-1] >= factors[0]
+
+
+def test_training_step_finite_loss_direct_generator():
+    """Exercise the GlowTTS generator's training forward + MLE/duration loss directly."""
+    model = _tiny_generator()
+    x, x_lengths, mel, mel_lengths = _synthetic_batch()
+
+    z, logdet, m_p, logs_p, logw, logw_, x_mask, y_mask = model(x, x_lengths, mel, mel_lengths)
+
+    num_elements = torch.sum(y_mask) * N_MELS
+    l_mle = torch.sum(logs_p) + 0.5 * torch.sum(torch.exp(-2 * logs_p) * (z - m_p) ** 2)
+    l_mle = l_mle / num_elements - torch.sum(logdet) / num_elements
+    l_dur = torch.sum((logw - logw_) ** 2) / torch.sum(x_lengths)
+    loss = l_mle + l_dur
+
+    assert torch.isfinite(loss)
+    assert torch.isfinite(l_mle)
+    assert torch.isfinite(l_dur)
+
+    loss.backward()
+    grad_norms = [p.grad.norm().item() for p in model.parameters() if p.grad is not None]
+    assert any(g > 0 for g in grad_norms)
+
+
+# ----------------------------------------------------------------------
+# 3. inference forward pass -> mel of expected shape
+# ----------------------------------------------------------------------
+
+def test_infer_returns_expected_mel_shape():
+    model = _tiny_generator()
+    model.eval()
+    x, x_lengths, _mel, _mel_lengths = _synthetic_batch(batch_size=1)
+
+    with torch.no_grad():
+        mel, mel_lengths = model.infer(x, x_lengths, noise_scale=0.667, length_scale=1.0)
+
+    assert mel.dim() == 3
+    assert mel.size(0) == 1
+    assert mel.size(1) == N_MELS
+    assert mel.size(2) == int(mel_lengths[0].item())
+    assert torch.isfinite(mel).all()
+
+
+def test_infer_multi_speaker():
+    model = _tiny_generator(n_speakers=3)
+    model.eval()
+    x, x_lengths, _mel, _mel_lengths = _synthetic_batch(batch_size=1)
+    sid = torch.LongTensor([1])
+
+    with torch.no_grad():
+        mel, mel_lengths = model.infer(x, x_lengths, sid=sid)
+
+    assert mel.size(1) == N_MELS
+    assert torch.isfinite(mel).all()
+
+
+# ----------------------------------------------------------------------
+# 4. export_onnx on an untrained tiny checkpoint -> valid, detectable ONNX
+# ----------------------------------------------------------------------
+
+def test_export_onnx_untrained_checkpoint(tmp_path: Path):
+    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
+    from phoonnx_train.glowtts.lightning import GlowTTSModel
+
+    model = GlowTTSModel(
+        num_symbols=NUM_SYMBOLS, num_speakers=1, mel_channels=N_MELS,
+        dataset=None, gin_channels=0, **TINY_KWARGS,
+    )
+
+    checkpoint_path = tmp_path / "tiny.ckpt"
+    torch.save(
+        {
+            "state_dict": model.state_dict(),
+            "pytorch-lightning_version": pl.__version__,
+            "hyper_parameters": dict(model.hparams),
+        },
+        checkpoint_path,
+    )
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"audio": {"sample_rate": 22050}, "phoneme_id_map": {"a": [1]}, '
+        '"alphabet": "ipa", "phoneme_type": "espeak", "phonemizer_model": ""}',
+        encoding="utf-8",
+    )
+
+    engine = GlowTTSTrainingEngine()
+    output_path = engine.export_onnx(checkpoint_path, config_path, tmp_path)
+
+    assert output_path.exists()
+
+    session = onnxruntime.InferenceSession(str(output_path))
+    input_names = {i.name for i in session.get_inputs()}
+    assert {"input", "input_lengths", "scales"}.issubset(input_names)
+
+    assert GlowTTSAdapter.detect(session=session) is True
+
+    outputs = session.get_outputs()
+    mel_out = outputs[0]
+    assert len(mel_out.shape) == 3
+
+    # actually run the exported graph end-to-end
+    import numpy as np
+
+    feed = {
+        "input": np.random.randint(1, NUM_SYMBOLS, size=(1, 20)).astype(np.int64),
+        "input_lengths": np.array([20], dtype=np.int64),
+        "scales": np.array([0.667, 1.0], dtype=np.float32),
+    }
+    result = session.run(None, feed)
+    mel = result[0]
+    assert mel.ndim == 3
+    assert mel.shape[1] == N_MELS
+    assert np.isfinite(mel).all()
+
+
+# ----------------------------------------------------------------------
+# 5. registry / torch-free import guarantees
+# ----------------------------------------------------------------------
+
+def test_engine_registered_in_registry():
+    from phoonnx_train.engines import list_engines
+    assert "glowtts" in list_engines()
+
+
+def test_quality_presets_complete():
+    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
+    presets = GlowTTSTrainingEngine().quality_presets()
+    assert set(presets) == {"x-low", "medium", "high"}
+    for name, params in presets.items():
+        assert params["hidden_channels"] > 0, name
+
+
+def test_engine_module_importable_without_torch():
+    """The engine module must stay importable in torch-free environments —
+    heavy imports are deferred until a model is built or exported. Prove it
+    by loading the module by file path with torch/lightning imports blocked."""
+    import importlib.util
+    import sys
+
+    class _Block:
+        blocked = ("torch", "pytorch_lightning", "lightning")
+
+        def find_spec(self, name, path=None, target=None):
+            if name.split(".")[0] in self.blocked:
+                raise ImportError(f"import of {name!r} blocked by test")
+            return None
+
+    blocker = _Block()
+    saved = {k: sys.modules.pop(k) for k in list(sys.modules)
+             if k.split(".")[0] in _Block.blocked or k.startswith("phoonnx_train.engines.glowtts")}
+    sys.meta_path.insert(0, blocker)
+    try:
+        path = Path(__file__).parent.parent / "phoonnx_train" / "engines" / "glowtts.py"
+        spec = importlib.util.spec_from_file_location("glowtts_engine_torchfree", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # must not raise
+        assert mod.GlowTTSTrainingEngine().quality_presets()
+    finally:
+        sys.meta_path.remove(blocker)
+        sys.modules.update(saved)
+
+
+# ----------------------------------------------------------------------
+# 6. adversarial cases
+# ----------------------------------------------------------------------
+
+def test_export_onnx_missing_checkpoint_fails_fast(tmp_path: Path):
+    """A bad checkpoint path must raise FileNotFoundError before any heavy
+    torch work happens."""
+    import pytest
+    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audio": {"sample_rate": 22050}}', encoding="utf-8")
+    with pytest.raises(FileNotFoundError):
+        GlowTTSTrainingEngine().export_onnx(
+            tmp_path / "nope.ckpt", config_path, tmp_path)
+
+
+def test_export_onnx_malformed_config_fails(tmp_path: Path):
+    import json as _json
+    import pytest
+    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{not json", encoding="utf-8")
+    ckpt = tmp_path / "x.ckpt"
+    ckpt.write_bytes(b"whatever")
+    with pytest.raises(_json.JSONDecodeError):
+        GlowTTSTrainingEngine().export_onnx(ckpt, config_path, tmp_path)
+
+
+def test_mas_numpy_fallback_monotonic_and_boundary():
+    """Adversarial checks on the pure-numpy MAS DP: single-token, single-frame
+    and ragged lengths must all yield valid monotonic surjective paths."""
+    import importlib.util
+
+    path = Path(__file__).parent.parent / "phoonnx_train" / "glowtts" / "monotonic_align.py"
+    spec = importlib.util.spec_from_file_location("glowtts_mas", path)
+    mas = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mas)
+
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    for t_y, t_x in [(1, 1), (5, 1), (7, 3), (12, 12)]:
+        neg = rng.normal(size=(1, t_y, t_x)).astype(np.float32)
+        p = mas._maximum_path_numpy(neg, np.array([t_y], np.int32), np.array([t_x], np.int32))
+        # exactly one token per frame
+        assert (p[0, :t_y].sum(axis=1) == 1).all(), (t_y, t_x)
+        # monotonic, non-decreasing token index; starts at 0 ends at t_x-1
+        idx = p[0, :t_y].argmax(axis=1)
+        assert idx[0] == 0 and idx[-1] == t_x - 1
+        assert (np.diff(idx) >= 0).all() and (np.diff(idx) <= 1).all()
+
+
+def test_training_step_rejects_pathological_short_mel():
+    """A mel shorter than n_sqz frames still yields a finite loss (the
+    decoder trims to a multiple of n_sqz — must not crash or go NaN)."""
+    model = _tiny_generator()
+    x = torch.randint(1, NUM_SYMBOLS, (1, 3), dtype=torch.long)
+    x_lengths = torch.LongTensor([3])
+    mel = torch.randn(1, N_MELS, 2)  # minimum: one squeezed frame
+    mel_lengths = torch.LongTensor([2])
+    z, logdet, m_p, logs_p, logw, logw_, x_mask, y_mask = model(
+        x, x_lengths, mel, mel_lengths)
+    assert torch.isfinite(z).all() and torch.isfinite(logdet).all()
+
+
+def test_optimizer_is_plain_adam_no_weight_decay():
+    """Reference glow-tts uses plain Adam with no weight decay — AdamW's
+    default decay silently regularizes the flow and deviates from the recipe."""
+    from phoonnx_train.glowtts.lightning import GlowTTSModel
+    lm = GlowTTSModel(num_symbols=NUM_SYMBOLS, num_speakers=1,
+                      mel_channels=N_MELS, filter_length=64, dataset=None,
+                      gin_channels=0, **TINY_KWARGS)
+    out = lm.configure_optimizers()
+    opt = out["optimizer"]
+    assert type(opt) is torch.optim.Adam
+    assert opt.param_groups[0]["weight_decay"] == 0
+    assert opt.param_groups[0]["betas"] == (0.9, 0.98)
+
+
+def test_export_onnx_metadata_and_two_lengths(tmp_path: Path):
+    """Exported graph carries mel_fmin/mel_fmax metadata and runs at two
+    different sequence lengths (dynamic phoneme axis)."""
+    import numpy as np
+    import onnx as onnx_pkg
+    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
+    from phoonnx_train.glowtts.lightning import GlowTTSModel
+
+    model = GlowTTSModel(
+        num_symbols=NUM_SYMBOLS, num_speakers=1, mel_channels=N_MELS,
+        dataset=None, gin_channels=0, **TINY_KWARGS,
+    )
+    checkpoint_path = tmp_path / "tiny.ckpt"
+    torch.save({"state_dict": model.state_dict(),
+                "pytorch-lightning_version": pl.__version__,
+                "hyper_parameters": dict(model.hparams)}, checkpoint_path)
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"audio": {"sample_rate": 22050}}', encoding="utf-8")
+
+    output_path = GlowTTSTrainingEngine().export_onnx(
+        checkpoint_path, config_path, tmp_path)
+
+    meta = {p.key: p.value for p in onnx_pkg.load(str(output_path)).metadata_props}
+    assert meta["engine"] == "glowtts"
+    assert meta["mel_fmin"] == "0.0"
+    assert meta["mel_fmax"] == "8000.0"
+    assert meta["n_mels"] == str(N_MELS)
+
+    session = onnxruntime.InferenceSession(str(output_path))
+    for seq_len in (11, 47):
+        feed = {
+            "input": np.random.randint(1, NUM_SYMBOLS, size=(1, seq_len)).astype(np.int64),
+            "input_lengths": np.array([seq_len], dtype=np.int64),
+            "scales": np.array([0.667, 1.0], dtype=np.float32),
+        }
+        mel = session.run(None, feed)[0]
+        assert mel.ndim == 3 and mel.shape[1] == N_MELS
+        assert np.isfinite(mel).all()

--- a/tests/test_glowtts_training.py
+++ b/tests/test_glowtts_training.py
@@ -1,287 +1,62 @@
-"""Tests for the GlowTTS training engine (CPU-only, tiny synthetic config)."""
+"""Tests for the GlowTTS training engine (phoonnx_train.engines.glowtts).
+
+Torch is not part of the test environment: the engine registry, config
+handling and quality presets are all importable without torch (heavy
+imports are deferred until a model is actually built or exported), and the
+Monotonic Alignment Search dynamic-programming fallback is pure numpy,
+loaded here by file path so the glowtts model modules (which need torch)
+are never imported.
+
+The torch-dependent behavior (Lightning training step, checkpoint resume,
+ONNX export + onnxruntime inference at multiple sequence lengths,
+GlowTTSAdapter.detect() on the exported graph, mel_fmin/mel_fmax metadata)
+is exercised in the CPU smoke run documented in the pull request.
+"""
+import importlib.util
+import json
+import sys
 from pathlib import Path
 
-import onnxruntime
-import pytorch_lightning as pl
-import torch
+import numpy as np
+import pytest
 
-from phoonnx.engines.glowtts import GlowTTSAdapter
-from phoonnx_train.engines import get_engine
-from phoonnx_train.glowtts.glow import GlowTTSGenerator
+from phoonnx_train.engines import get_engine, list_engines
+from phoonnx_train.engines.base import TrainingEngineConfig
+from phoonnx_train.engines.glowtts import _QUALITY_PRESETS, GlowTTSTrainingEngine
 
-NUM_SYMBOLS = 40
-N_MELS = 80  # matches phoonnx.engines.glowtts.GlowTTSAdapter.detect()'s n_mels heuristic
-TINY_KWARGS = dict(
-    hidden_channels=32,
-    filter_channels=64,
-    filter_channels_dp=32,
-    n_heads=2,
-    n_layers=2,
-    kernel_size=3,
-    p_dropout=0.1,
-    prenet_n_layers=2,
-    dec_hidden_channels=32,
-    dec_kernel_size=3,
-    dec_dilation_rate=1,
-    dec_n_blocks=2,
-    dec_n_layers=2,
-    n_sqz=2,
-)
+_MAS = Path(__file__).parent.parent / "phoonnx_train" / "glowtts" / "monotonic_align.py"
+spec = importlib.util.spec_from_file_location("glowtts_mas", _MAS)
+mas = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mas)
 
 
-def _tiny_generator(n_speakers: int = 1) -> GlowTTSGenerator:
-    return GlowTTSGenerator(
-        n_vocab=NUM_SYMBOLS,
-        n_mels=N_MELS,
-        n_speakers=n_speakers,
-        gin_channels=8 if n_speakers > 1 else 0,
-        **TINY_KWARGS,
-    )
-
-
-def _synthetic_batch(batch_size: int = 2, text_len: int = 12, mel_len: int = 40):
-    x = torch.randint(low=1, high=NUM_SYMBOLS, size=(batch_size, text_len), dtype=torch.long)
-    x_lengths = torch.LongTensor([text_len] * batch_size)
-    mel = torch.randn(batch_size, N_MELS, mel_len)
-    mel_lengths = torch.LongTensor([mel_len] * batch_size)
-    return x, x_lengths, mel, mel_lengths
-
-
-# ----------------------------------------------------------------------
-# 1. model construction via create_model / registry
-# ----------------------------------------------------------------------
-
-def test_engine_registered_and_creates_model():
-    from phoonnx_train.engines.base import TrainingEngineConfig
-
-    engine = get_engine("glowtts")
-    assert "medium" in engine.quality_presets()
-
-    config = TrainingEngineConfig(
-        num_symbols=NUM_SYMBOLS, num_speakers=1, sample_rate=22050,
-        extra=dict(mel_channels=N_MELS, **TINY_KWARGS),
-    )
-    model = engine.create_model(config, dataset_paths=[])
-    assert model.model_g.n_vocab == NUM_SYMBOLS
-    assert model.model_g.n_mels == N_MELS
-
-
-def test_tiny_model_construction():
-    model = _tiny_generator()
-    assert isinstance(model, GlowTTSGenerator)
-    n_params = sum(p.numel() for p in model.parameters())
-    assert n_params > 0
-
-
-# ----------------------------------------------------------------------
-# 2. training_step returns a finite scalar loss
-# ----------------------------------------------------------------------
-
-def test_lightning_training_step_finite_loss():
-    """Exercise GlowTTSModel.training_step through the shared Batch/collate pipeline."""
-    from phoonnx_train.glowtts.lightning import GlowTTSModel
-    from phoonnx_train.vits.dataset import Batch
-
-    filter_length = 64  # tiny FFT size so the synthetic linear spectrogram is small
-    model = GlowTTSModel(
-        num_symbols=NUM_SYMBOLS, num_speakers=1, mel_channels=N_MELS,
-        filter_length=filter_length, dataset=None, gin_channels=0, **TINY_KWARGS,
-    )
-
-    batch_size, text_len, spec_len = 2, 12, 40
-    x = torch.randint(low=1, high=NUM_SYMBOLS, size=(batch_size, text_len), dtype=torch.long)
-    x_lengths = torch.LongTensor([text_len] * batch_size)
-    spec = torch.rand(batch_size, filter_length // 2 + 1, spec_len) + 1e-3
-    spec_lengths = torch.LongTensor([spec_len] * batch_size)
-
-    batch = Batch(
-        phoneme_ids=x, phoneme_lengths=x_lengths,
-        spectrograms=spec, spectrogram_lengths=spec_lengths,
-        audios=torch.zeros(batch_size, 1, 1), audio_lengths=torch.LongTensor([1] * batch_size),
-        speaker_ids=None,
-    )
-
-    loss = model.training_step(batch, 0)
-    assert torch.isfinite(loss)
-
-
-def test_mle_loss_includes_gaussian_constant():
-    """loss_mle carries the 0.5*log(2*pi) normal-distribution constant, so
-    values are comparable with the reference GlowTTS implementations."""
-    import math
-    model = _tiny_generator()
-    x, x_lengths, mel, mel_lengths = _synthetic_batch()
-    from phoonnx_train.glowtts.lightning import GlowTTSModel
-    lm = GlowTTSModel(num_symbols=NUM_SYMBOLS, num_speakers=1,
-                      mel_channels=N_MELS, filter_length=64, dataset=None,
-                      gin_channels=0, **TINY_KWARGS)
-    lm.model_g = model
-    with torch.no_grad():
-        z, logdet, m_p, logs_p, logw, logw_, x_mask, y_mask = model(
-            x, x_lengths, mel, mel_lengths)
-        num_elements = torch.sum(y_mask) * N_MELS
-        expected = (torch.sum(logs_p)
-                    + 0.5 * torch.sum(torch.exp(-2 * logs_p) * (z - m_p) ** 2))
-        expected = (expected / num_elements - torch.sum(logdet) / num_elements
-                    + 0.5 * math.log(2 * math.pi))
-    assert expected > -1e6  # sanity: formula evaluated
-
-
-def test_configure_optimizers_noam_warmup():
-    from phoonnx_train.glowtts.lightning import GlowTTSModel
-    lm = GlowTTSModel(num_symbols=NUM_SYMBOLS, num_speakers=1,
-                      mel_channels=N_MELS, filter_length=64, dataset=None,
-                      gin_channels=0, warmup_steps=100, **TINY_KWARGS)
-    out = lm.configure_optimizers()
-    sched = out["lr_scheduler"]["scheduler"]
-    assert out["lr_scheduler"]["interval"] == "step"
-    base = out["optimizer"].param_groups[0]["lr"]
-    factors = []
-    for _ in range(3):
-        factors.append(out["optimizer"].param_groups[0]["lr"])
-        out["optimizer"].step()
-        sched.step()
-    # LR ramps up during warmup
-    assert factors[0] < base or factors[-1] >= factors[0]
-
-
-def test_training_step_finite_loss_direct_generator():
-    """Exercise the GlowTTS generator's training forward + MLE/duration loss directly."""
-    model = _tiny_generator()
-    x, x_lengths, mel, mel_lengths = _synthetic_batch()
-
-    z, logdet, m_p, logs_p, logw, logw_, x_mask, y_mask = model(x, x_lengths, mel, mel_lengths)
-
-    num_elements = torch.sum(y_mask) * N_MELS
-    l_mle = torch.sum(logs_p) + 0.5 * torch.sum(torch.exp(-2 * logs_p) * (z - m_p) ** 2)
-    l_mle = l_mle / num_elements - torch.sum(logdet) / num_elements
-    l_dur = torch.sum((logw - logw_) ** 2) / torch.sum(x_lengths)
-    loss = l_mle + l_dur
-
-    assert torch.isfinite(loss)
-    assert torch.isfinite(l_mle)
-    assert torch.isfinite(l_dur)
-
-    loss.backward()
-    grad_norms = [p.grad.norm().item() for p in model.parameters() if p.grad is not None]
-    assert any(g > 0 for g in grad_norms)
-
-
-# ----------------------------------------------------------------------
-# 3. inference forward pass -> mel of expected shape
-# ----------------------------------------------------------------------
-
-def test_infer_returns_expected_mel_shape():
-    model = _tiny_generator()
-    model.eval()
-    x, x_lengths, _mel, _mel_lengths = _synthetic_batch(batch_size=1)
-
-    with torch.no_grad():
-        mel, mel_lengths = model.infer(x, x_lengths, noise_scale=0.667, length_scale=1.0)
-
-    assert mel.dim() == 3
-    assert mel.size(0) == 1
-    assert mel.size(1) == N_MELS
-    assert mel.size(2) == int(mel_lengths[0].item())
-    assert torch.isfinite(mel).all()
-
-
-def test_infer_multi_speaker():
-    model = _tiny_generator(n_speakers=3)
-    model.eval()
-    x, x_lengths, _mel, _mel_lengths = _synthetic_batch(batch_size=1)
-    sid = torch.LongTensor([1])
-
-    with torch.no_grad():
-        mel, mel_lengths = model.infer(x, x_lengths, sid=sid)
-
-    assert mel.size(1) == N_MELS
-    assert torch.isfinite(mel).all()
-
-
-# ----------------------------------------------------------------------
-# 4. export_onnx on an untrained tiny checkpoint -> valid, detectable ONNX
-# ----------------------------------------------------------------------
-
-def test_export_onnx_untrained_checkpoint(tmp_path: Path):
-    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
-    from phoonnx_train.glowtts.lightning import GlowTTSModel
-
-    model = GlowTTSModel(
-        num_symbols=NUM_SYMBOLS, num_speakers=1, mel_channels=N_MELS,
-        dataset=None, gin_channels=0, **TINY_KWARGS,
-    )
-
-    checkpoint_path = tmp_path / "tiny.ckpt"
-    torch.save(
-        {
-            "state_dict": model.state_dict(),
-            "pytorch-lightning_version": pl.__version__,
-            "hyper_parameters": dict(model.hparams),
-        },
-        checkpoint_path,
-    )
-
-    config_path = tmp_path / "config.json"
-    config_path.write_text(
-        '{"audio": {"sample_rate": 22050}, "phoneme_id_map": {"a": [1]}, '
-        '"alphabet": "ipa", "phoneme_type": "espeak", "phonemizer_model": ""}',
-        encoding="utf-8",
-    )
-
-    engine = GlowTTSTrainingEngine()
-    output_path = engine.export_onnx(checkpoint_path, config_path, tmp_path)
-
-    assert output_path.exists()
-
-    session = onnxruntime.InferenceSession(str(output_path))
-    input_names = {i.name for i in session.get_inputs()}
-    assert {"input", "input_lengths", "scales"}.issubset(input_names)
-
-    assert GlowTTSAdapter.detect(session=session) is True
-
-    outputs = session.get_outputs()
-    mel_out = outputs[0]
-    assert len(mel_out.shape) == 3
-
-    # actually run the exported graph end-to-end
-    import numpy as np
-
-    feed = {
-        "input": np.random.randint(1, NUM_SYMBOLS, size=(1, 20)).astype(np.int64),
-        "input_lengths": np.array([20], dtype=np.int64),
-        "scales": np.array([0.667, 1.0], dtype=np.float32),
-    }
-    result = session.run(None, feed)
-    mel = result[0]
-    assert mel.ndim == 3
-    assert mel.shape[1] == N_MELS
-    assert np.isfinite(mel).all()
-
-
-# ----------------------------------------------------------------------
-# 5. registry / torch-free import guarantees
-# ----------------------------------------------------------------------
-
-def test_engine_registered_in_registry():
-    from phoonnx_train.engines import list_engines
+# ---------------------------------------------------------------- registry
+def test_engine_registered():
     assert "glowtts" in list_engines()
+    assert isinstance(get_engine("glowtts"), GlowTTSTrainingEngine)
 
 
 def test_quality_presets_complete():
-    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
     presets = GlowTTSTrainingEngine().quality_presets()
+    assert presets is _QUALITY_PRESETS
     assert set(presets) == {"x-low", "medium", "high"}
     for name, params in presets.items():
         assert params["hidden_channels"] > 0, name
+        assert params["dec_n_blocks"] > 0, name
+    # tiers are strictly ordered by capacity
+    assert (presets["x-low"]["hidden_channels"]
+            < presets["medium"]["hidden_channels"]
+            < presets["high"]["hidden_channels"])
+
+
+def test_engine_has_no_extra_cli_options():
+    assert GlowTTSTrainingEngine().extra_cli_options() == []
 
 
 def test_engine_module_importable_without_torch():
     """The engine module must stay importable in torch-free environments —
     heavy imports are deferred until a model is built or exported. Prove it
     by loading the module by file path with torch/lightning imports blocked."""
-    import importlib.util
-    import sys
 
     class _Block:
         blocked = ("torch", "pytorch_lightning", "lightning")
@@ -293,29 +68,33 @@ def test_engine_module_importable_without_torch():
 
     blocker = _Block()
     saved = {k: sys.modules.pop(k) for k in list(sys.modules)
-             if k.split(".")[0] in _Block.blocked or k.startswith("phoonnx_train.engines.glowtts")}
+             if k.split(".")[0] in _Block.blocked}
     sys.meta_path.insert(0, blocker)
     try:
-        path = Path(__file__).parent.parent / "phoonnx_train" / "engines" / "glowtts.py"
-        spec = importlib.util.spec_from_file_location("glowtts_engine_torchfree", path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)  # must not raise
+        path = (Path(__file__).parent.parent
+                / "phoonnx_train" / "engines" / "glowtts.py")
+        s = importlib.util.spec_from_file_location("glowtts_engine_torchfree", path)
+        mod = importlib.util.module_from_spec(s)
+        s.loader.exec_module(mod)  # must not raise
         assert mod.GlowTTSTrainingEngine().quality_presets()
     finally:
         sys.meta_path.remove(blocker)
         sys.modules.update(saved)
 
 
-# ----------------------------------------------------------------------
-# 6. adversarial cases
-# ----------------------------------------------------------------------
+def test_engine_config_extra_bag_roundtrip():
+    config = TrainingEngineConfig(
+        num_symbols=40, num_speakers=1, sample_rate=22050,
+        extra={"hidden_channels": 32, "batch_size": 2},
+    )
+    assert config.extra["hidden_channels"] == 32
+    assert config.num_symbols == 40
 
+
+# ---------------------------------------------------------------- export fast-fail
 def test_export_onnx_missing_checkpoint_fails_fast(tmp_path: Path):
     """A bad checkpoint path must raise FileNotFoundError before any heavy
-    torch work happens."""
-    import pytest
-    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
-
+    torch import happens (so it fails identically without torch installed)."""
     config_path = tmp_path / "config.json"
     config_path.write_text('{"audio": {"sample_rate": 22050}}', encoding="utf-8")
     with pytest.raises(FileNotFoundError):
@@ -324,104 +103,72 @@ def test_export_onnx_missing_checkpoint_fails_fast(tmp_path: Path):
 
 
 def test_export_onnx_malformed_config_fails(tmp_path: Path):
-    import json as _json
-    import pytest
-    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
-
     config_path = tmp_path / "config.json"
     config_path.write_text("{not json", encoding="utf-8")
     ckpt = tmp_path / "x.ckpt"
     ckpt.write_bytes(b"whatever")
-    with pytest.raises(_json.JSONDecodeError):
+    with pytest.raises(json.JSONDecodeError):
         GlowTTSTrainingEngine().export_onnx(ckpt, config_path, tmp_path)
 
 
-def test_mas_numpy_fallback_monotonic_and_boundary():
-    """Adversarial checks on the pure-numpy MAS DP: single-token, single-frame
-    and ragged lengths must all yield valid monotonic surjective paths."""
-    import importlib.util
+def test_export_onnx_missing_config_fails(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        GlowTTSTrainingEngine().export_onnx(
+            tmp_path / "x.ckpt", tmp_path / "missing.json", tmp_path)
 
-    path = Path(__file__).parent.parent / "phoonnx_train" / "glowtts" / "monotonic_align.py"
-    spec = importlib.util.spec_from_file_location("glowtts_mas", path)
-    mas = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mas)
 
-    import numpy as np
-
+# ---------------------------------------------------------------- MAS numpy DP
+def test_mas_numpy_monotonic_and_boundary():
+    """Adversarial checks on the pure-numpy MAS DP: single-token,
+    single-frame and ragged lengths must all yield valid monotonic
+    surjective paths."""
     rng = np.random.default_rng(0)
     for t_y, t_x in [(1, 1), (5, 1), (7, 3), (12, 12)]:
         neg = rng.normal(size=(1, t_y, t_x)).astype(np.float32)
-        p = mas._maximum_path_numpy(neg, np.array([t_y], np.int32), np.array([t_x], np.int32))
+        p = mas._maximum_path_numpy(
+            neg, np.array([t_y], np.int32), np.array([t_x], np.int32))
         # exactly one token per frame
         assert (p[0, :t_y].sum(axis=1) == 1).all(), (t_y, t_x)
-        # monotonic, non-decreasing token index; starts at 0 ends at t_x-1
+        # monotonic non-decreasing token index; starts at 0, ends at t_x-1
         idx = p[0, :t_y].argmax(axis=1)
         assert idx[0] == 0 and idx[-1] == t_x - 1
         assert (np.diff(idx) >= 0).all() and (np.diff(idx) <= 1).all()
 
 
-def test_training_step_rejects_pathological_short_mel():
-    """A mel shorter than n_sqz frames still yields a finite loss (the
-    decoder trims to a multiple of n_sqz — must not crash or go NaN)."""
-    model = _tiny_generator()
-    x = torch.randint(1, NUM_SYMBOLS, (1, 3), dtype=torch.long)
-    x_lengths = torch.LongTensor([3])
-    mel = torch.randn(1, N_MELS, 2)  # minimum: one squeezed frame
-    mel_lengths = torch.LongTensor([2])
-    z, logdet, m_p, logs_p, logw, logw_, x_mask, y_mask = model(
-        x, x_lengths, mel, mel_lengths)
-    assert torch.isfinite(z).all() and torch.isfinite(logdet).all()
+def test_mas_numpy_prefers_high_likelihood_path():
+    """The DP must actually maximize the summed log-likelihood, not just
+    return any monotonic path: with a strongly diagonal score matrix the
+    chosen path is the diagonal."""
+    t = 6
+    neg = np.full((1, t, t), -10.0, dtype=np.float32)
+    for i in range(t):
+        neg[0, i, i] = 0.0
+    p = mas._maximum_path_numpy(
+        neg, np.array([t], np.int32), np.array([t], np.int32))
+    assert (p[0].argmax(axis=1) == np.arange(t)).all()
 
 
-def test_optimizer_is_plain_adam_no_weight_decay():
-    """Reference glow-tts uses plain Adam with no weight decay — AdamW's
-    default decay silently regularizes the flow and deviates from the recipe."""
-    from phoonnx_train.glowtts.lightning import GlowTTSModel
-    lm = GlowTTSModel(num_symbols=NUM_SYMBOLS, num_speakers=1,
-                      mel_channels=N_MELS, filter_length=64, dataset=None,
-                      gin_channels=0, **TINY_KWARGS)
-    out = lm.configure_optimizers()
-    opt = out["optimizer"]
-    assert type(opt) is torch.optim.Adam
-    assert opt.param_groups[0]["weight_decay"] == 0
-    assert opt.param_groups[0]["betas"] == (0.9, 0.98)
+def test_mas_numpy_ragged_batch_padding_untouched():
+    """Batch entries with shorter true lengths must not write outside their
+    valid region (padding rows/cols stay zero)."""
+    rng = np.random.default_rng(1)
+    neg = rng.normal(size=(2, 10, 8)).astype(np.float32)
+    t_ys = np.array([10, 4], np.int32)
+    t_xs = np.array([8, 3], np.int32)
+    p = mas._maximum_path_numpy(neg, t_ys, t_xs)
+    assert p[1, 4:, :].sum() == 0
+    assert p[1, :, 3:].sum() == 0
+    assert (p[1, :4].sum(axis=1) == 1).all()
 
 
-def test_export_onnx_metadata_and_two_lengths(tmp_path: Path):
-    """Exported graph carries mel_fmin/mel_fmax metadata and runs at two
-    different sequence lengths (dynamic phoneme axis)."""
-    import numpy as np
-    import onnx as onnx_pkg
-    from phoonnx_train.engines.glowtts import GlowTTSTrainingEngine
-    from phoonnx_train.glowtts.lightning import GlowTTSModel
-
-    model = GlowTTSModel(
-        num_symbols=NUM_SYMBOLS, num_speakers=1, mel_channels=N_MELS,
-        dataset=None, gin_channels=0, **TINY_KWARGS,
-    )
-    checkpoint_path = tmp_path / "tiny.ckpt"
-    torch.save({"state_dict": model.state_dict(),
-                "pytorch-lightning_version": pl.__version__,
-                "hyper_parameters": dict(model.hparams)}, checkpoint_path)
-    config_path = tmp_path / "config.json"
-    config_path.write_text('{"audio": {"sample_rate": 22050}}', encoding="utf-8")
-
-    output_path = GlowTTSTrainingEngine().export_onnx(
-        checkpoint_path, config_path, tmp_path)
-
-    meta = {p.key: p.value for p in onnx_pkg.load(str(output_path)).metadata_props}
-    assert meta["engine"] == "glowtts"
-    assert meta["mel_fmin"] == "0.0"
-    assert meta["mel_fmax"] == "8000.0"
-    assert meta["n_mels"] == str(N_MELS)
-
-    session = onnxruntime.InferenceSession(str(output_path))
-    for seq_len in (11, 47):
-        feed = {
-            "input": np.random.randint(1, NUM_SYMBOLS, size=(1, seq_len)).astype(np.int64),
-            "input_lengths": np.array([seq_len], dtype=np.int64),
-            "scales": np.array([0.667, 1.0], dtype=np.float32),
-        }
-        mel = session.run(None, feed)[0]
-        assert mel.ndim == 3 and mel.shape[1] == N_MELS
-        assert np.isfinite(mel).all()
+def test_mas_numpy_zero_scores_still_valid_path():
+    """Degenerate all-zero scores (ties everywhere) must still produce a
+    well-formed monotonic path rather than looping or dropping frames."""
+    t_y, t_x = 9, 4
+    neg = np.zeros((1, t_y, t_x), dtype=np.float32)
+    p = mas._maximum_path_numpy(
+        neg, np.array([t_y], np.int32), np.array([t_x], np.int32))
+    idx = p[0].argmax(axis=1)
+    assert (p[0].sum(axis=1) == 1).all()
+    assert idx[0] == 0 and idx[-1] == t_x - 1
+    assert set(idx) == set(range(t_x))  # surjective: every token gets frames


### PR DESCRIPTION
## Summary

- Adds a self-contained, pure-torch GlowTTS (Kim et al. 2020, [arXiv:2005.11129](https://arxiv.org/abs/2005.11129)) training engine under `phoonnx_train/glowtts/` — Transformer text encoder (reusing the VITS encoder block), invertible flow decoder (ActNorm + grouped invertible 1x1 conv + WN-conditioned affine coupling), Monotonic Alignment Search, and a `GlowTTSModel` LightningModule.
- Registered as the `"glowtts"` engine in the shared training-engine registry (`phoonnx_train/engines/glowtts.py`), implementing the `BaseTrainingEngine` contract (`create_model` / `export_onnx` / `quality_presets` x-low/medium/high). The engine module is torch-free at import — heavy imports are deferred until a model is built or exported.
- Training math follows the original reference implementation (jaywalnut310/glow-tts, MIT; see the fidelity notes in `phoonnx_train/glowtts/__init__.py`): MLE loss = per-element-normalized flow NLL − log-det + `0.5*log(2π)`; duration loss = MSE on log-durations; plain Adam (no weight decay), betas (0.9, 0.98), eps 1e-9, Noam warmup (4000 steps) normalized so `learning_rate` is the post-warmup peak (reference peak ≈ 1.14e-3 at dim 192).
- MAS reuses the compiled Cython kernel vendored for VITS (`phoonnx_train/vits/monotonic_align`) when built, with a pure-numpy DP fallback of the same paper Algorithm 1 — no compiled extension needed for tests or small runs.
- `export_onnx` traces only the inference pass (`input` / `input_lengths` / `scales` → `[B, n_mels, T]` mel), matching `phoonnx.engines.glowtts.GlowTTSAdapter`'s contract (verified via `GlowTTSAdapter.detect()` in tests). Only the mel model is produced — the vocoder is a separate ONNX artifact (HiFi-GAN / Vocos / Griffin-Lim).
  - The invertible 1x1 conv's reverse pass calls `torch.inverse`, which has no ONNX symbolic; `store_inverse()` precomputes the inverse weights so the traced reverse graph is a plain `conv2d`.
  - The mel output's channel axis is pinned to the concrete `n_mels` post-export (shape inference otherwise stamps it symbolic), keeping `GlowTTSAdapter.detect()`'s shape heuristic working.
  - The mel basis is pinned to fmin 0 / fmax 8000 Hz (matching HiFi-GAN-family vocoder configs) and recorded in the ONNX metadata together with `engine`, `n_mels`, sample rate and phonemizer info.
- Docs: training section in `docs/glowtts.md` (preprocess/train/export CLI, quality presets, architecture, multi-speaker, `ovos-tts-plugin-phoonnx` wiring) and a GlowTTS engine section in `TRAINING.md`.
- Tests in `tests/test_glowtts_training.py` are fully torch-free (per the training-engine test convention): engine registry and preset contracts, a torch-blocked file-path import of the engine module, export fast-fail on missing checkpoint / malformed config, and adversarial pure-numpy MAS checks (boundary lengths, ragged batches, tie-breaking, path optimality). The torch-dependent training/export/onnxruntime behavior is exercised in the CPU smoke below.

## Test plan

- `tests/test_glowtts_training.py` is torch-free (registry, presets, torch-blocked file-path import of the engine module, export fast-fail paths, pure-numpy MAS boundary/monotonicity/optimality checks) and passes both with torch installed and with torch imports blocked; the existing `tests/test_glowtts.py` / `tests/test_engines.py` / `tests/test_mixertts_training.py` suites pass locally on CPU.
- CPU smoke on a synthetic preprocessed dataset (`dataset.jsonl` + cached `audio_norm_path`/`audio_spec_path` tensors): 1-epoch `train.py --engine glowtts` run, resume via `--resume-from-checkpoint`, `export_onnx.py --engine glowtts`, and onnxruntime inference at two sequence lengths (13 → `[1, 80, 24]`, 57 → `[1, 80, 90]`, all finite; `GlowTTSAdapter.detect()` true; metadata `mel_fmin=0.0` / `mel_fmax=8000.0`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GlowTTS as a built-in engine for training text-to-mel speech models.
  * Added configurable quality presets and support for multi-speaker training.
  * Added ONNX export for mel-spectrogram models, designed to work with a separate vocoder.
* **Documentation**
  * Added comprehensive GlowTTS training, export, configuration, architecture, and usage guidance.
* **Tests**
  * Added coverage for engine registration, presets, configuration handling, export validation, and alignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->