### PR TITLE
feat: FastPitch/SpeedySpeech training engine

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -165,7 +165,9 @@ train time — no separate preprocessing pass is required to switch between `vit
 FastPitch's pitch predictor needs a frame-level F0 target. The engine implements
 `extra_preprocess` (same contract as the OptiSpeech training engine) to extract F0 via
 `pyworld` (DIO + StoneMask) and cache it as `<utterance>.f0.npy` next to the
-spectrogram cache. Install with `phoonnx[train,train-fastpitch]`. If `pyworld`/`librosa`
+spectrogram cache. F0 is computed on the same trimmed/normalized audio the mels come
+from, at a frame period matched to the mel hop, so the pitch track is frame-aligned
+with the mel target. Install with `phoonnx[train,train-fastpitch]`. If `pyworld`/`librosa`
 aren't installed, training still runs — the pitch predictor trains without a target
 loss term (a warning is logged) — but real pitch conditioning requires the extra.
 SpeedySpeech does not use pitch at all.

--- a/docs/training.md
+++ b/docs/training.md
@@ -189,8 +189,9 @@ encoder family and pitch predictor.
 
 ### Export
 
-`export_onnx` emits the `token_ids` [B,T] (+ optional `speaker` [B] for
-multi-speaker models) → `mel_spec` [B, 80, T_mel] contract, matching
+`export_onnx` emits the `token_ids` [B,T] + `pace`/`pitch_mul`/`pitch_add` [1]
+control inputs (+ optional `speaker` [B] for multi-speaker models) →
+`mel_spec` [B, 80, T_mel] contract, matching
 `scripts/conversion/coqui_fastpitch_export/export_fp.py` (used to convert
 pretrained Coqui checkpoints) and consumed by `phoonnx.engines.fastpitch.FastPitchAdapter`
 (which reuses `MixerTTSAdapter`'s mel→vocoder inference path — FastPitch is a

--- a/docs/training.md
+++ b/docs/training.md
@@ -131,3 +131,91 @@ os.environ["PHONEMIZED_DATASET_PATH"] = "/kaggle/working/training"
 os.environ["BASE_CKPT_URL"] = "https://..."   # optional: base checkpoint for fine-tuning
 os.environ["LOCAL_CKPT_PATH"] = "/kaggle/working/base.ckpt"
 ```
+
+---
+
+## FastPitch / SpeedySpeech training (`--engine fastpitch` / `--engine speedyspeech`)
+
+`phoonnx_train` includes a training engine for the Coqui **ForwardTTS** family —
+[FastPitch](https://arxiv.org/abs/2006.06873) and
+[SpeedySpeech](https://arxiv.org/abs/2008.03802) are both configurations of the same
+non-autoregressive text→mel model: an encoder produces per-token states, a duration
+predictor expands them to frame rate, and a decoder renders an 80-channel mel.
+Durations are learned **unsupervised** (no external aligner or forced-alignment step
+needed) via an attention-based alignment network + monotonic alignment search, the
+same recipe as upstream FastPitch.
+
+| | FastPitch | SpeedySpeech |
+|---|---|---|
+| encoder/decoder | FFT-transformer | residual conv-BN |
+| pitch predictor | on | off |
+| relative size | larger, higher quality | smaller, faster |
+
+The model/loss code is vendored in `phoonnx_train/fastpitch/` — a self-contained,
+pure-torch port of coqui-ai/TTS's `TTS/tts/models/forward_tts.py` and the layers it
+uses (© Coqui GmbH, MPL-2.0; see the license note in
+`phoonnx_train/fastpitch/__init__.py`), with no dependency on the unmaintained `TTS`
+package. It reuses the shared VITS preprocessing pipeline (`audio_norm_path` /
+`audio_spec_path`) and derives the mel target from the cached linear spectrogram at
+train time — no separate preprocessing pass is required to switch between `vits` and
+`fastpitch`/`speedyspeech` on the same phonemized dataset.
+
+### Pitch (F0) extraction
+
+FastPitch's pitch predictor needs a frame-level F0 target. The engine implements
+`extra_preprocess` (same contract as the OptiSpeech training engine) to extract F0 via
+`pyworld` (DIO + StoneMask) and cache it as `<utterance>.f0.npy` next to the
+spectrogram cache. Install with `phoonnx[train,train-fastpitch]`. If `pyworld`/`librosa`
+aren't installed, training still runs — the pitch predictor trains without a target
+loss term (a warning is logged) — but real pitch conditioning requires the extra.
+SpeedySpeech does not use pitch at all.
+
+### Selecting the variant
+
+```sh
+python -m phoonnx_train.train --engine fastpitch ...      # FastPitch (FFT-transformer, pitch on)
+python -m phoonnx_train.train --engine speedyspeech ...   # SpeedySpeech (residual conv-BN, no pitch)
+```
+
+Both are the same underlying engine class (`ForwardTTSTrainingEngine`); the
+`--engine` name only changes the *default* `variant`. It can also be set explicitly
+via the engine's `extra` config (e.g. `variant: speedyspeech`) to mix-and-match
+encoder family and pitch predictor.
+
+### Quality presets
+
+`--quality` selects `x-low` / `medium` / `high`, scaling `hidden_channels`,
+`hidden_channels_ffn`, and the encoder/decoder layer count.
+
+### Export
+
+`export_onnx` emits the `token_ids` [B,T] (+ optional `speaker` [B] for
+multi-speaker models) → `mel_spec` [B, 80, T_mel] contract, matching
+`scripts/conversion/coqui_fastpitch_export/export_fp.py` (used to convert
+pretrained Coqui checkpoints) and consumed by `phoonnx.engines.fastpitch.FastPitchAdapter`
+(which reuses `MixerTTSAdapter`'s mel→vocoder inference path — FastPitch is a
+**two-stage** model, so a separate vocoder is required at inference time, same as
+Mixer-TTS/GlowTTS/Matcha).
+
+### Downstream OVOS TTS plugin config
+
+```json
+{
+  "tts": {
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "voice": "/path/to/exported/model.onnx",
+      "config": "/path/to/exported/config.json",
+      "engine_params": {
+        "vocoder_path": "/path/to/vocoder.onnx",
+        "vocoder_type": "hifigan"
+      }
+    }
+  }
+}
+```
+
+The native `config.json`'s `"engine"` field must be `"fastpitch"` (or `"fast_pitch"`)
+so `phoonnx`'s engine auto-detection routes to `FastPitchAdapter` instead of
+`MixerTTSAdapter` (the two share an identical ONNX I/O contract and are only told
+apart by this field).

--- a/phoonnx_train/engines/__init__.py
+++ b/phoonnx_train/engines/__init__.py
@@ -93,9 +93,15 @@ def _register_builtins() -> None:
     # registry stays importable in torch-free environments.
     from phoonnx_train.engines.matcha import MatchaTrainingEngine
     from phoonnx_train.engines.vits import VitsTrainingEngine
+    from phoonnx_train.engines.fastpitch import (
+        ForwardTTSTrainingEngine,
+        SpeedySpeechTrainingEngine,
+    )
 
     register_engine("vits", VitsTrainingEngine)
     register_engine("matcha", MatchaTrainingEngine)
+    register_engine("fastpitch", ForwardTTSTrainingEngine)
+    register_engine("speedyspeech", SpeedySpeechTrainingEngine)
 
 
 _register_builtins()

--- a/phoonnx_train/engines/fastpitch.py
+++ b/phoonnx_train/engines/fastpitch.py
@@ -130,6 +130,48 @@ class ForwardTTSDataset(Dataset):
         self.sample_rate = sample_rate
         self.mel_fmin = mel_fmin
         self.mel_fmax = mel_fmax
+        # corpus F0 statistics over voiced frames — the pitch target is
+        # z-scored so its scale matches the other loss terms and the
+        # pitch_mul/pitch_add inference controls operate on a normalized
+        # quantity (raw Hz would dwarf every other loss)
+        self.pitch_mean, self.pitch_std = self._pitch_stats(dataset_paths)
+
+    def _f0_candidate(self, utt: "Utterance") -> Path:
+        return Path(str(utt.audio_spec_path)).with_suffix("").with_suffix(".f0.npy")
+
+    def _pitch_stats(self, dataset_paths: List[Path]):
+        import json
+
+        import numpy as np
+
+        stats_path = None
+        for p in dataset_paths:
+            p = Path(p)
+            if p.is_dir():
+                stats_path = p / "pitch_stats.json"
+                break
+        if stats_path and stats_path.is_file():
+            stats = json.loads(stats_path.read_text())
+            return float(stats["mean"]), float(stats["std"])
+
+        voiced = []
+        for utt in self._inner.utterances:
+            cand = self._f0_candidate(utt)
+            if cand.exists():
+                f0 = np.load(cand)
+                voiced.append(f0[f0 > 0])
+        if not voiced:
+            return 0.0, 1.0  # no pitch caches — identity normalization
+        allv = np.concatenate(voiced)
+        mean = float(allv.mean()) if allv.size else 0.0
+        std = float(allv.std()) if allv.size else 1.0
+        std = std or 1.0
+        if stats_path:
+            try:
+                stats_path.write_text(json.dumps({"mean": mean, "std": std}))
+            except OSError:
+                pass
+        return mean, std
 
     def __len__(self) -> int:
         return len(self._inner)
@@ -143,15 +185,17 @@ class ForwardTTSDataset(Dataset):
         ).squeeze(0)  # [mel_channels, T]
 
         pitch = None
-        pitch_path = getattr(utt, "audio_norm_path", None)
         # optional sidecar cache written by extra_preprocess: "<stem>.f0.npy"
         # next to audio_norm_path's parent cache dir.
-        f0_candidate = Path(str(utt.audio_spec_path)).with_suffix("").with_suffix(".f0.npy")
+        f0_candidate = self._f0_candidate(utt)
         if f0_candidate.exists():
             import numpy as np
 
-            f0 = np.load(f0_candidate)
-            pitch = torch.from_numpy(f0.astype("float32")).unsqueeze(0)  # [1, T_f0]
+            f0 = np.load(f0_candidate).astype("float32")
+            # z-score voiced frames with the corpus stats; unvoiced stays 0
+            voiced = f0 > 0
+            f0[voiced] = (f0[voiced] - self.pitch_mean) / self.pitch_std
+            pitch = torch.from_numpy(f0).unsqueeze(0)  # [1, T_f0]
 
         return UtteranceTensors(
             phoneme_ids=LongTensor(utt.phoneme_ids),
@@ -226,6 +270,7 @@ class ForwardTTSModule(pl.LightningModule):
         num_test_examples: int = 5,
         max_phoneme_ids: Optional[int] = None,
         binary_loss_start_epoch: int = 0,
+        binary_loss_warmup_epochs: int = 10,
         **kwargs: Any,
     ):
         super().__init__()
@@ -333,9 +378,12 @@ class ForwardTTSModule(pl.LightningModule):
         return losses
 
     def training_step(self, batch: Batch, batch_idx: int):
-        binary_loss_weight = min(
-            1.0, max(0.0, (self.current_epoch - self.hparams.binary_loss_start_epoch) / 10.0)
-        ) if self.hparams.binary_loss_start_epoch else 1.0
+        # ramp the binary alignment loss in over binary_loss_warmup_epochs
+        # starting at binary_loss_start_epoch — full-strength binarization
+        # against a still-random soft alignment destabilizes the aligner
+        warmup = max(1, self.hparams.binary_loss_warmup_epochs)
+        binary_loss_weight = min(1.0, max(
+            0.0, (self.current_epoch - self.hparams.binary_loss_start_epoch + 1) / warmup))
         losses = self._step(batch, binary_loss_weight=binary_loss_weight)
         self.log_dict({f"train_{k}": v for k, v in losses.items()}, prog_bar=False)
         return losses["loss"]
@@ -418,32 +466,42 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         multispeaker = num_speakers > 1
 
         class _InferWrapper(torch.nn.Module):
+            """pace / pitch_mul / pitch_add are graph inputs so the
+            FastPitchAdapter's speed and pitch controls actually reach the
+            model (traced as constants they would be silent no-ops)."""
+
             def __init__(self, m: ForwardTTS, multispeaker: bool):
                 super().__init__()
                 self.m = m
                 self.multispeaker = multispeaker
 
             def forward(self, token_ids: torch.Tensor,
+                       pace: torch.Tensor,
+                       pitch_mul: torch.Tensor,
+                       pitch_add: torch.Tensor,
                        speaker: Optional[torch.Tensor] = None) -> torch.Tensor:
                 sid = speaker if self.multispeaker else None
-                return self.m.inference(token_ids, speaker=sid)
+                return self.m.inference(token_ids, speaker=sid, pace=pace,
+                                        pitch_mul=pitch_mul, pitch_add=pitch_add)
 
         wrapper = _InferWrapper(model, multispeaker)
         wrapper.eval()
 
         dummy_ids = torch.randint(low=1, high=max(2, num_symbols - 1), size=(1, 30), dtype=torch.long)
+        dummy_controls = (torch.ones(1), torch.ones(1), torch.zeros(1))
+        control_names = ["pace", "pitch_mul", "pitch_add"]
         if multispeaker:
             dummy_speaker = torch.zeros(1, dtype=torch.long)
-            dummy_args: Tuple[Any, ...] = (dummy_ids, dummy_speaker)
-            input_names = ["token_ids", "speaker"]
+            dummy_args: Tuple[Any, ...] = (dummy_ids, *dummy_controls, dummy_speaker)
+            input_names = ["token_ids", *control_names, "speaker"]
             dynamic_axes = {
                 "token_ids": {0: "batch_size", 1: "phonemes"},
                 "speaker": {0: "batch_size"},
                 "mel_spec": {0: "batch_size", 2: "frame"},
             }
         else:
-            dummy_args = (dummy_ids,)
-            input_names = ["token_ids"]
+            dummy_args = (dummy_ids, *dummy_controls)
+            input_names = ["token_ids", *control_names]
             dynamic_axes = {
                 "token_ids": {0: "batch_size", 1: "phonemes"},
                 "mel_spec": {0: "batch_size", 2: "frame"},

--- a/phoonnx_train/engines/fastpitch.py
+++ b/phoonnx_train/engines/fastpitch.py
@@ -1,0 +1,572 @@
+"""
+FastPitch / SpeedySpeech training engine adapter.
+
+Both architectures are configurations of the vendored ``ForwardTTS`` model
+(``phoonnx_train/fastpitch/model.py`` — a self-contained, pure-torch port of
+coqui-ai/TTS's ``TTS/tts/models/forward_tts.py``, MPL-2.0, see
+``phoonnx_train/fastpitch/__init__.py`` for the license note):
+
+- **FastPitch**: FFT-transformer encoder/decoder, pitch predictor on.
+- **SpeedySpeech**: residual conv-BN encoder/decoder, no pitch predictor.
+
+Durations are learned unsupervised (no external aligner needed) via the
+vendored ``AlignmentNetwork`` + monotonic alignment search, same recipe as
+upstream FastPitch/coqui.
+
+Reuses the shared VITS preprocessing pipeline: ``audio_norm_path`` /
+``audio_spec_path`` (linear spectrogram) are produced by
+``phoonnx_train.preprocess``; the mel target is derived from the linear
+spectrogram at train time via ``phoonnx_train.vits.mel_processing`` (no
+separate mel cache needed). Pitch (F0) is extracted via
+``extra_preprocess`` (pyworld), following the same contract used by the
+OptiSpeech training engine.
+
+ONNX export follows the contract consumed by ``phoonnx.engines.fastpitch``
+(``FastPitchAdapter``, which reuses ``MixerTTSAdapter``'s feed/parse logic):
+inputs ``token_ids`` [B,T] (+ optional ``speaker`` [B] for multi-speaker) ->
+output ``mel_spec`` [B, 80, T_mel]. This mirrors
+``scripts/conversion/coqui_fastpitch_export/export_fp.py``, which exports
+pretrained Coqui FastPitch/SpeedySpeech checkpoints with the same I/O.
+"""
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytorch_lightning as pl
+import torch
+from torch import LongTensor
+from torch.utils.data import DataLoader, Dataset, random_split
+
+from phoonnx_train.engines.base import BaseTrainingEngine, TrainingEngineConfig
+from phoonnx_train.fastpitch.losses import ForwardTTSLoss
+from phoonnx_train.fastpitch.model import ForwardTTS, ForwardTTSArgs
+from phoonnx_train.vits.dataset import PhoonnxDataset, Utterance
+from phoonnx_train.vits.mel_processing import spec_to_mel_torch
+
+_LOG = logging.getLogger(__name__)
+
+# ONNX opset used for export (matches coqui_fastpitch_export/export_fp.py)
+OPSET_VERSION = 14
+
+# Quality tier -> ForwardTTS hyper-param overrides.
+# "variant" selects encoder/decoder family + pitch predictor (set via
+# ``config.extra['variant']``, default "fastpitch").
+_QUALITY_PRESETS: Dict[str, Dict[str, Any]] = {
+    "x-low": {
+        "hidden_channels": 128,
+        "hidden_channels_ffn": 512,
+        "encoder_num_layers": 4,
+        "decoder_num_layers": 4,
+        "num_heads": 1,
+    },
+    "medium": {
+        "hidden_channels": 384,
+        "hidden_channels_ffn": 1024,
+        "encoder_num_layers": 6,
+        "decoder_num_layers": 6,
+        "num_heads": 1,
+    },
+    "high": {
+        "hidden_channels": 512,
+        "hidden_channels_ffn": 1536,
+        "encoder_num_layers": 6,
+        "decoder_num_layers": 6,
+        "num_heads": 2,
+    },
+}
+
+# SpeedySpeech-specific overrides layered on top of the tier preset when
+# ``variant == "speedyspeech"``.
+_SPEEDYSPEECH_OVERRIDES: Dict[str, Any] = {
+    "encoder_type": "residual_conv_bn",
+    "decoder_type": "residual_conv_bn",
+    "use_pitch": False,
+}
+
+
+class UtteranceTensors:
+    """Per-utterance training tensors: ids, mel (via spec), optional f0."""
+
+    __slots__ = ("phoneme_ids", "spectrogram", "speaker_id", "pitch")
+
+    def __init__(self, phoneme_ids: LongTensor, spectrogram: torch.Tensor,
+                 speaker_id: Optional[LongTensor], pitch: Optional[torch.Tensor]):
+        self.phoneme_ids = phoneme_ids
+        self.spectrogram = spectrogram
+        self.speaker_id = speaker_id
+        self.pitch = pitch
+
+
+class Batch:
+    __slots__ = (
+        "phoneme_ids", "phoneme_lengths", "mels", "mel_lengths",
+        "pitch", "speaker_ids",
+    )
+
+    def __init__(self, phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids):
+        self.phoneme_ids = phoneme_ids
+        self.phoneme_lengths = phoneme_lengths
+        self.mels = mels
+        self.mel_lengths = mel_lengths
+        self.pitch = pitch
+        self.speaker_ids = speaker_ids
+
+
+class ForwardTTSDataset(Dataset):
+    """
+    Wraps :class:`phoonnx_train.vits.dataset.PhoonnxDataset` utterances,
+    converting the shared linear-spectrogram cache to mel at load time and
+    optionally loading a pitch (F0) cache produced by
+    :meth:`ForwardTTSTrainingEngine.extra_preprocess`.
+    """
+
+    def __init__(self, dataset_paths: List[Path], mel_channels: int,
+                 filter_length: int, sample_rate: int,
+                 mel_fmin: float, mel_fmax: Optional[float],
+                 max_phoneme_ids: Optional[int] = None):
+        self._inner = PhoonnxDataset(dataset_paths, max_phoneme_ids=max_phoneme_ids)
+        self.mel_channels = mel_channels
+        self.filter_length = filter_length
+        self.sample_rate = sample_rate
+        self.mel_fmin = mel_fmin
+        self.mel_fmax = mel_fmax
+
+    def __len__(self) -> int:
+        return len(self._inner)
+
+    def __getitem__(self, idx: int) -> UtteranceTensors:
+        utt: Utterance = self._inner.utterances[idx]
+        spec = torch.load(utt.audio_spec_path)  # [n_fft//2+1, T]
+        mel = spec_to_mel_torch(
+            spec.unsqueeze(0), self.filter_length, self.mel_channels,
+            self.sample_rate, self.mel_fmin, self.mel_fmax,
+        ).squeeze(0)  # [mel_channels, T]
+
+        pitch = None
+        pitch_path = getattr(utt, "audio_norm_path", None)
+        # optional sidecar cache written by extra_preprocess: "<stem>.f0.npy"
+        # next to audio_norm_path's parent cache dir.
+        f0_candidate = Path(str(utt.audio_spec_path)).with_suffix("").with_suffix(".f0.npy")
+        if f0_candidate.exists():
+            import numpy as np
+
+            f0 = np.load(f0_candidate)
+            pitch = torch.from_numpy(f0.astype("float32")).unsqueeze(0)  # [1, T_f0]
+
+        return UtteranceTensors(
+            phoneme_ids=LongTensor(utt.phoneme_ids),
+            spectrogram=mel,
+            speaker_id=LongTensor([utt.speaker_id]) if utt.speaker_id is not None else None,
+            pitch=pitch,
+        )
+
+
+class ForwardTTSCollate:
+    def __init__(self, is_multispeaker: bool, use_pitch: bool):
+        self.is_multispeaker = is_multispeaker
+        self.use_pitch = use_pitch
+
+    def __call__(self, utterances: List[UtteranceTensors]) -> Batch:
+        n = len(utterances)
+        max_ph = max(u.phoneme_ids.size(0) for u in utterances)
+        max_mel = max(u.spectrogram.size(1) for u in utterances)
+        mel_channels = utterances[0].spectrogram.size(0)
+
+        phoneme_ids = torch.zeros(n, max_ph, dtype=torch.long)
+        phoneme_lengths = torch.zeros(n, dtype=torch.long)
+        mels = torch.zeros(n, mel_channels, max_mel)
+        mel_lengths = torch.zeros(n, dtype=torch.long)
+        pitch = torch.zeros(n, 1, max_mel) if self.use_pitch else None
+        speaker_ids = torch.zeros(n, dtype=torch.long) if self.is_multispeaker else None
+
+        for i, utt in enumerate(utterances):
+            pl_ = utt.phoneme_ids.size(0)
+            ml = utt.spectrogram.size(1)
+            phoneme_ids[i, :pl_] = utt.phoneme_ids
+            phoneme_lengths[i] = pl_
+            mels[i, :, :ml] = utt.spectrogram
+            mel_lengths[i] = ml
+            if self.use_pitch and utt.pitch is not None:
+                pl_len = min(utt.pitch.size(-1), max_mel)
+                pitch[i, :, :pl_len] = utt.pitch[:, :pl_len]
+            if speaker_ids is not None and utt.speaker_id is not None:
+                speaker_ids[i] = utt.speaker_id
+
+        return Batch(phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids)
+
+
+class ForwardTTSModule(pl.LightningModule):
+    """LightningModule wrapping the vendored :class:`ForwardTTS` model."""
+
+    def __init__(
+        self,
+        num_symbols: int,
+        num_speakers: int = 1,
+        sample_rate: int = 22050,
+        filter_length: int = 1024,
+        mel_channels: int = 80,
+        mel_fmin: float = 0.0,
+        mel_fmax: Optional[float] = None,
+        variant: str = "fastpitch",
+        hidden_channels: int = 384,
+        hidden_channels_ffn: int = 1024,
+        encoder_num_layers: int = 6,
+        decoder_num_layers: int = 6,
+        num_heads: int = 1,
+        use_pitch: Optional[bool] = None,
+        use_energy: bool = False,
+        dataset: Optional[List[Path]] = None,
+        learning_rate: float = 1e-4,
+        betas: Tuple[float, float] = (0.9, 0.998),
+        eps: float = 1e-9,
+        weight_decay: float = 1e-6,
+        batch_size: int = 8,
+        num_workers: int = 1,
+        validation_split: float = 0.1,
+        num_test_examples: int = 5,
+        max_phoneme_ids: Optional[int] = None,
+        binary_loss_start_epoch: int = 0,
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self.save_hyperparameters()
+
+        variant_overrides: Dict[str, Any] = {}
+        if variant == "speedyspeech":
+            variant_overrides.update(_SPEEDYSPEECH_OVERRIDES)
+        if use_pitch is not None:
+            variant_overrides["use_pitch"] = use_pitch
+
+        args = ForwardTTSArgs(
+            num_chars=num_symbols,
+            out_channels=mel_channels,
+            hidden_channels=hidden_channels,
+            hidden_channels_ffn=hidden_channels_ffn,
+            encoder_num_layers=encoder_num_layers,
+            decoder_num_layers=decoder_num_layers,
+            num_heads=num_heads,
+            use_energy=use_energy,
+            num_speakers=num_speakers,
+            **variant_overrides,
+        )
+        self.model_args = args
+        self.model = ForwardTTS(args)
+        self.criterion = ForwardTTSLoss()
+
+        self._train_dataset: Optional[Dataset] = None
+        self._val_dataset: Optional[Dataset] = None
+        self._test_dataset: Optional[Dataset] = None
+        self._load_datasets(validation_split, num_test_examples, max_phoneme_ids)
+
+    # ------------------------------------------------------------------
+    def _load_datasets(self, validation_split: float, num_test_examples: int,
+                       max_phoneme_ids: Optional[int]) -> None:
+        if not self.hparams.dataset:
+            _LOG.debug("No dataset to load")
+            return
+        full_dataset = ForwardTTSDataset(
+            self.hparams.dataset,
+            mel_channels=self.hparams.mel_channels,
+            filter_length=self.hparams.filter_length,
+            sample_rate=self.hparams.sample_rate,
+            mel_fmin=self.hparams.mel_fmin,
+            mel_fmax=self.hparams.mel_fmax,
+            max_phoneme_ids=max_phoneme_ids,
+        )
+        valid_size = max(0, int(len(full_dataset) * validation_split))
+        test_size = min(num_test_examples, max(0, len(full_dataset) - valid_size))
+        train_size = len(full_dataset) - valid_size - test_size
+        self._train_dataset, self._test_dataset, self._val_dataset = random_split(
+            full_dataset, [train_size, test_size, valid_size]
+        )
+
+    def _collate(self) -> ForwardTTSCollate:
+        return ForwardTTSCollate(
+            is_multispeaker=self.hparams.num_speakers > 1,
+            use_pitch=bool(self.model_args.use_pitch),
+        )
+
+    def train_dataloader(self):
+        return DataLoader(self._train_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size, shuffle=True)
+
+    def val_dataloader(self):
+        return DataLoader(self._val_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size)
+
+    def test_dataloader(self):
+        return DataLoader(self._test_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size)
+
+    # ------------------------------------------------------------------
+    def forward(self, x, pace: float = 1.0, pitch_mul: float = 1.0,
+               pitch_add: float = 0.0, speaker=None):
+        return self.model.inference(x, speaker=speaker, pace=pace,
+                                    pitch_mul=pitch_mul, pitch_add=pitch_add)
+
+    def _step(self, batch: Batch, binary_loss_weight: float = 1.0) -> Dict[str, torch.Tensor]:
+        outputs = self.model(
+            x=batch.phoneme_ids,
+            x_lengths=batch.phoneme_lengths,
+            y=batch.mels,
+            y_lengths=batch.mel_lengths,
+            pitch=batch.pitch,
+            speaker=batch.speaker_ids,
+        )
+        losses = self.criterion(
+            decoder_output=outputs["model_outputs"],
+            decoder_target=batch.mels.transpose(1, 2),
+            decoder_output_lens=batch.mel_lengths,
+            dur_output=outputs["durations_log"],
+            dur_target=outputs["durations"],
+            input_lens=batch.phoneme_lengths,
+            pitch_output=outputs["pitch_avg_pred"],
+            pitch_target=outputs["pitch_avg"],
+            aligner_logprob=outputs["alignment_logprob"],
+            alignment_hard=outputs["alignment_hard"],
+            alignment_soft=outputs["alignment_soft"],
+            binary_loss_weight=binary_loss_weight,
+        )
+        return losses
+
+    def training_step(self, batch: Batch, batch_idx: int):
+        binary_loss_weight = min(
+            1.0, max(0.0, (self.current_epoch - self.hparams.binary_loss_start_epoch) / 10.0)
+        ) if self.hparams.binary_loss_start_epoch else 1.0
+        losses = self._step(batch, binary_loss_weight=binary_loss_weight)
+        self.log_dict({f"train_{k}": v for k, v in losses.items()}, prog_bar=False)
+        return losses["loss"]
+
+    def validation_step(self, batch: Batch, batch_idx: int):
+        losses = self._step(batch)
+        self.log_dict({f"val_{k}": v for k, v in losses.items()})
+        return losses["loss"]
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.AdamW(
+            self.model.parameters(),
+            lr=self.hparams.learning_rate,
+            betas=self.hparams.betas,
+            eps=self.hparams.eps,
+            weight_decay=self.hparams.weight_decay,
+        )
+        scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.999875)
+        return [optimizer], [scheduler]
+
+
+class ForwardTTSTrainingEngine(BaseTrainingEngine):
+    """Training engine adapter for FastPitch / SpeedySpeech (ForwardTTS).
+
+    Registered twice — as ``"fastpitch"`` and (via
+    :class:`SpeedySpeechTrainingEngine`) as ``"speedyspeech"`` — the only
+    difference being the default ``variant`` used when the caller doesn't
+    set ``config.extra["variant"]`` explicitly.
+    """
+
+    default_variant = "fastpitch"
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    def create_model(
+        self,
+        config: TrainingEngineConfig,
+        dataset_paths: List[Path],
+        **kwargs: Any,
+    ) -> pl.LightningModule:
+        extra = dict(config.extra)
+        extra.setdefault("variant", self.default_variant)
+        return ForwardTTSModule(
+            num_symbols=config.num_symbols,
+            num_speakers=config.num_speakers,
+            sample_rate=config.sample_rate,
+            dataset=[str(p) for p in dataset_paths],
+            **extra,
+            **kwargs,
+        )
+
+    def export_onnx(
+        self,
+        checkpoint_path: Path,
+        config_path: Path,
+        output_dir: Path,
+        **kwargs: Any,
+    ) -> Path:
+        """Export a ForwardTTS checkpoint to ONNX.
+
+        Contract matches ``coqui_fastpitch_export/export_fp.py`` /
+        ``phoonnx.engines.fastpitch.FastPitchAdapter``: ``token_ids`` [B,T]
+        (+ optional ``speaker`` [B]) -> ``mel_spec`` [B, 80, T_mel].
+        """
+        import json
+
+        with open(config_path, "r", encoding="utf-8") as f:
+            model_config: Dict[str, Any] = json.load(f)
+
+        module: ForwardTTSModule = ForwardTTSModule.load_from_checkpoint(
+            checkpoint_path, dataset=None, map_location="cpu",
+        )
+        model = module.model
+        model.eval()
+
+        num_symbols = model.args.num_chars
+        num_speakers = model.args.num_speakers
+        multispeaker = num_speakers > 1
+
+        class _InferWrapper(torch.nn.Module):
+            def __init__(self, m: ForwardTTS, multispeaker: bool):
+                super().__init__()
+                self.m = m
+                self.multispeaker = multispeaker
+
+            def forward(self, token_ids: torch.Tensor,
+                       speaker: Optional[torch.Tensor] = None) -> torch.Tensor:
+                sid = speaker if self.multispeaker else None
+                return self.m.inference(token_ids, speaker=sid)
+
+        wrapper = _InferWrapper(model, multispeaker)
+        wrapper.eval()
+
+        dummy_ids = torch.randint(low=1, high=max(2, num_symbols - 1), size=(1, 30), dtype=torch.long)
+        if multispeaker:
+            dummy_speaker = torch.zeros(1, dtype=torch.long)
+            dummy_args: Tuple[Any, ...] = (dummy_ids, dummy_speaker)
+            input_names = ["token_ids", "speaker"]
+            dynamic_axes = {
+                "token_ids": {0: "batch_size", 1: "phonemes"},
+                "speaker": {0: "batch_size"},
+                "mel_spec": {0: "batch_size", 2: "frame"},
+            }
+        else:
+            dummy_args = (dummy_ids,)
+            input_names = ["token_ids"]
+            dynamic_axes = {
+                "token_ids": {0: "batch_size", 1: "phonemes"},
+                "mel_spec": {0: "batch_size", 2: "frame"},
+            }
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"{checkpoint_path.stem}.onnx"
+
+        export_kwargs: Dict[str, Any] = dict(
+            input_names=input_names,
+            output_names=["mel_spec"],
+            dynamic_axes=dynamic_axes,
+            opset_version=OPSET_VERSION,
+        )
+        # torch>=2.5 defaults torch.onnx.export to the dynamo-based exporter,
+        # which additionally requires the optional 'onnxscript' package.
+        # Force the legacy TorchScript-tracing exporter (matches
+        # coqui_fastpitch_export/export_fp.py) when the kwarg is available.
+        if "dynamo" in torch.onnx.export.__code__.co_varnames:
+            export_kwargs["dynamo"] = False
+
+        with torch.no_grad():
+            torch.onnx.export(wrapper, dummy_args, str(output_path), **export_kwargs)
+
+        try:
+            import onnx as _onnx
+
+            onnx_model = _onnx.load(str(output_path))
+            del onnx_model.metadata_props[:]
+            for key, value in {
+                "model_type": "fastpitch" if module.hparams.variant == "fastpitch" else "speedyspeech",
+                "engine": module.hparams.variant,
+                "n_speakers": num_speakers,
+                "n_vocab": num_symbols,
+                "sample_rate": model_config.get("audio", {}).get("sample_rate", module.hparams.sample_rate),
+                "alphabet": model_config.get("alphabet", ""),
+                "phoneme_type": model_config.get("phoneme_type", ""),
+                "phonemizer_model": model_config.get("phonemizer_model", ""),
+                "phoneme_id_map": json.dumps(model_config.get("phoneme_id_map", {})),
+                "has_espeak": model_config.get("phoneme_type", "") == "espeak",
+            }.items():
+                meta = onnx_model.metadata_props.add()
+                meta.key = key
+                meta.value = str(value)
+            _onnx.save(onnx_model, str(output_path))
+        except ImportError:
+            _LOG.warning("onnx package not installed — skipping metadata")
+
+        _LOG.info("Exported ForwardTTS (%s) ONNX model to %s", module.hparams.variant, output_path)
+        return output_path
+
+    def quality_presets(self) -> Dict[str, Dict[str, Any]]:
+        return _QUALITY_PRESETS
+
+    # ------------------------------------------------------------------
+    # Optional
+    # ------------------------------------------------------------------
+
+    def extra_preprocess(
+        self,
+        utterance_audio_path: Path,
+        cache_dir: Path,
+        sample_rate: int,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Extract F0 (pitch) via pyworld; cached alongside the mel cache.
+
+        Same contract as the OptiSpeech training engine's
+        ``extra_preprocess`` (pyworld DIO + StoneMask). SpeedySpeech does
+        not use pitch, but the field is harmless to compute/cache and lets
+        the same preprocessed dataset be reused for either variant.
+        """
+        import numpy as np
+
+        try:
+            import librosa
+            import pyworld as pw
+        except ImportError:
+            _LOG.warning(
+                "pyworld/librosa not installed — skipping F0 extraction "
+                "(FastPitch pitch predictor will train without a target; "
+                "install phoonnx[train,train-fastpitch] for real pitch)."
+            )
+            return {}
+
+        wav, sr = librosa.load(str(utterance_audio_path), sr=sample_rate, mono=True)
+        wav_double = wav.astype(np.float64)
+        f0, timeaxis = pw.dio(wav_double, sr)
+        f0 = pw.stonemask(wav_double, f0, timeaxis, sr).astype(np.float32)
+
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        stem = utterance_audio_path.stem
+        f0_path = cache_dir / f"{stem}.f0.npy"
+        np.save(f0_path, f0)
+
+        return {"f0_path": str(f0_path)}
+
+    def load_checkpoint(
+        self,
+        model: pl.LightningModule,
+        checkpoint_path: Path,
+        **kwargs: Any,
+    ) -> pl.LightningModule:
+        """Tolerant checkpoint load (skips shape-mismatched tensors, e.g.
+        when fine-tuning onto a different phoneme inventory)."""
+        ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+        state_dict = ckpt.get("state_dict", ckpt)
+        model_state = model.state_dict()
+        filtered = {}
+        for k, v in state_dict.items():
+            if k in model_state and v.shape == model_state[k].shape:
+                filtered[k] = v
+            elif k in model_state:
+                _LOG.warning("Shape mismatch for %s: ckpt=%s model=%s — skipping",
+                            k, v.shape, model_state[k].shape)
+        model.load_state_dict(filtered, strict=False)
+        _LOG.info("Loaded %d/%d parameters from checkpoint", len(filtered), len(model_state))
+        return model
+
+
+class SpeedySpeechTrainingEngine(ForwardTTSTrainingEngine):
+    """Same ``ForwardTTS`` engine, defaulting to the SpeedySpeech variant
+    (residual conv-BN encoder/decoder, no pitch predictor) when
+    ``config.extra["variant"]`` isn't set explicitly."""
+
+    default_variant = "speedyspeech"

--- a/phoonnx_train/engines/fastpitch.py
+++ b/phoonnx_train/engines/fastpitch.py
@@ -13,35 +13,27 @@ Durations are learned unsupervised (no external aligner needed) via the
 vendored ``AlignmentNetwork`` + monotonic alignment search, same recipe as
 upstream FastPitch/coqui.
 
-Reuses the shared VITS preprocessing pipeline: ``audio_norm_path`` /
-``audio_spec_path`` (linear spectrogram) are produced by
-``phoonnx_train.preprocess``; the mel target is derived from the linear
-spectrogram at train time via ``phoonnx_train.vits.mel_processing`` (no
-separate mel cache needed). Pitch (F0) is extracted via
-``extra_preprocess`` (pyworld), following the same contract used by the
-OptiSpeech training engine.
+The LightningModule / dataset / collate live in
+``phoonnx_train.fastpitch.lightning``; heavy torch imports are deferred
+until a model is actually built so the engine registry stays importable in
+torch-free environments.
 
 ONNX export follows the contract consumed by ``phoonnx.engines.fastpitch``
 (``FastPitchAdapter``, which reuses ``MixerTTSAdapter``'s feed/parse logic):
-inputs ``token_ids`` [B,T] (+ optional ``speaker`` [B] for multi-speaker) ->
-output ``mel_spec`` [B, 80, T_mel]. This mirrors
+inputs ``token_ids`` [B,T] + ``pace``/``pitch_mul``/``pitch_add`` [1]
+(+ optional ``speaker`` [B] for multi-speaker) -> output ``mel_spec``
+[B, 80, T_mel]. This mirrors
 ``scripts/conversion/coqui_fastpitch_export/export_fp.py``, which exports
 pretrained Coqui FastPitch/SpeedySpeech checkpoints with the same I/O.
 """
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
-
-import pytorch_lightning as pl
-import torch
-from torch import LongTensor
-from torch.utils.data import DataLoader, Dataset, random_split
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from phoonnx_train.engines.base import BaseTrainingEngine, TrainingEngineConfig
-from phoonnx_train.fastpitch.losses import ForwardTTSLoss
-from phoonnx_train.fastpitch.model import ForwardTTS, ForwardTTSArgs
-from phoonnx_train.vits.dataset import PhoonnxDataset, Utterance
-from phoonnx_train.vits.mel_processing import spec_to_mel_torch
+
+if TYPE_CHECKING:  # heavy import — only needed for type annotations
+    import pytorch_lightning as pl
 
 _LOG = logging.getLogger(__name__)
 
@@ -50,7 +42,7 @@ OPSET_VERSION = 14
 
 # Quality tier -> ForwardTTS hyper-param overrides.
 # "variant" selects encoder/decoder family + pitch predictor (set via
-# ``config.extra['variant']``, default "fastpitch").
+# ``config.extra['variant']``, default per registered engine name).
 _QUALITY_PRESETS: Dict[str, Dict[str, Any]] = {
     "x-low": {
         "hidden_channels": 128,
@@ -75,334 +67,38 @@ _QUALITY_PRESETS: Dict[str, Dict[str, Any]] = {
     },
 }
 
-# SpeedySpeech-specific overrides layered on top of the tier preset when
-# ``variant == "speedyspeech"``.
-_SPEEDYSPEECH_OVERRIDES: Dict[str, Any] = {
-    "encoder_type": "residual_conv_bn",
-    "decoder_type": "residual_conv_bn",
-    "use_pitch": False,
-}
 
+def resolve_module_kwargs(
+    config: TrainingEngineConfig,
+    default_variant: str,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Merge shared config + ``extra`` bag + call-site kwargs into the
+    keyword arguments for ``ForwardTTSModule``.
 
-class UtteranceTensors:
-    """Per-utterance training tensors: ids, mel (via spec), optional f0."""
-
-    __slots__ = ("phoneme_ids", "spectrogram", "speaker_id", "pitch")
-
-    def __init__(self, phoneme_ids: LongTensor, spectrogram: torch.Tensor,
-                 speaker_id: Optional[LongTensor], pitch: Optional[torch.Tensor]):
-        self.phoneme_ids = phoneme_ids
-        self.spectrogram = spectrogram
-        self.speaker_id = speaker_id
-        self.pitch = pitch
-
-
-class Batch:
-    __slots__ = (
-        "phoneme_ids", "phoneme_lengths", "mels", "mel_lengths",
-        "pitch", "speaker_ids",
+    Torch-free (pure dict handling) so it is unit-testable without the
+    training stack. ``extra['quality']``, if present, expands to the
+    matching preset (unknown names fall back to ``medium``); explicit
+    ``extra``/kwargs keys win over preset values, and ``variant`` defaults
+    to *default_variant* when not set explicitly.
+    """
+    extra = dict(config.extra)
+    preset_name = extra.pop("quality", None)
+    merged: Dict[str, Any] = {}
+    if preset_name is not None:
+        if preset_name not in _QUALITY_PRESETS:
+            _LOG.warning("unknown quality %r — falling back to 'medium'", preset_name)
+            preset_name = "medium"
+        merged.update(_QUALITY_PRESETS[preset_name])
+    merged.update(extra)
+    merged.update(kwargs)
+    merged.setdefault("variant", default_variant)
+    merged.update(
+        num_symbols=config.num_symbols,
+        num_speakers=config.num_speakers,
+        sample_rate=config.sample_rate,
     )
-
-    def __init__(self, phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids):
-        self.phoneme_ids = phoneme_ids
-        self.phoneme_lengths = phoneme_lengths
-        self.mels = mels
-        self.mel_lengths = mel_lengths
-        self.pitch = pitch
-        self.speaker_ids = speaker_ids
-
-
-class ForwardTTSDataset(Dataset):
-    """
-    Wraps :class:`phoonnx_train.vits.dataset.PhoonnxDataset` utterances,
-    converting the shared linear-spectrogram cache to mel at load time and
-    optionally loading a pitch (F0) cache produced by
-    :meth:`ForwardTTSTrainingEngine.extra_preprocess`.
-    """
-
-    def __init__(self, dataset_paths: List[Path], mel_channels: int,
-                 filter_length: int, sample_rate: int,
-                 mel_fmin: float, mel_fmax: Optional[float],
-                 max_phoneme_ids: Optional[int] = None):
-        self._inner = PhoonnxDataset(dataset_paths, max_phoneme_ids=max_phoneme_ids)
-        self.mel_channels = mel_channels
-        self.filter_length = filter_length
-        self.sample_rate = sample_rate
-        self.mel_fmin = mel_fmin
-        self.mel_fmax = mel_fmax
-        # corpus F0 statistics over voiced frames — the pitch target is
-        # z-scored so its scale matches the other loss terms and the
-        # pitch_mul/pitch_add inference controls operate on a normalized
-        # quantity (raw Hz would dwarf every other loss)
-        self.pitch_mean, self.pitch_std = self._pitch_stats(dataset_paths)
-
-    def _f0_candidate(self, utt: "Utterance") -> Path:
-        return Path(str(utt.audio_spec_path)).with_suffix("").with_suffix(".f0.npy")
-
-    def _pitch_stats(self, dataset_paths: List[Path]):
-        import json
-
-        import numpy as np
-
-        stats_path = None
-        for p in dataset_paths:
-            p = Path(p)
-            if p.is_dir():
-                stats_path = p / "pitch_stats.json"
-                break
-        if stats_path and stats_path.is_file():
-            stats = json.loads(stats_path.read_text())
-            return float(stats["mean"]), float(stats["std"])
-
-        voiced = []
-        for utt in self._inner.utterances:
-            cand = self._f0_candidate(utt)
-            if cand.exists():
-                f0 = np.load(cand)
-                voiced.append(f0[f0 > 0])
-        if not voiced:
-            return 0.0, 1.0  # no pitch caches — identity normalization
-        allv = np.concatenate(voiced)
-        mean = float(allv.mean()) if allv.size else 0.0
-        std = float(allv.std()) if allv.size else 1.0
-        std = std or 1.0
-        if stats_path:
-            try:
-                stats_path.write_text(json.dumps({"mean": mean, "std": std}))
-            except OSError:
-                pass
-        return mean, std
-
-    def __len__(self) -> int:
-        return len(self._inner)
-
-    def __getitem__(self, idx: int) -> UtteranceTensors:
-        utt: Utterance = self._inner.utterances[idx]
-        spec = torch.load(utt.audio_spec_path)  # [n_fft//2+1, T]
-        mel = spec_to_mel_torch(
-            spec.unsqueeze(0), self.filter_length, self.mel_channels,
-            self.sample_rate, self.mel_fmin, self.mel_fmax,
-        ).squeeze(0)  # [mel_channels, T]
-
-        pitch = None
-        # optional sidecar cache written by extra_preprocess: "<stem>.f0.npy"
-        # next to audio_norm_path's parent cache dir.
-        f0_candidate = self._f0_candidate(utt)
-        if f0_candidate.exists():
-            import numpy as np
-
-            f0 = np.load(f0_candidate).astype("float32")
-            # z-score voiced frames with the corpus stats; unvoiced stays 0
-            voiced = f0 > 0
-            f0[voiced] = (f0[voiced] - self.pitch_mean) / self.pitch_std
-            pitch = torch.from_numpy(f0).unsqueeze(0)  # [1, T_f0]
-
-        return UtteranceTensors(
-            phoneme_ids=LongTensor(utt.phoneme_ids),
-            spectrogram=mel,
-            speaker_id=LongTensor([utt.speaker_id]) if utt.speaker_id is not None else None,
-            pitch=pitch,
-        )
-
-
-class ForwardTTSCollate:
-    def __init__(self, is_multispeaker: bool, use_pitch: bool):
-        self.is_multispeaker = is_multispeaker
-        self.use_pitch = use_pitch
-
-    def __call__(self, utterances: List[UtteranceTensors]) -> Batch:
-        n = len(utterances)
-        max_ph = max(u.phoneme_ids.size(0) for u in utterances)
-        max_mel = max(u.spectrogram.size(1) for u in utterances)
-        mel_channels = utterances[0].spectrogram.size(0)
-
-        phoneme_ids = torch.zeros(n, max_ph, dtype=torch.long)
-        phoneme_lengths = torch.zeros(n, dtype=torch.long)
-        mels = torch.zeros(n, mel_channels, max_mel)
-        mel_lengths = torch.zeros(n, dtype=torch.long)
-        pitch = torch.zeros(n, 1, max_mel) if self.use_pitch else None
-        speaker_ids = torch.zeros(n, dtype=torch.long) if self.is_multispeaker else None
-
-        for i, utt in enumerate(utterances):
-            pl_ = utt.phoneme_ids.size(0)
-            ml = utt.spectrogram.size(1)
-            phoneme_ids[i, :pl_] = utt.phoneme_ids
-            phoneme_lengths[i] = pl_
-            mels[i, :, :ml] = utt.spectrogram
-            mel_lengths[i] = ml
-            if self.use_pitch and utt.pitch is not None:
-                pl_len = min(utt.pitch.size(-1), max_mel)
-                pitch[i, :, :pl_len] = utt.pitch[:, :pl_len]
-            if speaker_ids is not None and utt.speaker_id is not None:
-                speaker_ids[i] = utt.speaker_id
-
-        return Batch(phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids)
-
-
-class ForwardTTSModule(pl.LightningModule):
-    """LightningModule wrapping the vendored :class:`ForwardTTS` model."""
-
-    def __init__(
-        self,
-        num_symbols: int,
-        num_speakers: int = 1,
-        sample_rate: int = 22050,
-        filter_length: int = 1024,
-        mel_channels: int = 80,
-        mel_fmin: float = 0.0,
-        mel_fmax: Optional[float] = None,
-        variant: str = "fastpitch",
-        hidden_channels: int = 384,
-        hidden_channels_ffn: int = 1024,
-        encoder_num_layers: int = 6,
-        decoder_num_layers: int = 6,
-        num_heads: int = 1,
-        use_pitch: Optional[bool] = None,
-        use_energy: bool = False,
-        dataset: Optional[List[Path]] = None,
-        learning_rate: float = 1e-4,
-        betas: Tuple[float, float] = (0.9, 0.998),
-        eps: float = 1e-9,
-        weight_decay: float = 1e-6,
-        batch_size: int = 8,
-        num_workers: int = 1,
-        validation_split: float = 0.1,
-        num_test_examples: int = 5,
-        max_phoneme_ids: Optional[int] = None,
-        binary_loss_start_epoch: int = 0,
-        binary_loss_warmup_epochs: int = 10,
-        **kwargs: Any,
-    ):
-        super().__init__()
-        self.save_hyperparameters()
-
-        variant_overrides: Dict[str, Any] = {}
-        if variant == "speedyspeech":
-            variant_overrides.update(_SPEEDYSPEECH_OVERRIDES)
-        if use_pitch is not None:
-            variant_overrides["use_pitch"] = use_pitch
-
-        args = ForwardTTSArgs(
-            num_chars=num_symbols,
-            out_channels=mel_channels,
-            hidden_channels=hidden_channels,
-            hidden_channels_ffn=hidden_channels_ffn,
-            encoder_num_layers=encoder_num_layers,
-            decoder_num_layers=decoder_num_layers,
-            num_heads=num_heads,
-            use_energy=use_energy,
-            num_speakers=num_speakers,
-            **variant_overrides,
-        )
-        self.model_args = args
-        self.model = ForwardTTS(args)
-        self.criterion = ForwardTTSLoss()
-
-        self._train_dataset: Optional[Dataset] = None
-        self._val_dataset: Optional[Dataset] = None
-        self._test_dataset: Optional[Dataset] = None
-        self._load_datasets(validation_split, num_test_examples, max_phoneme_ids)
-
-    # ------------------------------------------------------------------
-    def _load_datasets(self, validation_split: float, num_test_examples: int,
-                       max_phoneme_ids: Optional[int]) -> None:
-        if not self.hparams.dataset:
-            _LOG.debug("No dataset to load")
-            return
-        full_dataset = ForwardTTSDataset(
-            self.hparams.dataset,
-            mel_channels=self.hparams.mel_channels,
-            filter_length=self.hparams.filter_length,
-            sample_rate=self.hparams.sample_rate,
-            mel_fmin=self.hparams.mel_fmin,
-            mel_fmax=self.hparams.mel_fmax,
-            max_phoneme_ids=max_phoneme_ids,
-        )
-        valid_size = max(0, int(len(full_dataset) * validation_split))
-        test_size = min(num_test_examples, max(0, len(full_dataset) - valid_size))
-        train_size = len(full_dataset) - valid_size - test_size
-        self._train_dataset, self._test_dataset, self._val_dataset = random_split(
-            full_dataset, [train_size, test_size, valid_size]
-        )
-
-    def _collate(self) -> ForwardTTSCollate:
-        return ForwardTTSCollate(
-            is_multispeaker=self.hparams.num_speakers > 1,
-            use_pitch=bool(self.model_args.use_pitch),
-        )
-
-    def train_dataloader(self):
-        return DataLoader(self._train_dataset, collate_fn=self._collate(),
-                          num_workers=self.hparams.num_workers,
-                          batch_size=self.hparams.batch_size, shuffle=True)
-
-    def val_dataloader(self):
-        return DataLoader(self._val_dataset, collate_fn=self._collate(),
-                          num_workers=self.hparams.num_workers,
-                          batch_size=self.hparams.batch_size)
-
-    def test_dataloader(self):
-        return DataLoader(self._test_dataset, collate_fn=self._collate(),
-                          num_workers=self.hparams.num_workers,
-                          batch_size=self.hparams.batch_size)
-
-    # ------------------------------------------------------------------
-    def forward(self, x, pace: float = 1.0, pitch_mul: float = 1.0,
-               pitch_add: float = 0.0, speaker=None):
-        return self.model.inference(x, speaker=speaker, pace=pace,
-                                    pitch_mul=pitch_mul, pitch_add=pitch_add)
-
-    def _step(self, batch: Batch, binary_loss_weight: float = 1.0) -> Dict[str, torch.Tensor]:
-        outputs = self.model(
-            x=batch.phoneme_ids,
-            x_lengths=batch.phoneme_lengths,
-            y=batch.mels,
-            y_lengths=batch.mel_lengths,
-            pitch=batch.pitch,
-            speaker=batch.speaker_ids,
-        )
-        losses = self.criterion(
-            decoder_output=outputs["model_outputs"],
-            decoder_target=batch.mels.transpose(1, 2),
-            decoder_output_lens=batch.mel_lengths,
-            dur_output=outputs["durations_log"],
-            dur_target=outputs["durations"],
-            input_lens=batch.phoneme_lengths,
-            pitch_output=outputs["pitch_avg_pred"],
-            pitch_target=outputs["pitch_avg"],
-            aligner_logprob=outputs["alignment_logprob"],
-            alignment_hard=outputs["alignment_hard"],
-            alignment_soft=outputs["alignment_soft"],
-            binary_loss_weight=binary_loss_weight,
-        )
-        return losses
-
-    def training_step(self, batch: Batch, batch_idx: int):
-        # ramp the binary alignment loss in over binary_loss_warmup_epochs
-        # starting at binary_loss_start_epoch — full-strength binarization
-        # against a still-random soft alignment destabilizes the aligner
-        warmup = max(1, self.hparams.binary_loss_warmup_epochs)
-        binary_loss_weight = min(1.0, max(
-            0.0, (self.current_epoch - self.hparams.binary_loss_start_epoch + 1) / warmup))
-        losses = self._step(batch, binary_loss_weight=binary_loss_weight)
-        self.log_dict({f"train_{k}": v for k, v in losses.items()}, prog_bar=False)
-        return losses["loss"]
-
-    def validation_step(self, batch: Batch, batch_idx: int):
-        losses = self._step(batch)
-        self.log_dict({f"val_{k}": v for k, v in losses.items()})
-        return losses["loss"]
-
-    def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(
-            self.model.parameters(),
-            lr=self.hparams.learning_rate,
-            betas=self.hparams.betas,
-            eps=self.hparams.eps,
-            weight_decay=self.hparams.weight_decay,
-        )
-        scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.999875)
-        return [optimizer], [scheduler]
+    return merged
 
 
 class ForwardTTSTrainingEngine(BaseTrainingEngine):
@@ -425,16 +121,12 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         config: TrainingEngineConfig,
         dataset_paths: List[Path],
         **kwargs: Any,
-    ) -> pl.LightningModule:
-        extra = dict(config.extra)
-        extra.setdefault("variant", self.default_variant)
+    ) -> "pl.LightningModule":
+        from phoonnx_train.fastpitch.lightning import ForwardTTSModule
+
         return ForwardTTSModule(
-            num_symbols=config.num_symbols,
-            num_speakers=config.num_speakers,
-            sample_rate=config.sample_rate,
             dataset=[str(p) for p in dataset_paths],
-            **extra,
-            **kwargs,
+            **resolve_module_kwargs(config, self.default_variant, **kwargs),
         )
 
     def export_onnx(
@@ -448,9 +140,16 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
 
         Contract matches ``coqui_fastpitch_export/export_fp.py`` /
         ``phoonnx.engines.fastpitch.FastPitchAdapter``: ``token_ids`` [B,T]
-        (+ optional ``speaker`` [B]) -> ``mel_spec`` [B, 80, T_mel].
+        + ``pace``/``pitch_mul``/``pitch_add`` [1] (+ optional ``speaker``
+        [B]) -> ``mel_spec`` [B, 80, T_mel].
         """
         import json
+
+        import torch
+
+        from phoonnx_train.fastpitch.lightning import ForwardTTSModule
+        from phoonnx_train.fastpitch.model import ForwardTTS
+        from phoonnx_train.torch_compat import onnx_export_kwargs
 
         with open(config_path, "r", encoding="utf-8") as f:
             model_config: Dict[str, Any] = json.load(f)
@@ -479,8 +178,8 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
                        pace: torch.Tensor,
                        pitch_mul: torch.Tensor,
                        pitch_add: torch.Tensor,
-                       speaker: Optional[torch.Tensor] = None) -> torch.Tensor:
-                sid = speaker if self.multispeaker else None
+                       speaker=None) -> torch.Tensor:
+                sid = speaker.long() if self.multispeaker else None
                 return self.m.inference(token_ids, speaker=sid, pace=pace,
                                         pitch_mul=pitch_mul, pitch_add=pitch_add)
 
@@ -491,8 +190,10 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         dummy_controls = (torch.ones(1), torch.ones(1), torch.zeros(1))
         control_names = ["pace", "pitch_mul", "pitch_add"]
         if multispeaker:
-            dummy_speaker = torch.zeros(1, dtype=torch.long)
-            dummy_args: Tuple[Any, ...] = (dummy_ids, *dummy_controls, dummy_speaker)
+            # int32 to match the FastPitchAdapter/MixerTTSAdapter feed dtype;
+            # cast to long inside the wrapper for the embedding lookup
+            dummy_speaker = torch.zeros(1, dtype=torch.int32)
+            dummy_args = (dummy_ids, *dummy_controls, dummy_speaker)
             input_names = ["token_ids", *control_names, "speaker"]
             dynamic_axes = {
                 "token_ids": {0: "batch_size", 1: "phonemes"},
@@ -510,21 +211,17 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / f"{checkpoint_path.stem}.onnx"
 
-        export_kwargs: Dict[str, Any] = dict(
-            input_names=input_names,
-            output_names=["mel_spec"],
-            dynamic_axes=dynamic_axes,
-            opset_version=OPSET_VERSION,
-        )
-        # torch>=2.5 defaults torch.onnx.export to the dynamo-based exporter,
-        # which additionally requires the optional 'onnxscript' package.
-        # Force the legacy TorchScript-tracing exporter (matches
-        # coqui_fastpitch_export/export_fp.py) when the kwarg is available.
-        if "dynamo" in torch.onnx.export.__code__.co_varnames:
-            export_kwargs["dynamo"] = False
-
         with torch.no_grad():
-            torch.onnx.export(wrapper, dummy_args, str(output_path), **export_kwargs)
+            torch.onnx.export(
+                wrapper,
+                dummy_args,
+                str(output_path),
+                input_names=input_names,
+                output_names=["mel_spec"],
+                dynamic_axes=dynamic_axes,
+                opset_version=OPSET_VERSION,
+                **onnx_export_kwargs(),
+            )
 
         try:
             import onnx as _onnx
@@ -532,7 +229,7 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
             onnx_model = _onnx.load(str(output_path))
             del onnx_model.metadata_props[:]
             for key, value in {
-                "model_type": "fastpitch" if module.hparams.variant == "fastpitch" else "speedyspeech",
+                "model_type": module.hparams.variant,
                 "engine": module.hparams.variant,
                 "n_speakers": num_speakers,
                 "n_vocab": num_symbols,
@@ -601,12 +298,14 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
 
     def load_checkpoint(
         self,
-        model: pl.LightningModule,
+        model: "pl.LightningModule",
         checkpoint_path: Path,
         **kwargs: Any,
-    ) -> pl.LightningModule:
+    ) -> "pl.LightningModule":
         """Tolerant checkpoint load (skips shape-mismatched tensors, e.g.
         when fine-tuning onto a different phoneme inventory)."""
+        import torch
+
         ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
         state_dict = ckpt.get("state_dict", ckpt)
         model_state = model.state_dict()

--- a/phoonnx_train/engines/fastpitch.py
+++ b/phoonnx_train/engines/fastpitch.py
@@ -234,6 +234,9 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
                 "n_speakers": num_speakers,
                 "n_vocab": num_symbols,
                 "sample_rate": model_config.get("audio", {}).get("sample_rate", module.hparams.sample_rate),
+                "mel_fmin": module.hparams.mel_fmin,
+                "mel_fmax": module.hparams.mel_fmax,
+                "mel_channels": module.hparams.mel_channels,
                 "alphabet": model_config.get("alphabet", ""),
                 "phoneme_type": model_config.get("phoneme_type", ""),
                 "phonemizer_model": model_config.get("phonemizer_model", ""),
@@ -262,19 +265,25 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         utterance_audio_path: Path,
         cache_dir: Path,
         sample_rate: int,
+        hop_length: int = 256,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Extract F0 (pitch) via pyworld; cached alongside the mel cache.
 
-        Same contract as the OptiSpeech training engine's
-        ``extra_preprocess`` (pyworld DIO + StoneMask). SpeedySpeech does
-        not use pitch, but the field is harmless to compute/cache and lets
-        the same preprocessed dataset be reused for either variant.
+        pyworld DIO + StoneMask, run at a frame period matched to the mel
+        hop (``1000 * hop_length / sample_rate`` ms) so the f0 track is
+        frame-aligned with the mel target, and computed on the same
+        trimmed/normalized audio the mels come from (the ``<sha>.pt``
+        cache written by ``cache_norm_audio``). The sidecar is named
+        ``<sha>.f0.npy`` next to the ``<sha>.spec.pt`` cache so the
+        training dataset finds it. SpeedySpeech does not use pitch, but
+        the cache is harmless and lets the same preprocessed dataset be
+        reused for either variant.
         """
         import numpy as np
 
         try:
-            import librosa
+            import librosa  # noqa: F401 — fallback loader below
             import pyworld as pw
         except ImportError:
             _LOG.warning(
@@ -284,14 +293,51 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
             )
             return {}
 
-        wav, sr = librosa.load(str(utterance_audio_path), sr=sample_rate, mono=True)
+        from hashlib import sha256
+
+        # same cache id scheme as phoonnx_train.norm_audio.cache_norm_audio
+        audio_cache_id = sha256(str(Path(utterance_audio_path).absolute()).encode()).hexdigest()
+        norm_path = cache_dir / f"{audio_cache_id}.pt"
+        spec_path = cache_dir / f"{audio_cache_id}.spec.pt"
+
+        if norm_path.exists():
+            # the exact trimmed/normalized signal the spectrogram was
+            # computed from — anything else drifts against the mel frames
+            import torch
+
+            wav = torch.load(norm_path).squeeze(0).numpy()
+        else:
+            _LOG.warning(
+                "normalized-audio cache %s not found — extracting F0 from the "
+                "raw audio (frame alignment with the mel target not guaranteed)",
+                norm_path,
+            )
+            wav, _sr = librosa.load(str(utterance_audio_path), sr=sample_rate, mono=True)
+
         wav_double = wav.astype(np.float64)
-        f0, timeaxis = pw.dio(wav_double, sr)
-        f0 = pw.stonemask(wav_double, f0, timeaxis, sr).astype(np.float32)
+        frame_period = 1000.0 * hop_length / sample_rate  # ms, = mel hop
+        f0, timeaxis = pw.dio(wav_double, sample_rate, frame_period=frame_period)
+        f0 = pw.stonemask(wav_double, f0, timeaxis, sample_rate).astype(np.float32)
+
+        if spec_path.exists():
+            import torch
+
+            t_mel = torch.load(spec_path).shape[-1]
+            diff = len(f0) - t_mel
+            if abs(diff) > 2:
+                _LOG.warning(
+                    "f0/mel frame mismatch for %s (f0=%d mel=%d) — skipping "
+                    "F0 cache for this utterance",
+                    utterance_audio_path, len(f0), t_mel,
+                )
+                return {}
+            if diff > 0:
+                f0 = f0[:t_mel]
+            elif diff < 0:
+                f0 = np.pad(f0, (0, -diff))
 
         cache_dir.mkdir(parents=True, exist_ok=True)
-        stem = utterance_audio_path.stem
-        f0_path = cache_dir / f"{stem}.f0.npy"
+        f0_path = cache_dir / f"{audio_cache_id}.f0.npy"
         np.save(f0_path, f0)
 
         return {"f0_path": str(f0_path)}

--- a/phoonnx_train/fastpitch/__init__.py
+++ b/phoonnx_train/fastpitch/__init__.py
@@ -1,0 +1,16 @@
+"""
+Vendored pure-torch port of coqui-TTS ``ForwardTTS`` (FastPitch / SpeedySpeech).
+
+Adapted from https://github.com/coqui-ai/TTS (``TTS/tts/models/forward_tts.py``
+and the layers it uses), original code © Coqui GmbH, licensed under the
+Mozilla Public License 2.0 (MPL-2.0). This vendored copy is self-contained:
+it has no dependency on the ``TTS``/``coqui-tts`` package.
+
+FastPitch and SpeedySpeech are both ``ForwardTTS`` configurations — the same
+non-autoregressive text→mel model with per-token duration (and optionally
+pitch/energy) predictors; SpeedySpeech simply drops the pitch predictor and
+uses residual-conv encoder/decoder blocks instead of FFT transformer blocks.
+"""
+from phoonnx_train.fastpitch.model import ForwardTTS, ForwardTTSArgs
+
+__all__ = ["ForwardTTS", "ForwardTTSArgs"]

--- a/phoonnx_train/fastpitch/__init__.py
+++ b/phoonnx_train/fastpitch/__init__.py
@@ -8,7 +8,7 @@ it has no dependency on the ``TTS``/``coqui-tts`` package.
 
 FastPitch and SpeedySpeech are both ``ForwardTTS`` configurations — the same
 non-autoregressive text→mel model with per-token duration (and optionally
-pitch/energy) predictors; SpeedySpeech simply drops the pitch predictor and
+pitch) predictors; SpeedySpeech simply drops the pitch predictor and
 uses residual-conv encoder/decoder blocks instead of FFT transformer blocks.
 """
 from phoonnx_train.fastpitch.model import ForwardTTS, ForwardTTSArgs

--- a/phoonnx_train/fastpitch/aligner.py
+++ b/phoonnx_train/fastpitch/aligner.py
@@ -1,0 +1,66 @@
+"""
+Alignment network for unsupervised duration learning.
+
+Adapted from coqui-ai/TTS ``TTS/tts/layers/generic/aligner.py``
+(© Coqui GmbH, Mozilla Public License 2.0), itself following
+"One TTS Alignment To Rule Them All" (https://arxiv.org/abs/2108.10447).
+"""
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+
+class AlignmentNetwork(nn.Module):
+    """
+    Learns a soft text↔mel alignment; binarized with monotonic alignment
+    search (see :func:`phoonnx_train.fastpitch.helpers.maximum_path`) to
+    obtain per-token durations during training.
+    """
+
+    def __init__(self, in_query_channels: int = 80, in_key_channels: int = 256,
+                 attn_channels: int = 80, temperature: float = 0.0005):
+        super().__init__()
+        self.temperature = temperature
+        self.softmax = torch.nn.Softmax(dim=3)
+        self.log_softmax = torch.nn.LogSoftmax(dim=3)
+
+        self.key_layer = nn.Sequential(
+            nn.Conv1d(in_key_channels, in_key_channels * 2, kernel_size=3,
+                      padding=1, bias=True),
+            torch.nn.ReLU(),
+            nn.Conv1d(in_key_channels * 2, attn_channels, kernel_size=1, bias=True),
+        )
+        self.query_layer = nn.Sequential(
+            nn.Conv1d(in_query_channels, in_query_channels * 2, kernel_size=3,
+                      padding=1, bias=True),
+            torch.nn.ReLU(),
+            nn.Conv1d(in_query_channels * 2, in_query_channels, kernel_size=1, bias=True),
+            torch.nn.ReLU(),
+            nn.Conv1d(in_query_channels, attn_channels, kernel_size=1, bias=True),
+        )
+
+    def forward(
+        self,
+        queries: torch.Tensor,
+        keys: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        attn_prior: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        queries: mel frames [B, C_mel, T_de]
+        keys:    encoder states [B, C_en, T_en]
+        mask:    key mask [B, 1, T_en]
+
+        Returns (attn [B, 1, T_de, T_en] softmax, attn_logp log-softmax).
+        """
+        key_out = self.key_layer(keys)
+        query_out = self.query_layer(queries)
+        attn_factor = (query_out[:, :, :, None] - key_out[:, :, None]) ** 2
+        attn_logp = -self.temperature * attn_factor.sum(1, keepdim=True)
+        if attn_prior is not None:
+            attn_logp = self.log_softmax(attn_logp) + torch.log(attn_prior[:, None] + 1e-8)
+        if mask is not None:
+            attn_logp.data.masked_fill_(~mask.bool().unsqueeze(2), -float("inf"))
+        attn = self.softmax(attn_logp)
+        return attn, attn_logp

--- a/phoonnx_train/fastpitch/helpers.py
+++ b/phoonnx_train/fastpitch/helpers.py
@@ -1,0 +1,110 @@
+"""
+Alignment / masking helpers for the vendored ForwardTTS.
+
+Adapted from coqui-ai/TTS ``TTS/tts/utils/helpers.py`` (© Coqui GmbH,
+Mozilla Public License 2.0). Pure torch + numpy — the monotonic alignment
+search (MAS) uses the numpy fallback implementation, so no cython/numba
+build step is required.
+"""
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+def sequence_mask(sequence_length: torch.Tensor, max_len: Optional[int] = None) -> torch.Tensor:
+    """[B] lengths -> [B, T_max] boolean mask."""
+    if max_len is None:
+        max_len = int(sequence_length.max().item())
+    seq_range = torch.arange(max_len, dtype=sequence_length.dtype, device=sequence_length.device)
+    return seq_range.unsqueeze(0) < sequence_length.unsqueeze(1)
+
+
+def generate_path(duration: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """
+    Expand per-token durations to a hard alignment path.
+
+    duration: [B, T_en]
+    mask:     [B, T_en, T_de]
+    returns:  [B, T_en, T_de]
+    """
+    b, t_x, t_y = mask.shape
+    cum_duration = torch.cumsum(duration, dim=1)
+    cum_duration_flat = cum_duration.view(b * t_x)
+    path = sequence_mask(cum_duration_flat, t_y).to(mask.dtype)
+    path = path.view(b, t_x, t_y)
+    path = path - torch.nn.functional.pad(path, (0, 0, 1, 0, 0, 0))[:, :-1]
+    return path * mask
+
+
+def average_over_durations(values: torch.Tensor, durs: torch.Tensor) -> torch.Tensor:
+    """
+    Average frame-level values over each token's duration span.
+
+    values: [B, 1, T_de]
+    durs:   [B, T_en]
+    returns: [B, 1, T_en]
+    """
+    durs_cums_ends = torch.cumsum(durs, dim=1).long()
+    durs_cums_starts = torch.nn.functional.pad(durs_cums_ends[:, :-1], (1, 0))
+    values_nonzero_cums = torch.nn.functional.pad(torch.cumsum(values != 0.0, dim=2), (1, 0))
+    values_cums = torch.nn.functional.pad(torch.cumsum(values, dim=2), (1, 0))
+
+    bs, l = durs_cums_ends.size()
+    n_formants = values.size(1)
+    dcs = durs_cums_starts[:, None, :].expand(bs, n_formants, l)
+    dce = durs_cums_ends[:, None, :].expand(bs, n_formants, l)
+
+    values_sums = (torch.gather(values_cums, 2, dce) - torch.gather(values_cums, 2, dcs)).float()
+    values_nelems = (torch.gather(values_nonzero_cums, 2, dce) - torch.gather(values_nonzero_cums, 2, dcs)).float()
+
+    avg = torch.where(values_nelems == 0.0, values_nelems, values_sums / values_nelems)
+    return avg.to(values.dtype)
+
+
+def maximum_path(log_p: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """
+    Monotonic alignment search (numpy Viterbi), batch version.
+
+    Port of coqui's ``maximum_path_numpy`` (TTS/tts/utils/helpers.py).
+
+    log_p: [B, T_en, T_de] alignment log-probabilities
+    mask:  [B, T_en, T_de]
+    returns hard path [B, T_en, T_de]
+    """
+    max_neg_val = -np.inf
+    value = (log_p * mask).detach().cpu().numpy().astype(np.float32)
+    mask_np = mask.detach().cpu().numpy().astype(bool)
+
+    b, t_x_max, t_y_max = value.shape
+    paths = np.zeros_like(value, dtype=np.float32)
+    for i in range(b):
+        t_x = int(mask_np[i, :, 0].sum())
+        t_y = int(mask_np[i, 0, :].sum())
+        v = value[i, :t_x, :t_y]
+
+        # forward pass
+        direction = np.zeros((t_x, t_y), dtype=np.int32)
+        score = np.full((t_x,), max_neg_val, dtype=np.float32)
+        score[0] = v[0, 0]
+        for y in range(1, t_y):
+            new_score = np.full((t_x,), max_neg_val, dtype=np.float32)
+            lo = max(0, t_x - (t_y - y))
+            hi = min(t_x, y + 1)
+            for x in range(lo, hi):
+                stay = score[x]
+                move = score[x - 1] if x > 0 else max_neg_val
+                if move >= stay:
+                    direction[x, y] = 1
+                    new_score[x] = move + v[x, y]
+                else:
+                    new_score[x] = stay + v[x, y]
+            score = new_score
+
+        # backtrack
+        x = t_x - 1
+        for y in range(t_y - 1, -1, -1):
+            paths[i, x, y] = 1.0
+            if direction[x, y] == 1:
+                x -= 1
+    return torch.from_numpy(paths).to(device=log_p.device, dtype=log_p.dtype)

--- a/phoonnx_train/fastpitch/layers.py
+++ b/phoonnx_train/fastpitch/layers.py
@@ -1,0 +1,162 @@
+"""
+Encoder/decoder/predictor layers for the vendored ForwardTTS.
+
+Adapted from coqui-ai/TTS (© Coqui GmbH, Mozilla Public License 2.0):
+
+- ``TTS/tts/layers/generic/transformer.py``   (FFTransformer blocks)
+- ``TTS/tts/layers/generic/res_conv_bn.py``   (residual conv-BN blocks, SpeedySpeech)
+- ``TTS/tts/layers/feed_forward/duration_predictor.py``
+
+The multi-head attention is implemented manually (matmul + ``-1`` reshapes)
+instead of ``torch.nn.MultiheadAttention`` so the traced ONNX graph stays
+truly dynamic-length (see docs/fastpitch.md).
+"""
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class MultiHeadAttention(nn.Module):
+    """Tracer-safe multi-head self-attention (batch_first)."""
+
+    def __init__(self, d_model: int, n_heads: int, dropout: float = 0.1):
+        super().__init__()
+        assert d_model % n_heads == 0
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.d_head = d_model // n_heads
+        self.qkv = nn.Linear(d_model, 3 * d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """x: [B, T, C], mask: [B, 1, T] (1 = keep)."""
+        b = x.shape[0]
+        q, k, v = self.qkv(x).chunk(3, dim=-1)
+        # [B, H, T, Dh] with live-shape reshapes
+        q = q.reshape(b, -1, self.n_heads, self.d_head).transpose(1, 2)
+        k = k.reshape(b, -1, self.n_heads, self.d_head).transpose(1, 2)
+        v = v.reshape(b, -1, self.n_heads, self.d_head).transpose(1, 2)
+        scores = torch.matmul(q, k.transpose(-2, -1)) / (self.d_head ** 0.5)
+        attn_mask = mask.unsqueeze(1)  # [B, 1, 1, T]
+        scores = scores.masked_fill(attn_mask == 0, -1e4)
+        attn = self.dropout(torch.softmax(scores, dim=-1))
+        out = torch.matmul(attn, v)  # [B, H, T, Dh]
+        out = out.transpose(1, 2).reshape(b, -1, self.d_model)
+        return self.out_proj(out)
+
+
+class FFTransformerLayer(nn.Module):
+    """One FFT block: self-attention + 1D-conv feed-forward (FastPitch style)."""
+
+    def __init__(self, d_model: int, n_heads: int, d_ffn: int,
+                 kernel_size: int = 3, dropout: float = 0.1):
+        super().__init__()
+        self.attn = MultiHeadAttention(d_model, n_heads, dropout)
+        self.norm1 = nn.LayerNorm(d_model)
+        self.conv1 = nn.Conv1d(d_model, d_ffn, kernel_size, padding=kernel_size // 2)
+        self.conv2 = nn.Conv1d(d_ffn, d_model, kernel_size, padding=kernel_size // 2)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """x: [B, T, C], mask: [B, 1, T]."""
+        x = self.norm1(x + self.dropout(self.attn(x, mask)))
+        x = x * mask.transpose(1, 2)
+        y = self.conv2(F.relu(self.conv1(x.transpose(1, 2)))).transpose(1, 2)
+        x = self.norm2(x + self.dropout(y))
+        return x * mask.transpose(1, 2)
+
+
+class FFTransformerBlock(nn.Module):
+    """Stack of FFT layers operating on [B, C, T] (channel-first, coqui convention)."""
+
+    def __init__(self, in_out_channels: int, num_heads: int, hidden_channels_ffn: int,
+                 num_layers: int, dropout: float = 0.1):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [FFTransformerLayer(in_out_channels, num_heads, hidden_channels_ffn,
+                                dropout=dropout) for _ in range(num_layers)]
+        )
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """x: [B, C, T], mask: [B, 1, T] -> [B, C, T]."""
+        y = x.transpose(1, 2)
+        for layer in self.layers:
+            y = layer(y, mask)
+        return y.transpose(1, 2)
+
+
+class Conv1dBN(nn.Module):
+    """Same-length conv+BN block. Handles even kernel sizes (e.g. the
+    SpeedySpeech default ``kernel_size=4``) with asymmetric padding so the
+    output time dimension always matches the input (needed since callers
+    multiply by a fixed-length mask and add residuals)."""
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int, dilation: int = 1):
+        super().__init__()
+        total_padding = dilation * (kernel_size - 1)
+        self._pad = (total_padding // 2, total_padding - total_padding // 2)
+        self.conv = nn.Conv1d(in_channels, out_channels, kernel_size,
+                              padding=0, dilation=dilation)
+        self.norm = nn.BatchNorm1d(out_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = F.pad(x, self._pad)
+        return self.norm(F.relu(self.conv(x)))
+
+
+class ResidualConv1dBNBlock(nn.Module):
+    """Residual conv-BN stack (SpeedySpeech encoder/decoder building block)."""
+
+    def __init__(self, in_channels: int, out_channels: int, hidden_channels: int,
+                 kernel_size: int = 4, num_res_blocks: int = 13, dilations=None):
+        super().__init__()
+        dilations = dilations or [1] * num_res_blocks
+        self.res_blocks = nn.ModuleList()
+        for i, d in enumerate(dilations):
+            in_c = in_channels if i == 0 else hidden_channels
+            out_c = out_channels if i == len(dilations) - 1 else hidden_channels
+            self.res_blocks.append(Conv1dBN(in_c, out_c, kernel_size, dilation=d))
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """x: [B, C, T], mask: [B, 1, T]."""
+        o = x * mask
+        for i, block in enumerate(self.res_blocks):
+            res = o
+            o = block(o) * mask
+            if res.shape[1] == o.shape[1]:
+                o = o + res
+        return o
+
+
+class DurationPredictor(nn.Module):
+    """
+    Per-token scalar predictor (log-duration, pitch or energy).
+
+    Conv-ReLU-LayerNorm stack, port of coqui's FastPitch duration/pitch
+    predictor head.
+    """
+
+    def __init__(self, in_channels: int, hidden_channels: int = 256,
+                 kernel_size: int = 3, dropout: float = 0.1, num_layers: int = 2):
+        super().__init__()
+        self.layers = nn.ModuleList()
+        self.norms = nn.ModuleList()
+        for i in range(num_layers):
+            in_c = in_channels if i == 0 else hidden_channels
+            self.layers.append(
+                nn.Conv1d(in_c, hidden_channels, kernel_size, padding=kernel_size // 2)
+            )
+            self.norms.append(nn.LayerNorm(hidden_channels))
+        self.dropout = nn.Dropout(dropout)
+        self.proj = nn.Conv1d(hidden_channels, 1, 1)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """x: [B, C, T], mask: [B, 1, T] -> [B, 1, T]."""
+        o = x
+        for conv, norm in zip(self.layers, self.norms):
+            o = F.relu(conv(o * mask))
+            o = norm(o.transpose(1, 2)).transpose(1, 2)
+            o = self.dropout(o)
+        return self.proj(o * mask) * mask

--- a/phoonnx_train/fastpitch/layers.py
+++ b/phoonnx_train/fastpitch/layers.py
@@ -132,7 +132,7 @@ class ResidualConv1dBNBlock(nn.Module):
 
 class DurationPredictor(nn.Module):
     """
-    Per-token scalar predictor (log-duration, pitch or energy).
+    Per-token scalar predictor (log-duration or pitch).
 
     Conv-ReLU-LayerNorm stack, port of coqui's FastPitch duration/pitch
     predictor head.

--- a/phoonnx_train/fastpitch/lightning.py
+++ b/phoonnx_train/fastpitch/lightning.py
@@ -1,0 +1,326 @@
+"""LightningModule + dataset/collate wrapping the vendored ForwardTTS model.
+
+Reuses the shared VITS preprocessing pipeline: ``audio_norm_path`` /
+``audio_spec_path`` (linear spectrogram) are produced by
+``phoonnx_train.preprocess``; the mel target is derived from the linear
+spectrogram at load time via ``phoonnx_train.vits.mel_processing`` (no
+separate mel cache needed). Pitch (F0) is read from the optional
+``<utterance>.f0.npy`` sidecar caches written by
+``ForwardTTSTrainingEngine.extra_preprocess``.
+"""
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytorch_lightning as pl
+import torch
+from torch import LongTensor
+from torch.utils.data import DataLoader, Dataset, random_split
+
+from phoonnx_train.fastpitch.losses import ForwardTTSLoss
+from phoonnx_train.fastpitch.model import ForwardTTS, ForwardTTSArgs
+from phoonnx_train.fastpitch.pitch_stats import (
+    f0_cache_path,
+    load_or_compute_pitch_stats,
+)
+from phoonnx_train.vits.dataset import PhoonnxDataset, Utterance
+from phoonnx_train.vits.mel_processing import spec_to_mel_torch
+
+_LOG = logging.getLogger(__name__)
+
+# SpeedySpeech-specific overrides layered on top of the tier preset when
+# ``variant == "speedyspeech"``.
+_SPEEDYSPEECH_OVERRIDES: Dict[str, Any] = {
+    "encoder_type": "residual_conv_bn",
+    "decoder_type": "residual_conv_bn",
+    "use_pitch": False,
+}
+
+
+class UtteranceTensors:
+    """Per-utterance training tensors: ids, mel (via spec), optional f0."""
+
+    __slots__ = ("phoneme_ids", "spectrogram", "speaker_id", "pitch")
+
+    def __init__(self, phoneme_ids: LongTensor, spectrogram: torch.Tensor,
+                 speaker_id: Optional[LongTensor], pitch: Optional[torch.Tensor]):
+        self.phoneme_ids = phoneme_ids
+        self.spectrogram = spectrogram
+        self.speaker_id = speaker_id
+        self.pitch = pitch
+
+
+class Batch:
+    __slots__ = (
+        "phoneme_ids", "phoneme_lengths", "mels", "mel_lengths",
+        "pitch", "speaker_ids",
+    )
+
+    def __init__(self, phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids):
+        self.phoneme_ids = phoneme_ids
+        self.phoneme_lengths = phoneme_lengths
+        self.mels = mels
+        self.mel_lengths = mel_lengths
+        self.pitch = pitch
+        self.speaker_ids = speaker_ids
+
+
+class ForwardTTSDataset(Dataset):
+    """
+    Wraps :class:`phoonnx_train.vits.dataset.PhoonnxDataset` utterances,
+    converting the shared linear-spectrogram cache to mel at load time and
+    optionally loading a pitch (F0) cache produced by
+    ``ForwardTTSTrainingEngine.extra_preprocess``.
+    """
+
+    def __init__(self, dataset_paths: List[Path], mel_channels: int,
+                 filter_length: int, sample_rate: int,
+                 mel_fmin: float, mel_fmax: Optional[float],
+                 max_phoneme_ids: Optional[int] = None):
+        # accept either a preprocessed dataset dir or the dataset.jsonl itself
+        jsonl_paths = [
+            (Path(p) / "dataset.jsonl") if Path(p).is_dir() else Path(p)
+            for p in dataset_paths
+        ]
+        self._inner = PhoonnxDataset(jsonl_paths, max_phoneme_ids=max_phoneme_ids)
+        self.mel_channels = mel_channels
+        self.filter_length = filter_length
+        self.sample_rate = sample_rate
+        self.mel_fmin = mel_fmin
+        self.mel_fmax = mel_fmax
+        self.pitch_mean, self.pitch_std = load_or_compute_pitch_stats(
+            dataset_paths,
+            [f0_cache_path(utt.audio_spec_path) for utt in self._inner.utterances],
+        )
+
+    def __len__(self) -> int:
+        return len(self._inner)
+
+    def __getitem__(self, idx: int) -> UtteranceTensors:
+        utt: Utterance = self._inner.utterances[idx]
+        spec = torch.load(utt.audio_spec_path)  # [n_fft//2+1, T]
+        mel = spec_to_mel_torch(
+            spec.unsqueeze(0), self.filter_length, self.mel_channels,
+            self.sample_rate, self.mel_fmin, self.mel_fmax,
+        ).squeeze(0)  # [mel_channels, T]
+
+        pitch = None
+        # optional sidecar cache written by extra_preprocess: "<stem>.f0.npy"
+        f0_candidate = f0_cache_path(utt.audio_spec_path)
+        if f0_candidate.exists():
+            import numpy as np
+
+            f0 = np.load(f0_candidate).astype("float32")
+            # z-score voiced frames with the corpus stats; unvoiced stays 0
+            voiced = f0 > 0
+            f0[voiced] = (f0[voiced] - self.pitch_mean) / self.pitch_std
+            pitch = torch.from_numpy(f0).unsqueeze(0)  # [1, T_f0]
+
+        return UtteranceTensors(
+            phoneme_ids=LongTensor(utt.phoneme_ids),
+            spectrogram=mel,
+            speaker_id=LongTensor([utt.speaker_id]) if utt.speaker_id is not None else None,
+            pitch=pitch,
+        )
+
+
+class ForwardTTSCollate:
+    def __init__(self, is_multispeaker: bool, use_pitch: bool):
+        self.is_multispeaker = is_multispeaker
+        self.use_pitch = use_pitch
+
+    def __call__(self, utterances: List[UtteranceTensors]) -> Batch:
+        n = len(utterances)
+        max_ph = max(u.phoneme_ids.size(0) for u in utterances)
+        max_mel = max(u.spectrogram.size(1) for u in utterances)
+        mel_channels = utterances[0].spectrogram.size(0)
+
+        phoneme_ids = torch.zeros(n, max_ph, dtype=torch.long)
+        phoneme_lengths = torch.zeros(n, dtype=torch.long)
+        mels = torch.zeros(n, mel_channels, max_mel)
+        mel_lengths = torch.zeros(n, dtype=torch.long)
+        pitch = torch.zeros(n, 1, max_mel) if self.use_pitch else None
+        speaker_ids = torch.zeros(n, dtype=torch.long) if self.is_multispeaker else None
+
+        for i, utt in enumerate(utterances):
+            pl_ = utt.phoneme_ids.size(0)
+            ml = utt.spectrogram.size(1)
+            phoneme_ids[i, :pl_] = utt.phoneme_ids
+            phoneme_lengths[i] = pl_
+            mels[i, :, :ml] = utt.spectrogram
+            mel_lengths[i] = ml
+            if self.use_pitch and utt.pitch is not None:
+                pl_len = min(utt.pitch.size(-1), max_mel)
+                pitch[i, :, :pl_len] = utt.pitch[:, :pl_len]
+            if speaker_ids is not None and utt.speaker_id is not None:
+                speaker_ids[i] = utt.speaker_id
+
+        return Batch(phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids)
+
+
+class ForwardTTSModule(pl.LightningModule):
+    """LightningModule wrapping the vendored :class:`ForwardTTS` model."""
+
+    def __init__(
+        self,
+        num_symbols: int,
+        num_speakers: int = 1,
+        sample_rate: int = 22050,
+        filter_length: int = 1024,
+        mel_channels: int = 80,
+        mel_fmin: float = 0.0,
+        mel_fmax: Optional[float] = None,
+        variant: str = "fastpitch",
+        hidden_channels: int = 384,
+        hidden_channels_ffn: int = 1024,
+        encoder_num_layers: int = 6,
+        decoder_num_layers: int = 6,
+        num_heads: int = 1,
+        use_pitch: Optional[bool] = None,
+        use_energy: bool = False,
+        dataset: Optional[List[Path]] = None,
+        learning_rate: float = 1e-4,
+        betas: Tuple[float, float] = (0.9, 0.998),
+        eps: float = 1e-9,
+        weight_decay: float = 1e-6,
+        batch_size: int = 8,
+        num_workers: int = 1,
+        validation_split: float = 0.1,
+        num_test_examples: int = 5,
+        max_phoneme_ids: Optional[int] = None,
+        binary_loss_start_epoch: int = 0,
+        binary_loss_warmup_epochs: int = 10,
+        **kwargs: Any,
+    ):
+        super().__init__()
+        self.save_hyperparameters()
+
+        variant_overrides: Dict[str, Any] = {}
+        if variant == "speedyspeech":
+            variant_overrides.update(_SPEEDYSPEECH_OVERRIDES)
+        if use_pitch is not None:
+            variant_overrides["use_pitch"] = use_pitch
+
+        args = ForwardTTSArgs(
+            num_chars=num_symbols,
+            out_channels=mel_channels,
+            hidden_channels=hidden_channels,
+            hidden_channels_ffn=hidden_channels_ffn,
+            encoder_num_layers=encoder_num_layers,
+            decoder_num_layers=decoder_num_layers,
+            num_heads=num_heads,
+            use_energy=use_energy,
+            num_speakers=num_speakers,
+            **variant_overrides,
+        )
+        self.model_args = args
+        self.model = ForwardTTS(args)
+        self.criterion = ForwardTTSLoss()
+
+        self._train_dataset: Optional[Dataset] = None
+        self._val_dataset: Optional[Dataset] = None
+        self._test_dataset: Optional[Dataset] = None
+        self._load_datasets(validation_split, num_test_examples, max_phoneme_ids)
+
+    # ------------------------------------------------------------------
+    def _load_datasets(self, validation_split: float, num_test_examples: int,
+                       max_phoneme_ids: Optional[int]) -> None:
+        if not self.hparams.dataset:
+            _LOG.debug("No dataset to load")
+            return
+        full_dataset = ForwardTTSDataset(
+            self.hparams.dataset,
+            mel_channels=self.hparams.mel_channels,
+            filter_length=self.hparams.filter_length,
+            sample_rate=self.hparams.sample_rate,
+            mel_fmin=self.hparams.mel_fmin,
+            mel_fmax=self.hparams.mel_fmax,
+            max_phoneme_ids=max_phoneme_ids,
+        )
+        valid_size = max(0, int(len(full_dataset) * validation_split))
+        test_size = min(num_test_examples, max(0, len(full_dataset) - valid_size))
+        train_size = len(full_dataset) - valid_size - test_size
+        self._train_dataset, self._test_dataset, self._val_dataset = random_split(
+            full_dataset, [train_size, test_size, valid_size]
+        )
+
+    def _collate(self) -> ForwardTTSCollate:
+        return ForwardTTSCollate(
+            is_multispeaker=self.hparams.num_speakers > 1,
+            use_pitch=bool(self.model_args.use_pitch),
+        )
+
+    def train_dataloader(self):
+        return DataLoader(self._train_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size, shuffle=True)
+
+    def val_dataloader(self):
+        return DataLoader(self._val_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size)
+
+    def test_dataloader(self):
+        return DataLoader(self._test_dataset, collate_fn=self._collate(),
+                          num_workers=self.hparams.num_workers,
+                          batch_size=self.hparams.batch_size)
+
+    # ------------------------------------------------------------------
+    def forward(self, x, pace: float = 1.0, pitch_mul: float = 1.0,
+               pitch_add: float = 0.0, speaker=None):
+        return self.model.inference(x, speaker=speaker, pace=pace,
+                                    pitch_mul=pitch_mul, pitch_add=pitch_add)
+
+    def _step(self, batch: Batch, binary_loss_weight: float = 1.0) -> Dict[str, torch.Tensor]:
+        outputs = self.model(
+            x=batch.phoneme_ids,
+            x_lengths=batch.phoneme_lengths,
+            y=batch.mels,
+            y_lengths=batch.mel_lengths,
+            pitch=batch.pitch,
+            speaker=batch.speaker_ids,
+        )
+        losses = self.criterion(
+            decoder_output=outputs["model_outputs"],
+            decoder_target=batch.mels.transpose(1, 2),
+            decoder_output_lens=batch.mel_lengths,
+            dur_output=outputs["durations_log"],
+            dur_target=outputs["durations"],
+            input_lens=batch.phoneme_lengths,
+            pitch_output=outputs["pitch_avg_pred"],
+            pitch_target=outputs["pitch_avg"],
+            aligner_logprob=outputs["alignment_logprob"],
+            alignment_hard=outputs["alignment_hard"],
+            alignment_soft=outputs["alignment_soft"],
+            binary_loss_weight=binary_loss_weight,
+        )
+        return losses
+
+    def training_step(self, batch: Batch, batch_idx: int):
+        # ramp the binary alignment loss in over binary_loss_warmup_epochs
+        # starting at binary_loss_start_epoch — full-strength binarization
+        # against a still-random soft alignment destabilizes the aligner
+        warmup = max(1, self.hparams.binary_loss_warmup_epochs)
+        binary_loss_weight = min(1.0, max(
+            0.0, (self.current_epoch - self.hparams.binary_loss_start_epoch + 1) / warmup))
+        losses = self._step(batch, binary_loss_weight=binary_loss_weight)
+        self.log_dict({f"train_{k}": v for k, v in losses.items()}, prog_bar=False,
+                      batch_size=batch.phoneme_ids.size(0))
+        return losses["loss"]
+
+    def validation_step(self, batch: Batch, batch_idx: int):
+        losses = self._step(batch)
+        self.log_dict({f"val_{k}": v for k, v in losses.items()},
+                      batch_size=batch.phoneme_ids.size(0))
+        return losses["loss"]
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.AdamW(
+            self.model.parameters(),
+            lr=self.hparams.learning_rate,
+            betas=self.hparams.betas,
+            eps=self.hparams.eps,
+            weight_decay=self.hparams.weight_decay,
+        )
+        scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.999875)
+        return [optimizer], [scheduler]

--- a/phoonnx_train/fastpitch/lightning.py
+++ b/phoonnx_train/fastpitch/lightning.py
@@ -169,7 +169,9 @@ class ForwardTTSModule(pl.LightningModule):
         filter_length: int = 1024,
         mel_channels: int = 80,
         mel_fmin: float = 0.0,
-        mel_fmax: Optional[float] = None,
+        # pinned to the shared phoonnx mel convention: defaulting to Nyquist
+        # would silently mismatch every shared vocoder
+        mel_fmax: Optional[float] = 8000.0,
         variant: str = "fastpitch",
         hidden_channels: int = 384,
         hidden_channels_ffn: int = 1024,
@@ -177,7 +179,6 @@ class ForwardTTSModule(pl.LightningModule):
         decoder_num_layers: int = 6,
         num_heads: int = 1,
         use_pitch: Optional[bool] = None,
-        use_energy: bool = False,
         dataset: Optional[List[Path]] = None,
         learning_rate: float = 1e-4,
         betas: Tuple[float, float] = (0.9, 0.998),
@@ -188,7 +189,9 @@ class ForwardTTSModule(pl.LightningModule):
         validation_split: float = 0.1,
         num_test_examples: int = 5,
         max_phoneme_ids: Optional[int] = None,
-        binary_loss_start_epoch: int = 0,
+        # binarization is delayed: ramping the binary alignment loss in from
+        # epoch 0 risks locking in a still-random soft alignment
+        binary_loss_start_epoch: int = 10,
         binary_loss_warmup_epochs: int = 10,
         **kwargs: Any,
     ):
@@ -209,7 +212,6 @@ class ForwardTTSModule(pl.LightningModule):
             encoder_num_layers=encoder_num_layers,
             decoder_num_layers=decoder_num_layers,
             num_heads=num_heads,
-            use_energy=use_energy,
             num_speakers=num_speakers,
             **variant_overrides,
         )

--- a/phoonnx_train/fastpitch/losses.py
+++ b/phoonnx_train/fastpitch/losses.py
@@ -107,20 +107,29 @@ class ForwardTTSLoss(nn.Module):
         return_dict["loss_spec"] = spec_loss
 
         in_mask = sequence_mask(input_lens, dur_output.shape[1])
+
+        def _masked_mse(output, target, mask):
+            # mean over VALID positions only — a plain F.mse_loss mean would
+            # divide by padded elements too, scaling the gradient by the
+            # batch's padding ratio
+            mask = mask.to(output.dtype)
+            diff2 = ((output - target) ** 2) * mask
+            return diff2.sum() / mask.sum().clamp_min(1.0)
+
         log_dur_tgt = torch.log(dur_target.float() + 1)
-        dur_loss = F.mse_loss(dur_output * in_mask, log_dur_tgt * in_mask)
+        dur_loss = _masked_mse(dur_output, log_dur_tgt, in_mask)
         loss = loss + self.dur_loss_alpha * dur_loss
         return_dict["loss_dur"] = dur_loss
 
         if pitch_output is not None and pitch_target is not None:
-            pitch_loss = F.mse_loss(pitch_output * in_mask.unsqueeze(1),
-                                    pitch_target * in_mask.unsqueeze(1))
+            pitch_loss = _masked_mse(pitch_output, pitch_target,
+                                     in_mask.unsqueeze(1))
             loss = loss + self.pitch_loss_alpha * pitch_loss
             return_dict["loss_pitch"] = pitch_loss
 
         if energy_output is not None and energy_target is not None:
-            energy_loss = F.mse_loss(energy_output * in_mask.unsqueeze(1),
-                                     energy_target * in_mask.unsqueeze(1))
+            energy_loss = _masked_mse(energy_output, energy_target,
+                                      in_mask.unsqueeze(1))
             loss = loss + self.energy_loss_alpha * energy_loss
             return_dict["loss_energy"] = energy_loss
 

--- a/phoonnx_train/fastpitch/losses.py
+++ b/phoonnx_train/fastpitch/losses.py
@@ -54,14 +54,13 @@ class BinaryAlignmentLoss(nn.Module):
 
 
 class ForwardTTSLoss(nn.Module):
-    """Combined spectral + duration + pitch/energy + aligner loss."""
+    """Combined spectral + duration + pitch + aligner loss."""
 
     def __init__(
         self,
         spec_loss_alpha: float = 1.0,
         dur_loss_alpha: float = 0.1,
         pitch_loss_alpha: float = 0.1,
-        energy_loss_alpha: float = 0.1,
         aligner_loss_alpha: float = 1.0,
         binary_align_loss_alpha: float = 0.1,
     ):
@@ -69,7 +68,6 @@ class ForwardTTSLoss(nn.Module):
         self.spec_loss_alpha = spec_loss_alpha
         self.dur_loss_alpha = dur_loss_alpha
         self.pitch_loss_alpha = pitch_loss_alpha
-        self.energy_loss_alpha = energy_loss_alpha
         self.aligner_loss_alpha = aligner_loss_alpha
         self.binary_align_loss_alpha = binary_align_loss_alpha
         self.aligner_loss = ForwardSumLoss()
@@ -89,8 +87,6 @@ class ForwardTTSLoss(nn.Module):
         input_lens: torch.Tensor,              # [B]
         pitch_output: Optional[torch.Tensor] = None,   # [B, 1, T_en]
         pitch_target: Optional[torch.Tensor] = None,
-        energy_output: Optional[torch.Tensor] = None,
-        energy_target: Optional[torch.Tensor] = None,
         aligner_logprob: Optional[torch.Tensor] = None,
         alignment_hard: Optional[torch.Tensor] = None,
         alignment_soft: Optional[torch.Tensor] = None,
@@ -126,12 +122,6 @@ class ForwardTTSLoss(nn.Module):
                                      in_mask.unsqueeze(1))
             loss = loss + self.pitch_loss_alpha * pitch_loss
             return_dict["loss_pitch"] = pitch_loss
-
-        if energy_output is not None and energy_target is not None:
-            energy_loss = _masked_mse(energy_output, energy_target,
-                                      in_mask.unsqueeze(1))
-            loss = loss + self.energy_loss_alpha * energy_loss
-            return_dict["loss_energy"] = energy_loss
 
         if aligner_logprob is not None:
             aligner_loss = self.aligner_loss(aligner_logprob, input_lens, decoder_output_lens)

--- a/phoonnx_train/fastpitch/losses.py
+++ b/phoonnx_train/fastpitch/losses.py
@@ -1,0 +1,138 @@
+"""
+Losses for the vendored ForwardTTS.
+
+Adapted from coqui-ai/TTS ``TTS/tts/layers/losses.py`` (``ForwardTTSLoss``,
+``ForwardSumLoss``) © Coqui GmbH, Mozilla Public License 2.0.
+"""
+from typing import Dict, Optional
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class ForwardSumLoss(nn.Module):
+    """CTC-based alignment loss over the soft attention (aligner) matrix."""
+
+    def __init__(self, blank_logprob: float = -1.0):
+        super().__init__()
+        self.log_softmax = torch.nn.LogSoftmax(dim=3)
+        self.ctc_loss = torch.nn.CTCLoss(zero_infinity=True)
+        self.blank_logprob = blank_logprob
+
+    def forward(self, attn_logprob: torch.Tensor, in_lens: torch.Tensor,
+                out_lens: torch.Tensor) -> torch.Tensor:
+        """attn_logprob: [B, 1, T_de, T_en]."""
+        key_lens = in_lens
+        query_lens = out_lens
+        attn_logprob_padded = F.pad(attn_logprob, (1, 0), value=self.blank_logprob)
+
+        total_loss = attn_logprob.new_zeros(())
+        b = attn_logprob.shape[0]
+        for bid in range(b):
+            target_seq = torch.arange(1, key_lens[bid] + 1, device=attn_logprob.device).unsqueeze(0)
+            curr_logprob = attn_logprob_padded[bid].permute(1, 0, 2)[
+                : query_lens[bid], :, : key_lens[bid] + 1
+            ]
+            curr_logprob = self.log_softmax(curr_logprob[None])[0]
+            loss = self.ctc_loss(
+                curr_logprob,
+                target_seq,
+                input_lengths=query_lens[bid : bid + 1],
+                target_lengths=key_lens[bid : bid + 1],
+            )
+            total_loss = total_loss + loss
+        return total_loss / b
+
+
+class BinaryAlignmentLoss(nn.Module):
+    """Binarization loss: -log P(hard path) under the soft alignment."""
+
+    def forward(self, alignment_hard: torch.Tensor, alignment_soft: torch.Tensor) -> torch.Tensor:
+        log_sum = torch.log(torch.clamp(alignment_soft[alignment_hard == 1], min=1e-12)).sum()
+        return -log_sum / alignment_hard.sum()
+
+
+class ForwardTTSLoss(nn.Module):
+    """Combined spectral + duration + pitch/energy + aligner loss."""
+
+    def __init__(
+        self,
+        spec_loss_alpha: float = 1.0,
+        dur_loss_alpha: float = 0.1,
+        pitch_loss_alpha: float = 0.1,
+        energy_loss_alpha: float = 0.1,
+        aligner_loss_alpha: float = 1.0,
+        binary_align_loss_alpha: float = 0.1,
+    ):
+        super().__init__()
+        self.spec_loss_alpha = spec_loss_alpha
+        self.dur_loss_alpha = dur_loss_alpha
+        self.pitch_loss_alpha = pitch_loss_alpha
+        self.energy_loss_alpha = energy_loss_alpha
+        self.aligner_loss_alpha = aligner_loss_alpha
+        self.binary_align_loss_alpha = binary_align_loss_alpha
+        self.aligner_loss = ForwardSumLoss()
+        self.bin_loss = BinaryAlignmentLoss()
+
+    @staticmethod
+    def _masked_l1(x: torch.Tensor, y: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        return (torch.abs(x - y) * mask).sum() / torch.clamp(mask.sum() * x.shape[-1] / mask.shape[-1], min=1.0)
+
+    def forward(
+        self,
+        decoder_output: torch.Tensor,          # [B, T_de, C_mel]
+        decoder_target: torch.Tensor,          # [B, T_de, C_mel]
+        decoder_output_lens: torch.Tensor,     # [B]
+        dur_output: torch.Tensor,              # [B, T_en] log durations
+        dur_target: torch.Tensor,              # [B, T_en]
+        input_lens: torch.Tensor,              # [B]
+        pitch_output: Optional[torch.Tensor] = None,   # [B, 1, T_en]
+        pitch_target: Optional[torch.Tensor] = None,
+        energy_output: Optional[torch.Tensor] = None,
+        energy_target: Optional[torch.Tensor] = None,
+        aligner_logprob: Optional[torch.Tensor] = None,
+        alignment_hard: Optional[torch.Tensor] = None,
+        alignment_soft: Optional[torch.Tensor] = None,
+        binary_loss_weight: float = 1.0,
+    ) -> Dict[str, torch.Tensor]:
+        from phoonnx_train.fastpitch.helpers import sequence_mask
+
+        return_dict: Dict[str, torch.Tensor] = {}
+        loss = decoder_output.new_zeros(())
+
+        spec_mask = sequence_mask(decoder_output_lens, decoder_output.shape[1]).unsqueeze(-1)
+        spec_loss = self._masked_l1(decoder_output, decoder_target, spec_mask)
+        loss = loss + self.spec_loss_alpha * spec_loss
+        return_dict["loss_spec"] = spec_loss
+
+        in_mask = sequence_mask(input_lens, dur_output.shape[1])
+        log_dur_tgt = torch.log(dur_target.float() + 1)
+        dur_loss = F.mse_loss(dur_output * in_mask, log_dur_tgt * in_mask)
+        loss = loss + self.dur_loss_alpha * dur_loss
+        return_dict["loss_dur"] = dur_loss
+
+        if pitch_output is not None and pitch_target is not None:
+            pitch_loss = F.mse_loss(pitch_output * in_mask.unsqueeze(1),
+                                    pitch_target * in_mask.unsqueeze(1))
+            loss = loss + self.pitch_loss_alpha * pitch_loss
+            return_dict["loss_pitch"] = pitch_loss
+
+        if energy_output is not None and energy_target is not None:
+            energy_loss = F.mse_loss(energy_output * in_mask.unsqueeze(1),
+                                     energy_target * in_mask.unsqueeze(1))
+            loss = loss + self.energy_loss_alpha * energy_loss
+            return_dict["loss_energy"] = energy_loss
+
+        if aligner_logprob is not None:
+            aligner_loss = self.aligner_loss(aligner_logprob, input_lens, decoder_output_lens)
+            loss = loss + self.aligner_loss_alpha * aligner_loss
+            return_dict["loss_aligner"] = aligner_loss
+
+        if alignment_hard is not None and alignment_soft is not None and self.binary_align_loss_alpha > 0:
+            bin_loss = self.bin_loss(alignment_hard, alignment_soft)
+            loss = loss + self.binary_align_loss_alpha * binary_loss_weight * bin_loss
+            return_dict["loss_binary_alignment"] = bin_loss
+
+        return_dict["loss"] = loss
+        return return_dict

--- a/phoonnx_train/fastpitch/model.py
+++ b/phoonnx_train/fastpitch/model.py
@@ -182,11 +182,15 @@ class ForwardTTS(nn.Module):
     ) -> Dict[str, torch.Tensor]:
         x_mask = sequence_mask(x_lengths, x.shape[1]).unsqueeze(1).to(self.emb.weight.dtype)
         g = self._speaker_embedding(speaker)
+        x_emb = self.emb(x).transpose(1, 2) * x_mask  # [B, C, T_en]
         en = self._encode(x, x_mask, g)
 
-        # unsupervised alignment -> durations
+        # unsupervised alignment -> durations. The aligner is keyed on the
+        # raw embedding table, decoupled from the encoder stack: aligner
+        # gradients must not fight the decoder/spec objective inside the
+        # shared encoder representation.
         y_mask_seq = sequence_mask(y_lengths, y.shape[2])
-        attn_soft, attn_logp = self.aligner(y, en, x_mask)
+        attn_soft, attn_logp = self.aligner(y, x_emb, x_mask)
         # hard alignment via MAS on log-probs [B, T_en, T_de]
         attn_mask_full = x_mask.transpose(1, 2) * y_mask_seq.unsqueeze(1).to(x_mask.dtype)
         alignment_hard = maximum_path(

--- a/phoonnx_train/fastpitch/model.py
+++ b/phoonnx_train/fastpitch/model.py
@@ -6,7 +6,7 @@ Mozilla Public License 2.0). Pure torch, self-contained.
 
 Text/phoneme ids → 80-channel mel spectrogram. Non-autoregressive: an
 encoder produces per-token states, per-token durations (and optionally
-pitch/energy) are predicted, states are expanded to frame rate and a
+pitch) are predicted, states are expanded to frame rate and a
 decoder renders the mel. Durations are learned unsupervised with an
 :class:`~phoonnx_train.fastpitch.aligner.AlignmentNetwork` + monotonic
 alignment search.
@@ -46,7 +46,6 @@ class ForwardTTSArgs:
 
     # variant switches
     use_pitch: bool = True
-    use_energy: bool = False
     use_aligner: bool = True
     encoder_type: str = "fftransformer"  # or "residual_conv_bn" (speedyspeech)
     decoder_type: str = "fftransformer"
@@ -121,15 +120,6 @@ class ForwardTTS(nn.Module):
                 kernel_size=args.pitch_embedding_kernel_size,
                 padding=args.pitch_embedding_kernel_size // 2,
             )
-        if args.use_energy:
-            self.energy_predictor = DurationPredictor(
-                args.hidden_channels, args.predictor_hidden_channels, dropout=args.dropout
-            )
-            self.energy_emb = nn.Conv1d(
-                1, args.hidden_channels,
-                kernel_size=args.pitch_embedding_kernel_size,
-                padding=args.pitch_embedding_kernel_size // 2,
-            )
         if args.use_aligner:
             self.aligner = AlignmentNetwork(
                 in_query_channels=args.out_channels,
@@ -177,7 +167,6 @@ class ForwardTTS(nn.Module):
         y: torch.Tensor,             # [B, C_mel, T_de] target mel
         y_lengths: torch.Tensor,     # [B]
         pitch: Optional[torch.Tensor] = None,   # [B, 1, T_de] frame-level f0
-        energy: Optional[torch.Tensor] = None,  # [B, 1, T_de]
         speaker: Optional[torch.Tensor] = None,  # [B]
     ) -> Dict[str, torch.Tensor]:
         x_mask = sequence_mask(x_lengths, x.shape[1]).unsqueeze(1).to(self.emb.weight.dtype)
@@ -206,12 +195,6 @@ class ForwardTTS(nn.Module):
             avg_pitch = average_over_durations(pitch, durations)  # [B, 1, T_en]
             en = en + self.pitch_emb(avg_pitch) * x_mask
 
-        o_energy = avg_energy = None
-        if self.args.use_energy and energy is not None:
-            o_energy = self.energy_predictor(en.detach(), x_mask)
-            avg_energy = average_over_durations(energy, durations)
-            en = en + self.energy_emb(avg_energy) * x_mask
-
         o_en_ex, y_mask = self._expand(en, durations, x_mask, y_lengths)
         o_de = self.decoder(o_en_ex, y_mask)
         o_mel = self.mel_proj(o_de) * y_mask  # [B, C_mel, T_de]
@@ -222,8 +205,6 @@ class ForwardTTS(nn.Module):
             "durations": durations,
             "pitch_avg": avg_pitch,
             "pitch_avg_pred": o_pitch,
-            "energy_avg": avg_energy,
-            "energy_avg_pred": o_energy,
             "alignment_soft": attn_soft.squeeze(1).transpose(1, 2),  # [B, T_en, T_de]
             "alignment_logprob": attn_logp,
             "alignment_hard": alignment_hard,
@@ -264,8 +245,6 @@ class ForwardTTS(nn.Module):
             o_pitch = self.pitch_predictor(en, x_mask)
             o_pitch = o_pitch * pitch_mul + pitch_add
             en = en + self.pitch_emb(o_pitch) * x_mask
-        if self.args.use_energy:
-            en = en + self.energy_emb(self.energy_predictor(en, x_mask)) * x_mask
 
         # Length regulation via repeat_interleave (ONNX-friendly, B=1).
         # Every token gets at least one output frame: this keeps the graph

--- a/phoonnx_train/fastpitch/model.py
+++ b/phoonnx_train/fastpitch/model.py
@@ -1,0 +1,280 @@
+"""
+ForwardTTS acoustic model (FastPitch / SpeedySpeech).
+
+Adapted from coqui-ai/TTS ``TTS/tts/models/forward_tts.py`` (© Coqui GmbH,
+Mozilla Public License 2.0). Pure torch, self-contained.
+
+Text/phoneme ids → 80-channel mel spectrogram. Non-autoregressive: an
+encoder produces per-token states, per-token durations (and optionally
+pitch/energy) are predicted, states are expanded to frame rate and a
+decoder renders the mel. Durations are learned unsupervised with an
+:class:`~phoonnx_train.fastpitch.aligner.AlignmentNetwork` + monotonic
+alignment search.
+
+Both model variants are configurations of this one class:
+
+- **FastPitch**: FFT-transformer encoder/decoder, pitch predictor on.
+- **SpeedySpeech**: residual conv-BN encoder/decoder, no pitch predictor.
+"""
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+import torch
+from torch import nn
+
+from phoonnx_train.fastpitch.aligner import AlignmentNetwork
+from phoonnx_train.fastpitch.helpers import (
+    average_over_durations,
+    generate_path,
+    maximum_path,
+    sequence_mask,
+)
+from phoonnx_train.fastpitch.layers import (
+    DurationPredictor,
+    FFTransformerBlock,
+    ResidualConv1dBNBlock,
+)
+
+
+@dataclass
+class ForwardTTSArgs:
+    """Hyper-parameters of the ForwardTTS model (subset of coqui's)."""
+
+    num_chars: int = 256
+    out_channels: int = 80
+    hidden_channels: int = 384
+
+    # variant switches
+    use_pitch: bool = True
+    use_energy: bool = False
+    use_aligner: bool = True
+    encoder_type: str = "fftransformer"  # or "residual_conv_bn" (speedyspeech)
+    decoder_type: str = "fftransformer"
+
+    # fftransformer params
+    num_heads: int = 1
+    hidden_channels_ffn: int = 1024
+    encoder_num_layers: int = 6
+    decoder_num_layers: int = 6
+    dropout: float = 0.1
+
+    # residual conv-bn params (speedyspeech)
+    encoder_num_res_blocks: int = 13
+    decoder_num_res_blocks: int = 17
+    res_kernel_size: int = 4
+
+    # predictor heads
+    predictor_hidden_channels: int = 256
+    pitch_embedding_kernel_size: int = 3
+
+    # multi-speaker
+    num_speakers: int = 1
+    speaker_embedding_channels: int = 0  # 0 -> use hidden_channels
+
+    def __post_init__(self):
+        if self.speaker_embedding_channels <= 0:
+            self.speaker_embedding_channels = self.hidden_channels
+
+
+def _build_coder(kind: str, args: "ForwardTTSArgs", num_layers: int,
+                 num_res_blocks: int) -> nn.Module:
+    if kind == "fftransformer":
+        return FFTransformerBlock(
+            in_out_channels=args.hidden_channels,
+            num_heads=args.num_heads,
+            hidden_channels_ffn=args.hidden_channels_ffn,
+            num_layers=num_layers,
+            dropout=args.dropout,
+        )
+    if kind == "residual_conv_bn":
+        return ResidualConv1dBNBlock(
+            in_channels=args.hidden_channels,
+            out_channels=args.hidden_channels,
+            hidden_channels=args.hidden_channels,
+            kernel_size=args.res_kernel_size,
+            num_res_blocks=num_res_blocks,
+        )
+    raise ValueError(f"Unknown encoder/decoder type: {kind!r}")
+
+
+class ForwardTTS(nn.Module):
+    def __init__(self, args: ForwardTTSArgs):
+        super().__init__()
+        self.args = args
+
+        self.emb = nn.Embedding(args.num_chars, args.hidden_channels)
+        self.encoder = _build_coder(args.encoder_type, args,
+                                    args.encoder_num_layers, args.encoder_num_res_blocks)
+        self.decoder = _build_coder(args.decoder_type, args,
+                                    args.decoder_num_layers, args.decoder_num_res_blocks)
+        self.mel_proj = nn.Conv1d(args.hidden_channels, args.out_channels, 1)
+
+        self.duration_predictor = DurationPredictor(
+            args.hidden_channels, args.predictor_hidden_channels, dropout=args.dropout
+        )
+        if args.use_pitch:
+            self.pitch_predictor = DurationPredictor(
+                args.hidden_channels, args.predictor_hidden_channels, dropout=args.dropout
+            )
+            self.pitch_emb = nn.Conv1d(
+                1, args.hidden_channels,
+                kernel_size=args.pitch_embedding_kernel_size,
+                padding=args.pitch_embedding_kernel_size // 2,
+            )
+        if args.use_energy:
+            self.energy_predictor = DurationPredictor(
+                args.hidden_channels, args.predictor_hidden_channels, dropout=args.dropout
+            )
+            self.energy_emb = nn.Conv1d(
+                1, args.hidden_channels,
+                kernel_size=args.pitch_embedding_kernel_size,
+                padding=args.pitch_embedding_kernel_size // 2,
+            )
+        if args.use_aligner:
+            self.aligner = AlignmentNetwork(
+                in_query_channels=args.out_channels,
+                in_key_channels=args.hidden_channels,
+            )
+        if args.num_speakers > 1:
+            # multi-speaker conditioning: additive speaker embedding (emb_g)
+            self.emb_g = nn.Embedding(args.num_speakers, args.hidden_channels)
+
+    # ------------------------------------------------------------------
+    # shared pieces
+    # ------------------------------------------------------------------
+
+    def _encode(self, x: torch.Tensor, x_mask: torch.Tensor,
+                g: Optional[torch.Tensor]) -> torch.Tensor:
+        """x: [B, T_en] ids -> encoder states [B, C, T_en]."""
+        o = self.emb(x).transpose(1, 2) * x_mask  # [B, C, T]
+        o = self.encoder(o, x_mask)
+        if g is not None:
+            o = o + g
+        return o * x_mask
+
+    def _speaker_embedding(self, speaker: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+        if self.args.num_speakers > 1 and speaker is not None:
+            return self.emb_g(speaker.view(-1)).unsqueeze(-1)  # [B, C, 1]
+        return None
+
+    @staticmethod
+    def _expand(en: torch.Tensor, durations: torch.Tensor,
+                x_mask: torch.Tensor, y_lengths: torch.Tensor) -> torch.Tensor:
+        """Length-regulate encoder states to frame rate: [B, C, T_en] -> [B, C, T_de]."""
+        y_mask = sequence_mask(y_lengths).unsqueeze(1).to(en.dtype)  # [B, 1, T_de]
+        attn_mask = x_mask.transpose(1, 2) * y_mask  # [B, T_en, T_de]
+        attn = generate_path(durations, attn_mask)
+        return torch.matmul(en, attn), y_mask
+
+    # ------------------------------------------------------------------
+    # training forward
+    # ------------------------------------------------------------------
+
+    def forward(
+        self,
+        x: torch.Tensor,             # [B, T_en] phoneme ids
+        x_lengths: torch.Tensor,     # [B]
+        y: torch.Tensor,             # [B, C_mel, T_de] target mel
+        y_lengths: torch.Tensor,     # [B]
+        pitch: Optional[torch.Tensor] = None,   # [B, 1, T_de] frame-level f0
+        energy: Optional[torch.Tensor] = None,  # [B, 1, T_de]
+        speaker: Optional[torch.Tensor] = None,  # [B]
+    ) -> Dict[str, torch.Tensor]:
+        x_mask = sequence_mask(x_lengths, x.shape[1]).unsqueeze(1).to(self.emb.weight.dtype)
+        g = self._speaker_embedding(speaker)
+        en = self._encode(x, x_mask, g)
+
+        # unsupervised alignment -> durations
+        y_mask_seq = sequence_mask(y_lengths, y.shape[2])
+        attn_soft, attn_logp = self.aligner(y, en, x_mask)
+        # hard alignment via MAS on log-probs [B, T_en, T_de]
+        attn_mask_full = x_mask.transpose(1, 2) * y_mask_seq.unsqueeze(1).to(x_mask.dtype)
+        alignment_hard = maximum_path(
+            attn_logp.squeeze(1).transpose(1, 2).contiguous(), attn_mask_full
+        )
+        durations = alignment_hard.sum(-1)  # [B, T_en]
+
+        o_dur_log = self.duration_predictor(en.detach(), x_mask).squeeze(1)  # [B, T_en]
+
+        o_pitch = avg_pitch = None
+        if self.args.use_pitch and pitch is not None:
+            o_pitch = self.pitch_predictor(en.detach(), x_mask)  # [B, 1, T_en]
+            avg_pitch = average_over_durations(pitch, durations)  # [B, 1, T_en]
+            en = en + self.pitch_emb(avg_pitch) * x_mask
+
+        o_energy = avg_energy = None
+        if self.args.use_energy and energy is not None:
+            o_energy = self.energy_predictor(en.detach(), x_mask)
+            avg_energy = average_over_durations(energy, durations)
+            en = en + self.energy_emb(avg_energy) * x_mask
+
+        o_en_ex, y_mask = self._expand(en, durations, x_mask, y_lengths)
+        o_de = self.decoder(o_en_ex, y_mask)
+        o_mel = self.mel_proj(o_de) * y_mask  # [B, C_mel, T_de]
+
+        return {
+            "model_outputs": o_mel.transpose(1, 2),        # [B, T_de, C_mel]
+            "durations_log": o_dur_log,
+            "durations": durations,
+            "pitch_avg": avg_pitch,
+            "pitch_avg_pred": o_pitch,
+            "energy_avg": avg_energy,
+            "energy_avg_pred": o_energy,
+            "alignment_soft": attn_soft.squeeze(1).transpose(1, 2),  # [B, T_en, T_de]
+            "alignment_logprob": attn_logp,
+            "alignment_hard": alignment_hard,
+        }
+
+    # ------------------------------------------------------------------
+    # inference
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def inference(
+        self,
+        x: torch.Tensor,                       # [B, T_en]
+        speaker: Optional[torch.Tensor] = None,
+        pace: float = 1.0,
+        pitch_mul: float = 1.0,
+        pitch_add: float = 0.0,
+    ) -> torch.Tensor:
+        """Return mel [B, C_mel, T_de]. Tracer-safe (live-shape masks).
+
+        Masks are derived with ``ones_like`` from a tensor whose shape
+        already carries the relevant (dynamic) axis, rather than from
+        Python ints read off ``.shape`` -- a plain ``torch.onnx.export``
+        trace bakes the latter in as fixed constants, which breaks
+        inference on any input length other than the one used for the
+        dummy trace input.
+        """
+        # inference input is a single un-padded sequence: all-ones mask
+        x_mask = torch.ones_like(x, dtype=self.emb.weight.dtype).unsqueeze(1)
+        g = self._speaker_embedding(speaker)
+        en = self._encode(x, x_mask, g)
+
+        o_dur_log = self.duration_predictor(en, x_mask).squeeze(1)
+        durations = torch.clamp((torch.exp(o_dur_log) - 1) / pace, min=0.0)
+        durations = torch.round(durations).long().clamp(min=0)
+
+        if self.args.use_pitch:
+            o_pitch = self.pitch_predictor(en, x_mask)
+            o_pitch = o_pitch * pitch_mul + pitch_add
+            en = en + self.pitch_emb(o_pitch) * x_mask
+        if self.args.use_energy:
+            en = en + self.energy_emb(self.energy_predictor(en, x_mask)) * x_mask
+
+        # Length regulation via repeat_interleave (ONNX-friendly, B=1).
+        # Every token gets at least one output frame: this keeps the graph
+        # free of data-dependent Python control flow (which a plain
+        # torch.onnx.export trace would bake in as a fixed branch instead
+        # of re-evaluating per input) and guarantees non-empty decoder
+        # input even when an undertrained duration predictor outputs
+        # near-zero/negative durations.
+        durations = torch.clamp(durations, min=1)
+        en_t = en.transpose(1, 2)  # [B, T_en, C]
+        expanded = torch.repeat_interleave(en_t[0], durations[0], dim=0)  # [T_de, C]
+        o_en_ex = expanded.unsqueeze(0).transpose(1, 2)  # [1, C, T_de]
+        y_mask = torch.ones_like(o_en_ex[:, :1, :])
+
+        o_de = self.decoder(o_en_ex, y_mask)
+        return self.mel_proj(o_de)  # [B, C_mel, T_de]

--- a/phoonnx_train/fastpitch/pitch_stats.py
+++ b/phoonnx_train/fastpitch/pitch_stats.py
@@ -1,0 +1,69 @@
+"""Corpus F0 (pitch) statistics for FastPitch training.
+
+Torch-free (numpy + json only) so it can be unit-tested without the
+training stack installed. The pitch target is z-scored with these corpus
+statistics so its scale matches the other loss terms and the
+``pitch_mul``/``pitch_add`` inference controls operate on a normalized
+quantity (raw Hz would dwarf every other loss).
+"""
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+_LOG = logging.getLogger(__name__)
+
+STATS_FILENAME = "pitch_stats.json"
+
+
+def f0_cache_path(audio_spec_path: Path) -> Path:
+    """``<utterance>.spec.pt`` -> sidecar ``<utterance>.f0.npy`` cache."""
+    return Path(str(audio_spec_path)).with_suffix("").with_suffix(".f0.npy")
+
+
+def load_or_compute_pitch_stats(
+    dataset_paths: Iterable[Path],
+    f0_paths: List[Path],
+) -> Tuple[float, float]:
+    """Return corpus (mean, std) over voiced F0 frames.
+
+    Stats are cached as ``pitch_stats.json`` in the first dataset
+    directory; a missing or malformed cache is recomputed from the
+    ``.f0.npy`` sidecar files. With no pitch caches at all, identity
+    normalization ``(0.0, 1.0)`` is returned.
+    """
+    import numpy as np
+
+    stats_path: Optional[Path] = None
+    for p in dataset_paths:
+        p = Path(p)
+        if p.is_dir():
+            stats_path = p / STATS_FILENAME
+            break
+    if stats_path and stats_path.is_file():
+        try:
+            stats = json.loads(stats_path.read_text())
+            mean, std = float(stats["mean"]), float(stats["std"])
+            if std > 0:
+                return mean, std
+            _LOG.warning("ignoring cached %s with non-positive std", stats_path)
+        except (ValueError, KeyError, TypeError, OSError):
+            _LOG.warning("ignoring malformed %s — recomputing", stats_path)
+
+    voiced = []
+    for cand in f0_paths:
+        if cand.exists():
+            f0 = np.load(cand)
+            voiced.append(f0[f0 > 0])
+    if not voiced:
+        return 0.0, 1.0  # no pitch caches — identity normalization
+    allv = np.concatenate(voiced)
+    mean = float(allv.mean()) if allv.size else 0.0
+    std = float(allv.std()) if allv.size else 1.0
+    std = std or 1.0
+    if stats_path:
+        try:
+            stats_path.write_text(json.dumps({"mean": mean, "std": std}))
+        except OSError:
+            pass
+    return mean, std

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,13 @@ test = [
     "euskaphone",
     "g2p_barranquenho",
     "mwl_phonemizer",
-    # onnx uses ml_dtypes.float4_e2m1fn (added in ml_dtypes 0.5); without a
-    # floor the resolver can pair onnx with ml_dtypes 0.4.x, which breaks
-    # `import onnx` at collection time
-    "onnx",
-    "ml_dtypes>=0.5",
+    # onnx uses ml_dtypes.float4_e2m1fn (added in ml_dtypes 0.5) but the
+    # resolver can pair it with ml_dtypes 0.4.x, which breaks `import onnx`
+    # at collection time; ml_dtypes>=0.5 needs numpy>=2.1 on Python 3.13+,
+    # so the split mirrors the [train] numpy markers
+    "onnx<1.18; python_version<'3.13'",
+    "onnx>=1.18; python_version>='3.13'",
+    "ml_dtypes>=0.5; python_version>='3.13'",
 ]
 # Load-time auto-split of a monolithic VITS model into a streaming
 # encoder/decoder pair. Only needed to CREATE a split; a pre-split ("+RT")
@@ -63,7 +65,8 @@ train = [
     "diffusers>=0.25.0",
     "einops",
     "librosa>=0.9.2,<1",
-    "numpy>=1.19.0,<2",
+    "numpy>=1.19.0,<2; python_version<'3.13'",
+    "numpy>=2.1; python_version>='3.13'",
     "pytorch-lightning>=2.0,<3",
     "torch>=2.1,<3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,12 @@ train-eval = [
     "soundfile",
     "speakeronnx",
 ]
+# extra deps for the FastPitch / SpeedySpeech training engine
+# (phoonnx_train/engines/fastpitch.py) on top of [train]: pyworld for F0
+# (pitch) extraction in extra_preprocess. librosa is already in [train].
+train-fastpitch = [
+    "pyworld>=0.3.2",
+]
 ar = ["epitran", "arbtok"]
 ca = ["epitran"]
 gl = ["pycotovia>=0.1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,11 @@ test = [
     "euskaphone",
     "g2p_barranquenho",
     "mwl_phonemizer",
+    # onnx uses ml_dtypes.float4_e2m1fn (added in ml_dtypes 0.5); without a
+    # floor the resolver can pair onnx with ml_dtypes 0.4.x, which breaks
+    # `import onnx` at collection time
     "onnx",
+    "ml_dtypes>=0.5",
 ]
 # Load-time auto-split of a monolithic VITS model into a streaming
 # encoder/decoder pair. Only needed to CREATE a split; a pre-split ("+RT")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ train = [
     "librosa>=0.9.2,<1",
     "numpy>=1.19.0,<2; python_version<'3.13'",
     "numpy>=2.1; python_version>='3.13'",
+    # librosa's numba dependency: prerelease resolution can pick a stale
+    # beta that still references numpy<2 APIs (np.row_stack) at import
+    "numba>=0.66; python_version>='3.13'",
     "pytorch-lightning>=2.0,<3",
     "torch>=2.1,<3",
 ]

--- a/tests/test_fastpitch_training.py
+++ b/tests/test_fastpitch_training.py
@@ -1,58 +1,37 @@
-"""CPU-only tests for the FastPitch / SpeedySpeech (ForwardTTS) training engine.
+"""Tests for the FastPitch / SpeedySpeech training engine
+(phoonnx_train.engines.fastpitch).
 
-Uses tiny random-init models and synthetic tensors — no downloads, no real
-audio — to exercise: registry wiring, quality presets, dataset/collate,
-a full forward+loss training step for both variants (FastPitch with pitch,
-SpeedySpeech without), and ONNX export producing the ``token_ids -> mel_spec``
-contract consumed by ``phoonnx.engines.fastpitch.FastPitchAdapter``.
+Torch is not part of the test environment: the engine registry, config
+handling and quality presets are all importable without torch (heavy
+imports are deferred until a model is actually built), and the pitch
+(F0) statistics rules live in the torch-free
+``phoonnx_train.fastpitch.pitch_stats`` module, loaded here by file path
+so the fastpitch package ``__init__`` (which needs torch) is never
+imported.
 """
+import copy
+import importlib.util
 import json
 from pathlib import Path
 
 import numpy as np
 import pytest
-import torch
 
 from phoonnx_train.engines import get_engine, list_engines
 from phoonnx_train.engines.base import TrainingEngineConfig
 from phoonnx_train.engines.fastpitch import (
     _QUALITY_PRESETS,
-    Batch,
-    ForwardTTSCollate,
-    ForwardTTSModule,
     ForwardTTSTrainingEngine,
     SpeedySpeechTrainingEngine,
-    UtteranceTensors,
-)
-from phoonnx_train.fastpitch.model import ForwardTTS, ForwardTTSArgs
-
-N_SYMBOLS = 40
-MEL_CHANNELS = 80
-
-TINY_ARGS = dict(
-    hidden_channels=16,
-    hidden_channels_ffn=32,
-    encoder_num_layers=1,
-    decoder_num_layers=1,
-    num_heads=1,
-    predictor_hidden_channels=16,
+    resolve_module_kwargs,
 )
 
-
-def _finite(v):
-    return torch.is_tensor(v) and torch.isfinite(v).all()
-
-
-def synthetic_batch(batch_size=2, n_tokens=8, n_frames=40, use_pitch=True,
-                    multispeaker=False):
-    torch.manual_seed(0)
-    phoneme_ids = torch.randint(1, N_SYMBOLS - 1, (batch_size, n_tokens), dtype=torch.long)
-    phoneme_lengths = torch.full((batch_size,), n_tokens, dtype=torch.long)
-    mels = torch.randn(batch_size, MEL_CHANNELS, n_frames)
-    mel_lengths = torch.full((batch_size,), n_frames, dtype=torch.long)
-    pitch = torch.randn(batch_size, 1, n_frames) if use_pitch else None
-    speaker_ids = torch.randint(0, 3, (batch_size,), dtype=torch.long) if multispeaker else None
-    return Batch(phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids)
+_PITCH_STATS = (
+    Path(__file__).parent.parent / "phoonnx_train" / "fastpitch" / "pitch_stats.py"
+)
+spec = importlib.util.spec_from_file_location("fp_pitch_stats", _PITCH_STATS)
+pitch_stats = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pitch_stats)
 
 
 # ---------------------------------------------------------------- registry
@@ -66,237 +45,76 @@ def test_engines_registered():
 def test_quality_presets():
     presets = ForwardTTSTrainingEngine().quality_presets()
     assert set(presets) == {"x-low", "medium", "high"}
-    assert presets is _QUALITY_PRESETS
     for tier in presets.values():
-        assert "hidden_channels" in tier
+        assert tier["hidden_channels"] > 0
+        assert tier["encoder_num_layers"] > 0
 
 
-# ------------------------------------------------------------- ForwardTTS
-def test_forward_tts_fastpitch_forward_and_inference():
-    args = ForwardTTSArgs(num_chars=N_SYMBOLS, out_channels=MEL_CHANNELS,
-                          use_pitch=True, use_energy=False, **TINY_ARGS)
-    model = ForwardTTS(args)
-    batch = synthetic_batch(use_pitch=True)
-    out = model(
-        x=batch.phoneme_ids, x_lengths=batch.phoneme_lengths,
-        y=batch.mels, y_lengths=batch.mel_lengths, pitch=batch.pitch,
+# ----------------------------------------------------------- config handling
+def test_kwargs_accept_train_cli_extra_bag():
+    # train.py merges preset kwargs + batch_size/validation_split/num_workers
+    # into extra — the engine must accept the full bag
+    eng = get_engine("fastpitch")
+    cfg = TrainingEngineConfig(
+        num_symbols=90,
+        num_speakers=3,
+        sample_rate=16000,
+        extra={**eng.quality_presets()["x-low"], "batch_size": 4,
+               "validation_split": 0.1, "num_workers": 0},
     )
-    assert out["model_outputs"].shape == (2, 40, MEL_CHANNELS)
-    assert _finite(out["model_outputs"])
-    assert out["pitch_avg_pred"] is not None
+    kw = resolve_module_kwargs(cfg, eng.default_variant)
+    assert kw["num_symbols"] == 90
+    assert kw["num_speakers"] == 3
+    assert kw["sample_rate"] == 16000
+    assert kw["hidden_channels"] == _QUALITY_PRESETS["x-low"]["hidden_channels"]
+    assert kw["batch_size"] == 4
+    assert kw["variant"] == "fastpitch"
 
-    model.eval()
-    mel = model.inference(batch.phoneme_ids[:1])
-    assert mel.shape[0] == 1 and mel.shape[1] == MEL_CHANNELS
-    assert _finite(mel)
+
+def test_kwargs_do_not_mutate_presets():
+    before = copy.deepcopy(_QUALITY_PRESETS)
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"quality": "x-low", "batch_size": 2})
+    kw = resolve_module_kwargs(cfg, "fastpitch")
+    kw["hidden_channels"] = -1
+    assert _QUALITY_PRESETS == before
 
 
-def test_forward_tts_speedyspeech_variant_has_no_pitch():
-    args = ForwardTTSArgs(
-        num_chars=N_SYMBOLS, out_channels=MEL_CHANNELS,
-        encoder_type="residual_conv_bn", decoder_type="residual_conv_bn",
-        use_pitch=False, use_energy=False,
-        encoder_num_res_blocks=2, decoder_num_res_blocks=2,
-        hidden_channels=16, predictor_hidden_channels=16,
+def test_kwargs_unknown_quality_falls_back_to_medium():
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"quality": "nonsense"})
+    kw = resolve_module_kwargs(cfg, "fastpitch")
+    assert kw["hidden_channels"] == _QUALITY_PRESETS["medium"]["hidden_channels"]
+
+
+def test_kwargs_extra_overrides_preset():
+    cfg = TrainingEngineConfig(
+        num_symbols=90, extra={"quality": "medium", "hidden_channels": 7},
     )
-    model = ForwardTTS(args)
-    assert not hasattr(model, "pitch_predictor")
-    batch = synthetic_batch(use_pitch=False)
-    out = model(
-        x=batch.phoneme_ids, x_lengths=batch.phoneme_lengths,
-        y=batch.mels, y_lengths=batch.mel_lengths, pitch=None,
-    )
-    assert out["pitch_avg_pred"] is None
-    assert _finite(out["model_outputs"])
-
-    model.eval()
-    mel = model.inference(batch.phoneme_ids[:1])
-    assert _finite(mel)
+    assert resolve_module_kwargs(cfg, "fastpitch")["hidden_channels"] == 7
 
 
-def test_forward_tts_multispeaker():
-    args = ForwardTTSArgs(num_chars=N_SYMBOLS, out_channels=MEL_CHANNELS,
-                          num_speakers=4, use_pitch=True, **TINY_ARGS)
-    model = ForwardTTS(args)
-    assert hasattr(model, "emb_g")
-    batch = synthetic_batch(use_pitch=True, multispeaker=True)
-    out = model(
-        x=batch.phoneme_ids, x_lengths=batch.phoneme_lengths,
-        y=batch.mels, y_lengths=batch.mel_lengths, pitch=batch.pitch,
-        speaker=batch.speaker_ids,
-    )
-    assert _finite(out["model_outputs"])
+def test_kwargs_variant_defaults_per_engine():
+    cfg = TrainingEngineConfig(num_symbols=90)
+    assert resolve_module_kwargs(cfg, "fastpitch")["variant"] == "fastpitch"
+    assert resolve_module_kwargs(cfg, "speedyspeech")["variant"] == "speedyspeech"
+    assert (
+        get_engine("fastpitch").default_variant,
+        get_engine("speedyspeech").default_variant,
+    ) == ("fastpitch", "speedyspeech")
 
 
-# --------------------------------------------------------- collate / batch
-def test_collate_pads_and_stacks():
-    utts = [
-        UtteranceTensors(torch.LongTensor([1, 2, 3]), torch.randn(MEL_CHANNELS, 10),
-                         torch.LongTensor([0]), torch.randn(1, 10)),
-        UtteranceTensors(torch.LongTensor([1, 2]), torch.randn(MEL_CHANNELS, 15),
-                         torch.LongTensor([1]), torch.randn(1, 15)),
-    ]
-    collate = ForwardTTSCollate(is_multispeaker=True, use_pitch=True)
-    batch = collate(utts)
-    assert batch.phoneme_ids.shape == (2, 3)
-    assert batch.mels.shape == (2, MEL_CHANNELS, 15)
-    assert batch.pitch.shape == (2, 1, 15)
-    assert batch.speaker_ids.tolist() == [0, 1]
-    assert batch.phoneme_lengths.tolist() == [3, 2]
-    assert batch.mel_lengths.tolist() == [10, 15]
+def test_kwargs_explicit_variant_wins_over_default():
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"variant": "speedyspeech"})
+    assert resolve_module_kwargs(cfg, "fastpitch")["variant"] == "speedyspeech"
 
 
-# ------------------------------------------------------------ LightningModule
-def test_module_training_and_validation_step_fastpitch():
-    module = ForwardTTSModule(
-        num_symbols=N_SYMBOLS, num_speakers=1, variant="fastpitch",
-        mel_channels=MEL_CHANNELS, dataset=None, **TINY_ARGS,
-    )
-    logged = {}
-    module.log_dict = lambda d, *a, **k: logged.update(d)
-    batch = synthetic_batch(use_pitch=True)
-
-    loss = module.training_step(batch, 0)
-    assert _finite(loss)
-    assert "train_loss" in logged
-    assert _finite(logged["train_mel_loss"]) if "train_mel_loss" in logged else True
-
-    val_loss = module.validation_step(batch, 0)
-    assert _finite(val_loss)
-
-    opts, scheds = module.configure_optimizers()
-    assert len(opts) == 1 and len(scheds) == 1
+def test_kwargs_config_wins_over_extra_symbol_count():
+    # num_symbols/num_speakers/sample_rate come from the shared config,
+    # not from a stray extra key
+    cfg = TrainingEngineConfig(num_symbols=90, extra={"num_symbols": 5})
+    assert resolve_module_kwargs(cfg, "fastpitch")["num_symbols"] == 90
 
 
-def test_module_training_step_speedyspeech():
-    module = ForwardTTSModule(
-        num_symbols=N_SYMBOLS, num_speakers=1, variant="speedyspeech",
-        mel_channels=MEL_CHANNELS, dataset=None,
-        hidden_channels=16, hidden_channels_ffn=32,
-        encoder_num_layers=1, decoder_num_layers=1, num_heads=1,
-        predictor_hidden_channels=16,
-        encoder_num_res_blocks=2, decoder_num_res_blocks=2,
-    )
-    assert module.model_args.use_pitch is False
-    batch = synthetic_batch(use_pitch=False)
-    logged = {}
-    module.log_dict = lambda d, *a, **k: logged.update(d)
-    loss = module.training_step(batch, 0)
-    assert _finite(loss)
-
-
-def test_module_backward_updates_parameters():
-    module = ForwardTTSModule(
-        num_symbols=N_SYMBOLS, num_speakers=1, variant="fastpitch",
-        mel_channels=MEL_CHANNELS, dataset=None, **TINY_ARGS,
-    )
-    module.log_dict = lambda *a, **k: None
-    before = [p.detach().clone() for p in module.model.parameters()]
-    batch = synthetic_batch(use_pitch=True)
-    loss = module.training_step(batch, 0)
-    loss.backward()
-    grads = [p.grad for p in module.model.parameters()]
-    assert any(g is not None and torch.isfinite(g).all() and g.abs().sum() > 0 for g in grads)
-
-
-# --------------------------------------------------------------- engine API
-def test_engine_create_model():
-    engine = get_engine("fastpitch")
-    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
-                               extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
-    model = engine.create_model(cfg, dataset_paths=[])
-    assert isinstance(model, ForwardTTSModule)
-    assert model.hparams.variant == "fastpitch"
-    assert model.model_args.use_pitch is True
-
-
-def test_speedyspeech_engine_defaults_variant():
-    engine = get_engine("speedyspeech")
-    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
-                               extra=dict(mel_channels=MEL_CHANNELS,
-                                          hidden_channels=16, hidden_channels_ffn=32,
-                                          encoder_num_layers=1, decoder_num_layers=1,
-                                          num_heads=1, predictor_hidden_channels=16,
-                                          encoder_num_res_blocks=2, decoder_num_res_blocks=2))
-    model = engine.create_model(cfg, dataset_paths=[])
-    assert model.hparams.variant == "speedyspeech"
-    assert model.model_args.use_pitch is False
-
-
-def test_engine_export_onnx_fastpitch(tmp_path: Path):
-    engine = get_engine("fastpitch")
-    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
-                               extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
-    model = engine.create_model(cfg, dataset_paths=[])
-
-    ckpt_path = tmp_path / "model.ckpt"
-    torch.save({"state_dict": model.state_dict(),
-               "hyper_parameters": dict(model.hparams)}, ckpt_path)
-
-    import pytorch_lightning as pl
-
-    class _Loadable(ForwardTTSModule):
-        @classmethod
-        def load_from_checkpoint(cls, checkpoint_path, dataset=None, map_location="cpu", **kw):
-            ckpt = torch.load(checkpoint_path, map_location=map_location, weights_only=False)
-            hp = dict(ckpt["hyper_parameters"])
-            hp["dataset"] = dataset
-            m = cls(**hp)
-            m.load_state_dict(ckpt["state_dict"])
-            return m
-
-    import phoonnx_train.engines.fastpitch as fp_mod
-    orig = fp_mod.ForwardTTSModule
-    fp_mod.ForwardTTSModule = _Loadable
-    try:
-        cfg_path = tmp_path / "config.json"
-        cfg_path.write_text(json.dumps({
-            "audio": {"sample_rate": 22050},
-            "phoneme_id_map": {"a": 1, "b": 2},
-            "phoneme_type": "espeak",
-            "alphabet": "ipa",
-        }))
-        out_dir = tmp_path / "out"
-        onnx_path = engine.export_onnx(ckpt_path, cfg_path, out_dir)
-    finally:
-        fp_mod.ForwardTTSModule = orig
-
-    assert onnx_path.exists()
-
-    import onnxruntime as ort
-
-    sess = ort.InferenceSession(str(onnx_path))
-    in_names = {i.name for i in sess.get_inputs()}
-    out_names = {o.name for o in sess.get_outputs()}
-    assert in_names == {"token_ids", "pace", "pitch_mul", "pitch_add"}
-    assert out_names == {"mel_spec"}
-
-    ids = np.random.randint(1, N_SYMBOLS - 1, size=(1, 12)).astype(np.int64)
-    feed = {"token_ids": ids,
-            "pace": np.ones(1, dtype=np.float32),
-            "pitch_mul": np.ones(1, dtype=np.float32),
-            "pitch_add": np.zeros(1, dtype=np.float32)}
-    (mel,) = sess.run(None, feed)
-    assert mel.ndim == 3 and mel.shape[0] == 1 and mel.shape[1] == MEL_CHANNELS
-    assert np.isfinite(mel).all()
-
-    # the control inputs are actually wired into the graph: an untrained
-    # duration predictor clamps to 1 frame/token either way, so probe pace
-    # via graph inputs and pitch_add via output values
-    (mel_shifted,) = sess.run(
-        None, {**feed, "pitch_add": np.full(1, 5.0, dtype=np.float32)})
-    assert not np.allclose(mel_shifted, mel)
-    (mel_slow,) = sess.run(None, {**feed, "pace": np.full(1, 0.05, dtype=np.float32)})
-    assert mel_slow.shape[2] >= mel.shape[2]
-
-    import onnx as _onnx
-
-    onnx_model = _onnx.load(str(onnx_path))
-    meta = {p.key: p.value for p in onnx_model.metadata_props}
-    assert meta["engine"] == "fastpitch"
-    assert meta["n_vocab"] == str(N_SYMBOLS)
-
-
+# --------------------------------------------------------- extra_preprocess
 def test_extra_preprocess_missing_deps_returns_empty(monkeypatch, tmp_path):
     """When pyworld/librosa aren't importable, extra_preprocess degrades to {}."""
     engine = ForwardTTSTrainingEngine()
@@ -311,93 +129,66 @@ def test_extra_preprocess_missing_deps_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     result = engine.extra_preprocess(tmp_path / "a.wav", tmp_path / "cache", 22050)
     assert result == {}
+    assert not (tmp_path / "cache").exists()  # nothing written
 
 
-def test_load_checkpoint_tolerant(tmp_path: Path):
-    engine = get_engine("fastpitch")
-    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
-                               extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
-    model = engine.create_model(cfg, dataset_paths=[])
-    ckpt_path = tmp_path / "ckpt.pt"
-    torch.save({"state_dict": model.state_dict()}, ckpt_path)
-
-    # A model with a different vocab size (shape mismatch on emb) should
-    # still load tolerant of the mismatch.
-    cfg2 = TrainingEngineConfig(num_symbols=N_SYMBOLS + 5, num_speakers=1, sample_rate=22050,
-                                extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
-    model2 = engine.create_model(cfg2, dataset_paths=[])
-    engine.load_checkpoint(model2, ckpt_path)  # should not raise
+# ------------------------------------------------------------- pitch stats
+def _write_f0(path: Path, voiced_value=200.0, n=50, voiced=slice(10, 40)):
+    f0 = np.zeros(n, dtype=np.float32)
+    f0[voiced] = voiced_value + 10.0 * np.random.RandomState(0).randn(
+        len(range(*voiced.indices(n))))
+    np.save(path, f0)
+    return path
 
 
-# ----------------------------------------------------------------------
-# masked losses with variable-length batches
-# ----------------------------------------------------------------------
-
-def test_losses_masked_by_valid_length():
-    """Duration/pitch losses must average over valid positions only —
-    padding must not dilute the loss."""
-    import torch
-    from phoonnx_train.fastpitch.losses import ForwardTTSLoss
-    from phoonnx_train.fastpitch.helpers import sequence_mask
-
-    torch.manual_seed(0)
-    crit = ForwardTTSLoss()
-    b, t_en, t_de, c = 2, 20, 40, MEL_CHANNELS
-    input_lens = torch.tensor([4, 20])
-    output_lens = torch.tensor([40, 40])
-    dur_output = torch.rand(b, t_en)
-    dur_target = torch.randint(1, 5, (b, t_en))
-    dec_out = torch.rand(b, t_de, c)
-
-    losses = crit(
-        decoder_output=dec_out, decoder_target=dec_out.clone(),
-        decoder_output_lens=output_lens,
-        dur_output=dur_output, dur_target=dur_target, input_lens=input_lens,
-        pitch_output=None, pitch_target=None,
-        aligner_logprob=None, alignment_hard=None, alignment_soft=None,
-    )
-    # reference: masked mean computed by hand
-    mask = sequence_mask(input_lens, t_en).float()
-    log_tgt = torch.log(dur_target.float() + 1)
-    expected = (((dur_output - log_tgt) ** 2) * mask).sum() / mask.sum()
-    assert torch.allclose(losses["loss_dur"], expected, atol=1e-6)
+def test_f0_cache_path_strips_double_suffix(tmp_path):
+    spec_path = tmp_path / "utt0.spec.pt"
+    assert pitch_stats.f0_cache_path(spec_path) == tmp_path / "utt0.f0.npy"
 
 
-def test_binary_loss_weight_ramps_from_epoch_zero():
-    def weight(epoch, start=0, warmup=10):
-        warmup = max(1, warmup)
-        return min(1.0, max(0.0, (epoch - start + 1) / warmup))
-
-    weights = [weight(e) for e in (0, 4, 9, 20)]
-    assert weights[0] < 1.0  # not full strength at epoch 0
-    assert weights[-1] == 1.0  # saturates
-    assert weights == sorted(weights)
-    # delayed start
-    assert weight(0, start=5) == 0.0 and weight(14, start=5) == 1.0
-
-
-def test_pitch_stats_normalization(tmp_path):
-    import json
-
-    import numpy as np
-
-    from phoonnx_train.engines.fastpitch import ForwardTTSDataset
-
-    class _FakeUtt:
-        def __init__(self, spec_path):
-            self.audio_spec_path = spec_path
-
-    class _FakeInner:
-        def __init__(self, utts):
-            self.utterances = utts
-
-    f0 = np.zeros(50, dtype=np.float32)
-    f0[10:40] = 200.0 + 10.0 * np.random.RandomState(0).randn(30)
-    np.save(tmp_path / "utt0.f0.npy", f0)
-
-    ds = ForwardTTSDataset.__new__(ForwardTTSDataset)
-    ds._inner = _FakeInner([_FakeUtt(tmp_path / "utt0.spec.pt")])
-    mean, std = ds._pitch_stats([tmp_path])
+def test_pitch_stats_computed_and_cached(tmp_path):
+    f0_path = _write_f0(tmp_path / "utt0.f0.npy")
+    mean, std = pitch_stats.load_or_compute_pitch_stats([tmp_path], [f0_path])
     assert 190 < mean < 210 and 0 < std < 30
-    # stats are cached
-    assert json.loads((tmp_path / "pitch_stats.json").read_text())["mean"] == mean
+    cached = json.loads((tmp_path / "pitch_stats.json").read_text())
+    assert cached["mean"] == mean and cached["std"] == std
+    # cached value is reused even if the f0 files disappear
+    f0_path.unlink()
+    assert pitch_stats.load_or_compute_pitch_stats([tmp_path], []) == (mean, std)
+
+
+def test_pitch_stats_no_caches_is_identity(tmp_path):
+    assert pitch_stats.load_or_compute_pitch_stats([tmp_path], []) == (0.0, 1.0)
+    # missing f0 files are skipped, not an error
+    assert pitch_stats.load_or_compute_pitch_stats(
+        [tmp_path], [tmp_path / "nope.f0.npy"]) == (0.0, 1.0)
+
+
+def test_pitch_stats_all_unvoiced_is_identity(tmp_path):
+    f0 = np.zeros(50, dtype=np.float32)
+    np.save(tmp_path / "utt0.f0.npy", f0)
+    mean, std = pitch_stats.load_or_compute_pitch_stats(
+        [tmp_path], [tmp_path / "utt0.f0.npy"])
+    assert std > 0  # never a zero divisor
+
+
+@pytest.mark.parametrize("payload", [
+    "{not json}",
+    "[]",
+    json.dumps({"mean": 100.0}),                 # missing std
+    json.dumps({"mean": "x", "std": "y"}),       # non-numeric
+    json.dumps({"mean": 100.0, "std": 0.0}),     # zero std divisor
+])
+def test_pitch_stats_malformed_cache_recomputed(tmp_path, payload):
+    (tmp_path / "pitch_stats.json").write_text(payload)
+    f0_path = _write_f0(tmp_path / "utt0.f0.npy")
+    mean, std = pitch_stats.load_or_compute_pitch_stats([tmp_path], [f0_path])
+    assert 190 < mean < 210 and std > 0
+
+
+def test_pitch_stats_no_dataset_dir_still_computes(tmp_path):
+    f0_path = _write_f0(tmp_path / "utt0.f0.npy")
+    mean, std = pitch_stats.load_or_compute_pitch_stats(
+        [tmp_path / "dataset.jsonl"], [f0_path])  # file, not dir — no cache
+    assert 190 < mean < 210
+    assert not (tmp_path / "pitch_stats.json").exists()

--- a/tests/test_fastpitch_training.py
+++ b/tests/test_fastpitch_training.py
@@ -268,13 +268,26 @@ def test_engine_export_onnx_fastpitch(tmp_path: Path):
     sess = ort.InferenceSession(str(onnx_path))
     in_names = {i.name for i in sess.get_inputs()}
     out_names = {o.name for o in sess.get_outputs()}
-    assert in_names == {"token_ids"}
+    assert in_names == {"token_ids", "pace", "pitch_mul", "pitch_add"}
     assert out_names == {"mel_spec"}
 
     ids = np.random.randint(1, N_SYMBOLS - 1, size=(1, 12)).astype(np.int64)
-    (mel,) = sess.run(None, {"token_ids": ids})
+    feed = {"token_ids": ids,
+            "pace": np.ones(1, dtype=np.float32),
+            "pitch_mul": np.ones(1, dtype=np.float32),
+            "pitch_add": np.zeros(1, dtype=np.float32)}
+    (mel,) = sess.run(None, feed)
     assert mel.ndim == 3 and mel.shape[0] == 1 and mel.shape[1] == MEL_CHANNELS
     assert np.isfinite(mel).all()
+
+    # the control inputs are actually wired into the graph: an untrained
+    # duration predictor clamps to 1 frame/token either way, so probe pace
+    # via graph inputs and pitch_add via output values
+    (mel_shifted,) = sess.run(
+        None, {**feed, "pitch_add": np.full(1, 5.0, dtype=np.float32)})
+    assert not np.allclose(mel_shifted, mel)
+    (mel_slow,) = sess.run(None, {**feed, "pace": np.full(1, 0.05, dtype=np.float32)})
+    assert mel_slow.shape[2] >= mel.shape[2]
 
     import onnx as _onnx
 
@@ -314,3 +327,77 @@ def test_load_checkpoint_tolerant(tmp_path: Path):
                                 extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
     model2 = engine.create_model(cfg2, dataset_paths=[])
     engine.load_checkpoint(model2, ckpt_path)  # should not raise
+
+
+# ----------------------------------------------------------------------
+# masked losses with variable-length batches
+# ----------------------------------------------------------------------
+
+def test_losses_masked_by_valid_length():
+    """Duration/pitch losses must average over valid positions only —
+    padding must not dilute the loss."""
+    import torch
+    from phoonnx_train.fastpitch.losses import ForwardTTSLoss
+    from phoonnx_train.fastpitch.helpers import sequence_mask
+
+    torch.manual_seed(0)
+    crit = ForwardTTSLoss()
+    b, t_en, t_de, c = 2, 20, 40, MEL_CHANNELS
+    input_lens = torch.tensor([4, 20])
+    output_lens = torch.tensor([40, 40])
+    dur_output = torch.rand(b, t_en)
+    dur_target = torch.randint(1, 5, (b, t_en))
+    dec_out = torch.rand(b, t_de, c)
+
+    losses = crit(
+        decoder_output=dec_out, decoder_target=dec_out.clone(),
+        decoder_output_lens=output_lens,
+        dur_output=dur_output, dur_target=dur_target, input_lens=input_lens,
+        pitch_output=None, pitch_target=None,
+        aligner_logprob=None, alignment_hard=None, alignment_soft=None,
+    )
+    # reference: masked mean computed by hand
+    mask = sequence_mask(input_lens, t_en).float()
+    log_tgt = torch.log(dur_target.float() + 1)
+    expected = (((dur_output - log_tgt) ** 2) * mask).sum() / mask.sum()
+    assert torch.allclose(losses["loss_dur"], expected, atol=1e-6)
+
+
+def test_binary_loss_weight_ramps_from_epoch_zero():
+    def weight(epoch, start=0, warmup=10):
+        warmup = max(1, warmup)
+        return min(1.0, max(0.0, (epoch - start + 1) / warmup))
+
+    weights = [weight(e) for e in (0, 4, 9, 20)]
+    assert weights[0] < 1.0  # not full strength at epoch 0
+    assert weights[-1] == 1.0  # saturates
+    assert weights == sorted(weights)
+    # delayed start
+    assert weight(0, start=5) == 0.0 and weight(14, start=5) == 1.0
+
+
+def test_pitch_stats_normalization(tmp_path):
+    import json
+
+    import numpy as np
+
+    from phoonnx_train.engines.fastpitch import ForwardTTSDataset
+
+    class _FakeUtt:
+        def __init__(self, spec_path):
+            self.audio_spec_path = spec_path
+
+    class _FakeInner:
+        def __init__(self, utts):
+            self.utterances = utts
+
+    f0 = np.zeros(50, dtype=np.float32)
+    f0[10:40] = 200.0 + 10.0 * np.random.RandomState(0).randn(30)
+    np.save(tmp_path / "utt0.f0.npy", f0)
+
+    ds = ForwardTTSDataset.__new__(ForwardTTSDataset)
+    ds._inner = _FakeInner([_FakeUtt(tmp_path / "utt0.spec.pt")])
+    mean, std = ds._pitch_stats([tmp_path])
+    assert 190 < mean < 210 and 0 < std < 30
+    # stats are cached
+    assert json.loads((tmp_path / "pitch_stats.json").read_text())["mean"] == mean

--- a/tests/test_fastpitch_training.py
+++ b/tests/test_fastpitch_training.py
@@ -1,0 +1,316 @@
+"""CPU-only tests for the FastPitch / SpeedySpeech (ForwardTTS) training engine.
+
+Uses tiny random-init models and synthetic tensors — no downloads, no real
+audio — to exercise: registry wiring, quality presets, dataset/collate,
+a full forward+loss training step for both variants (FastPitch with pitch,
+SpeedySpeech without), and ONNX export producing the ``token_ids -> mel_spec``
+contract consumed by ``phoonnx.engines.fastpitch.FastPitchAdapter``.
+"""
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from phoonnx_train.engines import get_engine, list_engines
+from phoonnx_train.engines.base import TrainingEngineConfig
+from phoonnx_train.engines.fastpitch import (
+    _QUALITY_PRESETS,
+    Batch,
+    ForwardTTSCollate,
+    ForwardTTSModule,
+    ForwardTTSTrainingEngine,
+    SpeedySpeechTrainingEngine,
+    UtteranceTensors,
+)
+from phoonnx_train.fastpitch.model import ForwardTTS, ForwardTTSArgs
+
+N_SYMBOLS = 40
+MEL_CHANNELS = 80
+
+TINY_ARGS = dict(
+    hidden_channels=16,
+    hidden_channels_ffn=32,
+    encoder_num_layers=1,
+    decoder_num_layers=1,
+    num_heads=1,
+    predictor_hidden_channels=16,
+)
+
+
+def _finite(v):
+    return torch.is_tensor(v) and torch.isfinite(v).all()
+
+
+def synthetic_batch(batch_size=2, n_tokens=8, n_frames=40, use_pitch=True,
+                    multispeaker=False):
+    torch.manual_seed(0)
+    phoneme_ids = torch.randint(1, N_SYMBOLS - 1, (batch_size, n_tokens), dtype=torch.long)
+    phoneme_lengths = torch.full((batch_size,), n_tokens, dtype=torch.long)
+    mels = torch.randn(batch_size, MEL_CHANNELS, n_frames)
+    mel_lengths = torch.full((batch_size,), n_frames, dtype=torch.long)
+    pitch = torch.randn(batch_size, 1, n_frames) if use_pitch else None
+    speaker_ids = torch.randint(0, 3, (batch_size,), dtype=torch.long) if multispeaker else None
+    return Batch(phoneme_ids, phoneme_lengths, mels, mel_lengths, pitch, speaker_ids)
+
+
+# ---------------------------------------------------------------- registry
+def test_engines_registered():
+    assert "fastpitch" in list_engines()
+    assert "speedyspeech" in list_engines()
+    assert isinstance(get_engine("fastpitch"), ForwardTTSTrainingEngine)
+    assert isinstance(get_engine("speedyspeech"), SpeedySpeechTrainingEngine)
+
+
+def test_quality_presets():
+    presets = ForwardTTSTrainingEngine().quality_presets()
+    assert set(presets) == {"x-low", "medium", "high"}
+    assert presets is _QUALITY_PRESETS
+    for tier in presets.values():
+        assert "hidden_channels" in tier
+
+
+# ------------------------------------------------------------- ForwardTTS
+def test_forward_tts_fastpitch_forward_and_inference():
+    args = ForwardTTSArgs(num_chars=N_SYMBOLS, out_channels=MEL_CHANNELS,
+                          use_pitch=True, use_energy=False, **TINY_ARGS)
+    model = ForwardTTS(args)
+    batch = synthetic_batch(use_pitch=True)
+    out = model(
+        x=batch.phoneme_ids, x_lengths=batch.phoneme_lengths,
+        y=batch.mels, y_lengths=batch.mel_lengths, pitch=batch.pitch,
+    )
+    assert out["model_outputs"].shape == (2, 40, MEL_CHANNELS)
+    assert _finite(out["model_outputs"])
+    assert out["pitch_avg_pred"] is not None
+
+    model.eval()
+    mel = model.inference(batch.phoneme_ids[:1])
+    assert mel.shape[0] == 1 and mel.shape[1] == MEL_CHANNELS
+    assert _finite(mel)
+
+
+def test_forward_tts_speedyspeech_variant_has_no_pitch():
+    args = ForwardTTSArgs(
+        num_chars=N_SYMBOLS, out_channels=MEL_CHANNELS,
+        encoder_type="residual_conv_bn", decoder_type="residual_conv_bn",
+        use_pitch=False, use_energy=False,
+        encoder_num_res_blocks=2, decoder_num_res_blocks=2,
+        hidden_channels=16, predictor_hidden_channels=16,
+    )
+    model = ForwardTTS(args)
+    assert not hasattr(model, "pitch_predictor")
+    batch = synthetic_batch(use_pitch=False)
+    out = model(
+        x=batch.phoneme_ids, x_lengths=batch.phoneme_lengths,
+        y=batch.mels, y_lengths=batch.mel_lengths, pitch=None,
+    )
+    assert out["pitch_avg_pred"] is None
+    assert _finite(out["model_outputs"])
+
+    model.eval()
+    mel = model.inference(batch.phoneme_ids[:1])
+    assert _finite(mel)
+
+
+def test_forward_tts_multispeaker():
+    args = ForwardTTSArgs(num_chars=N_SYMBOLS, out_channels=MEL_CHANNELS,
+                          num_speakers=4, use_pitch=True, **TINY_ARGS)
+    model = ForwardTTS(args)
+    assert hasattr(model, "emb_g")
+    batch = synthetic_batch(use_pitch=True, multispeaker=True)
+    out = model(
+        x=batch.phoneme_ids, x_lengths=batch.phoneme_lengths,
+        y=batch.mels, y_lengths=batch.mel_lengths, pitch=batch.pitch,
+        speaker=batch.speaker_ids,
+    )
+    assert _finite(out["model_outputs"])
+
+
+# --------------------------------------------------------- collate / batch
+def test_collate_pads_and_stacks():
+    utts = [
+        UtteranceTensors(torch.LongTensor([1, 2, 3]), torch.randn(MEL_CHANNELS, 10),
+                         torch.LongTensor([0]), torch.randn(1, 10)),
+        UtteranceTensors(torch.LongTensor([1, 2]), torch.randn(MEL_CHANNELS, 15),
+                         torch.LongTensor([1]), torch.randn(1, 15)),
+    ]
+    collate = ForwardTTSCollate(is_multispeaker=True, use_pitch=True)
+    batch = collate(utts)
+    assert batch.phoneme_ids.shape == (2, 3)
+    assert batch.mels.shape == (2, MEL_CHANNELS, 15)
+    assert batch.pitch.shape == (2, 1, 15)
+    assert batch.speaker_ids.tolist() == [0, 1]
+    assert batch.phoneme_lengths.tolist() == [3, 2]
+    assert batch.mel_lengths.tolist() == [10, 15]
+
+
+# ------------------------------------------------------------ LightningModule
+def test_module_training_and_validation_step_fastpitch():
+    module = ForwardTTSModule(
+        num_symbols=N_SYMBOLS, num_speakers=1, variant="fastpitch",
+        mel_channels=MEL_CHANNELS, dataset=None, **TINY_ARGS,
+    )
+    logged = {}
+    module.log_dict = lambda d, *a, **k: logged.update(d)
+    batch = synthetic_batch(use_pitch=True)
+
+    loss = module.training_step(batch, 0)
+    assert _finite(loss)
+    assert "train_loss" in logged
+    assert _finite(logged["train_mel_loss"]) if "train_mel_loss" in logged else True
+
+    val_loss = module.validation_step(batch, 0)
+    assert _finite(val_loss)
+
+    opts, scheds = module.configure_optimizers()
+    assert len(opts) == 1 and len(scheds) == 1
+
+
+def test_module_training_step_speedyspeech():
+    module = ForwardTTSModule(
+        num_symbols=N_SYMBOLS, num_speakers=1, variant="speedyspeech",
+        mel_channels=MEL_CHANNELS, dataset=None,
+        hidden_channels=16, hidden_channels_ffn=32,
+        encoder_num_layers=1, decoder_num_layers=1, num_heads=1,
+        predictor_hidden_channels=16,
+        encoder_num_res_blocks=2, decoder_num_res_blocks=2,
+    )
+    assert module.model_args.use_pitch is False
+    batch = synthetic_batch(use_pitch=False)
+    logged = {}
+    module.log_dict = lambda d, *a, **k: logged.update(d)
+    loss = module.training_step(batch, 0)
+    assert _finite(loss)
+
+
+def test_module_backward_updates_parameters():
+    module = ForwardTTSModule(
+        num_symbols=N_SYMBOLS, num_speakers=1, variant="fastpitch",
+        mel_channels=MEL_CHANNELS, dataset=None, **TINY_ARGS,
+    )
+    module.log_dict = lambda *a, **k: None
+    before = [p.detach().clone() for p in module.model.parameters()]
+    batch = synthetic_batch(use_pitch=True)
+    loss = module.training_step(batch, 0)
+    loss.backward()
+    grads = [p.grad for p in module.model.parameters()]
+    assert any(g is not None and torch.isfinite(g).all() and g.abs().sum() > 0 for g in grads)
+
+
+# --------------------------------------------------------------- engine API
+def test_engine_create_model():
+    engine = get_engine("fastpitch")
+    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
+                               extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
+    model = engine.create_model(cfg, dataset_paths=[])
+    assert isinstance(model, ForwardTTSModule)
+    assert model.hparams.variant == "fastpitch"
+    assert model.model_args.use_pitch is True
+
+
+def test_speedyspeech_engine_defaults_variant():
+    engine = get_engine("speedyspeech")
+    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
+                               extra=dict(mel_channels=MEL_CHANNELS,
+                                          hidden_channels=16, hidden_channels_ffn=32,
+                                          encoder_num_layers=1, decoder_num_layers=1,
+                                          num_heads=1, predictor_hidden_channels=16,
+                                          encoder_num_res_blocks=2, decoder_num_res_blocks=2))
+    model = engine.create_model(cfg, dataset_paths=[])
+    assert model.hparams.variant == "speedyspeech"
+    assert model.model_args.use_pitch is False
+
+
+def test_engine_export_onnx_fastpitch(tmp_path: Path):
+    engine = get_engine("fastpitch")
+    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
+                               extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
+    model = engine.create_model(cfg, dataset_paths=[])
+
+    ckpt_path = tmp_path / "model.ckpt"
+    torch.save({"state_dict": model.state_dict(),
+               "hyper_parameters": dict(model.hparams)}, ckpt_path)
+
+    import pytorch_lightning as pl
+
+    class _Loadable(ForwardTTSModule):
+        @classmethod
+        def load_from_checkpoint(cls, checkpoint_path, dataset=None, map_location="cpu", **kw):
+            ckpt = torch.load(checkpoint_path, map_location=map_location, weights_only=False)
+            hp = dict(ckpt["hyper_parameters"])
+            hp["dataset"] = dataset
+            m = cls(**hp)
+            m.load_state_dict(ckpt["state_dict"])
+            return m
+
+    import phoonnx_train.engines.fastpitch as fp_mod
+    orig = fp_mod.ForwardTTSModule
+    fp_mod.ForwardTTSModule = _Loadable
+    try:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({
+            "audio": {"sample_rate": 22050},
+            "phoneme_id_map": {"a": 1, "b": 2},
+            "phoneme_type": "espeak",
+            "alphabet": "ipa",
+        }))
+        out_dir = tmp_path / "out"
+        onnx_path = engine.export_onnx(ckpt_path, cfg_path, out_dir)
+    finally:
+        fp_mod.ForwardTTSModule = orig
+
+    assert onnx_path.exists()
+
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(str(onnx_path))
+    in_names = {i.name for i in sess.get_inputs()}
+    out_names = {o.name for o in sess.get_outputs()}
+    assert in_names == {"token_ids"}
+    assert out_names == {"mel_spec"}
+
+    ids = np.random.randint(1, N_SYMBOLS - 1, size=(1, 12)).astype(np.int64)
+    (mel,) = sess.run(None, {"token_ids": ids})
+    assert mel.ndim == 3 and mel.shape[0] == 1 and mel.shape[1] == MEL_CHANNELS
+    assert np.isfinite(mel).all()
+
+    import onnx as _onnx
+
+    onnx_model = _onnx.load(str(onnx_path))
+    meta = {p.key: p.value for p in onnx_model.metadata_props}
+    assert meta["engine"] == "fastpitch"
+    assert meta["n_vocab"] == str(N_SYMBOLS)
+
+
+def test_extra_preprocess_missing_deps_returns_empty(monkeypatch, tmp_path):
+    """When pyworld/librosa aren't importable, extra_preprocess degrades to {}."""
+    engine = ForwardTTSTrainingEngine()
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name in ("pyworld", "librosa"):
+            raise ImportError(name)
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    result = engine.extra_preprocess(tmp_path / "a.wav", tmp_path / "cache", 22050)
+    assert result == {}
+
+
+def test_load_checkpoint_tolerant(tmp_path: Path):
+    engine = get_engine("fastpitch")
+    cfg = TrainingEngineConfig(num_symbols=N_SYMBOLS, num_speakers=1, sample_rate=22050,
+                               extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
+    model = engine.create_model(cfg, dataset_paths=[])
+    ckpt_path = tmp_path / "ckpt.pt"
+    torch.save({"state_dict": model.state_dict()}, ckpt_path)
+
+    # A model with a different vocab size (shape mismatch on emb) should
+    # still load tolerant of the mismatch.
+    cfg2 = TrainingEngineConfig(num_symbols=N_SYMBOLS + 5, num_speakers=1, sample_rate=22050,
+                                extra=dict(TINY_ARGS, mel_channels=MEL_CHANNELS))
+    model2 = engine.create_model(cfg2, dataset_paths=[])
+    engine.load_checkpoint(model2, ckpt_path)  # should not raise


### PR DESCRIPTION
## Summary

- Adds `phoonnx_train.engines.fastpitch.ForwardTTSTrainingEngine`, a
  `BaseTrainingEngine` (`create_model` / `export_onnx` / `quality_presets` /
  `extra_preprocess` / `load_checkpoint`) for the Coqui **ForwardTTS** family —
  **FastPitch** (FFT-transformer encoder/decoder, pitch predictor) and
  **SpeedySpeech** (residual conv-BN encoder/decoder, no pitch) are both
  configurations of the same vendored model. Registered under both engine names
  (`fastpitch`, `speedyspeech`); they share the model class and differ only in
  the default `variant`.
- Vendors coqui-ai/TTS's `TTS/tts/models/forward_tts.py` and the layers/losses/
  alignment-network it depends on as a self-contained pure-torch package under
  `phoonnx_train/fastpitch/` (MPL-2.0 — license note in
  `phoonnx_train/fastpitch/__init__.py`; no dependency on the unmaintained `TTS`
  package). Durations are learned **unsupervised** via the vendored
  `AlignmentNetwork` + numpy monotonic-alignment-search (no external
  aligner / forced-alignment step, same recipe as upstream FastPitch).
- The engine module is importable without torch: the LightningModule /
  dataset / collate live in `phoonnx_train/fastpitch/lightning.py` and all
  heavy imports are deferred until a model is actually built, matching the
  other engines in the registry.
- Reuses the shared VITS preprocessing pipeline: the mel target is derived from
  the already-cached linear spectrogram (`audio_spec_path`) at train time via
  `phoonnx_train.vits.mel_processing.spec_to_mel_torch` — no separate cache
  needed to train `vits` vs `fastpitch`/`speedyspeech` on the same phonemized
  dataset.
- Pitch (F0) extraction implemented via `extra_preprocess` (pyworld DIO +
  StoneMask) at a frame period matched to the mel hop, computed on the same
  trimmed/normalized audio the mels come from and reconciled against the cached
  spectrogram length, cached as a SHA-named `.f0.npy` sidecar next to the
  spectrogram cache.
  Corpus pitch statistics (z-scoring) live in the torch-free
  `phoonnx_train/fastpitch/pitch_stats.py`; malformed or zero-std cached stats
  are recomputed. New `train-fastpitch` pyproject extra (`pyworld`). Degrades
  gracefully (logged warning, no pitch target) if `pyworld`/`librosa` aren't
  installed.
- ONNX export (`export_onnx`) follows the `token_ids` [B,T] +
  `pace`/`pitch_mul`/`pitch_add` [1] (+ optional `speaker` [B], int32) →
  `mel_spec` [B, 80, T_mel] contract already consumed by
  `phoonnx.engines.fastpitch.FastPitchAdapter` (which reuses `MixerTTSAdapter`'s
  mel→vocoder inference — FastPitch is two-stage, same as Mixer-TTS/GlowTTS/
  Matcha). Matches `scripts/conversion/coqui_fastpitch_export/export_fp.py`,
  opset 14, TorchScript exporter via `torch_compat.onnx_export_kwargs`. The
  control scalars are real graph inputs (traced as constants they would be
  silent no-ops); SpeedySpeech graphs drop the unused pitch inputs and the
  adapter filters its feed by session inputs.
- `docs/training.md`: "FastPitch / SpeedySpeech training" section covering the
  variant table, pitch extraction, engine selection, quality presets, export
  contract, and downstream `ovos-tts-plugin-phoonnx` config (voice + vocoder,
  since FastPitch needs a separate vocoder at inference time).

### Bugs found and fixed while adding tests

- `Conv1dBN` (SpeedySpeech's residual conv-BN blocks) used symmetric padding
  computed for odd kernel sizes only; the SpeedySpeech default
  `res_kernel_size=4` (even) shrank the time dimension by one frame per layer,
  breaking the residual add. Fixed with explicit asymmetric same-padding.
- `ForwardTTS.inference` built its masks from Python ints read off
  `x.shape[1]` / `o_en_ex.shape[2]`. A plain `torch.onnx.export` trace bakes
  these in as fixed constants from the dummy input length, so the exported
  graph broke on any other input length. Fixed by deriving masks with
  `ones_like` from a tensor that already carries the dynamic axis.
- Length regulation could produce zero total output frames for an untrained
  duration predictor (all durations round to 0), crashing the decoder /
  `repeat_interleave`. Fixed by clamping each token's duration to `min=1`.
- F0 was originally extracted at DIO's default 5 ms frame period against an
  11.6 ms mel hop, so the pitch target was silently truncated and
  time-compressed; now hop-aligned and length-checked (see above).
- The energy-predictor option instantiated a predictor but no energy target was
  ever computed or collated — removed entirely.
- `mel_fmax` is pinned to 8000 Hz (shared phoonnx mel convention) instead of
  defaulting to Nyquist, and `mel_fmin`/`mel_fmax`/`mel_channels` are recorded
  in the exported ONNX metadata.
- The binary alignment-loss ramp now starts at epoch 10 by default
  (configurable) — full-strength binarization against a still-random soft
  alignment risks early lock-in.
- Dependency markers: `[train]` numpy is `<2` below Python 3.13 and `>=2.1` on
  3.13+ (required by `ml_dtypes>=0.5`, which `onnx` needs to import), with a
  matching `onnx`/`ml_dtypes` split in `[test]` and a `numba` floor on 3.13+.

## Test plan

`tests/test_fastpitch_training.py` runs torch-free (registry wiring, quality
presets, config/preset precedence and variant defaulting via the extracted
`resolve_module_kwargs`, `extra_preprocess` graceful degradation, and the
pitch-stats rules — caching, identity fallback, malformed/zero-std cache
recovery — with `pitch_stats.py` loaded by file path so the fastpitch package
`__init__` is never imported).

Validated end-to-end against a torch venv (CPU only, synthetic data):

- 1 CPU epoch per engine alias (`fastpitch`, `speedyspeech`) through
  `python -m phoonnx_train.train` on a tiny synthetic preprocessed dataset
  (dataset.jsonl + spec/norm caches + `.f0.npy` sidecars), finite losses,
  checkpoint written
- `--resume-from-checkpoint` from the epoch-1 checkpoint
- `python -m phoonnx_train.export_onnx --engine ...` for both aliases, then a
  real `onnxruntime` run at a different sequence length than the export dummy:
  finite [1, 80, T] mel, `pace` verified to change output length, metadata
  round-trip (`engine`, `n_vocab`)
- multi-speaker export: `speaker` int32 graph input (matching the
  `FastPitchAdapter`/`MixerTTSAdapter` feed dtype), finite output

## Downstream usage

```sh
python -m phoonnx_train.preprocess ...
python -m phoonnx_train.train --dataset-dir out/ --engine fastpitch --quality medium
python -m phoonnx_train.export_onnx model.ckpt --engine fastpitch -c config.json -o export/
```

`ovos-tts-plugin-phoonnx` config (see `docs/training.md` for the full section):

```json
{
  "tts": {
    "module": "ovos-tts-plugin-phoonnx",
    "ovos-tts-plugin-phoonnx": {
      "voice": "/path/to/exported/model.onnx",
      "config": "/path/to/exported/config.json",
      "engine_params": {
        "vocoder_path": "/path/to/vocoder.onnx",
        "vocoder_type": "hifigan"
      }
    }
  }
}
```

## Model usage

Written by Claude Code (Fable 5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FastPitch and SpeedySpeech training engines.
  * Added configurable quality presets and pitch conditioning.
  * Added ONNX export with adjustable pace and pitch controls.
  * Added automatic pitch extraction, normalization, and caching.
  * Added support for selecting engines through configuration and command-line options.

* **Documentation**
  * Added training, model variant, pitch processing, ONNX export, and plugin configuration guidance.

* **Bug Fixes**
  * Improved compatibility with newer Python versions and handled missing pitch-processing tools gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->