### PR TITLE
feat: SILMA TTS v1 (Arabic+English) voice via the f5tts engine

### DIFF
--- a/docs/f5tts.md
+++ b/docs/f5tts.md
@@ -14,15 +14,17 @@ an Euler ODE sampling loop rather than a single-pass graph.
 | Paper | *F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching* — [arXiv:2410.06885](https://arxiv.org/abs/2410.06885) |
 | ONNX export | <https://github.com/DakeQQ/F5-TTS-ONNX> |
 | Habibi-TTS | <https://github.com/SWivid/Habibi-TTS> — Arabic dialectal fine-tune |
+| SILMA TTS | <https://github.com/SILMA-AI/silma-tts> — bilingual Arabic (MSA/Fusha) + English, 150M DiT pretrained from scratch |
 | Languages | Multilingual (trained on Emilia: ZH, EN, + more) |
-| PyTorch weights | [`SWivid/F5-TTS`](https://huggingface.co/SWivid/F5-TTS) (CC-BY-NC-4.0), [`SWivid/Habibi-TTS`](https://huggingface.co/SWivid/Habibi-TTS) (CC-BY-NC-SA-4.0) |
-| **Ready-made ONNX voices** | [`OpenVoiceOS/phoonnx-f5tts`](https://huggingface.co/OpenVoiceOS/phoonnx-f5tts) — `f5tts-v1-base` (multilingual) + `habibi-tts-unified` (Arabic) |
+| PyTorch weights | [`SWivid/F5-TTS`](https://huggingface.co/SWivid/F5-TTS) (CC-BY-NC-4.0), [`SWivid/Habibi-TTS`](https://huggingface.co/SWivid/Habibi-TTS) (CC-BY-NC-SA-4.0), [`silma-ai/silma-tts`](https://huggingface.co/silma-ai/silma-tts) (Apache-2.0) |
+| **Ready-made ONNX voices** | [`OpenVoiceOS/phoonnx-f5tts`](https://huggingface.co/OpenVoiceOS/phoonnx-f5tts) — `f5tts-v1-base` (multilingual) + `habibi-tts-unified` (Arabic) + `silma-tts-v1` (Arabic + English) |
 
 > **License**: the F5-TTS checkpoints are **CC-BY-NC-4.0** (non-commercial).
 > Habibi-TTS licensing is per model (see the
 > [model card](https://huggingface.co/SWivid/Habibi-TTS)): **Unified, SAU and
 > UAE are CC-BY-NC-SA-4.0** (restricted by the SADA and Mixat datasets), while
-> **ALG, EGY, IRQ, MAR and MSA are Apache-2.0**. The ONNX conversions in
+> **ALG, EGY, IRQ, MAR and MSA are Apache-2.0**. **SILMA TTS v1 weights are
+> Apache-2.0** (commercial use allowed). The ONNX conversions in
 > `OpenVoiceOS/phoonnx-f5tts` inherit those licenses.
 
 ## Architecture
@@ -242,6 +244,8 @@ The catalog voices ship in `phoonnx/voice_index/f5tts.json`:
 | `habibi/ar-alg` | Habibi-TTS Specialized ALG | Arabic (Algerian) |
 | `habibi/ar-irq` | Habibi-TTS Specialized IRQ | Arabic (Iraqi) |
 | `habibi/ar-mar` | Habibi-TTS Specialized MAR | Arabic (Moroccan) |
+| `silma/v1` | SILMA TTS v1 (Apache-2.0, commercial OK) | Arabic (MSA/Fusha, full tashkeel support) |
+| `silma/v1-en` | SILMA TTS v1 (same model, English listing) | English |
 
 The model manager downloads the three ONNX graphs on first use (the
 `aux_model_urls` mechanism resolves `preprocess_path` / `decode_path` to the
@@ -254,6 +258,7 @@ locally-cached files automatically).
 | **F5-TTS** | base model (DiT + ConvNeXt V2) |
 | **F5-TTS v1** | improved training and inference (2025/03) |
 | **Habibi-TTS** | Arabic dialectal fine-tune (Unified + Specialized) |
+| **SILMA TTS v1** | bilingual Arabic/English 150M DiT (dim 768, depth 18) pretrained from scratch |
 | **E2-TTS** | Flat-UNet variant (same flow-matching approach) |
 
 Any model using the F5-TTS ONNX export layout (preprocess + transformer + decode)

--- a/phoonnx/voice_index/f5tts.json
+++ b/phoonnx/voice_index/f5tts.json
@@ -151,5 +151,39 @@
             "preprocess_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/habibi-tts-uae/F5_Preprocess.onnx",
             "decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/habibi-tts-uae/F5_Decode.onnx"
         }
+    },
+    "silma/v1": {
+        "voice_id": "silma/v1",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "graphemes",
+        "alphabet": "unicode",
+        "engine": "f5tts",
+        "lang": "ar",
+        "aux_model_urls": {
+            "preprocess_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/F5_Preprocess.onnx",
+            "decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/F5_Decode.onnx"
+        }
+    },
+    "silma/v1-en": {
+        "voice_id": "silma/v1-en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "graphemes",
+        "alphabet": "unicode",
+        "engine": "f5tts",
+        "lang": "en",
+        "aux_model_urls": {
+            "preprocess_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/F5_Preprocess.onnx",
+            "decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/F5_Decode.onnx"
+        }
     }
 }

--- a/tests/test_f5tts.py
+++ b/tests/test_f5tts.py
@@ -248,6 +248,7 @@ def test_f5tts_voice_index_catalog():
         entries = json.load(f)
     assert "f5tts/v1-base" in entries
     assert "habibi/ar-unified" in entries
+    assert "silma/v1" in entries
     for voice_id, entry in entries.items():
         info = TTSModelInfo(**entry)
         assert info.engine == "f5tts"
@@ -290,3 +291,46 @@ def test_f5tts_resample():
     assert F5TTSAdapter._resample(a, 24000, 24000) is a  # no-op
     out = F5TTSAdapter._resample(a, 22050, 24000)
     assert abs(len(out) - 1000 * 24000 / 22050) <= 2
+
+
+def test_silma_voice_index_entries():
+    """SILMA TTS v1 ships as two catalog listings (Arabic primary + English)
+    pointing at the same silma-tts-v1 ONNX export."""
+    import json
+    import os
+    from phoonnx.model_manager import TTSModelInfo
+
+    index = os.path.join(os.path.dirname(__file__), "..", "phoonnx",
+                         "voice_index", "f5tts.json")
+    with open(index, "r", encoding="utf-8") as f:
+        entries = json.load(f)
+
+    ar = TTSModelInfo(**entries["silma/v1"])
+    en = TTSModelInfo(**entries["silma/v1-en"])
+    assert ar.lang == "ar"
+    assert en.lang == "en"
+    for info in (ar, en):
+        assert info.engine == "f5tts"
+        assert info.phoneme_type == "graphemes"
+        assert "/silma-tts-v1/" in info.model_url
+        assert info.model_url.endswith("model.onnx")
+        assert info.aux_model_urls["preprocess_path"].endswith("F5_Preprocess.onnx")
+        assert info.aux_model_urls["decode_path"].endswith("F5_Decode.onnx")
+    # both listings resolve to the exact same artifacts
+    assert ar.model_url == en.model_url
+    assert ar.aux_model_urls == en.aux_model_urls
+
+
+def test_silma_listed_for_arabic_and_english():
+    """The model manager surfaces the silma voices for ar/en lookups."""
+    from phoonnx.model_manager import TTSModelManager
+
+    manager = TTSModelManager()
+    manager.cache.clear()
+    manager.merge_default_voices()
+    assert "silma/v1" in manager.voices
+    assert "silma/v1-en" in manager.voices
+    ar_ids = [v.voice_id for v in manager.get_lang_voices("ar")]
+    en_ids = [v.voice_id for v in manager.get_lang_voices("en-US")]
+    assert "silma/v1" in ar_ids
+    assert "silma/v1-en" in en_ids


### PR DESCRIPTION
## What

Adds [**SILMA TTS v1**](https://huggingface.co/silma-ai/silma-tts) (`silma-ai/silma-tts`) to the phoonnx voice catalog:

- `silma/v1` — Arabic (MSA/Fusha, full tashkeel support)
- `silma/v1-en` — English (same model, second-language listing)

SILMA TTS v1 is a bilingual 150M-parameter flow-matching DiT (**F5-TTS architecture**, `dim=768`, `depth=18`, `heads=12`, char tokenizer, 24 kHz Vocos mel) pretrained from scratch by SILMA AI. **No engine changes are needed** — the existing `F5TTSAdapter` (`engine: "f5tts"`) drives it unchanged, so the PR is catalog + docs + tests only.

## How the library uses the model

Upstream ships only PyTorch weights (`model.pt`). The checkpoint was exported with [DakeQQ/F5-TTS-ONNX](https://github.com/DakeQQ/F5-TTS-ONNX) into the standard three-graph phoonnx F5 pipeline (`model.onnx` transformer + `F5_Preprocess.onnx` + `F5_Decode.onnx` with Vocos/ISTFT baked in), same as the existing `f5tts-v1-base` / `habibi-*` voices. The model manager resolves `aux_model_urls` (`preprocess_path` / `decode_path`) on first use; synthesis is in-context voice cloning — a <8 s 24 kHz reference clip + its transcription per call:

```python
from phoonnx.voice import TTSVoice, SynthesisConfig
voice = TTSVoice.load("model.onnx", config_path="config.json",
                      engine_params={"preprocess_path": "F5_Preprocess.onnx",
                                     "decode_path": "F5_Decode.onnx"})
```

Live-verified locally: Arabic sentence synthesized end-to-end through `TTSVoice` (5.6 s of 24 kHz audio, non-silent) using the exporter's reference clip.

## Downstream OVOS plugin config

```json
{
  "tts": {
    "module": "ovos-tts-plugin-phoonnx",
    "ovos-tts-plugin-phoonnx": {
      "voice": "silma/v1",
      "speaker_reference": "~/reference.wav",
      "speaker_reference_text": "transcription of the reference clip"
    }
  }
}
```

## License

Upstream weights are **Apache-2.0** (commercial use allowed; code MIT). The ONNX conversion inherits Apache-2.0 — this is the first commercially-usable Arabic voice in the f5tts catalog (Habibi Unified is CC-BY-NC-SA-4.0).

## Model artifacts

The exported ONNX artifacts are published at `OpenVoiceOS/phoonnx-f5tts` under `silma-tts-v1/` (all catalog URLs verified live) and the repo is listed in the [Phoonnx TTS models](https://huggingface.co/collections/TigreGotico/phoonnx-tts-models-68cd76d5b485394d9b71032e) collection.

## Tests

- `test_silma_voice_index_entries` — both listings build valid `TTSModelInfo`, same artifacts, correct langs
- `test_silma_listed_for_arabic_and_english` — model manager surfaces the voices for `ar` / `en-US`
- existing catalog test extended to assert `silma/v1`
- full suite: 307 passed, 7 skipped, 1 deselected (pre-existing local numba/numpy env failure in `test_griffinlim_mel_to_audio`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
