### PR TITLE
feat: configurable ONNX Runtime execution providers (AMD/ROCm, DirectML, CoreML, ...)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,3 +126,62 @@ Engine.MIMIC3        # "mimic3"
 Engine.COQUI         # "coqui"
 Engine.TRANSFORMERS  # "transformers"
 ```
+
+## Execution Providers
+
+Every ONNX session phoonnx creates — the voice model and the auxiliary graphs an
+engine loads (vocoders, speaker encoders, text encoders, diacritizers) — runs on a
+resolved, ordered list of ONNX Runtime execution providers.
+
+Pass the list explicitly:
+
+```python
+from phoonnx.voice import TTSVoice
+
+voice = TTSVoice.load(
+    "model.onnx", "config.json",
+    providers=["ROCMExecutionProvider", "CPUExecutionProvider"],
+)
+```
+
+Or set it once for the process:
+
+```bash
+export PHOONNX_ONNX_PROVIDERS="ROCMExecutionProvider,CPUExecutionProvider"
+export PHOONNX_ONNX_PROVIDERS="auto"   # the default: pick the best available
+```
+
+With neither, the best provider the installed runtime offers is auto-detected, in
+this preference order:
+
+`CUDAExecutionProvider` (NVIDIA) → `ROCMExecutionProvider` (AMD) →
+`MIGraphXExecutionProvider` (AMD) → `DmlExecutionProvider` (DirectML) →
+`CoreMLExecutionProvider` (Apple) → `OpenVINOExecutionProvider` (Intel) →
+`CPUExecutionProvider`
+
+A requested provider that the installed runtime does not offer is skipped with a
+warning, and `CPUExecutionProvider` is always appended, so synthesis keeps working
+on any machine.
+
+`use_cuda=True` is a deprecated alias for `providers=["CUDAExecutionProvider"]`.
+
+### Runtime packages
+
+Which providers exist depends on the installed ONNX Runtime build, not on phoonnx.
+The default `onnxruntime` wheel is CPU-only (plus a few platform providers); GPU
+providers need a matching build, and only one of them can be installed at a time:
+
+| Hardware | Package | Provider |
+|---|---|---|
+| NVIDIA | `onnxruntime-gpu` | `CUDAExecutionProvider`, `TensorrtExecutionProvider` |
+| AMD (ROCm) | `onnxruntime-rocm` | `ROCMExecutionProvider`, `MIGraphXExecutionProvider` |
+| Windows (any DX12 GPU) | `onnxruntime-directml` | `DmlExecutionProvider` |
+| Intel | `onnxruntime-openvino` | `OpenVINOExecutionProvider` |
+| Apple | `onnxruntime` | `CoreMLExecutionProvider` |
+
+Check what a machine actually offers:
+
+```python
+import onnxruntime
+print(onnxruntime.get_available_providers())
+```

--- a/docs/ovos_plugin.md
+++ b/docs/ovos_plugin.md
@@ -46,6 +46,28 @@ For the Catalan multiaccent model the indices are: `quim` 0 / `olga` 1 (balear),
 `grau` 2 / `elia` 3 (central), `pere` 4 / `emma` 5 (nord-occidental),
 `lluc` 6 / `gina` 7 (valencià).
 
+### Execution providers
+
+`onnx_providers` takes an ordered list of ONNX Runtime execution providers; the
+first one available on the machine runs the models, with `CPUExecutionProvider`
+always kept as a final fallback. Unset, providers come from the
+`PHOONNX_ONNX_PROVIDERS` environment variable or are auto-detected.
+
+```json
+{
+  "tts": {
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "onnx_providers": ["ROCMExecutionProvider", "CPUExecutionProvider"]
+    }
+  }
+}
+```
+
+Running on a GPU needs the matching ONNX Runtime build (`onnxruntime-rocm`,
+`onnxruntime-gpu`, `onnxruntime-directml`, ...) — see
+[configuration.md](configuration.md#execution-providers).
+
 ## How It Works
 
 `PhoonnxTTSPlugin` extends the `ovos-plugin-manager` `TTS` base class. On initialization, it:

--- a/phoonnx/engines/f5tts.py
+++ b/phoonnx/engines/f5tts.py
@@ -49,6 +49,7 @@ from phoonnx.engines.base import (
     AdapterSynthesisResult,
     BaseOnnxAdapter,
 )
+from phoonnx.providers import make_session
 
 
 # Habibi-TTS dialect control tokens (Unified model only). Upstream wraps the
@@ -94,9 +95,7 @@ class F5TTSAdapter(BaseOnnxAdapter):
     def configure(self, voice_config: Any) -> None:
         """Load auxiliary ONNX graphs and optional vocoder from engine_params."""
         ep = getattr(voice_config, "engine_params", None) or {}
-        sess = lambda p: onnxruntime.InferenceSession(
-            str(p), providers=["CPUExecutionProvider"]
-        )
+        sess = lambda p: make_session(p, providers=ep.get("providers"))
 
         if self.preprocess is None and ep.get("preprocess_path"):
             self.preprocess = sess(ep["preprocess_path"])

--- a/phoonnx/engines/speaker_encoders/coqui_resnet.py
+++ b/phoonnx/engines/speaker_encoders/coqui_resnet.py
@@ -5,14 +5,14 @@ import numpy as np
 import onnxruntime
 
 from phoonnx.engines.speaker_encoders.base import BaseSpeakerEncoder
+from phoonnx.providers import make_session
 
 
 class CoquiResNetSpeakerEncoder(BaseSpeakerEncoder):
     sample_rate = 16000
 
     def __init__(self, model_path: str, config: Optional[Dict[str, Any]] = None):
-        self.session = onnxruntime.InferenceSession(
-            str(model_path), providers=["CPUExecutionProvider"])
+        self.session = make_session(model_path, providers=(config or {}).get("providers"))
         self._input = self.session.get_inputs()[0].name
 
     def encode(self, audio: np.ndarray, sample_rate: int) -> np.ndarray:

--- a/phoonnx/engines/speaker_encoders/styletts2_style.py
+++ b/phoonnx/engines/speaker_encoders/styletts2_style.py
@@ -5,13 +5,14 @@ import numpy as np
 import onnxruntime
 
 from phoonnx.engines.speaker_encoders.base import BaseSpeakerEncoder
+from phoonnx.providers import make_session
 
 
 class StyleTTS2StyleEncoder(BaseSpeakerEncoder):
     sample_rate = 24000
 
     def __init__(self, model_path: str, config: Optional[Dict[str, Any]] = None):
-        self.session = onnxruntime.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+        self.session = make_session(model_path, providers=(config or {}).get("providers"))
         self._input = self.session.get_inputs()[0].name
         self._outs = [o.name for o in self.session.get_outputs()]
 

--- a/phoonnx/engines/styletts2.py
+++ b/phoonnx/engines/styletts2.py
@@ -53,7 +53,7 @@ class StyleTTS2Adapter(BaseOnnxAdapter):
         if self.speaker_encoder is None and ep.get("speaker_encoder_path"):
             from phoonnx.engines.speaker_encoders import build_speaker_encoder
             self.speaker_encoder = build_speaker_encoder(
-                ep["speaker_encoder_path"], ep.get("speaker_encoder_type"))
+                ep["speaker_encoder_path"], ep.get("speaker_encoder_type"), ep)
 
     def build_feed_dict(
         self,

--- a/phoonnx/engines/vocoders/__init__.py
+++ b/phoonnx/engines/vocoders/__init__.py
@@ -80,7 +80,7 @@ def build_vocoder(
 
     # Auto-detection needs the session to inspect the output layout.
     if session is None and model_path:
-        session = load_onnx_session(model_path)
+        session = load_onnx_session(model_path, providers=config.get("providers"))
 
     for name in _DETECT_ORDER:
         try:

--- a/phoonnx/engines/vocoders/base.py
+++ b/phoonnx/engines/vocoders/base.py
@@ -15,19 +15,18 @@ A ``BaseVocoder`` hides those differences behind ``mel_to_audio`` so the
 acoustic-model adapter never has to know which vocoder it is driving.
 """
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
 import onnxruntime
 
+from phoonnx.providers import ProviderSpec, make_session
 
-def load_onnx_session(model_path: str) -> onnxruntime.InferenceSession:
-    """Load an ONNX vocoder on the CPU execution provider."""
-    return onnxruntime.InferenceSession(
-        str(model_path),
-        sess_options=onnxruntime.SessionOptions(),
-        providers=["CPUExecutionProvider"],
-    )
+
+def load_onnx_session(model_path: str,
+                      providers: Optional[Sequence[ProviderSpec]] = None) -> onnxruntime.InferenceSession:
+    """Load an ONNX vocoder on the given (or auto-detected) execution providers."""
+    return make_session(model_path, providers=providers)
 
 
 class BaseVocoder(ABC):
@@ -95,7 +94,8 @@ class BaseVocoder(ABC):
                     f"{type(self).__name__} requires a vocoder 'model_path' "
                     f"(set engine_params.vocoder_path)"
                 )
-            self._session = load_onnx_session(self.model_path)
+            self._session = load_onnx_session(self.model_path,
+                                              providers=self.config.get("providers"))
         return self._session
 
     @property

--- a/phoonnx/engines/yourtts.py
+++ b/phoonnx/engines/yourtts.py
@@ -45,7 +45,7 @@ class YourTTSAdapter(BaseOnnxAdapter):
         if self.speaker_encoder is None and ep.get("speaker_encoder_path"):
             from phoonnx.engines.speaker_encoders import build_speaker_encoder
             self.speaker_encoder = build_speaker_encoder(
-                ep["speaker_encoder_path"], ep.get("speaker_encoder_type"))
+                ep["speaker_encoder_path"], ep.get("speaker_encoder_type"), ep)
 
     def _resolve_dvector(self, params: Dict[str, Any]) -> Optional[np.ndarray]:
         # priority: clone from a reference clip > a d-vector passed in params

--- a/phoonnx/engines/zipvoice.py
+++ b/phoonnx/engines/zipvoice.py
@@ -27,6 +27,7 @@ import numpy as np
 import onnxruntime
 
 from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
 
 
 def _resample(audio: np.ndarray, sr: int, target_sr: int) -> np.ndarray:
@@ -63,7 +64,7 @@ class ZipVoiceAdapter(BaseOnnxAdapter):
         """Load the auxiliary graphs (mel front end, text encoder) and the Vocos
         vocoder from ``engine_params``; the fm_decoder is the voice's own session."""
         ep = getattr(voice_config, "engine_params", None) or {}
-        sess = lambda p: onnxruntime.InferenceSession(str(p), providers=["CPUExecutionProvider"])
+        sess = lambda p: make_session(p, providers=ep.get("providers"))
         if self.text_encoder is None and ep.get("text_encoder_path"):
             self.text_encoder = sess(ep["text_encoder_path"])
         if self.mel is None and ep.get("mel_path"):

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -3,12 +3,13 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Dict, List, Any
+from typing import Optional, Dict, List, Any, Sequence
 import requests
 from json_database import JsonStorageXDG, JsonStorage
 
 from phoonnx.config import PhonemeType, get_phonemizer, VoiceConfig, Engine, Alphabet
 from phoonnx.util import match_lang, normalize_lang, LOG
+from phoonnx.providers import ProviderSpec
 from phoonnx.voice import TTSVoice
 
 
@@ -419,9 +420,14 @@ class TTSModelInfo:
                 params[key] = str(self._fetch_onnx(url, self.voice_path / fname))
         return params
 
-    def load(self) -> TTSVoice:
+    def load(self, providers: Optional[Sequence[ProviderSpec]] = None) -> TTSVoice:
         """
         Load and return a TTSVoice for this model, ensuring the ONNX model is downloaded and the voice configuration is applied.
+
+        Parameters:
+            providers (Sequence, optional): Ordered ONNX Runtime execution providers,
+                e.g. ``["ROCMExecutionProvider", "CPUExecutionProvider"]``. When omitted the
+                providers are resolved from the environment / auto-detection.
         
         Loads a TTSVoice from the cached model and config files (and tokens file if available). If this TTSModelInfo specifies a different phoneme type or alphabet than the loaded voice, updates the loaded voice's phoneme_type and alphabet and rebuilds its phonemizer accordingly.
         
@@ -456,6 +462,7 @@ class TTSModelInfo:
                               phoneme_type_str=self.config.phoneme_type,
                               alphabet_str=self.config.alphabet,
                               engine_params=self.engine_params() or None,
+                              providers=providers,
                               phonemes_txt=str(tokens_path) if self.tokens_url else None)
         # override phoneme_type, if config.json is wrong
         if self.phoneme_type != voice.config.phoneme_type or self.alphabet != voice.config.alphabet:

--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 import wave
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from ovos_utils.log import LOG
 from ovos_plugin_manager.templates.tts import TTS
 
@@ -65,6 +65,20 @@ class PhoonnxTTSPlugin(TTS):
             if key in self.config:
                 return self.config[key]
         return default
+
+    def _providers(self) -> Optional[List[str]]:
+        """
+        Read the ONNX Runtime execution providers from the plugin config.
+
+        ``onnx_providers`` (or ``providers``) takes an ordered list, e.g.
+        ``["ROCMExecutionProvider", "CPUExecutionProvider"]``; a bare string is
+        accepted for a single provider. Unset, providers come from
+        ``PHOONNX_ONNX_PROVIDERS`` or auto-detection.
+        """
+        providers = self._cfg_opt(None, "onnx_providers", "providers")
+        if isinstance(providers, str):
+            return [providers]
+        return list(providers) if providers else None
 
     def _resolve_speaker(self, voice_info) -> Optional[int]:
         """
@@ -155,7 +169,7 @@ class PhoonnxTTSPlugin(TTS):
             if voice_id not in self.model_manager.voices:
                 raise Exception(f"Unknown voice: {voice_id}")
         LOG.debug(f"Using voice: {voice_id}")
-        self.voices[voice_id] = self.model_manager.voices[voice_id].load()
+        self.voices[voice_id] = self.model_manager.voices[voice_id].load(providers=self._providers())
         return self.voices[voice_id]
 
     def get_tts(self, sentence, wav_file, lang=None, voice=None):

--- a/phoonnx/phonemizers/mul.py
+++ b/phoonnx/phonemizers/mul.py
@@ -3,7 +3,7 @@
 import json
 import os
 import subprocess
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Sequence
 
 import numpy as np
 import onnxruntime
@@ -11,6 +11,7 @@ import requests
 
 from phoonnx.config import Alphabet
 from phoonnx.phonemizers.base import BasePhonemizer
+from phoonnx.providers import ProviderSpec, make_session
 
 
 class EspeakError(Exception):
@@ -37,6 +38,7 @@ class ByT5Phonemizer(BasePhonemizer):
                    'it', 'ja', 'ko', 'nl', 'no', 'pl', 'pt', 'pt-br', 'qu', 'ro', 'sr', 'sv', 'tr', 'zh', 'zh-yue']
 
     def __init__(self, model: Optional[str] = None, tokenizer_config: Optional[str] = None,
+                 providers: Optional[Sequence[ProviderSpec]] = None,
                  use_cuda=bool(os.environ.get("CUDA", False))):
         """
         Initializes the ByT5Phonemizer with the ONNX model and tokenizer configuration.
@@ -45,6 +47,8 @@ class ByT5Phonemizer(BasePhonemizer):
         Args:
             model (str, optional): Path to the ONNX model file. If None, it will be downloaded.
             tokenizer_config (str, optional): Path to the tokenizer configuration JSON file. If None, it will be downloaded.
+            providers (Sequence, optional): Ordered ONNX Runtime execution providers.
+            use_cuda (bool): Deprecated alias for ``providers=["CUDAExecutionProvider"]``.
         """
         super().__init__(Alphabet.IPA)
         model = model or "OpenVoiceOS/g2p-mbyt5-12l-ipa-childes-espeak-onnx"
@@ -93,17 +97,7 @@ class ByT5Phonemizer(BasePhonemizer):
             except requests.exceptions.RequestException as e:
                 raise IOError(f"Failed to download tokenizer config: {e}")
 
-        if use_cuda:
-            providers = [
-                (
-                    "CUDAExecutionProvider",
-                    {"cudnn_conv_algo_search": "HEURISTIC"},
-                )
-            ]
-            #LOG.debug("Using CUDA")
-        else:
-            providers = ["CPUExecutionProvider"]
-        self.session = onnxruntime.InferenceSession(self.onnx_model_path, providers=providers)
+        self.session = make_session(self.onnx_model_path, providers=providers, use_cuda=use_cuda)
         with open(self.tokenizer_config, "r") as f:
             self.tokens: Dict[str, int] = json.load(f).get("added_tokens_decoder", {})
 
@@ -254,6 +248,7 @@ class CharsiuPhonemizer(ByT5Phonemizer):
                   'gle', 'enm', 'syc', 'glg', 'sme', 'egy']
 
     def __init__(self, model: Optional[str] = None, tokenizer_config: Optional[str] = None,
+                 providers: Optional[Sequence[ProviderSpec]] = None,
                  use_cuda=bool(os.environ.get("CUDA", False))):
         """
         Initializes the ByT5Phonemizer with the ONNX model and tokenizer configuration.
@@ -262,9 +257,11 @@ class CharsiuPhonemizer(ByT5Phonemizer):
         Args:
             model (str, optional): Path to the ONNX model file. If None, it will be downloaded.
             tokenizer_config (str, optional): Path to the tokenizer configuration JSON file. If None, it will be downloaded.
+            providers (Sequence, optional): Ordered ONNX Runtime execution providers.
+            use_cuda (bool): Deprecated alias for ``providers=["CUDAExecutionProvider"]``.
         """
         model = model or "Jarbas/charsiu_g2p_multilingual_byT5_tiny_16_layers_100_onnx"
-        super().__init__(model, tokenizer_config, use_cuda)
+        super().__init__(model, tokenizer_config, providers, use_cuda)
 
     @classmethod
     def get_lang(cls, target_lang: str) -> str:

--- a/phoonnx/providers.py
+++ b/phoonnx/providers.py
@@ -1,0 +1,153 @@
+"""
+ONNX Runtime execution-provider selection.
+
+Every ``InferenceSession`` in phoonnx is created through :func:`make_session`,
+so a single provider decision applies to the voice model *and* to every
+auxiliary graph it pulls in (vocoders, speaker encoders, text encoders,
+diacritizers).
+
+A provider list is resolved from the first of these that yields something:
+
+1. an explicit ``providers=[...]`` argument (the caller controls the order,
+   including its own fallbacks);
+2. the ``PHOONNX_ONNX_PROVIDERS`` environment variable — a comma-separated
+   provider list, or ``auto``;
+3. auto-detection — :data:`PREFERRED_PROVIDERS` intersected with what the
+   installed ``onnxruntime`` build actually offers.
+
+Requested providers that the installed runtime does not offer are dropped with
+a warning, and ``CPUExecutionProvider`` is always appended, so a session never
+fails because of the provider list.
+
+GPU providers come from the ONNX Runtime build, not from phoonnx: the default
+``onnxruntime`` wheel is CPU-only (plus a few platform providers), ``ROCm``
+needs ``onnxruntime-rocm``, ``DirectML`` needs ``onnxruntime-directml``, and
+CUDA needs ``onnxruntime-gpu``.
+"""
+import os
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import onnxruntime
+
+from phoonnx.util import LOG
+
+#: A provider is either a name or a ``(name, options)`` pair.
+ProviderSpec = Union[str, Tuple[str, Dict[str, Any]]]
+
+CPU_PROVIDER = "CPUExecutionProvider"
+
+#: Environment variable holding a comma-separated provider list, or ``auto``.
+PROVIDERS_ENV_VAR = "PHOONNX_ONNX_PROVIDERS"
+
+#: Auto-detection preference order, best first. Only providers the installed
+#: runtime reports as available are kept.
+PREFERRED_PROVIDERS: List[str] = [
+    "CUDAExecutionProvider",  # NVIDIA
+    "ROCMExecutionProvider",  # AMD
+    "MIGraphXExecutionProvider",  # AMD
+    "DmlExecutionProvider",  # DirectML (Windows)
+    "CoreMLExecutionProvider",  # Apple
+    "OpenVINOExecutionProvider",  # Intel
+    CPU_PROVIDER,
+]
+
+#: Default session options per provider, applied when a provider is requested
+#: by name only.
+PROVIDER_OPTIONS: Dict[str, Dict[str, Any]] = {
+    "CUDAExecutionProvider": {"cudnn_conv_algo_search": "HEURISTIC"},
+}
+
+
+def available_providers() -> List[str]:
+    """Providers offered by the installed ONNX Runtime build."""
+    try:
+        return list(onnxruntime.get_available_providers())
+    except Exception as err:  # pragma: no cover - defensive, ORT always answers
+        LOG.warning(f"could not query onnxruntime providers: {err}")
+        return [CPU_PROVIDER]
+
+
+def _name(provider: ProviderSpec) -> str:
+    return provider[0] if isinstance(provider, tuple) else provider
+
+
+def _with_options(provider: ProviderSpec) -> ProviderSpec:
+    """Attach the default options of a provider given by bare name."""
+    if isinstance(provider, tuple):
+        return provider
+    options = PROVIDER_OPTIONS.get(provider)
+    return (provider, dict(options)) if options else provider
+
+
+def _from_env() -> Optional[Sequence[str]]:
+    raw = os.environ.get(PROVIDERS_ENV_VAR, "").strip()
+    if not raw or raw.lower() == "auto":
+        return None
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def _autodetect() -> List[ProviderSpec]:
+    available = available_providers()
+    return [_with_options(p) for p in PREFERRED_PROVIDERS if p in available]
+
+
+def resolve_providers(
+        providers: Optional[Sequence[ProviderSpec]] = None,
+        use_cuda: bool = False,
+) -> List[ProviderSpec]:
+    """
+    Resolve the execution providers to run a session with.
+
+    Parameters:
+        providers: Ordered provider list; names or ``(name, options)`` pairs.
+            When omitted, ``PHOONNX_ONNX_PROVIDERS`` is consulted and otherwise
+            the best available provider is auto-detected.
+        use_cuda: Deprecated alias for ``providers=["CUDAExecutionProvider"]``.
+            Ignored when ``providers`` is given.
+
+    Returns:
+        A provider list, filtered to what the runtime offers and always ending
+        in ``CPUExecutionProvider``.
+    """
+    if providers is None and use_cuda:
+        LOG.warning("'use_cuda' is deprecated, pass "
+                    "providers=['CUDAExecutionProvider'] instead")
+        providers = ["CUDAExecutionProvider"]
+
+    if providers is None:
+        providers = _from_env()
+
+    if providers is None:
+        resolved = _autodetect()
+    else:
+        available = available_providers()
+        resolved = []
+        for provider in providers:
+            if _name(provider) in available:
+                resolved.append(_with_options(provider))
+            else:
+                LOG.warning(
+                    f"'{_name(provider)}' is not available in this onnxruntime "
+                    f"build (available: {available}), skipping it. Install the "
+                    f"matching onnxruntime package to enable it."
+                )
+
+    if not any(_name(p) == CPU_PROVIDER for p in resolved):
+        resolved.append(CPU_PROVIDER)
+
+    LOG.debug(f"onnxruntime execution providers: {[_name(p) for p in resolved]}")
+    return resolved
+
+
+def make_session(
+        model_path: Any,
+        providers: Optional[Sequence[ProviderSpec]] = None,
+        sess_options: Optional[onnxruntime.SessionOptions] = None,
+        use_cuda: bool = False,
+) -> onnxruntime.InferenceSession:
+    """Create an ``InferenceSession`` on the resolved execution providers."""
+    return onnxruntime.InferenceSession(
+        str(model_path),
+        sess_options=sess_options or onnxruntime.SessionOptions(),
+        providers=resolve_providers(providers, use_cuda=use_cuda),
+    )

--- a/phoonnx/thirdparty/tashkeel/__init__.py
+++ b/phoonnx/thirdparty/tashkeel/__init__.py
@@ -7,10 +7,10 @@ Ported with the help of ChatGPT 2025-05-01.
 
 import json
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 import numpy as np
-from onnxruntime import InferenceSession
+from phoonnx.providers import ProviderSpec, make_session
 
 TASHKEEL_DIR = Path(__file__).parent
 CHAR_LIMIT = 12000
@@ -30,10 +30,11 @@ class TashkeelError(Exception):
 class TashkeelDiacritizer:
     """Add diacritics for Arabic text with libtashkeel."""
 
-    def __init__(self, model_dir: Union[str, Path] = TASHKEEL_DIR) -> None:
+    def __init__(self, model_dir: Union[str, Path] = TASHKEEL_DIR,
+                 providers: Optional[Sequence[ProviderSpec]] = None) -> None:
         """Initialize diacritizer."""
         model_dir = Path(model_dir)
-        self.session = InferenceSession(model_dir / "model.onnx")
+        self.session = make_session(model_dir / "model.onnx", providers=providers)
 
         # Load JSON maps
         with open(

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -12,7 +12,7 @@ import re
 import wave
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional, Union, Dict
+from typing import Any, Iterable, Optional, Sequence, Union, Dict
 
 import numpy as np
 import onnxruntime
@@ -26,6 +26,7 @@ from phoonnx.engines.base import (
     BaseOnnxAdapter,
 )
 from phoonnx.phonemizers import Phonemizer
+from phoonnx.providers import ProviderSpec, make_session, resolve_providers
 from phoonnx.phonemizers.base import PhonemizedChunks
 from phoonnx.tokenizer import TTSTokenizer
 from phoonnx.util import LOG
@@ -202,6 +203,7 @@ class TTSVoice:
             phoneme_type_str: Optional[str] = None,
             alphabet_str: Optional[str] = None,
             engine_params: Optional[Dict[str, Any]] = None,
+            providers: Optional[Sequence[ProviderSpec]] = None,
             use_cuda: bool = False
     ) -> "TTSVoice":
         """
@@ -215,7 +217,13 @@ class TTSVoice:
             lang_code (str, optional): Language code to override or set in the loaded voice configuration.
             phoneme_type_str (str, optional): Phoneme type identifier to override the configuration (for example, "arpabet" or "ipa").
             alphabet_str (str, optional): Alphabet override to pass into the VoiceConfig during load.
-            use_cuda (bool): If true, prefer CUDA execution provider for ONNX Runtime; otherwise use the CPU provider.
+            providers (Sequence, optional): Ordered ONNX Runtime execution providers, e.g.
+                ``["ROCMExecutionProvider", "CPUExecutionProvider"]``. When omitted, the
+                ``PHOONNX_ONNX_PROVIDERS`` environment variable is used, falling back to
+                auto-detecting the best provider the installed runtime offers. The resolved
+                list also drives the auxiliary graphs an engine loads (vocoders, speaker
+                encoders, ...).
+            use_cuda (bool): Deprecated alias for ``providers=["CUDAExecutionProvider"]``.
         
         Returns:
             TTSVoice: A TTSVoice instance prepared with the loaded ONNX session and merged configuration.
@@ -237,23 +245,9 @@ class TTSVoice:
             if tokenizer_config_path and os.path.isfile(tokenizer_config_path):
                 with open(tokenizer_config_path, "r", encoding="utf-8") as tokenizer_file:
                     tokenizer_dict = json.load(tokenizer_file)
-        providers: list[Union[str, tuple[str, dict[str, Any]]]]
-        if use_cuda:
-            providers = [
-                (
-                    "CUDAExecutionProvider",
-                    {"cudnn_conv_algo_search": "HEURISTIC"},
-                )
-            ]
-            LOG.debug("Using CUDA")
-        else:
-            providers = ["CPUExecutionProvider"]
+        resolved_providers = resolve_providers(providers, use_cuda=use_cuda)
 
-        session = onnxruntime.InferenceSession(
-            str(model_path),
-            sess_options=onnxruntime.SessionOptions(),
-            providers=providers,
-        )
+        session = make_session(model_path, providers=resolved_providers)
 
         # Auto-detect engine adapter from config + session
         adapter = detect_engine(config=config_dict, session=session)
@@ -262,6 +256,10 @@ class TTSVoice:
         # the caller (the voice manager injects locally-downloaded paths) or
         # from the model's own config JSON.
         engine_params = engine_params or config_dict.get("engine_params") or {}
+        # Engines load auxiliary graphs of their own (vocoders, speaker encoders,
+        # text encoders); they run on the same providers as the voice itself.
+        engine_params = dict(engine_params)
+        engine_params.setdefault("providers", resolved_providers)
 
         voice_config = VoiceConfig.from_dict(
             config_dict,

--- a/tests/test_opm.py
+++ b/tests/test_opm.py
@@ -31,8 +31,10 @@ class _FakeVoiceInfo:
         self.lang = lang
         self.config = _FakeVoiceConfig(speaker_id_map=speaker_id_map)
         self.tts_voice = MagicMock(name=f"TTSVoice[{voice_id}]")
+        self.load_providers = "unset"
 
-    def load(self):
+    def load(self, providers=None):
+        self.load_providers = providers
         return self.tts_voice
 
 
@@ -127,6 +129,28 @@ class TestVoiceResolution(unittest.TestCase):
         plugin, _ = _make_plugin(voices=[v])
         with self.assertRaises(Exception):
             plugin.get_model("OpenVoiceOS/nope")
+
+    def test_configured_providers_reach_the_voice_loader(self):
+        v = _FakeVoiceInfo("OpenVoiceOS/known")
+        plugin, _ = _make_plugin(
+            config={"onnx_providers": ["ROCMExecutionProvider", "CPUExecutionProvider"]},
+            voices=[v])
+        plugin.get_model(v.voice_id)
+        self.assertEqual(v.load_providers,
+                         ["ROCMExecutionProvider", "CPUExecutionProvider"])
+
+    def test_single_provider_string_is_wrapped_in_a_list(self):
+        v = _FakeVoiceInfo("OpenVoiceOS/known")
+        plugin, _ = _make_plugin(config={"providers": "ROCMExecutionProvider"},
+                                 voices=[v])
+        plugin.get_model(v.voice_id)
+        self.assertEqual(v.load_providers, ["ROCMExecutionProvider"])
+
+    def test_unconfigured_providers_are_left_to_autodetection(self):
+        v = _FakeVoiceInfo("OpenVoiceOS/known")
+        plugin, _ = _make_plugin(voices=[v])
+        plugin.get_model(v.voice_id)
+        self.assertIsNone(v.load_providers)
 
     def test_get_model_caches(self):
         v = _FakeVoiceInfo("OpenVoiceOS/known")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,190 @@
+import unittest
+from unittest.mock import patch
+
+from phoonnx import providers
+from phoonnx.providers import (
+    CPU_PROVIDER,
+    PROVIDERS_ENV_VAR,
+    make_session,
+    resolve_providers,
+)
+
+CPU_ONLY = ["CPUExecutionProvider"]
+ROCM_BOX = ["ROCMExecutionProvider", "MIGraphXExecutionProvider", "CPUExecutionProvider"]
+CUDA_BOX = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+
+def _available(names):
+    """Pretend the installed onnxruntime build offers exactly *names*."""
+    return patch.object(providers, "available_providers", lambda: list(names))
+
+
+def _names(resolved):
+    return [p[0] if isinstance(p, tuple) else p for p in resolved]
+
+
+class TestExplicitProviders(unittest.TestCase):
+    def setUp(self):
+        patcher = patch.dict("os.environ", {}, clear=False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        import os
+        os.environ.pop(PROVIDERS_ENV_VAR, None)
+
+    def test_explicit_list_is_kept_in_order(self):
+        with _available(ROCM_BOX):
+            resolved = resolve_providers(
+                ["MIGraphXExecutionProvider", "ROCMExecutionProvider", CPU_PROVIDER])
+        self.assertEqual(
+            _names(resolved),
+            ["MIGraphXExecutionProvider", "ROCMExecutionProvider", CPU_PROVIDER])
+
+    def test_cpu_fallback_is_appended_when_omitted(self):
+        with _available(ROCM_BOX):
+            resolved = resolve_providers(["ROCMExecutionProvider"])
+        self.assertEqual(_names(resolved), ["ROCMExecutionProvider", CPU_PROVIDER])
+
+    def test_provider_options_are_preserved(self):
+        with _available(CUDA_BOX):
+            resolved = resolve_providers(
+                [("CUDAExecutionProvider", {"device_id": 1})])
+        self.assertEqual(resolved[0], ("CUDAExecutionProvider", {"device_id": 1}))
+
+    def test_named_cuda_gets_default_options(self):
+        with _available(CUDA_BOX):
+            resolved = resolve_providers(["CUDAExecutionProvider"])
+        self.assertEqual(
+            resolved[0],
+            ("CUDAExecutionProvider", {"cudnn_conv_algo_search": "HEURISTIC"}))
+
+
+class TestAutoDetection(unittest.TestCase):
+    def setUp(self):
+        import os
+        os.environ.pop(PROVIDERS_ENV_VAR, None)
+
+    def test_best_available_provider_wins(self):
+        with _available(ROCM_BOX):
+            resolved = resolve_providers()
+        self.assertEqual(
+            _names(resolved),
+            ["ROCMExecutionProvider", "MIGraphXExecutionProvider", CPU_PROVIDER])
+
+    def test_cpu_only_build_resolves_to_cpu(self):
+        with _available(CPU_ONLY):
+            resolved = resolve_providers()
+        self.assertEqual(_names(resolved), [CPU_PROVIDER])
+
+    def test_unknown_available_providers_are_ignored(self):
+        with _available(["MadeUpExecutionProvider", "CPUExecutionProvider"]):
+            resolved = resolve_providers()
+        self.assertEqual(_names(resolved), [CPU_PROVIDER])
+
+
+class TestUnavailableProviderFallback(unittest.TestCase):
+    def setUp(self):
+        import os
+        os.environ.pop(PROVIDERS_ENV_VAR, None)
+
+    def test_unavailable_provider_is_dropped_with_a_warning(self):
+        with _available(CPU_ONLY):
+            with patch.object(providers.LOG, "warning") as warn:
+                resolved = resolve_providers(["ROCMExecutionProvider"])
+        self.assertEqual(_names(resolved), [CPU_PROVIDER])
+        warned = " ".join(str(c) for c in warn.call_args_list)
+        self.assertIn("ROCMExecutionProvider", warned)
+
+    def test_partially_available_list_keeps_what_works(self):
+        with _available(CUDA_BOX):
+            resolved = resolve_providers(
+                ["ROCMExecutionProvider", "CUDAExecutionProvider", CPU_PROVIDER])
+        self.assertEqual(_names(resolved), ["CUDAExecutionProvider", CPU_PROVIDER])
+
+
+class TestUseCudaBackCompat(unittest.TestCase):
+    def setUp(self):
+        import os
+        os.environ.pop(PROVIDERS_ENV_VAR, None)
+
+    def test_use_cuda_warns_that_it_is_deprecated(self):
+        with _available(CUDA_BOX):
+            with patch.object(providers.LOG, "warning") as warn:
+                resolve_providers(use_cuda=True)
+        self.assertTrue(warn.called)
+
+    def test_use_cuda_selects_cuda_when_available(self):
+        with _available(CUDA_BOX):
+            resolved = resolve_providers(use_cuda=True)
+        self.assertEqual(_names(resolved), ["CUDAExecutionProvider", CPU_PROVIDER])
+        self.assertEqual(
+            resolved[0][1], {"cudnn_conv_algo_search": "HEURISTIC"})
+
+    def test_use_cuda_falls_back_to_cpu_without_cuda(self):
+        with _available(ROCM_BOX):
+            resolved = resolve_providers(use_cuda=True)
+        self.assertEqual(_names(resolved), [CPU_PROVIDER])
+
+    def test_use_cuda_false_does_not_force_cpu(self):
+        with _available(ROCM_BOX):
+            resolved = resolve_providers(use_cuda=False)
+        self.assertEqual(_names(resolved)[0], "ROCMExecutionProvider")
+
+    def test_explicit_providers_win_over_use_cuda(self):
+        with _available(["ROCMExecutionProvider", "CUDAExecutionProvider", CPU_PROVIDER]):
+            resolved = resolve_providers(["ROCMExecutionProvider"], use_cuda=True)
+        self.assertEqual(_names(resolved), ["ROCMExecutionProvider", CPU_PROVIDER])
+
+
+class TestEnvVar(unittest.TestCase):
+    def test_env_var_provider_list(self):
+        with patch.dict("os.environ",
+                        {PROVIDERS_ENV_VAR: "ROCMExecutionProvider, CPUExecutionProvider"}):
+            with _available(ROCM_BOX):
+                resolved = resolve_providers()
+        self.assertEqual(_names(resolved), ["ROCMExecutionProvider", CPU_PROVIDER])
+
+    def test_env_var_auto_means_autodetect(self):
+        with patch.dict("os.environ", {PROVIDERS_ENV_VAR: "auto"}):
+            with _available(ROCM_BOX):
+                resolved = resolve_providers()
+        self.assertEqual(_names(resolved)[0], "ROCMExecutionProvider")
+
+    def test_explicit_providers_win_over_env_var(self):
+        with patch.dict("os.environ", {PROVIDERS_ENV_VAR: "CPUExecutionProvider"}):
+            with _available(CUDA_BOX):
+                resolved = resolve_providers(["CUDAExecutionProvider"])
+        self.assertEqual(_names(resolved)[0], "CUDAExecutionProvider")
+
+    def test_unavailable_env_provider_warns_and_falls_back(self):
+        with patch.dict("os.environ", {PROVIDERS_ENV_VAR: "DmlExecutionProvider"}):
+            with _available(CPU_ONLY):
+                with patch.object(providers.LOG, "warning") as warn:
+                    resolved = resolve_providers()
+        self.assertEqual(_names(resolved), [CPU_PROVIDER])
+        self.assertTrue(warn.called)
+
+
+class TestMakeSession(unittest.TestCase):
+    def test_session_is_built_with_resolved_providers(self):
+        import os
+        os.environ.pop(PROVIDERS_ENV_VAR, None)
+        with _available(ROCM_BOX):
+            with patch.object(providers.onnxruntime, "InferenceSession") as session:
+                make_session("model.onnx", providers=["ROCMExecutionProvider"])
+        _, kwargs = session.call_args
+        self.assertEqual(
+            _names(kwargs["providers"]), ["ROCMExecutionProvider", CPU_PROVIDER])
+
+    def test_session_honours_use_cuda(self):
+        import os
+        os.environ.pop(PROVIDERS_ENV_VAR, None)
+        with _available(CUDA_BOX):
+            with patch.object(providers.onnxruntime, "InferenceSession") as session:
+                make_session("model.onnx", use_cuda=True)
+        _, kwargs = session.call_args
+        self.assertEqual(
+            _names(kwargs["providers"]), ["CUDAExecutionProvider", CPU_PROVIDER])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Execution-provider selection was a CPU/CUDA binary in `TTSVoice.load`, so there was no way to run on an AMD GPU (`ROCMExecutionProvider` / `MIGraphXExecutionProvider`), DirectML, CoreML or OpenVINO — `use_cuda=True` on a non-NVIDIA box could not help. Several engines also pinned `CPUExecutionProvider` unconditionally, which defeated any GPU setting.

## What this does

Adds `phoonnx/providers.py`, which resolves an ordered provider list from the first source that yields one:

1. an explicit `providers=[...]` argument (caller controls the order and its own fallbacks),
2. the `PHOONNX_ONNX_PROVIDERS` env var (comma-separated, or `auto`), or the plugin's `onnx_providers` config key,
3. auto-detection — a preference order (CUDA → ROCm → MIGraphX → DirectML → CoreML → OpenVINO → CPU) intersected with `onnxruntime.get_available_providers()`.

A requested provider the installed runtime does not offer is dropped with a clear warning, and `CPUExecutionProvider` is always appended, so a session never fails over its provider list.

Every `InferenceSession` goes through `make_session()` — the voice model plus the auxiliary graphs engines load (vocoders, speaker encoders, ZipVoice/F5-TTS text-encoder and mel graphs, the tashkeel diacritizer). The resolved list is carried in `engine_params["providers"]`, so an explicit choice reaches the auxiliary graphs too. No engine remains CPU-pinned.

`use_cuda` keeps working as a deprecated alias for `providers=["CUDAExecutionProvider"]` (warns, and falls back to CPU when CUDA is not available).

No new dependency: GPU providers come from the ONNX Runtime build (`onnxruntime-rocm`, `onnxruntime-gpu`, `onnxruntime-directml`, ...) and are detected at runtime. The optional installs are documented in `docs/configuration.md`.

## Usage

```python
voice = TTSVoice.load("model.onnx", "config.json",
                      providers=["ROCMExecutionProvider", "CPUExecutionProvider"])
```

```bash
export PHOONNX_ONNX_PROVIDERS="ROCMExecutionProvider,CPUExecutionProvider"
```

```json
{"tts": {"module": "ovos-tts-plugin-phoonnx",
         "ovos-tts-plugin-phoonnx": {"onnx_providers": ["ROCMExecutionProvider", "CPUExecutionProvider"]}}}
```

## Tests

`tests/test_providers.py` (20 tests) covers explicit lists, ordering and provider options, auto-detection, unavailable-provider fallback + warning, env-var handling and precedence, and `use_cuda` back-compat. Availability is mocked via `get_available_providers()`, so no GPU runtime is needed. `tests/test_opm.py` gains coverage for the `onnx_providers` config key.

Suite: 344 passed, 1 pre-existing failure (`test_griffinlim_mel_to_audio`, unrelated numba/librosa import).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ONNX Runtime execution providers for voice loading and auxiliary TTS components.
  * Added automatic hardware-provider detection with CPU fallback.
  * Added support for configuring providers per voice load, plugin settings, or environment variable.
  * Preserved `use_cuda` as a deprecated compatibility option.

* **Documentation**
  * Documented provider selection, runtime package requirements, configuration examples, and availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->