### PR TITLE
fix: tolerate offline sidecar probe when loading a cached voice

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -268,7 +268,11 @@ class TTSModelInfo:
         A graph with external weights references them by the original
         ``<name>.onnx_data`` filename, so that sidecar is saved under exactly that name
         next to the graph for the reference to resolve. Chatterbox's four graphs all use
-        external data; single-file graphs simply have no sidecar (404 -> skipped).
+        external data; single-file graphs (piper/vits exports) simply have no sidecar.
+
+        A missing sidecar may surface as an HTTP 404 (online) or as a connection
+        error (offline); both mean "no sidecar here", so a fully-cached voice loads
+        without the probe crashing when there is no network.
         """
         if not dest.is_file():
             with requests.get(url, timeout=120, stream=True) as r:
@@ -279,18 +283,24 @@ class TTSModelInfo:
                             f.write(chunk)
         data_dest = dest.parent / (url.split("/")[-1] + "_data")   # e.g. model_q4.onnx_data
         if not data_dest.is_file():
-            with requests.get(url + "_data", timeout=600, stream=True) as r:
-                if r.status_code != 404:
-                    r.raise_for_status()
-                    with open(data_dest, "wb") as f:
-                        for chunk in r.iter_content(chunk_size=8192):
-                            if chunk:
-                                f.write(chunk)
+            try:
+                with requests.get(url + "_data", timeout=600, stream=True) as r:
+                    if r.status_code != 404:
+                        r.raise_for_status()
+                        with open(data_dest, "wb") as f:
+                            for chunk in r.iter_content(chunk_size=8192):
+                                if chunk:
+                                    f.write(chunk)
+            except requests.exceptions.RequestException as e:
+                # Offline/DNS/timeout: treat like a 404 (sidecar simply absent) so a
+                # fully-cached voice still loads; a genuinely needed sidecar surfaces
+                # later when the graph is loaded.
+                LOG.debug(f"external-data sidecar unavailable for '{url}': {e}")
         return dest
 
-    def download_model(self):
+    def download_model(self) -> Path:
         """Download the primary ONNX graph (+ external-data sidecar, if any)."""
-        self._fetch_onnx(self.model_url, self.voice_path / "model.onnx")
+        return self._fetch_onnx(self.model_url, self.voice_path / "model.onnx")
 
     def download_vocoder(self) -> Optional[Path]:
         """

--- a/tests/test_offline_model_load.py
+++ b/tests/test_offline_model_load.py
@@ -1,0 +1,102 @@
+"""Offline-loading behaviour of the ONNX model downloader.
+
+Loading a voice whose graph is already cached probes for an optional
+external-data sidecar. That probe must tolerate a network failure (offline / DNS
+/ timeout) exactly like an HTTP 404 — the sidecar is simply absent — so a
+fully-cached voice loads without the probe crashing, while a genuine sidecar is
+still downloaded when the network is reachable.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import requests
+
+from phoonnx.model_manager import TTSModelInfo
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streamed ``requests`` response usable as a
+    context manager."""
+
+    def __init__(self, status_code=200, content=b""):
+        self.status_code = status_code
+        self._content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)
+
+    def iter_content(self, chunk_size=8192):
+        yield self._content
+
+
+class TestOfflineModelLoad(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmpdir.name)
+        self.info = TTSModelInfo(
+            voice_id="test/offline",
+            lang="en",
+            model_url="https://example.test/model.onnx",
+        )
+        # redirect the cache dir away from the real ~/.cache
+        self._patcher = patch.object(
+            type(self.info), "voice_path",
+            property(lambda _self: self.tmp),
+        )
+        self._patcher.start()
+        self.model_path = self.tmp / "model.onnx"
+
+    def tearDown(self):
+        self._patcher.stop()
+        self._tmpdir.cleanup()
+
+    def test_sidecar_connection_error_does_not_propagate(self):
+        """An offline sidecar probe must not crash a voice that has its graph."""
+        self.model_path.write_bytes(b"onnx-graph")
+
+        with patch("phoonnx.model_manager.requests.get",
+                   side_effect=requests.exceptions.ConnectionError("offline")):
+            # must not raise
+            result = self.info.download_model()
+
+        self.assertEqual(result, self.model_path)
+        self.assertTrue(self.model_path.is_file())
+
+    def test_missing_sidecar_404_is_tolerated(self):
+        """A single-file voice whose sidecar 404s loads without error."""
+        self.model_path.write_bytes(b"onnx-graph")
+
+        with patch("phoonnx.model_manager.requests.get",
+                   return_value=_FakeResponse(status_code=404)):
+            self.info.download_model()
+
+        self.assertFalse((self.tmp / "model.onnx_data").is_file())
+
+    def test_genuine_sidecar_is_downloaded(self):
+        """A voice that really needs external data downloads it when reachable."""
+        self.model_path.write_bytes(b"onnx-graph")
+        data_path = self.tmp / "model.onnx_data"
+
+        def fake_get(url, *a, **kw):
+            if url.endswith("_data"):
+                return _FakeResponse(status_code=200, content=b"weights")
+            raise AssertionError(f"unexpected url {url}")
+
+        with patch("phoonnx.model_manager.requests.get", side_effect=fake_get):
+            self.info.download_model()
+
+        self.assertTrue(data_path.is_file())
+        self.assertEqual(data_path.read_bytes(), b"weights")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Loading a fully-cached voice with no network **crashes**. `TTSModelInfo._fetch_onnx` probes for an optional external-data sidecar with `requests.get(url + "_data", ...)` and only tolerates an HTTP 404. Offline, that request raises `requests.exceptions.ConnectionError` (DNS/connection) before any status code exists, and the exception propagates — so a voice whose graph and config are already cached cannot be loaded without internet.

## Fix

Wrap the sidecar probe so any `requests.exceptions.RequestException` (offline / DNS / timeout) is treated exactly like a 404 — the sidecar is simply absent — logged at debug, and the load continues.

- Offline: a fully-cached voice loads without the probe crashing.
- Online: unchanged — the sidecar is probed once, a genuine sidecar (e.g. Chatterbox's four graphs) still downloads, and a 404 is tolerated as before.

## Tests

`tests/test_offline_model_load.py`, network mocked, no importorskip/skipif:
- a `ConnectionError` during the sidecar probe does not propagate for a voice whose graph is present (the crash regression);
- a 404 sidecar is tolerated;
- a genuine sidecar still downloads when the request succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)