### PR TITLE
fix: inline [[phoneme]] blocks crash on empty leading text

### DIFF
--- a/phoonnx/phonemizers/base.py
+++ b/phoonnx/phonemizers/base.py
@@ -57,7 +57,11 @@ class BasePhonemizer(metaclass=abc.ABCMeta):
 
     def phonemize(self, text: str, lang: str) -> PhonemizedChunks:
         if not text:
-            return [('', '', True)]
+            # PhonemizedChunks is list[list[str]]; empty text yields no
+            # sentences. (Returning the raw (str, str, bool) tuple form here
+            # corrupted the type and broke callers that mutate each sentence,
+            # e.g. inline ``[[phoneme]]`` blocks in TTSVoice.phonemize.)
+            return []
         results: RawPhonemizedChunks = []
         text = normalize(text, lang)
         for chunk, punct, eos in self.chunk_text(text):

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -299,6 +299,11 @@ class TTSVoice:
                 if not phonemes:
                     # Start new sentence
                     phonemes.append([])
+                # the preceding text chunk may have come back as an immutable
+                # sequence; ensure the current sentence is a mutable list before
+                # appending the inline phonemes to it
+                if not isinstance(phonemes[-1], list):
+                    phonemes[-1] = list(phonemes[-1])
 
                 if (i > 0) and (text_parts[i - 1].endswith(" ")):
                     phonemes[-1].append(" ")
@@ -310,7 +315,9 @@ class TTSVoice:
 
                 continue
 
-            phonemes.extend(self.phonemizer.phonemize(text_part, lang))
+            if not text_part:
+                continue
+            phonemes.extend(list(chunk) for chunk in self.phonemizer.phonemize(text_part, lang))
 
         if phonemes and (not phonemes[-1]):
             # Remove empty phonemes

--- a/tests/test_inline_phonemes.py
+++ b/tests/test_inline_phonemes.py
@@ -1,0 +1,68 @@
+"""Inline ``[[phoneme]]`` blocks in TTSVoice.phonemize.
+
+Regression tests for a crash where text wrapped in ``[[ ]]`` (fed to bypass the
+phonemizer and inject phonemes/IPA directly) raised
+``'tuple' object has no attribute 'extend'``. Root cause: BasePhonemizer.phonemize
+returned the raw ``(str, str, bool)`` tuple form for empty text, so the leading
+empty part before a block landed a tuple in the sentence list that the block
+branch then tried to mutate.
+"""
+from phoonnx.phonemizers.base import BasePhonemizer
+from phoonnx.voice import TTSVoice
+
+
+def _voice(phonemizer):
+    v = TTSVoice.__new__(TTSVoice)
+    v.phonemizer = phonemizer
+
+    class _Cfg:
+        lang_code = "ar"
+
+    v.config = _Cfg()
+    return v
+
+
+class _ListPhonemizer:
+    """Well-behaved: PhonemizedChunks == list[list[str]], [] for empty."""
+
+    def phonemize(self, text, lang):
+        return [list(text)] if text else []
+
+
+class _TuplePhonemizer:
+    """Adversarial: returns immutable tuples (and the old malformed empty form)."""
+
+    def phonemize(self, text, lang):
+        return [tuple(text)] if text else [("", "", True)]
+
+
+def test_base_phonemize_empty_returns_empty_list():
+    # the root fix: empty text must yield no sentences, not the raw tuple form
+    class _P(BasePhonemizer):
+        def phonemize_string(self, text, lang):
+            return text
+
+    p = _P.__new__(_P)
+    assert p.phonemize("", "ar") == []
+
+
+def test_inline_block_only():
+    out = _voice(_ListPhonemizer()).phonemize("[[abc]]")
+    assert out == [["a", "b", "c"]]
+
+
+def test_inline_block_after_text():
+    out = _voice(_ListPhonemizer()).phonemize("hi [[xy]]")
+    assert out and all(isinstance(s, list) for s in out)
+    assert "x" in out[-1] and "y" in out[-1]
+
+
+def test_inline_block_between_text():
+    out = _voice(_ListPhonemizer()).phonemize("[[ab]] cd")
+    assert out and all(isinstance(s, list) for s in out)
+
+
+def test_voice_robust_to_tuple_returning_phonemizer():
+    # even a phonemizer that returns tuples must not break inline blocks
+    out = _voice(_TuplePhonemizer()).phonemize("[[xy]]")
+    assert out and "x" in out[-1] and "y" in out[-1]


### PR DESCRIPTION
Feeding phonemes/IPA directly via the `[[...]]` inline-block syntax crashed with `tuple object has no attribute extend` whenever the block was at the start of the text (or preceded by an empty part).

## Root cause
`BasePhonemizer.phonemize("")` returned the **raw** `[("", "", True)]` tuple form instead of the processed `PhonemizedChunks` (`list[list[str]]`). The empty leading part before a `[[...]]` block therefore put a **tuple** into the sentence list, which the block branch then tried to `.extend()`.

## Fix
- `phonemizers/base.py`: empty text returns `[]` (no sentences) instead of the malformed tuple form.
- `voice.py` `phonemize`: made the inline-block path defensive — coerce the current sentence to a `list` before appending, skip empty text parts, and coerce phonemizer chunks to lists.

## Why it matters
Enables injecting phonemes/IPA directly, e.g. `get_tts("[[ɡahawa]]")` or mixing `"قهوة [[ɡahawa]] لذيذة"` — useful for dialect/accent control by feeding externally-generated IPA (bypassing espeak).

## Tests
New `tests/test_inline_phonemes.py` (5 tests): base empty→`[]`, block-only, block-after-text, block-between-text, and robustness to a tuple-returning phonemizer. Existing phonemizer/engine suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)