### PR TITLE
fix: honor voice config's add_diacritics (fixes F5-TTS Arabic output)

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -581,8 +581,10 @@ class SynthesisConfig:
 
     enable_phonetic_spellings: bool = True
 
-    """for arabic and hebrew models"""
-    add_diacritics: bool = True
+    """for arabic and hebrew models. ``None`` (the default) defers to the voice
+    config's own ``add_diacritics`` so a model that ships undiacritized (e.g.
+    grapheme F5-TTS voices) is not force-diacritized by the caller."""
+    add_diacritics: Optional[bool] = None
 
     # Engine-specific per-call params (d_factor, p_factor, e_factor, …)
     extra_params: Dict[str, Any] = field(default_factory=dict)

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -364,7 +364,12 @@ class TTSVoice:
         # user pronunciation overrides + (Arabic/Hebrew) diacritics.
         if self.phonetic_spellings and syn_config.enable_phonetic_spellings:
             text = self.phonetic_spellings.apply(text)
-        if syn_config.add_diacritics:
+        # A per-call value wins; when unset (None) defer to the voice config so a
+        # model that ships undiacritized is not force-diacritized by the caller.
+        do_diacritics = syn_config.add_diacritics
+        if do_diacritics is None:
+            do_diacritics = self.config.add_diacritics
+        if do_diacritics:
             text = self.phonemizer.add_diacritics(text, self.config.lang_code)
 
         # Language-aware phonemizers (e.g. Shami) provide per-phoneme language IDs;


### PR DESCRIPTION
## Problem

F5-TTS Arabic voices (Habibi, NAMAA, SILMA) produced fluent but semantically **garbage speech**.

## Root cause

`SynthesisConfig.add_diacritics` defaulted to `True` and **overrode the model's own config**. F5-TTS is a grapheme model trained on undiacritized text; force-injecting tashkeel inflated the token sequence and the estimated `max_duration` (a ~4s sentence budgeted 16s), causing over-generation and degraded output.

Verified against DakeQQ's reference F5-TTS-ONNX inference: with raw undiacritized text the exact same ONNX graphs transcribe **verbatim** (own SAMA ASR, WER 0). The ONNX export was never at fault.

## Fix

Default `add_diacritics` to `None` and fall back to the voice config, so an explicit caller value still wins but the model's declared behaviour is respected. Pairs with the F5 model configs on the model repo which now declare `inference.add_diacritics: false` and raw tokenization (no blank/BOS/EOS interleave).

## Tests

71 passed, 6 skipped (tokenizer / config / f5tts / golden tokenization) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)