### PR TITLE
feat: add NAMAA-Saudi-TTS-V2 F5 voice (namaa/ar-sa-v2)

### DIFF
--- a/docs/f5tts.md
+++ b/docs/f5tts.md
@@ -17,15 +17,17 @@ an Euler ODE sampling loop rather than a single-pass graph.
 | SILMA TTS | <https://github.com/SILMA-AI/silma-tts> — bilingual Arabic (MSA/Fusha) + English, 150M DiT pretrained from scratch |
 | Languages | Multilingual (trained on Emilia: ZH, EN, + more) |
 | PyTorch weights | [`SWivid/F5-TTS`](https://huggingface.co/SWivid/F5-TTS) (CC-BY-NC-4.0), [`SWivid/Habibi-TTS`](https://huggingface.co/SWivid/Habibi-TTS) (CC-BY-NC-SA-4.0), [`silma-ai/silma-tts`](https://huggingface.co/silma-ai/silma-tts) (Apache-2.0) |
-| **Ready-made ONNX voices** | [`OpenVoiceOS/phoonnx-f5tts`](https://huggingface.co/OpenVoiceOS/phoonnx-f5tts) — `f5tts-v1-base` (multilingual) + `habibi-tts-unified` (Arabic) + `silma-tts-v1` (Arabic + English) |
+| NAMAA Saudi TTS | [`NAMAA-Space/NAMAA-Saudi-TTS-V2`](https://huggingface.co/NAMAA-Space/NAMAA-Saudi-TTS-V2) — Habibi-TTS fine-tune for Saudi Arabic (335M DiT) |
+| **Ready-made ONNX voices** | [`OpenVoiceOS/phoonnx-f5tts`](https://huggingface.co/OpenVoiceOS/phoonnx-f5tts) — `f5tts-v1-base` (multilingual) + `habibi-tts-unified` (Arabic) + `silma-tts-v1` (Arabic + English) + `namaa-saudi-tts-v2` (Saudi Arabic) |
 
 > **License**: the F5-TTS checkpoints are **CC-BY-NC-4.0** (non-commercial).
 > Habibi-TTS licensing is per model (see the
 > [model card](https://huggingface.co/SWivid/Habibi-TTS)): **Unified, SAU and
 > UAE are CC-BY-NC-SA-4.0** (restricted by the SADA and Mixat datasets), while
 > **ALG, EGY, IRQ, MAR and MSA are Apache-2.0**. **SILMA TTS v1 weights are
-> Apache-2.0** (commercial use allowed). The ONNX conversions in
-> `OpenVoiceOS/phoonnx-f5tts` inherit those licenses.
+> Apache-2.0** (commercial use allowed). **NAMAA-Saudi-TTS-V2 is
+> CC-BY-NC-SA-4.0** (non-commercial — inherited from its Habibi-TTS base). The
+> ONNX conversions in `OpenVoiceOS/phoonnx-f5tts` inherit those licenses.
 
 ## Architecture
 
@@ -244,6 +246,7 @@ The catalog voices ship in `phoonnx/voice_index/f5tts.json`:
 | `habibi/ar-alg` | Habibi-TTS Specialized ALG | Arabic (Algerian) |
 | `habibi/ar-irq` | Habibi-TTS Specialized IRQ | Arabic (Iraqi) |
 | `habibi/ar-mar` | Habibi-TTS Specialized MAR | Arabic (Moroccan) |
+| `namaa/ar-sa-v2` | NAMAA Saudi TTS V2 (Habibi fine-tune, non-commercial) | Arabic (Saudi) |
 | `silma/v1` | SILMA TTS v1 (Apache-2.0, commercial OK) | Arabic (MSA/Fusha, full tashkeel support) |
 | `silma/v1-en` | SILMA TTS v1 (same model, English listing) | English |
 
@@ -258,6 +261,7 @@ locally-cached files automatically).
 | **F5-TTS** | base model (DiT + ConvNeXt V2) |
 | **F5-TTS v1** | improved training and inference (2025/03) |
 | **Habibi-TTS** | Arabic dialectal fine-tune (Unified + Specialized) |
+| **NAMAA-Saudi-TTS-V2** | Habibi-TTS fine-tune specialized for Saudi Arabic (335M DiT, 24 kHz, char-level 2704 vocab) |
 | **SILMA TTS v1** | bilingual Arabic/English 150M DiT (dim 768, depth 18) pretrained from scratch |
 | **E2-TTS** | Flat-UNet variant (same flow-matching approach) |
 

--- a/phoonnx/voice_index/f5tts.json
+++ b/phoonnx/voice_index/f5tts.json
@@ -152,6 +152,23 @@
             "decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/habibi-tts-uae/F5_Decode.onnx"
         }
     },
+    "namaa/ar-sa-v2": {
+        "voice_id": "namaa/ar-sa-v2",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/namaa-saudi-tts-v2/model.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/namaa-saudi-tts-v2/config.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "graphemes",
+        "alphabet": "unicode",
+        "engine": "f5tts",
+        "lang": "ar-SA",
+        "aux_model_urls": {
+            "preprocess_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/namaa-saudi-tts-v2/F5_Preprocess.onnx",
+            "decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/namaa-saudi-tts-v2/F5_Decode.onnx"
+        }
+    },
     "silma/v1": {
         "voice_id": "silma/v1",
         "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-f5tts/resolve/main/silma-tts-v1/model.onnx",

--- a/tests/test_f5tts.py
+++ b/tests/test_f5tts.py
@@ -334,3 +334,37 @@ def test_silma_listed_for_arabic_and_english():
     en_ids = [v.voice_id for v in manager.get_lang_voices("en-US")]
     assert "silma/v1" in ar_ids
     assert "silma/v1-en" in en_ids
+
+
+def test_namaa_saudi_voice_index_entry():
+    """NAMAA Saudi TTS V2 ships as a Saudi-Arabic F5-TTS catalog listing."""
+    import json
+    import os
+    from phoonnx.model_manager import TTSModelInfo
+
+    index = os.path.join(os.path.dirname(__file__), "..", "phoonnx",
+                         "voice_index", "f5tts.json")
+    with open(index, "r", encoding="utf-8") as f:
+        entries = json.load(f)
+
+    assert "namaa/ar-sa-v2" in entries
+    info = TTSModelInfo(**entries["namaa/ar-sa-v2"])
+    assert info.engine == "f5tts"
+    assert info.lang == "ar-SA"
+    assert info.phoneme_type == "graphemes"
+    assert "/namaa-saudi-tts-v2/" in info.model_url
+    assert info.model_url.endswith("model.onnx")
+    assert info.aux_model_urls["preprocess_path"].endswith("F5_Preprocess.onnx")
+    assert info.aux_model_urls["decode_path"].endswith("F5_Decode.onnx")
+
+
+def test_namaa_saudi_listed_for_arabic():
+    """The model manager surfaces the NAMAA Saudi voice for ar lookups."""
+    from phoonnx.model_manager import TTSModelManager
+
+    manager = TTSModelManager()
+    manager.cache.clear()
+    manager.merge_default_voices()
+    assert "namaa/ar-sa-v2" in manager.voices
+    ar_ids = [v.voice_id for v in manager.get_lang_voices("ar")]
+    assert "namaa/ar-sa-v2" in ar_ids


### PR DESCRIPTION
Adds the `namaa/ar-sa-v2` voice — a Habibi-TTS fine-tune specialised for Saudi Arabic (335M DiT, 24 kHz), CC-BY-NC-SA-4.0 (non-commercial). ONNX + raw-tokenization config published under `OpenVoiceOS/phoonnx-f5tts/namaa-saudi-tts-v2`. Verified to render intelligible Saudi Arabic speech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)