### PR TITLE
feat: espyak fallback for espeak phonemization

### DIFF
--- a/phoonnx/phonemizers/mul.py
+++ b/phoonnx/phonemizers/mul.py
@@ -302,8 +302,31 @@ class EspeakPhonemizer(BasePhonemizer):
                     'fr-ch', 'ka', 'en-gb-x-gbclan', 'ko', 'is', 'ca-nw', 'gn', 'kok', 'la', 'lb', 'am', 'kk', 'ku',
                     'kaa', 'jbo', 'eo', 'uz', 'nci', 'vi-vn-x-south', 'el', 'pl', 'grc', ]
 
-    def __init__(self):
+    _binary_available: Optional[bool] = None
+
+    def __init__(self, prefer_espyak: bool = False):
+        """
+        Args:
+            prefer_espyak: Use the pure-Python espyak G2P even when the
+                espeak-ng binary is installed. When False, espyak is only
+                used as a fallback if the binary is missing.
+        """
         super().__init__(Alphabet.IPA)
+        self.prefer_espyak = prefer_espyak
+        self._espyak_g2p: dict = {}
+
+    def _espyak_phonemize(self, text: str, lang: str) -> str:
+        from espyak import G2P
+        if lang not in self._espyak_g2p:
+            self._espyak_g2p[lang] = G2P(lang)
+        return self._espyak_g2p[lang].phonemize(text)
+
+    @classmethod
+    def _has_binary(cls) -> bool:
+        if cls._binary_available is None:
+            import shutil
+            cls._binary_available = shutil.which("espeak-ng") is not None
+        return cls._binary_available
 
     @classmethod
     def get_lang(cls, target_lang: str) -> str:
@@ -383,6 +406,16 @@ class EspeakPhonemizer(BasePhonemizer):
 
     def phonemize_string(self, text: str, lang: str) -> str:
         lang = self.get_lang(lang)
+        if self.prefer_espyak or not self._has_binary():
+            try:
+                return self._espyak_phonemize(text, lang)
+            except ImportError:
+                if not self._has_binary():
+                    raise EspeakError(
+                        "espeak-ng binary not found and espyak is not installed. "
+                        "Install espeak-ng or `pip install espyak` for the "
+                        "pure-Python fallback."
+                    )
         return self._run_espeak_command(
             ['-q', '-x', '--ipa', '-v', lang],
             input_text=text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ test = [
     "ovos-plugin-manager",
     "pycotovia>=0.1.0",
     "ahotts-g2p>=0.1.0",
+    "espyak>=0.0.2a1",
 ]
+espeak = ["espyak>=0.0.2a1"]
 train = [
     "cython>=0.29.0,<1",
     "librosa>=0.9.2,<1",

--- a/test/test_espyak_fallback.py
+++ b/test/test_espyak_fallback.py
@@ -1,0 +1,59 @@
+"""EspeakPhonemizer falls back to the pure-Python espyak G2P when the
+espeak-ng binary is unavailable, and can be forced to prefer it."""
+import unittest
+from unittest.mock import patch
+
+from phoonnx.phonemizers.mul import EspeakPhonemizer, EspeakError
+
+
+class TestEspyakFallback(unittest.TestCase):
+    def setUp(self):
+        EspeakPhonemizer._binary_available = None
+
+    def tearDown(self):
+        EspeakPhonemizer._binary_available = None
+
+    def test_prefer_espyak_skips_binary(self):
+        pho = EspeakPhonemizer(prefer_espyak=True)
+        with patch.object(EspeakPhonemizer, "_run_espeak_command") as run_cmd:
+            result = pho.phonemize_string("hello world", "en")
+            run_cmd.assert_not_called()
+        self.assertIn("ə", result)
+
+    def test_fallback_when_binary_missing(self):
+        with patch("shutil.which", return_value=None):
+            pho = EspeakPhonemizer()
+            result = pho.phonemize_string("hallo wereld", "nl")
+        self.assertTrue(result.strip())
+
+    def test_binary_used_when_available(self):
+        EspeakPhonemizer._binary_available = True
+        pho = EspeakPhonemizer()
+        with patch.object(EspeakPhonemizer, "_run_espeak_command",
+                          return_value="mocked") as run_cmd:
+            self.assertEqual(pho.phonemize_string("hello", "en"), "mocked")
+            run_cmd.assert_called_once()
+
+    def test_error_when_neither_available(self):
+        with patch("shutil.which", return_value=None), \
+                patch.object(EspeakPhonemizer, "_espyak_phonemize",
+                             side_effect=ImportError("no espyak")):
+            pho = EspeakPhonemizer()
+            with self.assertRaises(EspeakError):
+                pho.phonemize_string("hello", "en")
+
+    def test_g2p_instances_cached_per_lang(self):
+        pho = EspeakPhonemizer(prefer_espyak=True)
+        pho.phonemize_string("one", "en")
+        pho.phonemize_string("two", "en")
+        self.assertEqual(len(pho._espyak_g2p), 1)
+
+    def test_matches_binary_output_shape(self):
+        # dialect resolution goes through get_lang (en-gb -> en-gb-x-rp)
+        pho = EspeakPhonemizer(prefer_espyak=True)
+        result = pho.phonemize_string("water", "en-gb")
+        self.assertTrue(result.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `EspeakPhonemizer` falls back to [espyak](https://github.com/TigreGotico/espyak) (pure-Python, byte-exact espeak-ng G2P) when the `espeak-ng` binary is not on PATH, and can be forced with `prefer_espyak=True`.
- New `espeak` extra: `pip install phoonnx[espeak]` pulls `espyak>=0.0.2a1`; also added to the `test` extra.
- Clear error message when neither the binary nor espyak is available.

## Motivation
Voices with `"phoneme_type": "espeak"` currently require the espeak-ng executable, which is painful to package on Windows (e.g. the NVDA screen-reader add-on). With this fallback the phoonnx runtime can be vendored as pure Python + onnxruntime.

## Tests
`test/test_espyak_fallback.py` — 6 tests covering fallback selection, binary preference, per-language G2P caching, dialect resolution, and the neither-available error path. Verified locally (6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)