### PR TITLE
fix: register TTS plugin under opm.tts entry-point group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,13 @@ Homepage = "https://github.com/TigreGotico/phoonnx"
 [project.scripts]
 "phoonnx-voices" = "phoonnx.cli:cli"
 
-[project.entry-points."mycroft.plugin.tts"]
+[project.entry-points."opm.tts"]
 "ovos-tts-plugin-phoonnx" = "phoonnx.opm:PhoonnxTTSPlugin"
 
 [project.optional-dependencies]
 test = [
     "pytest",
-    "ovos-plugin-manager",
+    "ovos-plugin-manager>=2.1.0",
     "pycotovia>=0.1.0",
     "ahotts-g2p>=0.1.0",
     "espyak>=0.0.2a1",

--- a/tests/test_opm.py
+++ b/tests/test_opm.py
@@ -83,13 +83,23 @@ def _make_plugin(config=None, voices=(), lazy=()):
 
 class TestPluginEntryPoint(unittest.TestCase):
     def test_entry_point_resolves_to_plugin(self):
-        """The declared mycroft.plugin.tts entry point loads the plugin class."""
+        """The declared opm.tts entry point loads the plugin class."""
         from importlib.metadata import entry_points
 
-        eps = [e for e in entry_points(group="mycroft.plugin.tts")
+        eps = [e for e in entry_points(group="opm.tts")
                if e.name == "ovos-tts-plugin-phoonnx"]
         self.assertTrue(eps, "ovos-tts-plugin-phoonnx entry point not registered")
         self.assertIs(eps[0].load(), opm.PhoonnxTTSPlugin)
+
+    def test_no_legacy_entry_point_group(self):
+        """The plugin is not declared under the deprecated mycroft.plugin.tts
+        group, which ovos-plugin-manager only scans for backward compatibility
+        and flags with a warning on every discovery pass."""
+        from importlib.metadata import entry_points
+
+        legacy = [e.name for e in entry_points(group="mycroft.plugin.tts")
+                  if e.name == "ovos-tts-plugin-phoonnx"]
+        self.assertEqual(legacy, [])
 
     def test_is_a_tts_subclass(self):
         from ovos_plugin_manager.templates.tts import TTS


### PR DESCRIPTION
## Summary
- Register `ovos-tts-plugin-phoonnx` under the `opm.tts` entry-point group instead of the deprecated `mycroft.plugin.tts` group. ovos-plugin-manager only scans the old group for backward compatibility and logs a deprecation warning on every discovery pass (e.g. at every ovos-audio boot).
- The legacy group is dropped rather than duplicated: OPM warns on any entry it finds under `mycroft.plugin.tts`, so keeping a duplicate entry would keep the warning this fixes.
- Raise the `ovos-plugin-manager` floor in the `test` extra to `>=2.1.0`, the first release that scans the `opm.*` groups.

## Tests
- `tests/test_opm.py`: the entry-point resolution test now asserts the plugin resolves under `opm.tts` via `importlib.metadata` after an editable install, and a new test asserts the plugin is no longer declared under `mycroft.plugin.tts`.
- Verified locally in a fresh uv venv: `tests/test_opm.py` passes (24 tests); full suite unchanged apart from pre-existing optional-dependency failures. OPM discovery confirmed: `find_tts_plugins()` finds the plugin with no deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)