### PR TITLE
Streaming VITS engine + unicode-rbnf number pronunciation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,4 +53,5 @@ with wave.open("output.wav", "wb") as wav_file:
 - [OVOS Plugin](ovos_plugin.md)
 - [Docker / TTS Server](docker.md)
 - [Engine Architecture](engines.md) · [Vocoders](vocoders.md)
+- [Streaming (low-latency VITS)](streaming.md)
 - Engine guides: [Matcha](matcha.md) · [GlowTTS](glowtts.md) · [OptiSpeech](optispeech.md) · [MixerTTS](mixertts.md) · [FastPitch](fastpitch.md) · [ZipVoice](zipvoice.md) · [Shami](shami.md) · [Chatterbox](chatterbox.md)

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,209 @@
+# Streaming VITS Engine
+
+Standard Piper/VITS voices synthesize a whole sentence in one ONNX call, so the
+first audio sample is only available once the entire sentence is decoded. The
+**streaming** engine lowers *time-to-first-audio* (TTFA) by decoding the
+sentence in chunks and emitting each chunk as soon as it is ready.
+
+The `VitsStreamingAdapter` handles this. It is auto-selected for any voice whose
+config declares `"streaming": true` **and** ships a separate decoder graph.
+
+## The core requirement: you need a *split* model
+
+> **Streaming only works with a model that is split into two ONNX graphs:**
+> a separate **encoder** (`encoder.onnx`) and **decoder** (`decoder.onnx`),
+> with `"streaming": true` in the voice config.
+>
+> A normal single-file Piper/VITS `.onnx` **cannot stream** — there is no point
+> in the pipeline to cut. Loading a combined model will simply fall through to
+> the ordinary [`VitsAdapter`](./engines.md), which is correct but not streaming.
+
+There are two ways to get a split model:
+
+1. **Use a pre-split "+RT" voice.** The Sonata project publishes fast/streaming
+   variants of many Piper voices in the
+   [`mush42/piper-rt`](https://huggingface.co/datasets/mush42/piper-rt) dataset.
+   Each `<name>+RT-<quality>.tar` contains `encoder.onnx`, `decoder.onnx` and a
+   `<name>.json` config with `"streaming": true`. Extract it and point the voice
+   config at the two graphs (see [Loading](#loading-a-streaming-voice)).
+
+2. **Export your own split model from a checkpoint.** If you have a trained
+   Piper checkpoint you can export it as a split encoder/decoder pair. This is
+   the same route the `+RT` voices are produced by. **Verify the result** — see
+   [Verifying an exported split model](#verifying-an-exported-split-model), it is
+   easy to produce a subtly broken split (see the `ryan+RT` case study below).
+
+## How it works: discard-and-stitch
+
+The decoder is convolutional. If you naively slice the latent `z` on the time
+axis and decode each slice, the **edges** of every chunk are contaminated
+(~16-19 frames deep) because the convolutions near the boundary are missing
+their neighbours. A crossfade between chunks does *not* fix this — the error is
+in the samples, not the seam.
+
+The fix is **discard-and-stitch**: decode each chunk with a *context margin* of
+`M` extra frames on both sides, then throw the contaminated margins away and
+keep only the clean middle. Because the kept region had full convolutional
+context, it is **bit-identical** to a one-shot decode. Concatenating the clean
+middles reproduces the exact one-shot audio, seam-free.
+
+```
+latent frames:  ....[  margin | KEEP  | margin ]....
+decode this span --------^                ^------ discard both margins
+```
+
+## ONNX interface
+
+**Encoder** (the primary session), runs once per sentence:
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| `input` | int64 | `[B, T]` | Phoneme IDs |
+| `input_lengths` | int64 | `[B]` | Sequence length |
+| `scales` | float32 | `[3]` | `[noise_scale, length_scale, noise_w]` |
+| `sid` | int64 | `[B]` | Speaker ID (multi-speaker only) |
+| → `z` | float32 | `[B, 192, T]` | Latent sequence |
+| → `y_mask` | float32 | `[B, 1, T]` | Frame mask |
+
+**Decoder** (auxiliary graph), run once per chunk:
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| `z` | float32 | `[B, 192, T_slice]` | Latent slice (with margins) |
+| `y_mask` | float32 | `[B, 1, T_slice]` | Matching mask slice |
+| → `output` | float32 | `[B, 1, N]` or `[N]` | Waveform samples |
+
+The **hop length** (decoder samples per latent frame, almost always 256) is read
+from the config if present, otherwise measured from the first decode.
+
+## Loading a streaming voice
+
+Point the config at the two graphs via `engine_params`. The primary model path
+is the **encoder**; the decoder is an auxiliary graph:
+
+```json
+{
+    "streaming": true,
+    "engine": "vits_streaming",
+    "engine_params": {
+        "decoder_path": "decoder.onnx"
+    },
+    "inference": { "noise_scale": 0.667, "length_scale": 1.0, "noise_w": 0.8 }
+}
+```
+
+```python
+from phoonnx import TTSVoice
+voice = TTSVoice.load(model_path="encoder.onnx")  # config sits next to it
+```
+
+Detection is strict: the adapter claims a voice **only** when `"streaming": true`
+*and* `engine_params.decoder_path` are both present, so it never hijacks a normal
+single-graph voice.
+
+## Parameters
+
+All streaming parameters live under `engine_params.streaming` and have proven
+defaults — you only set them to tune. They were tuned empirically on high-tier
+voices (see [Tuning notes](#tuning-notes)).
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `context_margin` | 32 | `M`: frames of context decoded and discarded each side. **Safe on every voice tested.** 24 usually works and is ~6% faster; 16 corrupts edges. |
+| `first_chunk` | 8 | Frames in the first chunk. Smaller → lower TTFA. |
+| `next_chunk` | 160 | Frames per subsequent chunk. Balances per-chunk overhead vs. throughput. |
+| `fallback_frames` | 128 | Sentences this short or shorter are decoded one-shot (streaming can't help). |
+| `intra_op_num_threads` | `cores / 2` | onnxruntime threads for the decoder. See below. |
+
+## Tuning notes
+
+These defaults come from measurements on `en_US-lessac+RT-high` (a heavy
+high-tier decoder — the worst case for latency). Your mileage varies with model
+size and CPU, but the *shape* of the results is general.
+
+**Time-to-first-audio wins scale with sentence length.** Streaming pays off more
+the longer the sentence, because a one-shot decode has to finish the whole thing
+before any audio plays:
+
+| Sentence | one-shot TTFA | streaming TTFA | speedup |
+|----------|---------------|----------------|---------|
+| short (~1.3 s audio) | 1399 ms | 1382 ms | 1.0x (falls back) |
+| mid (~3.9 s) | 3342 ms | 1552 ms | 2.2x |
+| long (~11.7 s) | 4801 ms | 1965 ms | 2.4x |
+
+**Thread count.** onnxruntime defaults to using *all* logical cores, which
+measured **slower** on the heavy decoder — thread-coordination overhead and
+contention. On an 8-core machine, 4 threads was optimal; 8 was worse than 4 on
+both encoder and decoder. The default is therefore `cores / 2`. Override with
+`engine_params.intra_op_num_threads` if profiling says otherwise.
+
+**Context margin.** `M = 32` was bit-identical (float noise, maxabs ~3e-6) on
+every voice tested. `M = 24` was also bit-identical on lessac/libritts and ~6%
+faster, but on some models (e.g. the Claudio NL/EN voice) 24 left a tiny audible
+residual, so **32 is the conservative default**. `M = 16` visibly corrupts the
+audio (maxabs ~3e-3). If you lower `M`, verify with the maxabs check below.
+
+**Pipelining does not help.** Running the encoder for sentence N+1 while
+decoding sentence N was tested and *hurt* TTFA (the encoder thread steals cores
+from the decoder that is producing the first chunk). It is deliberately not
+implemented.
+
+## The `ryan+RT` case study: verify your split models
+
+Not every published `+RT` voice is correct. `en_US-ryan+RT-medium` produces
+**visibly wrong prosody** — stress lands too early (e.g. "COOL and calm" instead
+of "cool and CALM"). Investigation showed:
+
+- The phonemization is **correct** — espeak places the stress marks right.
+- The streaming split is **not** at fault — discard-and-stitch is bit-identical
+  to a one-shot decode of the same model.
+- The `+RT` model's **duration predictor** produces durations ~12% shorter than
+  the original `ryan-high` model, *deterministically* (same difference with
+  `noise_w = 0`). By contrast, `lessac+RT` and `libritts_r+RT` matched their
+  originals to **0.0%**.
+
+The root cause: `ryan` was trained with **piper 0.2.0** (PyTorch 1.11), then
+converted through the newer **piper 1.0.0** (PyTorch 2.2) export used for the
+`+RT` set. The duration predictor did not survive that version jump cleanly.
+`lessac`/`libritts` were already 1.0.0, so their re-export was clean.
+
+**Lessons:**
+
+- Streaming and the encoder/decoder split are prosody-neutral. If a `+RT` voice
+  sounds wrong, suspect the **export**, not the streaming.
+- Do not mix piper versions: export `+RT` models from a checkpoint whose piper
+  version matches the export pipeline.
+- **Always verify a split model** after exporting or before trusting a
+  downloaded one.
+
+## Verifying an exported split model
+
+Two checks catch the two failure modes.
+
+**1. Streaming is lossless** (the split + discard-and-stitch reproduce a one-shot
+decode). Encode once, then compare a full decode against the chunked decode of
+the *same* `z` (the encoder samples noise internally, so you must reuse one `z`):
+
+```python
+import numpy as np, onnxruntime as ort
+enc = ort.InferenceSession("encoder.onnx"); dec = ort.InferenceSession("decoder.onnx")
+z, ym = enc.run(["z", "y_mask"], feed)              # ONE encode
+ref = dec.run(["output"], {"z": z, "y_mask": ym})[0].squeeze()   # one-shot
+# ... run the discard-and-stitch loop over the same z, M=32 ...
+assert np.abs(stream[:len(ref)] - ref).max() < 1e-4   # float noise only
+```
+
+**2. The split preserves prosody** (duration predictor unchanged vs. the original
+single-graph model). With `noise_w = 0` (deterministic), the frame count `T`
+from the split encoder must match the original model's:
+
+```python
+# split:    z, _ = enc.run([...], scales=[0.667, 1.0, 0.0]); T_split = z.shape[2]
+# original: audio = original_voice(...); T_orig = len(audio) // hop
+assert T_split == T_orig    # a >1-2% difference means the export drifted (see ryan+RT)
+```
+
+## See also
+
+- [engines.md](./engines.md) — the adapter registry and auto-detection
+- [configuration.md](./configuration.md) — voice config schema

--- a/phoonnx/cli.py
+++ b/phoonnx/cli.py
@@ -30,8 +30,8 @@ def cli():
 @click.option("--no-clear", is_flag=True, help="Do not clear the existing cache before updating. Only adds new voices.")
 def update_cache(no_clear):
     """
-    Clears the local voice cache, fetches the latest voice lists from upstream
-    sources (Piper, Mimic3, OpenVoiceOS), and saves them to the cache.
+    Clears the local voice cache, loads the bundled voice indexes (Piper,
+    Mimic3, OpenVoiceOS, etc.), and saves them to the cache.
     """
     manager = TTSModelManager()
 
@@ -42,29 +42,14 @@ def update_cache(no_clear):
         click.echo("Loading existing voice cache...")
         manager.load()
 
-    click.echo("Fetching voice lists from upstream sources (this requires an internet connection)...")
+    click.echo("Loading bundled voice indexes...")
 
-    # Run the fetch methods to populate the cache
     try:
-        manager.get_ovos_voice_list()
-        click.echo("-> Fetched OpenVoiceOS voices.")
-        manager.get_proxectonos_voice_list()
-        click.echo("-> Fetched Proxectonos voices.")
-        manager.get_phonikud_voice_list()
-        click.echo("-> Fetched Phonikud voices.")
-        manager.get_piper_voice_list()
-        click.echo("-> Fetched Piper voices.")
-        manager.get_mimic3_voice_list()
-        click.echo("-> Fetched Mimic3 voices.")
-    except requests.exceptions.RequestException as e:
-        click.echo(f"\nError: Could not fetch voice lists due to a network or connection error.", err=True)
-        click.echo(f"Details: {e}", err=True)
-        return
+        manager.merge_default_voices(store=True)
     except Exception as e:
-        click.echo(f"An unexpected error occurred while fetching voice lists: {e}", err=True)
+        click.echo(f"An unexpected error occurred while loading voice lists: {e}", err=True)
         return
 
-    manager.save()
     click.echo(f"\nCache updated successfully!")
     click.echo(f"Total voices available: {len(manager.all_voices)}")
     click.echo(f"Total languages supported: {len(manager.supported_langs)}")
@@ -119,60 +104,56 @@ def list_voices(lang, verbose):
 @cli.command(name="list-available")
 def list_available():
     """
-    Lists all voice IDs available from upstream sources (Piper, Mimic3, etc.),
-    even if they are not yet in the local cache. (Requires network connection)
+    Lists all voice IDs bundled with phoonnx, grouped by source (Piper,
+    Mimic3, OVOS, etc.), without downloading any config or model files.
+    Use 'download <VOICE_ID>' to fetch a specific voice on demand.
     """
     manager = TTSModelManager()
-    
-    click.echo("Fetching all available voice IDs from upstream sources (Piper, Mimic3, OVOS, etc.)...")
-    
-    try:
-        available_voices = manager.get_all_available_voice_ids()
-    except requests.exceptions.RequestException as e:
-        click.echo(f"\nError: Could not fetch available voice lists due to a network or connection error.", err=True)
-        click.echo(f"Details: {e}", err=True)
-        return
-    except Exception as e:
-        click.echo(f"An unexpected error occurred while fetching available voice lists: {e}", err=True)
-        return
+
+    available_voices = manager.get_available_voice_ids_by_source()
 
     total_voices = sum(len(ids) for ids in available_voices.values())
-    click.echo(f"\nTotal available voices found (from all sources): {total_voices}\n")
-    
+    click.echo(f"\nTotal available voices found (bundled indexes): {total_voices}\n")
+
     for source, voice_ids in available_voices.items():
         click.echo(f"--- {source.upper()} Voices ({len(voice_ids)}) ---")
         for voice_id in voice_ids:
             click.echo(f"  {voice_id}")
         click.echo("-" * 40)
-    click.echo("Hint: Use 'update-cache' to download the configuration for these voices, or use 'download <VOICE_ID>' to download a specific voice directly.")
+    click.echo("Hint: Use 'update-cache' to populate the local cache, or use 'download <VOICE_ID>' to download a specific voice directly.")
 
 @cli.command(name="download")
 @click.argument("voice_id", type=str)
 def download_voice(voice_id):
     """
     Downloads the model, config, and token files for a specific VOICE_ID.
-    The VOICE_ID must exist in the local cache (run update-cache first).
+    Looks the voice up in the local cache first (run update-cache to
+    populate it); if it isn't cached yet, falls back to the bundled
+    voice indexes so a single voice can be downloaded on demand, without
+    having to load the whole catalog first.
     """
     manager = TTSModelManager()
     manager.load()
 
-    if voice_id not in manager.voices:
-        click.echo(f"Error: Voice ID '{voice_id}' not found in cache.", err=True)
-        click.echo("Hint: Run 'phoonnx_cli.py update-cache' first to fetch the list.", err=True)
-        return
-
-    # NOTE: metadata already downloaded when creating VoiceInfo object
-    #  we only need to download the .onnx file
-    voice_info = manager.voices[voice_id]
+    voice_info = manager.voices.get(voice_id)
 
     try:
-        click.echo(f"Attempting to download files for: {voice_id} ({voice_info.lang})")
+        if voice_info:
+            click.echo(f"Attempting to download files for: {voice_id} ({voice_info.lang})")
 
-        # Download model (model.onnx)
-        click.echo("-> Downloading ONNX model (this may take a while)...")
-        voice_info.download_model()
+            # NOTE: metadata already downloaded when creating VoiceInfo object
+            #  we only need to download the .onnx file
+            click.echo("-> Downloading ONNX model (this may take a while)...")
+            voice_info.download_model()
 
-        click.echo(f"\nDownload complete. Files saved to: {voice_info.voice_path}")
+            click.echo(f"\nDownload complete. Files saved to: {voice_info.voice_path}")
+        else:
+            click.echo(f"Voice ID '{voice_id}' not found in local cache, looking it up in bundled indexes...")
+            if not manager.download_voice_by_id(voice_id):
+                click.echo(f"Error: Voice ID '{voice_id}' not found.", err=True)
+                click.echo("Hint: Run 'phoonnx_cli.py list-available' to see available voice IDs.", err=True)
+                return
+            click.echo(f"\nDownload complete.")
 
     except requests.exceptions.RequestException as e:
         click.echo(f"\nDownload failed due to network error: {e}", err=True)

--- a/phoonnx/cli.py
+++ b/phoonnx/cli.py
@@ -7,6 +7,8 @@ import requests
 def print_voice_info(voice: TTSModelInfo):
     """Prints detailed info about a single voice."""
     click.echo(f"  ID:          {voice.voice_id}")
+    if voice.display_name:
+        click.echo(f"  Name:        {voice.display_name}")
     click.echo(f"  Language:    {voice.lang}")
     click.echo(f"  Engine:      {voice.engine.value}")
     click.echo(f"  Phoneme Type: {voice.phoneme_type}")
@@ -82,7 +84,6 @@ def list_langs():
     for l in manager.supported_langs:
         click.echo(f" - {l}")
 
-
 @cli.command(name="list-voices")
 @click.option("--lang", default=None, help="Filter voices by language code (e.g., 'en-US' or 'pt-PT').")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed information for each voice.")
@@ -110,8 +111,40 @@ def list_voices(lang, verbose):
         if verbose:
             print_voice_info(voice)
         else:
-            click.echo(f"* {voice.voice_id} ({voice.lang})")
+            if voice.display_name:
+                click.echo(f"* {voice.display_name} ({voice.lang})")
+            else:
+                click.echo(f"* {voice.voice_id} ({voice.lang})")
 
+@cli.command(name="list-available")
+def list_available():
+    """
+    Lists all voice IDs available from upstream sources (Piper, Mimic3, etc.),
+    even if they are not yet in the local cache. (Requires network connection)
+    """
+    manager = TTSModelManager()
+    
+    click.echo("Fetching all available voice IDs from upstream sources (Piper, Mimic3, OVOS, etc.)...")
+    
+    try:
+        available_voices = manager.get_all_available_voice_ids()
+    except requests.exceptions.RequestException as e:
+        click.echo(f"\nError: Could not fetch available voice lists due to a network or connection error.", err=True)
+        click.echo(f"Details: {e}", err=True)
+        return
+    except Exception as e:
+        click.echo(f"An unexpected error occurred while fetching available voice lists: {e}", err=True)
+        return
+
+    total_voices = sum(len(ids) for ids in available_voices.values())
+    click.echo(f"\nTotal available voices found (from all sources): {total_voices}\n")
+    
+    for source, voice_ids in available_voices.items():
+        click.echo(f"--- {source.upper()} Voices ({len(voice_ids)}) ---")
+        for voice_id in voice_ids:
+            click.echo(f"  {voice_id}")
+        click.echo("-" * 40)
+    click.echo("Hint: Use 'update-cache' to download the configuration for these voices, or use 'download <VOICE_ID>' to download a specific voice directly.")
 
 @cli.command(name="download")
 @click.argument("voice_id", type=str)

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -115,6 +115,7 @@ def list_engines() -> List[str]:
 
 def _register_builtins() -> None:
     from phoonnx.engines.vits import VitsAdapter
+    from phoonnx.engines.vits_streaming import VitsStreamingAdapter
     from phoonnx.engines.shami import ShamiAdapter
     from phoonnx.engines.matcha import MatchaAdapter
     from phoonnx.engines.optispeech import OptiSpeechAdapter
@@ -131,6 +132,10 @@ def _register_builtins() -> None:
     # a distinctive metadata + wav/durations output signature — check it first.
     register_engine("optispeech", OptiSpeechAdapter, detect_priority=35)
     register_engine("shami", ShamiAdapter, detect_priority=45)
+    # Streaming VITS must be probed *before* the plain VITS adapter: it only
+    # matches split models (streaming:true + decoder_path), so it never steals a
+    # normal single-graph voice, but a normal VITS voice must not steal a split one.
+    register_engine("vits_streaming", VitsStreamingAdapter, detect_priority=48)
     register_engine("vits", VitsAdapter, detect_priority=50)
     register_engine("matcha", MatchaAdapter, detect_priority=40)
     register_engine("glowtts", GlowTTSAdapter, detect_priority=42)

--- a/phoonnx/engines/vits_streaming.py
+++ b/phoonnx/engines/vits_streaming.py
@@ -1,0 +1,250 @@
+"""Streaming VITS inference adapter (split encoder/decoder).
+
+Standard Piper/VITS models are a **single** ONNX graph: phoneme IDs → waveform.
+A *streaming* VITS model is published as **two** ONNX graphs so that audio can be
+produced incrementally, lowering time-to-first-audio:
+
+1. **Encoder** — phoneme IDs → latent ``z`` [B, 192, T] and ``y_mask`` [B, 1, T].
+   Runs **once** per sentence. Samples the duration/noise internally.
+2. **Decoder** — a slice of ``z`` (+ ``y_mask``) → waveform for that slice.
+   Run **repeatedly** over the time axis, streaming chunks of audio.
+
+These are the Sonata "+RT" fast voices (config carries ``"streaming": true``),
+or any model exported with a split encoder/decoder. A combined single-graph model
+CANNOT stream — use the plain :class:`VitsAdapter` for those.
+
+The decoder is convolutional, so naively slicing ``z`` on the time axis
+contaminates the chunk edges (~16-19 frames deep). This adapter therefore uses
+**discard-and-stitch**: each chunk is decoded with a context margin of ``M``
+frames on both sides, the contaminated margins are discarded, and only the clean
+middle is kept. The stitched result is bit-identical to a one-shot decode.
+
+engine_params (in the voice config)::
+
+    "engine_params": {
+        "decoder_path": "decoder.onnx",   # required: the second graph
+        "streaming": {                     # optional: all have proven defaults
+            "context_margin": 32,          # M: frames of context each side
+            "first_chunk": 8,              # frames in the first (latency) chunk
+            "next_chunk": 160,             # frames per subsequent chunk
+            "fallback_frames": 128         # <= this many frames: one-shot decode
+        }
+    }
+
+ONNX interface (encoder = primary session):
+  IN  ``input``         int64    [B, T]   phoneme IDs
+      ``input_lengths`` int64    [B]
+      ``scales``        float32  [3]      [noise_scale, length_scale, noise_w]
+      ``sid``           int64    [B]      speaker ID (multi-speaker only)
+  OUT ``z``             float32  [B, 192, T]
+      ``y_mask``        float32  [B, 1, T]
+
+ONNX interface (decoder = auxiliary graph):
+  IN  ``z``             float32  [B, 192, T_slice]
+      ``y_mask``        float32  [B, 1, T_slice]
+  OUT ``output``        float32  [B, 1, N] or [N]   waveform samples
+"""
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest,
+    AdapterSynthesisResult,
+    BaseOnnxAdapter,
+)
+
+
+# Proven defaults from empirical tuning (see docs/streaming.md):
+#   context_margin=32  bit-identical on every voice tested (24 often works and is
+#                      ~6% faster, but 16 corrupts edges — 32 is the safe default).
+#   first_chunk=8      small first slice → lowest time-to-first-audio.
+#   next_chunk=160     balances per-chunk overhead against throughput.
+#   fallback_frames=128 short sentences decode one-shot (streaming can't help).
+_DEFAULT_STREAMING = {
+    "context_margin": 32,
+    "first_chunk": 8,
+    "next_chunk": 160,
+    "fallback_frames": 128,
+}
+
+
+class VitsStreamingAdapter(BaseOnnxAdapter):
+    """Adapter for split-graph (streaming) VITS models.
+
+    The primary ``session`` is the **encoder**; the **decoder** is loaded as an
+    auxiliary graph from ``engine_params["decoder_path"]``. ``synthesize`` is
+    overridden to run the discard-and-stitch chunk loop instead of a single
+    ``session.run``.
+    """
+
+    def __init__(self, decoder_session: Optional[onnxruntime.InferenceSession] = None):
+        self.decoder = decoder_session
+        self._engine_params: Dict[str, Any] = {}
+        self._streaming: Dict[str, int] = dict(_DEFAULT_STREAMING)
+        self._hop_length: Optional[int] = None  # resolved from config or measured
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def configure(self, voice_config: Any) -> None:
+        """Load the decoder graph and streaming parameters from the voice config."""
+        engine_params = getattr(voice_config, "engine_params", None) or {}
+        self.configure_from_params(engine_params)
+        hop = getattr(voice_config, "hop_length", None)
+        if hop:
+            self._hop_length = int(hop)
+
+    def configure_from_params(self, engine_params: Dict[str, Any]) -> None:
+        self._engine_params = engine_params or {}
+        user_streaming = self._engine_params.get("streaming") or {}
+        if isinstance(user_streaming, dict):
+            self._streaming = {**_DEFAULT_STREAMING, **user_streaming}
+        threads = self._engine_params.get("intra_op_num_threads")
+        decoder_path = self._engine_params.get("decoder_path")
+        if self.decoder is None and decoder_path:
+            self.decoder = self._build_decoder(decoder_path, threads)
+
+    @staticmethod
+    def _build_decoder(path: str, threads: Optional[int]) -> onnxruntime.InferenceSession:
+        import os
+        so = onnxruntime.SessionOptions()
+        if threads is None:
+            threads = max(1, (os.cpu_count() or 4) // 2)
+        so.intra_op_num_threads = int(threads)
+        so.inter_op_num_threads = 1
+        return onnxruntime.InferenceSession(path, so)
+
+
+    # ------------------------------------------------------------------
+    # Control parameters (shared with the plain VITS adapter)
+    # ------------------------------------------------------------------
+
+    def default_params(self) -> Dict[str, float]:
+        return {"noise_scale": 0.667, "length_scale": 1.0, "noise_w_scale": 0.8}
+
+    def parse_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        inference = config.get("inference", {})
+        defaults = self.default_params()
+        return {
+            "noise_scale": inference.get("noise_scale", defaults["noise_scale"]),
+            "length_scale": inference.get("length_scale", defaults["length_scale"]),
+            "noise_w_scale": inference.get("noise_w", defaults["noise_w_scale"]),
+        }
+
+    def param_labels(self) -> Dict[str, str]:
+        return {"noise_scale": "Noise scale",
+                "length_scale": "Length scale",
+                "noise_w_scale": "Noise W"}
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        """A streaming VITS model declares ``streaming: true`` and ships a decoder.
+        Both the config flag and a decoder graph are required — a bare
+        ``streaming`` flag on a single-graph model is not enough to stream."""
+        if not config:
+            return False
+        if not config.get("streaming"):
+            return False
+        engine_params = config.get("engine_params") or {}
+        return bool(engine_params.get("decoder_path"))
+
+    # ------------------------------------------------------------------
+    # Encoder feed (mirrors VitsAdapter.build_feed_dict, encoder outputs z/y_mask)
+    # ------------------------------------------------------------------
+
+    def build_feed_dict(self, request: AdapterSynthesisRequest,
+                        session: onnxruntime.InferenceSession) -> Dict[str, np.ndarray]:
+        params = request.params
+        d = self.default_params()
+        noise = np.float32(params.get("noise_scale", d["noise_scale"]))
+        length = np.float32(params.get("length_scale", d["length_scale"]))
+        noise_w = np.float32(params.get("noise_w_scale", d["noise_w_scale"]))
+        scales = np.array([noise, length, noise_w], dtype=np.float32)
+        rank = self._input_rank(session, "scales")
+        if rank is not None and rank >= 2:
+            scales = scales.reshape(1, -1)
+        args: Dict[str, np.ndarray] = {
+            "input": request.phoneme_ids,
+            "input_lengths": request.phoneme_lengths,
+            "scales": scales,
+        }
+        if request.speaker_id is not None:
+            args["sid"] = np.array([request.speaker_id], dtype=np.int64)
+        return self._filter_inputs(args, session)
+
+    def parse_outputs(self, outputs: List[np.ndarray],
+                      request: AdapterSynthesisRequest) -> AdapterSynthesisResult:
+        """Required by the base interface. Streaming synthesis is driven by
+        ``synthesize`` (which loops over the decoder), so this is only used if a
+        caller runs the encoder graph directly: it wraps the first output as audio."""
+        audio = np.asarray(outputs[0]).squeeze().astype(np.float32)
+        return AdapterSynthesisResult(audio=audio)
+
+
+    # ------------------------------------------------------------------
+    # Streaming synthesis: encode once, decode in discard-and-stitch chunks
+    # ------------------------------------------------------------------
+
+    def _resolve_hop(self, z_frames: int, sample_count: int) -> int:
+        """hop_length = decoder samples per latent frame. Prefer the configured
+        value; otherwise measure it from a one-shot decode (samples / frames)."""
+        if self._hop_length:
+            return self._hop_length
+        if z_frames > 0:
+            self._hop_length = max(1, round(sample_count / z_frames))
+        return self._hop_length or 256
+
+    def _decode(self, z: np.ndarray, y_mask: np.ndarray) -> np.ndarray:
+        out = self.decoder.run(["output"], {"z": z, "y_mask": y_mask})[0]
+        return np.asarray(out).squeeze()
+
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        if self.decoder is None:
+            raise RuntimeError(
+                "VitsStreamingAdapter has no decoder graph. Set "
+                "engine_params['decoder_path'] to the decoder .onnx.")
+
+        # 1) Encoder runs once, producing the full latent sequence.
+        feed = self.build_feed_dict(request, session)
+        z, y_mask = session.run(["z", "y_mask"], feed)
+        T = z.shape[2]
+
+        M = self._streaming["context_margin"]
+        first = self._streaming["first_chunk"]
+        nxt = self._streaming["next_chunk"]
+        fallback = self._streaming["fallback_frames"]
+
+        # 2) Short sentence: one-shot decode (streaming overhead can't pay off).
+        if T <= fallback:
+            audio = self._decode(z, y_mask)
+            self._resolve_hop(T, len(audio))
+            return AdapterSynthesisResult(audio=audio.astype(np.float32))
+
+        # 3) Determine hop from a throwaway measure only if unknown. We avoid an
+        #    extra full decode: use the first chunk to establish hop.
+        segments: List[np.ndarray] = []
+        start = 0
+        is_first = True
+        hop = self._hop_length or 256
+        while start < T:
+            size = first if is_first else nxt
+            end = min(start + size, T)
+            a = max(0, start - M)
+            b = min(T, end + M)
+            chunk_audio = self._decode(z[:, :, a:b], y_mask[:, :, a:b])
+            if is_first and not self._hop_length:
+                # first full-context decode lets us pin hop precisely
+                hop = self._resolve_hop(b - a, len(chunk_audio))
+            lo = (start - a) * hop
+            hi = min(lo + (end - start) * hop, len(chunk_audio))
+            segments.append(chunk_audio[lo:hi])
+            is_first = False
+            start = end
+
+        audio = np.concatenate(segments).astype(np.float32)
+        return AdapterSynthesisResult(audio=audio)

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -65,6 +65,10 @@ class TTSModelInfo:
     # token like "eg" is mapped here rather than derived from the (normalized) lang code.
     lang_tokens: Optional[Dict[str, str]] = None
 
+    # user-friendly name for UIs/CLIs; may contain "{engine}"/"{phoneme_type}"
+    # placeholders that get resolved once those fields are known
+    display_name: Optional[str] = None
+
     @property
     def config(self) -> VoiceConfig:
         # lazy loaded
@@ -163,6 +167,18 @@ class TTSModelInfo:
             self.alphabet = Alphabet(self.alphabet)
         if not isinstance(self.phoneme_type, PhonemeType) and isinstance(self.phoneme_type, str):
             self.phoneme_type = PhonemeType(self.phoneme_type)
+
+        # resolve "{engine}"/"{phoneme_type}" placeholders in display_name,
+        # if those fields are already known (avoids triggering a config
+        # download just to format a label)
+        if self.display_name and "{" in self.display_name:
+            try:
+                self.display_name = self.display_name.format(
+                    engine=self.engine.value if self.engine else "",
+                    phoneme_type=self.phoneme_type.value if self.phoneme_type else "",
+                )
+            except (AttributeError, KeyError):
+                LOG.warning(f"Could not format display_name for {self.voice_id}.")
 
     @property
     def voice_path(self) -> Path:
@@ -556,7 +572,8 @@ class TTSModelManager:
                                     "phoneme_map_url": voice_info.phoneme_map_url,
                                     "alphabet": voice_info.alphabet,
                                     "engine": voice_info.engine,
-                                    "config_url": voice_info.config_url}
+                                    "config_url": voice_info.config_url,
+                                    "display_name": voice_info.display_name}
         self.cache.store()
 
     def add_voice(self, voice_info: TTSModelInfo):
@@ -582,7 +599,8 @@ class TTSModelManager:
                                            "config_url": voice_info.config_url,
                                            "vocoder_url": voice_info.vocoder_url,
                                            "vocoder_config_url": voice_info.vocoder_config_url,
-                                           "vocoder_type": voice_info.vocoder_type}
+                                           "vocoder_type": voice_info.vocoder_type,
+                                           "display_name": voice_info.display_name}
 
     def get_lang_voices(self, lang: str) -> List[TTSModelInfo]:
         voices = sorted(
@@ -633,6 +651,82 @@ class TTSModelManager:
 
         if store:
             self.cache.store()
+
+    def get_available_voice_ids_by_source(self) -> Dict[str, List[str]]:
+        """
+        List all voice IDs bundled with phoonnx, grouped by source.
+
+        Reads the ``voice_index`` JSON files that ship with the package
+        directly (plain ``json.load``, no ``TTSModelInfo`` construction),
+        so this performs no network access and downloads no model/config
+        files - suitable for a quick "what's available" listing before
+        committing to downloading a specific voice via ``download_voice_by_id``.
+
+        Returns:
+            Dict[str, List[str]]: mapping of source name to sorted voice IDs.
+        """
+        base_path = Path(os.path.dirname(__file__)) / "voice_index"
+        sources = {
+            "ovos": "OVOS.json",
+            "mms": "MMS.json",
+            "proxectonos": "proxectonos.json",
+            "piper": "piper.json",
+            "piper_community": "piper_community.json",
+            "phonikud": "phonikud.json",
+            "neurlang": "neurlang.json",
+            "mimic3": "mimic3.json",
+            "transformers_community": "transformers_community.json",
+            "optispeech": "optispeech.json",
+            "glowtts": "glowtts.json",
+            "mixertts": "mixertts.json",
+            "fastpitch": "fastpitch.json",
+            "coqui_community": "coqui_community.json",
+            "vits2": "vits2.json",
+            "styletts2": "styletts2.json",
+            "coqui_vits": "coqui_vits.json",
+            "bsc": "BSC.json",
+        }
+        result: Dict[str, List[str]] = {}
+        for source, filename in sources.items():
+            path = base_path / filename
+            if not path.is_file():
+                continue
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            result[source] = sorted(data.keys())
+        return result
+
+    def download_voice_by_id(self, voice_id: str) -> bool:
+        """
+        Download a single voice's model (and side files) by its ID.
+
+        Looks the voice up in the in-memory registry first (populated via
+        ``load()``/``merge_default_voices()``); if not found there, falls
+        back to the bundled voice indexes so a voice can be downloaded
+        on-demand without first loading the full catalog into memory.
+
+        Returns:
+            bool: True if the voice was found and its download was attempted,
+            False if the voice ID could not be resolved.
+        """
+        voice_info = self.voices.get(voice_id)
+        if not voice_info:
+            base_path = Path(os.path.dirname(__file__)) / "voice_index"
+            for filename in os.listdir(base_path):
+                if not filename.endswith(".json"):
+                    continue
+                with open(base_path / filename, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if voice_id in data:
+                    voice_info = TTSModelInfo(**data[voice_id])
+                    break
+
+        if not voice_info:
+            LOG.error(f"Cannot find voice information for ID: {voice_id}")
+            return False
+
+        voice_info.download_model()
+        return True
 
 
 

--- a/phoonnx/util.py
+++ b/phoonnx/util.py
@@ -6,9 +6,11 @@ from datetime import date
 from typing import Union, List, Tuple
 
 from langcodes import tag_distance
+# Number pronunciation uses unicode_rbnf (see _number_to_words / _is_numeric below).
+# ovos_number_parser was dropped: it silently failed on English fractions and on
+# es/fr integers >= 100. Date/time pronunciation still uses ovos_date_parser, which
+# produces richer spoken dates ("monday, july thirteenth") than a pure number engine.
 from ovos_date_parser import nice_time, nice_date
-from ovos_number_parser import pronounce_number, pronounce_fraction
-from ovos_number_parser.util import is_numeric
 from unicode_rbnf import RbnfEngine, FormatPurpose
 from langcodes import standardize_tag, Language
 try:
@@ -467,6 +469,73 @@ UNITS = {
 }
 
 
+# Cache one RbnfEngine per language: construction parses rule files and is costly
+# to repeat per word. Keyed by the short language code (e.g. "en", "es").
+_RBNF_ENGINES: dict = {}
+
+
+def _get_rbnf_engine(full_lang: str):
+    """Return a cached RbnfEngine for the language, or None if unavailable."""
+    lang_code = full_lang.split("-")[0]
+    if lang_code not in _RBNF_ENGINES:
+        try:
+            _RBNF_ENGINES[lang_code] = RbnfEngine.for_language(lang_code)
+        except (ValueError, KeyError) as e:
+            LOG.debug(f"RBNF engine not available for '{lang_code}': {e}")
+            _RBNF_ENGINES[lang_code] = None
+    return _RBNF_ENGINES[lang_code]
+
+
+def _is_numeric(text: str) -> bool:
+    """True if the string parses as an int or float (replaces ovos is_numeric)."""
+    try:
+        float(text)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def _number_to_words(num, full_lang: str, rbnf_engine=None) -> str:
+    """Pronounce a number using unicode_rbnf (replaces ovos pronounce_number).
+
+    Integers use the CARDINAL rule set. Non-integers are read digit-by-digit
+    after the decimal point ("three point one four"), matching how the previous
+    engine handled decimals and how espeak expects them.
+    """
+    engine = rbnf_engine or _get_rbnf_engine(full_lang)
+    if engine is None:
+        return str(num)
+    # Integer (or integral float): single cardinal formatting.
+    if isinstance(num, int) or (isinstance(num, float) and num.is_integer()):
+        return engine.format_number(int(num), FormatPurpose.CARDINAL).text
+    # Decimal: whole part as cardinal, fractional part digit-by-digit.
+    neg = num < 0
+    whole, _, frac = f"{abs(num)}".partition(".")
+    whole_words = engine.format_number(int(whole), FormatPurpose.CARDINAL).text
+    point_word = _decimal_point_word(full_lang)
+    digits = [engine.format_number(int(d), FormatPurpose.CARDINAL).text for d in frac]
+    words = f"{whole_words} {point_word} " + " ".join(digits)
+    return ("minus " + words) if neg else words
+
+
+def _decimal_point_word(full_lang: str) -> str:
+    """The spoken decimal separator word for the language."""
+    lang_code = full_lang.split("-")[0]
+    return {"en": "point", "de": "Komma", "nl": "komma", "es": "coma",
+            "pt": "vírgula", "fr": "virgule", "it": "virgola"}.get(lang_code, "point")
+
+
+def _fraction_to_words(fraction: str, full_lang: str) -> str:
+    """Pronounce a fraction like '3/4'. rbnf has no fraction API, so we read it
+    as "<numerator> over <denominator>" — unambiguous and espeak-friendly. The
+    previous engine failed outright on English fractions, so this is an upgrade."""
+    try:
+        num, den = fraction.split("/")
+        return f"{_number_to_words(int(num), full_lang)} over {_number_to_words(int(den), full_lang)}"
+    except (ValueError, ZeroDivisionError):
+        return fraction
+
+
 def _get_number_separators(full_lang: str) -> tuple[str, str]:
     """
     Determines decimal and thousands separators based on language.
@@ -493,9 +562,9 @@ def _normalize_number_word(word: str, full_lang: str, rbnf_engine) -> str:
     # Handle fractions like '3/3'
     if is_fraction(cleaned_word):
         try:
-            return pronounce_fraction(cleaned_word, full_lang) + word[len(cleaned_word):]
+            return _fraction_to_words(cleaned_word, full_lang) + word[len(cleaned_word):]
         except Exception as e:
-            LOG.error(f"ovos-number-parser failed to pronounce fraction: {word} - ({e})")
+            LOG.error(f"failed to pronounce fraction: {word} - ({e})")
             return word
 
     # Handle numbers with locale-specific separators
@@ -513,20 +582,20 @@ def _normalize_number_word(word: str, full_lang: str, rbnf_engine) -> str:
     if has_thousands_and_decimal:
         temp_cleaned_word = temp_cleaned_word.replace(thousands_separator, "")
         temp_cleaned_word = temp_cleaned_word.replace(decimal_separator, ".")
-    elif decimal_separator in temp_cleaned_word and is_numeric(temp_cleaned_word.replace(decimal_separator, ".", 1)):
+    elif decimal_separator in temp_cleaned_word and _is_numeric(temp_cleaned_word.replace(decimal_separator, ".", 1)):
         # Handle cases like '1,2' -> '1.2'
         temp_cleaned_word = temp_cleaned_word.replace(decimal_separator, ".")
-    elif thousands_separator in temp_cleaned_word and is_numeric(temp_cleaned_word.replace(thousands_separator, "", 1)):
+    elif thousands_separator in temp_cleaned_word and _is_numeric(temp_cleaned_word.replace(thousands_separator, "", 1)):
         # Handle cases like '1.234' -> '1234'
         temp_cleaned_word = temp_cleaned_word.replace(thousands_separator, "")
 
     # Check if the word is a valid number after processing
-    if is_numeric(temp_cleaned_word):
+    if _is_numeric(temp_cleaned_word):
         try:
             num = float(temp_cleaned_word) if "." in temp_cleaned_word else int(temp_cleaned_word)
-            return pronounce_number(num, lang=full_lang) + word[len(cleaned_word):]
+            return _number_to_words(num, full_lang, rbnf_engine) + word[len(cleaned_word):]
         except Exception as e:
-            LOG.error(f"ovos-number-parser failed to pronounce number: {word} - ({e})")
+            LOG.error(f"failed to pronounce number: {word} - ({e})")
             return word
 
     elif rbnf_engine and cleaned_word.isdigit():
@@ -684,7 +753,7 @@ def _normalize_units(text: str, full_lang: str) -> str:
                 unit_symbol = match.group(2)
                 unit_word = symbolic_units[unit_symbol]
                 try:
-                    return f"{pronounce_number(float(number) if '.' in number else int(number), full_lang)} {unit_word}"
+                    return f"{_number_to_words(float(number) if '.' in number else int(number), full_lang)} {unit_word}"
                 except Exception as e:
                     LOG.error(f"Failed to pronounce number with unit: {number}{unit_symbol} - ({e})")
                     return match.group(0)
@@ -708,7 +777,7 @@ def _normalize_units(text: str, full_lang: str) -> str:
                     number = number.replace(decimal_separator, ".")
                 unit_symbol = match.group(2)
                 unit_word = alphanumeric_units[unit_symbol]
-                return f"{pronounce_number(float(number) if '.' in number else int(number), full_lang)} {unit_word}"
+                return f"{_number_to_words(float(number) if '.' in number else int(number), full_lang)} {unit_word}"
 
             text = alphanumeric_pattern.sub(replace_alphanumeric, text)
     return text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "onnxruntime",
     "quebra-frases",
     "langcodes",
-    "ovos-number-parser>=0.4.0",
+    "unicode-rbnf",
     "ovos-date-parser>=0.6.4a1",
 ]
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,5 +2,5 @@ numpy
 onnxruntime
 quebra-frases
 langcodes
-ovos-number-parser>=0.4.0
+unicode-rbnf
 ovos-date-parser>=0.6.4a1


### PR DESCRIPTION
## Summary

Two improvements, plus attribution cherry-picks.

### 1. Streaming VITS engine (low-latency, split encoder/decoder)

Adds `VitsStreamingAdapter` for split-graph VITS voices (separate
`encoder.onnx` + `decoder.onnx`, `"streaming": true`). It lowers
time-to-first-audio by decoding a sentence in chunks instead of one shot.

- **Method: discard-and-stitch.** Each chunk is decoded with a context margin
  of M frames per side; the convolution-contaminated margins are discarded and
  the clean middle kept, so the stitched output is bit-identical to a one-shot
  decode (verified maxabs ~3e-6 on lessac+RT-high, length delta 0).
- **Strict auto-detection** (streaming flag + decoder_path), registered just
  ahead of the plain VITS adapter, so a normal single-graph voice is never
  hijacked.
- **Tuned defaults, all config-driven:** context_margin=32 (safe on every voice
  tested; 24 often works and is ~6% faster, 16 corrupts edges), first_chunk=8,
  next_chunk=160, fallback_frames=128, intra_op_num_threads=cores/2 (using all
  cores measured slower on the heavy decoder). Encoder/decoder pipelining was
  tested and rejected (hurt TTFA).
- **docs/streaming.md** covers the split-model requirement, the two ways to get
  one (Sonata +RT voices or self-export), a case study of a broken export
  (`ryan+RT`, a piper 0.2.0 → 1.0.0 version mismatch that shifted the duration
  predictor ~12%), and copy-paste verification checks.

### 2. Drop ovos-number-parser for unicode-rbnf

Number pronunciation now uses `unicode-rbnf`. It is more robust: it correctly
pronounces integers >= 100 in es/fr (ovos returned raw digits) and handles
English fractions (ovos failed outright). Date/time pronunciation still uses
`ovos-date-parser` for its richer spoken dates. Verified regression-free against
an 18-case golden reference across en/es/de/nl/fr.

### 3. Attribution

Includes cherry-picks of @timonvanhasselt's CLI voice-listing commits
(display name + available-voice-ID listing), preserved with original authorship.

## Testing

- Streaming reproduces one-shot decode bit-for-bit (shared-z test).
- Adapter auto-detection: streaming model → `vits_streaming`, plain model →
  `vits`.
- Full package import + `normalize()` regression check pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added low-latency streaming support for compatible VITS voices.
  - Added a CLI command to list bundled voices without downloading files.
  - Voice downloads now work on demand from bundled catalogs.
  - Voice listings can show friendly display names.

- **Improvements**
  - Improved pronunciation of numbers, decimals, fractions, and unit expressions across supported languages.

- **Documentation**
  - Added comprehensive streaming setup, configuration, tuning, and verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->