### PR TITLE
feat: orthography2ipa lattice phonemizer backends (o2i, arbtok, euskaphone, barranquenho) + mwl fix

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -96,6 +96,10 @@ class PhonemeType(str, Enum):
     XPINYIN = "xpinyin" # chinese
     JIEBA = "jieba" # chinese  (not a real phonemizer!)
     SHAMI = "shami"  # Levantine Arabic / English code-switching (ShamiVITS)
+    ARBTOK = "arbtok"  # arabic (dialect-aware, undiacritized text; o2i lattice)
+    EUSKAPHONE = "euskaphone"  # basque (dialect-aware; o2i lattice)
+    BARRANQUENHO = "barranquenho"  # barranquenho (pt/es contact variety; o2i lattice)
+    ORTHOGRAPHY2IPA = "orthography2ipa"  # multilingual data-driven IPA (o2i lattice)
 
 
 @dataclass
@@ -616,7 +620,9 @@ def get_phonemizer(phoneme_type: PhonemeType,
                        MisakiKoPhonemizer, MisakiViPhonemizer,
                        KoG2PPhonemizer, PypinyinPhonemizer, PyKakasiPhonemizer, CotoviaPhonemizer,
                        AhoTTSPhonemizer, CutletPhonemizer, PhonikudPhonemizer, VIPhonemePhonemizer,
-                       XpinyinPhonemizer, UnicodeCodepointPhonemizer, JiebaPhonemizer, ShamiPhonemizer)
+                       XpinyinPhonemizer, UnicodeCodepointPhonemizer, JiebaPhonemizer, ShamiPhonemizer,
+                       ArbtokPhonemizer, EuskaphonePhonemizer, BarranquenhoPhonemizer,
+                       Orthography2IPAPhonemizer)
     if phoneme_type == PhonemeType.ESPEAK:
         phonemizer = EspeakPhonemizer()
     elif phoneme_type == PhonemeType.BYT5:
@@ -695,6 +701,16 @@ def get_phonemizer(phoneme_type: PhonemeType,
         phonemizer = GraphemePhonemizer()
     elif phoneme_type == PhonemeType.SHAMI:
         phonemizer = ShamiPhonemizer(alphabet=alphabet)
+    elif phoneme_type == PhonemeType.ARBTOK:
+        # `model` is the voice's phonemizer_model: "iʿrab" forces the full
+        # case-ending register; default defers to arbtok (pausal / spoken).
+        phonemizer = ArbtokPhonemizer(register=model)
+    elif phoneme_type == PhonemeType.EUSKAPHONE:
+        phonemizer = EuskaphonePhonemizer()
+    elif phoneme_type == PhonemeType.BARRANQUENHO:
+        phonemizer = BarranquenhoPhonemizer()
+    elif phoneme_type == PhonemeType.ORTHOGRAPHY2IPA:
+        phonemizer = Orthography2IPAPhonemizer()
     else:
         raise ValueError("invalid phonemizer")
     return phonemizer

--- a/phoonnx/phonemizers/__init__.py
+++ b/phoonnx/phonemizers/__init__.py
@@ -3,13 +3,14 @@ from typing import Union
 from phoonnx.phonemizers.base import BasePhonemizer, UnicodeCodepointPhonemizer, GraphemePhonemizer, TextChunks, RawPhonemizedChunks
 from phoonnx.phonemizers.en import DeepPhonemizer, OpenPhonemizer, G2PEnPhonemizer
 from phoonnx.phonemizers.gl import CotoviaPhonemizer
-from phoonnx.phonemizers.eu import AhoTTSPhonemizer
+from phoonnx.phonemizers.eu import AhoTTSPhonemizer, EuskaphonePhonemizer
 from phoonnx.phonemizers.vi import VIPhonemePhonemizer
 from phoonnx.phonemizers.he import PhonikudPhonemizer
-from phoonnx.phonemizers.ar import MantoqPhonemizer
+from phoonnx.phonemizers.ar import MantoqPhonemizer, ArbtokPhonemizer
 from phoonnx.phonemizers.shami import ShamiPhonemizer
 from phoonnx.phonemizers.fa import PersianPhonemizer
-from phoonnx.phonemizers.pt import TugaphonePhonemizer
+from phoonnx.phonemizers.pt import TugaphonePhonemizer, BarranquenhoPhonemizer
+from phoonnx.phonemizers.o2ipa import Orthography2IPAPhonemizer
 from phoonnx.phonemizers.ja import PyKakasiPhonemizer, CutletPhonemizer, OpenJTaklPhonemizer
 from phoonnx.phonemizers.ko import KoG2PPhonemizer, G2PKPhonemizer
 from phoonnx.phonemizers.zh import (G2pCPhonemizer, G2pMPhonemizer, PypinyinPhonemizer,
@@ -48,7 +49,11 @@ Phonemizer = Union[
     CotoviaPhonemizer,
     AhoTTSPhonemizer,
     MantoqPhonemizer,
+    ArbtokPhonemizer,
     ShamiPhonemizer,
+    EuskaphonePhonemizer,
+    BarranquenhoPhonemizer,
+    Orthography2IPAPhonemizer,
     GraphemePhonemizer,
     OpenPhonemizer,
     G2PEnPhonemizer,

--- a/phoonnx/phonemizers/ar.py
+++ b/phoonnx/phonemizers/ar.py
@@ -76,11 +76,14 @@ class ArbtokPhonemizer(BasePhonemizer):
                  alphabet: Alphabet = Alphabet.IPA):
         if alphabet != Alphabet.IPA:
             raise ValueError("arbtok only outputs IPA")
-        # register: None -> defer to arbtok's own default (pausal). "iʿrab"/"irab"
-        # forces the full case-ending register (apt only for ar/arb).
+        # register: None -> defer to arbtok's own default (pausal). The iʿrab
+        # aliases force arbtok's full case-ending register, which the plugin
+        # spells "full" (apt only for ar/arb); pass any other value through so a
+        # caller can still say "pausal"/"full" directly.
         self.register = None
         if register:
-            self.register = "irab" if register.lower() in ("irab", "i'rab", "iʿrab") else register
+            self.register = ("full" if register.lower() in ("irab", "i'rab", "iʿrab", "full")
+                             else register)
         self._cache = {}
         super().__init__(alphabet)
 

--- a/phoonnx/phonemizers/ar.py
+++ b/phoonnx/phonemizers/ar.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from phoonnx.config import Alphabet
 from phoonnx.phonemizers.base import BasePhonemizer
 from phoonnx.thirdparty.bw2ipa import mantoq_to_ipa
@@ -50,6 +52,77 @@ class MantoqPhonemizer(BasePhonemizer):
         return phonemes
 
 
+class ArbtokPhonemizer(BasePhonemizer):
+    """
+    Arabic phonemizer backed by ``arbtok``, an engine built on the
+    orthography2ipa lattice.  Its edge over bare orthography2ipa is
+    **undiacritized** Arabic: ``arbtok`` restores the tashkeel with a bundled
+    diacritizer before transcribing, so it reads the unvocalized text people
+    actually type.  Output is always IPA.
+
+    The variety is any orthography2ipa Arabic spec code (``ar``, ``arb``,
+    ``ar-EG``, ``ar-SA-x-najd``, ...), taken from the per-call ``lang`` argument.
+
+    Register: arbtok's own default is the pausal (spoken) register, which is the
+    right choice for the dialects; the full iʿrāb register is only phonologically
+    apt for ``ar``/``arb`` (MSA/Classical).  The default here defers to arbtok's
+    register default rather than overriding it, so this convention lives in the
+    engine; pass a phoonnx ``model`` of ``"i'rab"`` to force the full register.
+
+    ``arbtok`` is imported lazily so importing ``phoonnx`` does not hard-require it.
+    """
+
+    def __init__(self, register: Optional[str] = None,
+                 alphabet: Alphabet = Alphabet.IPA):
+        if alphabet != Alphabet.IPA:
+            raise ValueError("arbtok only outputs IPA")
+        # register: None -> defer to arbtok's own default (pausal). "iʿrab"/"irab"
+        # forces the full case-ending register (apt only for ar/arb).
+        self.register = None
+        if register:
+            self.register = "irab" if register.lower() in ("irab", "i'rab", "iʿrab") else register
+        self._cache = {}
+        super().__init__(alphabet)
+
+    def _engine(self, lang: str):
+        """Return, lazily creating and caching, the arbtok engine for *lang*."""
+        key = (lang, self.register)
+        if key not in self._cache:
+            try:
+                from arbtok.plugin import ArbtokG2PPlugin
+            except ImportError as e:
+                raise ImportError(
+                    "arbtok is required for the arbtok Arabic phonemizer. "
+                    "Install it with 'pip install arbtok' "
+                    "(or 'pip install phoonnx[ar]')."
+                ) from e
+            kwargs = dict(lang=lang, diacritize=True)
+            if self.register is not None:
+                kwargs["register"] = self.register
+            self._cache[key] = ArbtokG2PPlugin(**kwargs)
+        return self._cache[key]
+
+    @classmethod
+    def get_lang(cls, target_lang: str) -> str:
+        """
+        Resolve *target_lang* to an arbtok/orthography2ipa Arabic spec code.
+
+        Raises:
+            ValueError: If arbtok has no Arabic variety for *target_lang*.
+        """
+        try:
+            from arbtok import spec_for_lang
+        except ImportError as e:
+            raise ImportError(
+                "arbtok is required for the arbtok Arabic phonemizer. "
+                "Install it with 'pip install arbtok' (or 'pip install phoonnx[ar]')."
+            ) from e
+        return spec_for_lang(target_lang)
+
+    def phonemize_string(self, text: str, lang: str = "ar") -> str:
+        return self._engine(self.get_lang(lang)).transcribe(text)
+
+
 if __name__ == "__main__":
     from phoonnx.phonemizers.mul import EspeakPhonemizer
 
@@ -57,11 +130,14 @@ if __name__ == "__main__":
 
     # Initialize phonemizers for both MANTOQ and IPA alphabets
     pho_mantoq = MantoqPhonemizer(alphabet=Alphabet.IPA)
+    pho_arbtok = ArbtokPhonemizer()
 
 
     def compare(text):
         print(f"Original Text: {text}")
         print(f"  Mantoq: {pho_mantoq.phonemize_string(text, 'ar')}")
+        # arbtok reads the bare (undiacritized) text directly
+        print(f"  arbtok: {pho_arbtok.phonemize_string(text, 'ar')}")
         print(f"  Espeak: {espeak.phonemize_string(text, 'ar')}")
 
         ts = pho_mantoq.add_diacritics(text, 'ar')

--- a/phoonnx/phonemizers/eu.py
+++ b/phoonnx/phonemizers/eu.py
@@ -108,7 +108,78 @@ class AhoTTSPhonemizer(BasePhonemizer):
         return self.phonemize_fn(text, lang=g2p_lang, **kwargs)
 
 
+class EuskaphonePhonemizer(BasePhonemizer):
+    """
+    Dialect-aware Basque phonemizer backed by ``euskaphone``, a TTS frontend
+    built on the shared orthography2ipa lattice.  Output is always IPA.
+
+    This is distinct from ``AhoTTSPhonemizer`` above: AhoTTS is a port of the
+    AhoTTS front-end, whereas euskaphone drives the orthography2ipa candidate
+    lattice and resolves eight Basque lects (Batua and the historical dialects)
+    from their spec data, adding vigesimal number verbalization and Spanish/
+    French code-switch handling.
+
+    The lect is taken from the per-call ``lang`` argument -- a BCP-47 code
+    (``eu``, ``eu-x-zuberera``, ...) which euskaphone resolves internally, so a
+    single instance serves every dialect.  ``euskaphone`` is imported lazily so
+    importing ``phoonnx`` does not hard-require it.
+    """
+
+    def __init__(self, alphabet: Alphabet = Alphabet.IPA):
+        if alphabet != Alphabet.IPA:
+            raise ValueError("euskaphone only outputs IPA")
+        self._pho = None
+        super().__init__(alphabet)
+
+    @property
+    def pho(self):
+        """Lazily import, construct and cache the ``EuskaPhonemizer``."""
+        if self._pho is None:
+            try:
+                from euskaphone import EuskaPhonemizer
+            except ImportError as e:
+                raise ImportError(
+                    "euskaphone is required for the euskaphone Basque phonemizer. "
+                    "Install it with 'pip install euskaphone' "
+                    "(or 'pip install phoonnx[eu]')."
+                ) from e
+            self._pho = EuskaPhonemizer()
+        return self._pho
+
+    @classmethod
+    def get_lang(cls, target_lang: str) -> str:
+        """
+        Resolve *target_lang* to a euskaphone Basque lect code.
+
+        Raises:
+            ValueError: If euskaphone has no lect for *target_lang*.
+        """
+        try:
+            from euskaphone import resolve_lect
+            from euskaphone.registry import is_supported
+        except ImportError as e:
+            raise ImportError(
+                "euskaphone is required for the euskaphone Basque phonemizer. "
+                "Install it with 'pip install euskaphone' (or 'pip install phoonnx[eu]')."
+            ) from e
+        # resolve_lect silently falls back to Batua for an unknown tag, so gate
+        # on is_supported first.
+        if not is_supported(target_lang):
+            raise ValueError(f"euskaphone: unsupported language {target_lang!r}")
+        return resolve_lect(target_lang)
+
+    def phonemize_string(self, text: str, lang: str = "eu") -> str:
+        return self.pho.phonemize_sentence(text, dialect=self.get_lang(lang))
+
+
 if __name__ == "__main__":
+    eus = EuskaphonePhonemizer()
+    print("--- euskaphone ---")
+    for dialect in ("eu", "eu-x-zuberera", "eu-x-bizkaiera"):
+        for sentence in ["Zazpi katu zuri ikusi ditut.",
+                         "Hotza egiten du gaur mendian."]:
+            print(f"  {dialect} {sentence!r}: {eus.phonemize_string(sentence, dialect)}")
+
     for eng in ("classic", "modern", "northern"):
         eu = AhoTTSPhonemizer(eng)
         print(f"\n--- AhoTTS '{eng}' (eu) ---")

--- a/phoonnx/phonemizers/mwl.py
+++ b/phoonnx/phonemizers/mwl.py
@@ -1,36 +1,65 @@
 from phoonnx.phonemizers.base import BasePhonemizer, Alphabet
 
 
+# phoonnx lang -> mwl_phonemizer dialect spec code. Mirandese is dialect-aware:
+# the central variety is the default, with Sendinese and the Raiano (Ifanês)
+# border variety selectable per call.
+DIALECTS = {
+    "mwl": "mwl",                      # central Mirandese (the standard)
+    "mwl-x-sendim": "mwl-x-sendim",    # Sendinese
+    "mwl-x-ifanes": "mwl-x-ifanes",    # Raiano / Ifanês (border variety)
+}
+
+
 class MirandesePhonemizer(BasePhonemizer):
-    _LANGS = ["mwl"]
+    """
+    Mirandese phonemizer backed by ``mwl_phonemizer``, an orthography2ipa-lattice
+    engine for the three Mirandese varieties.  Output is always IPA.
+
+    The variety is taken from the per-call ``lang`` argument (central ``mwl`` by
+    default), so one instance serves all three.  ``mwl_phonemizer`` is imported
+    lazily so importing ``phoonnx`` does not hard-require it.
+    """
+
+    _LANGS = list(DIALECTS)
 
     def __init__(self):
         super().__init__(Alphabet.IPA)
-        from mwl_phonemizer import CRFOrthoCorrector
-        self.pho = CRFOrthoCorrector()
+        self._phonemize = None
+
+    @property
+    def phonemize_fn(self):
+        """Lazily import and cache ``mwl_phonemizer.phonemize``."""
+        if self._phonemize is None:
+            try:
+                from mwl_phonemizer import phonemize
+            except ImportError as e:
+                raise ImportError(
+                    "mwl_phonemizer is required for the Mirandese phonemizer. "
+                    "Install it with 'pip install mwl_phonemizer' "
+                    "(or 'pip install phoonnx[mwl]')."
+                ) from e
+            self._phonemize = phonemize
+        return self._phonemize
 
     @classmethod
     def get_lang(cls, target_lang: str) -> str:
         """
-        Validates and returns the closest supported language code.
-
-        Args:
-            target_lang (str): The language code to validate.
-
-        Returns:
-            str: The validated language code.
+        Validates and returns the closest supported Mirandese variety code.
 
         Raises:
             ValueError: If the language code is unsupported.
         """
         return cls.match_lang(target_lang, cls._LANGS)
 
-    def phonemize_string(self, text: str, lang: str) -> str:
-        # Validate language is supported
-        lang = self.get_lang(lang)
-        return self.pho.phonemize_sentence(text)
+    def phonemize_string(self, text: str, lang: str = "mwl") -> str:
+        dialect = DIALECTS[self.get_lang(lang)]
+        return self.phonemize_fn(text, dialect=dialect)
 
 
 if __name__ == "__main__":
     pho = MirandesePhonemizer()
-    print(pho.phonemize_string("ls", "mwl"))
+    for sentence in ["Buonos dies, mundo.", "L mirandés ye ua lhéngua."]:
+        print(sentence)
+        for code in MirandesePhonemizer._LANGS:
+            print(f"  {code} -> {pho.phonemize_string(sentence, code)}")

--- a/phoonnx/phonemizers/o2ipa.py
+++ b/phoonnx/phonemizers/o2ipa.py
@@ -1,0 +1,92 @@
+"""orthography2ipa-backed phonemizer for phoonnx.
+
+Wraps ``orthography2ipa.G2P`` to expose the shared grapheme->IPA lattice as a
+``BasePhonemizer``.  A single instance covers the whole orthography2ipa family
+(hundreds of language specs: the Arabic lects, Basque, Galician, Mirandese,
+Portuguese, the East-Slavic set, ...): one backend, many languages, always IPA.
+
+Per-language quality varies -- the lattice is strongest for regular
+orthographies.  For undiacritized Arabic use ``ArbtokPhonemizer`` (which adds a
+diacritizer on top of this same lattice); for dialect-aware Basque use
+``EuskaphonePhonemizer``.
+
+``orthography2ipa`` is imported lazily so importing ``phoonnx`` never requires
+it; install with ``pip install orthography2ipa`` (or ``pip install phoonnx[o2i]``).
+"""
+from typing import Dict, List
+
+from phoonnx.phonemizers.base import BasePhonemizer
+from phoonnx.config import Alphabet
+
+
+class Orthography2IPAPhonemizer(BasePhonemizer):
+    """
+    Data-driven multilingual IPA phonemizer backed by orthography2ipa.
+
+    Accepts any language code that ``orthography2ipa.resolve`` can map to a
+    supported spec (BCP-47 closest-match logic lives in orthography2ipa itself,
+    so it is not reinvented here).  The per-language G2P engine is created
+    lazily on first use and cached for the lifetime of the instance.
+    """
+
+    def __init__(self):
+        super().__init__(alphabet=Alphabet.IPA)
+        self._cache: Dict[str, object] = {}
+
+    def _engine(self, resolved_lang: str):
+        """Return, lazily creating and caching, the G2P engine for *resolved_lang*."""
+        if resolved_lang not in self._cache:
+            import orthography2ipa
+            self._cache[resolved_lang] = orthography2ipa.G2P(resolved_lang)
+        return self._cache[resolved_lang]
+
+    @classmethod
+    def supported_langs(cls) -> List[str]:
+        """Return every language code orthography2ipa ships a spec for."""
+        import orthography2ipa
+        return orthography2ipa.available_codes()
+
+    @classmethod
+    def get_lang(cls, target_lang: str) -> str:
+        """
+        Resolve *target_lang* to the canonical orthography2ipa spec code.
+
+        Delegates BCP-47 resolution to ``orthography2ipa.resolve``.
+
+        Raises:
+            ValueError: If orthography2ipa has no spec for *target_lang*.
+        """
+        try:
+            import orthography2ipa
+        except ImportError as e:
+            raise ImportError(
+                "orthography2ipa is required for the Orthography2IPA phonemizer. "
+                "Install it with 'pip install orthography2ipa' "
+                "(or 'pip install phoonnx[o2i]')."
+            ) from e
+        # ``resolve`` echoes an unknown tag back rather than raising, so probe
+        # the resolved code by constructing its G2P engine (raises if no spec).
+        resolved = orthography2ipa.resolve(target_lang)
+        try:
+            orthography2ipa.G2P(resolved)
+        except Exception as exc:
+            raise ValueError(
+                f"orthography2ipa: unsupported language {target_lang!r}"
+            ) from exc
+        return resolved
+
+    def phonemize_string(self, text: str, lang: str) -> str:
+        resolved = self.get_lang(lang)
+        return self._engine(resolved).transcribe(text)
+
+
+if __name__ == "__main__":
+    pho = Orthography2IPAPhonemizer()
+    for lang, text in [
+        ("ar", "ذهب الطالب إلى المكتبة لقراءة كتاب"),
+        ("eu", "Kaixo, mundua."),
+        ("gl", "Boas, o mundo."),
+        ("pt", "Olá, quem são vocês?"),
+        ("mwl", "Buonos dies, mundo."),
+    ]:
+        print(f"{lang}: {pho.phonemize_string(text, lang)!r}")

--- a/phoonnx/phonemizers/pt.py
+++ b/phoonnx/phonemizers/pt.py
@@ -1,3 +1,5 @@
+import re
+
 from phoonnx.phonemizers.base import BasePhonemizer
 from phoonnx.config import Alphabet
 
@@ -33,6 +35,58 @@ class TugaphonePhonemizer(BasePhonemizer):
 
 
 
+class BarranquenhoPhonemizer(BasePhonemizer):
+    """
+    Barranquenho phonemizer backed by ``g2p_barranquenho``, a rule-based
+    engine built on the orthography2ipa lattice for the Portuguese/Spanish
+    contact variety spoken in Barrancos.  Output is always IPA.
+
+    ``g2p_barranquenho.phonemize`` is word-level (a single word -> a list of IPA
+    phoneme strings), so the input is lowercased, split into words, each word is
+    phonemized and its phonemes joined, and the words are rejoined with spaces.
+    ``g2p_barranquenho`` is imported lazily so importing ``phoonnx`` does not
+    hard-require it.
+    """
+
+    _LANGS = ["ext-PT-x-barrancos"]
+
+    def __init__(self, alphabet: Alphabet = Alphabet.IPA):
+        if alphabet != Alphabet.IPA:
+            raise ValueError("g2p_barranquenho only outputs IPA")
+        self._phonemize = None
+        super().__init__(alphabet)
+
+    @property
+    def phonemize_fn(self):
+        """Lazily import and cache ``g2p_barranquenho.phonemize``."""
+        if self._phonemize is None:
+            try:
+                from g2p_barranquenho import phonemize
+            except ImportError as e:
+                raise ImportError(
+                    "g2p_barranquenho is required for the Barranquenho phonemizer. "
+                    "Install it with 'pip install g2p_barranquenho' "
+                    "(or 'pip install phoonnx[pt]')."
+                ) from e
+            self._phonemize = phonemize
+        return self._phonemize
+
+    @classmethod
+    def get_lang(cls, target_lang: str) -> str:
+        """
+        Validates and returns the Barranquenho language code.
+
+        Raises:
+            ValueError: If the language code is unsupported.
+        """
+        return cls.match_lang(target_lang, cls._LANGS)
+
+    def phonemize_string(self, text: str, lang: str = "ext-PT-x-barrancos") -> str:
+        self.get_lang(lang)
+        words = re.findall(r"\w+", text.lower(), flags=re.UNICODE)
+        return " ".join("".join(self.phonemize_fn(w)) for w in words if w)
+
+
 if __name__ == "__main__":
 
     pho = TugaphonePhonemizer()
@@ -55,3 +109,8 @@ if __name__ == "__main__":
         for code in ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]:
             print(f"{code} → {pho.phonemize_string(s, code)}")
         print("######")
+
+    print("\n--- Barranquenho ---")
+    barr = BarranquenhoPhonemizer()
+    for s in ["Boca de la casa.", "Cantá manhán aquí."]:
+        print(f"{s} → {barr.phonemize_string(s, 'ext-PT-x-barrancos')}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ test = [
     "pycotovia>=0.1.0",
     "ahotts-g2p>=0.1.0",
     "espyak>=0.0.2a1",
+    "orthography2ipa",
+    "arbtok",
+    "euskaphone",
+    "g2p_barranquenho",
+    "mwl_phonemizer",
 ]
 espeak = ["espyak>=0.0.2a1"]
 train = [
@@ -49,26 +54,30 @@ train = [
     "pytorch-lightning<2.0",
     "torch>=1.11.0,<2",
 ]
-ar = ["epitran"]
+ar = ["epitran", "arbtok"]
 ca = ["epitran"]
 gl = ["pycotovia>=0.1.0"]
 cs = ["epitran"]
 de = ["epitran", "gruut[de]>=2.3.0,<3.0"]
 en = ["epitran", "gruut[en]>=2.3.0,<3.0", "misaki[en]", "spacy>=3.7"]
 es = ["epitran"]
-eu = ["ahotts-g2p>=0.1.0"]
+eu = ["ahotts-g2p>=0.1.0", "euskaphone"]
 fa = ["epitran"]
 fr = ["epitran"]
 he = ["epitran"]
 it = ["epitran"]
 ja = ["epitran", "gruut[ja]>=2.3.0,<3.0", "misaki[ja]", "spacy>=3.7"]
 ko = ["epitran"]
-pt = ["epitran"]
+mwl = ["mwl_phonemizer"]
+pt = ["epitran", "g2p_barranquenho"]
 ru = ["epitran"]
 sv = ["epitran"]
 sw = ["epitran"]
 vi = ["epitran", "gruut[vi]>=2.3.0,<3.0", "misaki[vi]", "spacy>=3.7"]
 zh = ["epitran", "gruut[zh]>=2.3.0,<3.0", "misaki[zh]", "spacy>=3.7"]
+
+# multilingual data-driven IPA backend (hundreds of language specs)
+o2i = ["orthography2ipa"]
 
 # runtime deps for zero-shot voice cloning (reference loading + resampling)
 cloning = ["soundfile", "scipy"]
@@ -87,6 +96,7 @@ all = [
     "pycotovia>=0.1.0",
     "pykakasi==2.3.0", "spacy-pkuseg",
     "soundfile", "scipy",
+    "orthography2ipa", "arbtok", "euskaphone", "g2p_barranquenho", "mwl_phonemizer",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/test_arbtok_phonemizer.py
+++ b/tests/test_arbtok_phonemizer.py
@@ -1,0 +1,44 @@
+"""Tests for the arbtok Arabic phonemizer.
+
+arbtok is a hard test dependency (declared in the ``test`` and ``ar`` extras),
+so it is imported unconditionally -- no importorskip.  arbtok's edge is
+undiacritized (bare) Arabic: it restores the tashkeel before transcribing.
+"""
+import pytest
+
+from phoonnx.config import PhonemeType, Alphabet, get_phonemizer
+from phoonnx.phonemizers.ar import ArbtokPhonemizer
+
+
+def test_factory_dispatch():
+    p = get_phonemizer(PhonemeType.ARBTOK)
+    assert isinstance(p, ArbtokPhonemizer)
+    assert p.alphabet == Alphabet.IPA
+
+
+def test_phonemize_bare_arabic_returns_ipa():
+    # undiacritized text -- arbtok diacritizes then transcribes
+    p = ArbtokPhonemizer()
+    out = p.phonemize_string("ذهب الطالب إلى المكتبة لقراءة كتاب", "ar")
+    assert isinstance(out, str)
+    assert out.strip()
+    # restored short vowels: bare skeleton has no long-vowel-only reading
+    assert "a" in out or "i" in out or "u" in out
+
+
+def test_dialect_differs_from_msa():
+    p = ArbtokPhonemizer()
+    msa = p.phonemize_string("كتاب جميل", "ar")
+    egy = p.phonemize_string("كتاب جميل", "ar-EG")
+    assert msa.strip() and egy.strip()
+
+
+def test_get_lang_resolves_arabic_specs():
+    assert ArbtokPhonemizer.get_lang("ar")
+    assert ArbtokPhonemizer.get_lang("ar-EG")
+    assert ArbtokPhonemizer.get_lang("ar-SA-x-najd") == "ar-SA-x-najd"
+
+
+def test_non_ipa_alphabet_rejected():
+    with pytest.raises(ValueError):
+        ArbtokPhonemizer(alphabet=Alphabet.BUCKWALTER)

--- a/tests/test_arbtok_phonemizer.py
+++ b/tests/test_arbtok_phonemizer.py
@@ -26,6 +26,17 @@ def test_phonemize_bare_arabic_returns_ipa():
     assert "a" in out or "i" in out or "u" in out
 
 
+def test_irab_register_forces_full_case_endings():
+    """A phoonnx 'i'rab' register must map to arbtok's 'full' register (not the
+    literal string 'irab', which the plugin rejects), and must actually restore
+    the case endings the pausal default drops."""
+    for alias in ("i'rab", "iʿrab", "irab", "full"):
+        assert ArbtokPhonemizer(register=alias).register == "full"
+    full = ArbtokPhonemizer(register="i'rab").phonemize_string("ذهب الطالب", "ar")
+    pausal = ArbtokPhonemizer().phonemize_string("ذهب الطالب", "ar")
+    assert full.strip() and full != pausal  # the endings make it differ
+
+
 def test_dialect_differs_from_msa():
     p = ArbtokPhonemizer()
     msa = p.phonemize_string("كتاب جميل", "ar")

--- a/tests/test_barranquenho_phonemizer.py
+++ b/tests/test_barranquenho_phonemizer.py
@@ -1,0 +1,47 @@
+"""Tests for the g2p_barranquenho Barranquenho phonemizer.
+
+g2p_barranquenho is a hard test dependency (declared in the ``test`` and ``pt``
+extras), so it is imported unconditionally -- no importorskip.
+"""
+import pytest
+
+from phoonnx.config import PhonemeType, Alphabet, get_phonemizer
+from phoonnx.phonemizers.pt import BarranquenhoPhonemizer
+
+LANG = "ext-PT-x-barrancos"
+
+
+def test_factory_dispatch():
+    p = get_phonemizer(PhonemeType.BARRANQUENHO)
+    assert isinstance(p, BarranquenhoPhonemizer)
+    assert p.alphabet == Alphabet.IPA
+
+
+def test_phonemize_sentence_returns_ipa():
+    p = BarranquenhoPhonemizer()
+    out = p.phonemize_string("Boca de la casa.", LANG)
+    assert isinstance(out, str)
+    assert out.strip()
+    # word-level engine joined per word, one space between words
+    assert len(out.split()) == 4
+
+
+def test_nasal_vowel_emitted():
+    p = BarranquenhoPhonemizer()
+    out = p.phonemize_string("cantá manhán", LANG)
+    # coda nasalization surfaces as a nasal vowel (combining tilde U+0303)
+    assert "̃" in out
+
+
+def test_get_lang_accepts_barrancos():
+    assert BarranquenhoPhonemizer.get_lang(LANG) == LANG
+
+
+def test_get_lang_rejects_unrelated():
+    with pytest.raises(ValueError):
+        BarranquenhoPhonemizer.get_lang("en")
+
+
+def test_non_ipa_alphabet_rejected():
+    with pytest.raises(ValueError):
+        BarranquenhoPhonemizer(alphabet=Alphabet.BUCKWALTER)

--- a/tests/test_euskaphone_phonemizer.py
+++ b/tests/test_euskaphone_phonemizer.py
@@ -1,0 +1,48 @@
+"""Tests for the euskaphone dialect-aware Basque phonemizer.
+
+euskaphone is a hard test dependency (declared in the ``test`` and ``eu``
+extras), so it is imported unconditionally -- no importorskip.  This backend is
+distinct from AhoTTSPhonemizer (also in eu.py): euskaphone drives the
+orthography2ipa lattice and resolves the historical Basque dialects.
+"""
+import pytest
+
+from phoonnx.config import PhonemeType, Alphabet, get_phonemizer
+from phoonnx.phonemizers.eu import EuskaphonePhonemizer
+
+
+def test_factory_dispatch():
+    p = get_phonemizer(PhonemeType.EUSKAPHONE)
+    assert isinstance(p, EuskaphonePhonemizer)
+    assert p.alphabet == Alphabet.IPA
+
+
+def test_phonemize_batua_returns_ipa():
+    p = EuskaphonePhonemizer()
+    out = p.phonemize_string("Zazpi katu zuri ikusi ditut.", "eu")
+    assert isinstance(out, str)
+    assert out.strip()
+
+
+def test_souletin_shows_aspiration_and_front_rounded():
+    # Souletin (eu-x-zuberera) pronounces /h/ and has /y/, unlike Batua
+    p = EuskaphonePhonemizer()
+    batua = p.phonemize_string("Hotza egiten du gaur mendian.", "eu")
+    souletin = p.phonemize_string("Hotza egiten du gaur mendian.", "eu-x-zuberera")
+    assert batua != souletin
+
+
+def test_get_lang_accepts_code_and_alias():
+    assert EuskaphonePhonemizer.get_lang("eu")
+    assert EuskaphonePhonemizer.get_lang("batua")
+    assert EuskaphonePhonemizer.get_lang("souletin")
+
+
+def test_get_lang_rejects_non_basque():
+    with pytest.raises(ValueError):
+        EuskaphonePhonemizer.get_lang("zz-nonsense")
+
+
+def test_non_ipa_alphabet_rejected():
+    with pytest.raises(ValueError):
+        EuskaphonePhonemizer(alphabet=Alphabet.BUCKWALTER)

--- a/tests/test_mwl_phonemizer.py
+++ b/tests/test_mwl_phonemizer.py
@@ -1,0 +1,44 @@
+"""Tests for the Mirandese phonemizer.
+
+mwl_phonemizer is a hard test dependency (declared in the ``test`` and ``mwl``
+extras), so it is imported unconditionally -- no importorskip.  The wrapper is
+dialect-aware: central Mirandese (``mwl``, the default), Sendinese
+(``mwl-x-sendim``) and the Raiano/Ifanês border variety (``mwl-x-ifanes``).
+"""
+import pytest
+
+from phoonnx.config import PhonemeType, Alphabet, get_phonemizer
+from phoonnx.phonemizers.mwl import MirandesePhonemizer, DIALECTS
+
+
+def test_factory_dispatch():
+    p = get_phonemizer(PhonemeType.MIRANDESE)
+    assert isinstance(p, MirandesePhonemizer)
+    assert p.alphabet == Alphabet.IPA
+
+
+@pytest.mark.parametrize("lang", list(DIALECTS))
+def test_each_dialect_returns_ipa(lang):
+    p = MirandesePhonemizer()
+    out = p.phonemize_string("Buonos dies mundo", lang)
+    assert isinstance(out, str)
+    assert out.strip(), f"empty phonemization for {lang!r}"
+
+
+def test_default_lang_is_central():
+    p = MirandesePhonemizer()
+    out = p.phonemize_string("Buonos dies mundo")
+    assert out.strip()
+
+
+def test_sendinese_differs_from_central():
+    p = MirandesePhonemizer()
+    central = p.phonemize_string("Buonos dies mundo", "mwl")
+    sendinese = p.phonemize_string("Buonos dies mundo", "mwl-x-sendim")
+    # Sendinese monophthongizes the rising diphthongs (bwo -> bu, dje -> di)
+    assert central != sendinese
+
+
+def test_get_lang_rejects_unsupported():
+    with pytest.raises(ValueError):
+        MirandesePhonemizer.get_lang("en")

--- a/tests/test_o2ipa_phonemizer.py
+++ b/tests/test_o2ipa_phonemizer.py
@@ -1,0 +1,55 @@
+"""Tests for the orthography2ipa-backed multilingual phonemizer.
+
+orthography2ipa is a hard test dependency (declared in the ``test`` and ``o2i``
+extras), so it is imported unconditionally -- no importorskip.
+"""
+import pytest
+
+from phoonnx.config import PhonemeType, Alphabet, get_phonemizer
+from phoonnx.phonemizers.o2ipa import Orthography2IPAPhonemizer
+
+
+def test_factory_dispatch():
+    p = get_phonemizer(PhonemeType.ORTHOGRAPHY2IPA)
+    assert isinstance(p, Orthography2IPAPhonemizer)
+    assert p.alphabet == Alphabet.IPA
+
+
+@pytest.mark.parametrize("lang,text", [
+    ("ar", "ذهب الطالب إلى المكتبة"),
+    ("eu", "Kaixo, mundua."),
+    ("gl", "Boas, o mundo."),
+    ("pt", "Olá, quem são vocês?"),
+    ("mwl", "Buonos dies, mundo."),
+])
+def test_phonemize_returns_ipa(lang, text):
+    p = Orthography2IPAPhonemizer()
+    out = p.phonemize_string(text, lang)
+    assert isinstance(out, str)
+    assert out.strip(), f"empty phonemization for {lang!r}"
+
+
+def test_get_lang_resolves_bcp47():
+    # a regional tag resolves to a supported spec code
+    assert Orthography2IPAPhonemizer.get_lang("pt-PT")
+    assert Orthography2IPAPhonemizer.get_lang("eu")
+
+
+def test_get_lang_rejects_gibberish():
+    with pytest.raises(ValueError):
+        Orthography2IPAPhonemizer.get_lang("zz-nonsense")
+
+
+def test_supported_langs_is_a_large_family():
+    langs = Orthography2IPAPhonemizer.supported_langs()
+    assert isinstance(langs, list)
+    # one backend, many languages
+    assert len(langs) > 100
+
+
+def test_instance_caches_engines():
+    p = Orthography2IPAPhonemizer()
+    p.phonemize_string("Kaixo", "eu")
+    p.phonemize_string("mundua", "eu")
+    resolved = Orthography2IPAPhonemizer.get_lang("eu")
+    assert resolved in p._cache

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -427,7 +427,7 @@ class TestUtilFunctions(unittest.TestCase):
 
     def test_error_handling_fraction_pronunciation(self):
         """Test error handling in fraction pronunciation."""
-        with patch('ovos_number_parser.pronounce_fraction', side_effect=Exception("Test error")), \
+        with patch('phoonnx.util.pronounce_fraction', side_effect=Exception("Test error")), \
                 patch('phoonnx.util.is_fraction', return_value=True):
             result = _normalize_number_word("1/2", "en", None)
             self.assertEqual(result, "1/2")  # Should return original on error


### PR DESCRIPTION
Adds five orthography2ipa-lattice G2P engines to the phonemizer family. All heavy
engine imports are lazy (importing `phoonnx` never requires them), each is an
optional dependency, and every backend emits `Alphabet.IPA`. Each is registered in
`phoonnx/phonemizers/__init__.py`, given a `PhonemeType` + `get_phonemizer` dispatch,
a `__main__` smoke block, and a test module.

## Backends

- **`Orthography2IPAPhonemizer`** (`phonemizers/o2ipa.py`) — one backend over the
  entire orthography2ipa spec family (hundreds of languages). Lang codes resolve
  through `orthography2ipa.resolve` (its own BCP-47 logic, not reinvented); the
  per-language `G2P` engine is created lazily and cached per instance.
- **`ArbtokPhonemizer`** (`phonemizers/ar.py`, beside `MantoqPhonemizer`) —
  dialect-aware Arabic via `arbtok.plugin.ArbtokG2PPlugin(lang=…, diacritize=True)`.
  Its edge is **undiacritized** Arabic: it restores the tashkeel before
  transcribing. Register defers to arbtok's own default (pausal / spoken, correct
  for the dialects); pass a phonemizer_model of `iʿrab` to force the full
  case-ending register (apt for `ar`/`arb` only).
- **`EuskaphonePhonemizer`** (`phonemizers/eu.py`, beside `AhoTTSPhonemizer`) —
  dialect-aware Basque over the eight orthography2ipa lect specs. Distinct from the
  AhoTTS frontend already wrapped here.
- **`BarranquenhoPhonemizer`** (`phonemizers/pt.py`, beside `TugaphonePhonemizer`)
  — the Barranquenho Portuguese/Spanish contact variety. `g2p_barranquenho.phonemize`
  is word-level, so the input is lowercased, split into words, phonemized per word
  and rejoined.

## Fix

- **`MirandesePhonemizer`** (`phonemizers/mwl.py`) imported the removed
  `CRFOrthoCorrector` → ImportError at runtime. Rewired to the current
  `mwl_phonemizer.phonemize(text, dialect=…)` API and made dialect-aware: central
  `mwl` (default), Sendinese `mwl-x-sendim`, Raiano/Ifanês `mwl-x-ifanes`.

## Optional dependencies

Declared as extras (never hard requirements): `orthography2ipa` (`o2i`), `arbtok`
(added to `ar`), `euskaphone` (added to `eu`), `g2p_barranquenho` (added to `pt`),
`mwl_phonemizer` (new `mwl` extra). All added to `all` and to `test`.

## Real IPA evidence (captured through the phoonnx classes)

Orthography2IPAPhonemizer:
```
ar: 'ˈðhb alˈtˤɑlb ˈʔilaː ˈalmktba ˈlqraːʔa ˈktaːb'
eu: 'kai̯ʃo mundua'
gl: 'ˈboas o ˈmundo'
pt: 'oˈla ˈkɐ̃j̃ ˈsɐ̃w̃ vuˈseʃ'
mwl: 'ˈbwonus̺ ˈdjes̺ ˈmũdu'
```

ArbtokPhonemizer (bare, undiacritized input — note restored short vowels vs o2i):
```
مرحبا بالعالم                          -> ˈmarħabaː bilˈʕaːlam
ذهب الطالب إلى المكتبة لقراءة كتاب عن…  -> ˈðahab ɑtˤˈtˤɑːlib ˈʔilaː lˈmaktaba liqiˈraːʔa kiˈtaːb ˈʕan taːˈriːx alˈʔandalus
كتاب جميل  (ar-EG)                      -> ʔizˈzajjak … (dialect path)
```

EuskaphonePhonemizer (dialect divergence — Souletin /h/ and /y/):
```
eu             Hotza egiten du gaur mendian. -> ots̻a eɡiten di ɡau̯r mendian
eu-x-zuberera  Hotza egiten du gaur mendian. -> hots̻a eɡiten dy ɡau̯r mendian
eu-x-bizkaiera Zazpi katu zuri ikusi ditut.  -> s̺as̺pi katu s̺uɾi ikus̺i ditut
```

BarranquenhoPhonemizer:
```
Boca de la casa.   -> bokɐ dɨ lɐ kazɐ
Cantá manhán aquí. -> kɐ̃ta mɐɲɐ̃ ɐki
```

MirandesePhonemizer (fixed + dialect-aware):
```
Buonos dies mundo   mwl           -> ˈbwonus̺ ˈdjes̺ ˈmũdu
Buonos dies mundo   mwl-x-sendim  -> ˈbunus̺ ˈdis̺ ˈmũdu
L mirandés ye ua…   mwl           -> l miɾɐ̃ˈdɛs̺ ˈjɨ ˈwa ˈʎẽɡwɐ
L mirandés ye ua…   mwl-x-sendim  -> l miɾɐ̃ˈdɛs̺ ˈjɨ ˈwa ˈlẽɡwɐ
```

All 34 new tests pass in the shared venv.