### PR TITLE
fix: fraction error-handling test patched the wrong reference

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -427,7 +427,7 @@ class TestUtilFunctions(unittest.TestCase):
 
     def test_error_handling_fraction_pronunciation(self):
         """Test error handling in fraction pronunciation."""
-        with patch('ovos_number_parser.pronounce_fraction', side_effect=Exception("Test error")), \
+        with patch('phoonnx.util.pronounce_fraction', side_effect=Exception("Test error")), \
                 patch('phoonnx.util.is_fraction', return_value=True):
             result = _normalize_number_word("1/2", "en", None)
             self.assertEqual(result, "1/2")  # Should return original on error


### PR DESCRIPTION
`test_error_handling_fraction_pronunciation` patched `ovos_number_parser.pronounce_fraction`, but `util.py` does `from ovos_number_parser import pronounce_fraction`, binding the symbol into its own namespace — so the patch missed the reference `_normalize_number_word` actually calls. The real function ran ("1/2" → "one half"), the exception never raised, and the error path under test was never exercised; the assertion then failed. Patch `phoonnx.util.pronounce_fraction` instead, matching the sibling `test_error_handling_number_pronunciation`. The production error handling was already correct. All 65 test_util tests pass.