### PR TITLE
feat: checkpoint evaluation loop with UTMOS and speaker similarity

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -173,6 +173,56 @@ python export_onnx.py \
 
 -----
 
+## 3.5 Evaluating Checkpoints During Training
+
+`phoonnx_train/eval_loop.py` watches the training directory for new
+lightning checkpoints (`epoch=*.ckpt`) and scores each one on a fixed set of
+held-out sentences, synthesized on CPU so training keeps the GPU. Results are
+appended to `metrics.csv` (one summary row per epoch) plus per-utterance
+scores under `perutt/`, and the wavs of the best epoch so far are kept under
+`samples/`. The loop is idempotent: already-scored epochs are skipped on
+restart, so it can run alongside training or after the fact.
+
+Install the extra dependencies first:
+
+```bash
+pip install phoonnx[train-eval]
+```
+
+**Example Usage**
+
+```bash
+python eval_loop.py \
+  --train-dir /tmp/tts_train \
+  --config /tmp/tts_train/config.json \
+  --sentences heldout.txt \
+  --output-dir ./eval \
+  --speaker-ref-dir /path/to/dataset/wavs
+```
+
+Useful flags: `--once` (single pass instead of polling), `--poll N` (seconds
+between scans, default 60), `--dry-run` (verify config + sentence encoding
+without synthesis), and `--noise-scale` / `--length-scale` / `--noise-w` to
+override the inference scales from `config.json`.
+
+Two metrics are reported:
+
+- **UTMOS** (`utmos_mean` etc.): an automatic Mean-Opinion-Score predictor
+  (SpeechMOS `utmos22_strong`, 1–5 scale) estimating perceived
+  naturalness/quality of each clip. **Caveat:** UTMOS is trained on
+  English/Japanese MOS data; on other languages treat it as a *relative
+  ranker* between checkpoints of the same voice, not an absolute quality
+  score.
+- **Speaker similarity** (`spk_sim_mean` etc.): cosine similarity between
+  each synthesized clip's speaker embedding and a centroid built from
+  reference recordings of the target speaker (`--speaker-ref-dir`, using the
+  `--num-ref-wavs` largest files, default 60). Values closer to 1.0 mean the
+  model sounds more like the target voice. This metric is optional: without
+  `speakeronnx` or a reference directory, only UTMOS is scored and the
+  speaker-similarity columns are left empty.
+
+-----
+
 ## 4. Workflow Summary
 
 1. **Prepare dataset** in LJSpeech-style format.

--- a/phoonnx_train/eval_loop.py
+++ b/phoonnx_train/eval_loop.py
@@ -1,0 +1,302 @@
+"""Held-out evaluation loop for VITS training checkpoints.
+
+Watches a training directory for new lightning checkpoints (epoch=*.ckpt),
+synthesizes a fixed set of held-out sentences on CPU, scores each clip with
+UTMOS (SpeechMOS utmos22_strong) and, when available, speaker similarity
+(cosine against a reference-speaker centroid), then appends a summary row to
+metrics.csv plus per-utterance scores to perutt/epoch<N>.csv. Wavs of the
+best-scoring epoch so far are kept under samples/epoch<N>/.
+
+Idempotent: already-scored epochs are read back from metrics.csv on start and
+skipped. Ordering is by epoch number parsed from the filename, never
+wall-clock.
+"""
+import csv
+import json
+import logging
+import shutil
+import time
+from pathlib import Path
+
+import click
+import numpy as np
+import soundfile as sf
+import torch
+import torchaudio
+
+from phoonnx.config import PhonemeType, Alphabet, get_phonemizer
+from phoonnx.tokenizer import TTSTokenizer
+from phoonnx.util import normalize
+from phoonnx_train.eval_utils import (append_metrics, best_mean_so_far,
+                                      done_epochs, find_checkpoints,
+                                      largest_wavs, parse_step,
+                                      read_sentences, size_stable)
+from phoonnx_train.vits.lightning import VitsModel
+
+_LOGGER = logging.getLogger(__package__)
+
+# torch >=2.6 defaults torch.load(weights_only=True); lightning checkpoints
+# embed pathlib.PosixPath (and full pickled objects), which that rejects.
+# These are our own trusted checkpoints, so restore weights_only=False.
+_ORIG_TORCH_LOAD = torch.load
+
+
+def _torch_load(*a, **k):
+    k.setdefault("weights_only", False)
+    return _ORIG_TORCH_LOAD(*a, **k)
+
+
+torch.load = _torch_load
+
+
+def build_encoder(config, noise_scale, length_scale, noise_w):
+    """Return (phonemizer, tokenizer, lang, sample_rate, scales) matching
+    preprocess/train exactly."""
+    phoneme_type = PhonemeType(config["phoneme_type"])
+    alphabet = Alphabet(config.get("alphabet") or "ipa")
+    ph = get_phonemizer(phoneme_type, alphabet, config.get("phonemizer_model"))
+    tokenizer = TTSTokenizer.from_phoonnx_config(config)
+    lang = config.get("lang_code", "")
+    sample_rate = int(config.get("audio", {}).get("sample_rate", 22050))
+    inf = config.get("inference", {})
+    scales = [noise_scale if noise_scale is not None else float(inf.get("noise_scale", 0.667)),
+              length_scale if length_scale is not None else float(inf.get("length_scale", 1.0)),
+              noise_w if noise_w is not None else float(inf.get("noise_w", 0.8))]
+    return ph, tokenizer, lang, sample_rate, scales
+
+
+def text_to_ids(text, ph, tokenizer, lang):
+    """Replicate preprocess.py: normalize -> phonemize_to_list (drop '\\n')
+    -> tokenizer.tokenize (intersperse pad + BOS/EOS)."""
+    utt = normalize(text, lang)
+    phonemes = [p for p in ph.phonemize_to_list(utt, lang) if p != "\n"]
+    return phonemes, tokenizer.tokenize(phonemes)
+
+
+def load_model(ckpt_path):
+    model = VitsModel.load_from_checkpoint(str(ckpt_path), dataset=None,
+                                           map_location="cpu")
+    model = model.to("cpu")
+    model.eval()
+    with torch.no_grad():
+        model.model_g.dec.remove_weight_norm()
+    return model
+
+
+def synth(model, ids, scales):
+    """Run VitsModel.forward on CPU; return 1-D float32 waveform."""
+    text = torch.LongTensor(ids).unsqueeze(0)
+    text_lengths = torch.LongTensor([len(ids)])
+    scales_t = torch.FloatTensor(scales)
+    with torch.no_grad():
+        audio = model(text, text_lengths, scales_t, sid=None)
+    return audio.detach().cpu().float().squeeze().numpy().astype(np.float32)
+
+
+def load_speaker_reference(ref_dir, num_ref_wavs):
+    """Mean (unit-norm) speaker embedding over the largest reference wavs.
+
+    Returns (embedder, centroid) or (None, None) when speaker similarity
+    cannot be computed (speakeronnx missing or no wavs found).
+    """
+    try:
+        from speakeronnx import SpeakerEmbedder
+    except ImportError:
+        _LOGGER.warning("speakeronnx not installed; scoring UTMOS only")
+        return None, None
+    wavs = largest_wavs(ref_dir, num_ref_wavs)
+    if not wavs:
+        _LOGGER.warning("no reference wavs under %s; scoring UTMOS only", ref_dir)
+        return None, None
+    emb = SpeakerEmbedder()
+    vecs = []
+    for w in wavs:
+        try:
+            v = np.asarray(emb.embed(str(w)), dtype=np.float32)
+            vecs.append(v / (np.linalg.norm(v) + 1e-9))
+        except Exception:
+            _LOGGER.exception("failed to embed reference %s", w)
+    if not vecs:
+        _LOGGER.warning("no reference wavs could be embedded; scoring UTMOS only")
+        return None, None
+    ref = np.mean(vecs, axis=0)
+    ref /= np.linalg.norm(ref) + 1e-9
+    _LOGGER.info("speaker reference centroid from %d clips", len(vecs))
+    return emb, ref
+
+
+def speaker_similarity(emb, ref, wav_path):
+    v = np.asarray(emb.embed(str(wav_path)), dtype=np.float32)
+    v /= np.linalg.norm(v) + 1e-9
+    return float(np.dot(v, ref))
+
+
+def load_utmos():
+    _LOGGER.info("loading UTMOS (SpeechMOS utmos22_strong)...")
+    predictor = torch.hub.load("tarepan/SpeechMOS", "utmos22_strong",
+                               trust_repo=True)
+    predictor.eval()
+    return predictor
+
+
+def utmos_score(predictor, wav, sr):
+    """wav: 1-D np.float32 at sr. Resample to 16k mono and score."""
+    t = torch.from_numpy(np.ascontiguousarray(wav)).float()
+    if sr != 16000:
+        t = torchaudio.functional.resample(t, sr, 16000)
+    with torch.no_grad():
+        score = predictor(t.unsqueeze(0), 16000)
+    return float(score.squeeze().item())
+
+
+def evaluate_checkpoint(ckpt_path, epoch, sentences, ph, tokenizer, lang,
+                        sample_rate, scales, predictor, emb, ref, output_dir):
+    _LOGGER.info("evaluating epoch %d: %s", epoch, ckpt_path)
+    if not size_stable(ckpt_path):
+        _LOGGER.warning("checkpoint %s not stable yet, deferring", ckpt_path)
+        return False
+    try:
+        model = load_model(ckpt_path)
+    except Exception:
+        _LOGGER.exception("failed to load %s", ckpt_path)
+        return False
+
+    metrics_csv = output_dir / "metrics.csv"
+    tmp = output_dir / "_work" / f"epoch{epoch}"
+    tmp.mkdir(parents=True, exist_ok=True)
+    perutt = []
+    for i, text in enumerate(sentences):
+        try:
+            _, ids = text_to_ids(text, ph, tokenizer, lang)
+            wav = synth(model, ids, scales)
+            wpath = tmp / f"utt{i:02d}.wav"
+            sf.write(wpath, wav, sample_rate)
+            score = utmos_score(predictor, wav, sample_rate)
+            sim = speaker_similarity(emb, ref, wpath) if emb is not None else None
+            _LOGGER.info("  utt%02d dur=%.2fs utmos=%.3f spk_sim=%s  %s",
+                         i, len(wav) / sample_rate, score,
+                         f"{sim:.3f}" if sim is not None else "-", text[:30])
+            perutt.append((text, score, sim))
+        except Exception:
+            _LOGGER.exception("  failed utt %d: %s", i, text)
+
+    del model
+    if not perutt:
+        _LOGGER.error("no utterances scored for epoch %d", epoch)
+        return False
+
+    scores = np.array([s for _, s, _ in perutt], dtype=np.float64)
+    sims = np.array([m for _, _, m in perutt if m is not None], dtype=np.float64)
+
+    perutt_dir = output_dir / "perutt"
+    perutt_dir.mkdir(parents=True, exist_ok=True)
+    with open(perutt_dir / f"epoch{epoch}.csv", "w", newline="",
+              encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["sentence", "utmos", "spk_sim"])
+        for text, s, m in perutt:
+            w.writerow([text, f"{s:.4f}", f"{m:.4f}" if m is not None else ""])
+
+    row = {
+        "epoch": epoch,
+        "step": parse_step(ckpt_path.name),
+        "checkpoint": str(ckpt_path),
+        "utmos_mean": f"{scores.mean():.4f}",
+        "utmos_std": f"{scores.std():.4f}",
+        "utmos_min": f"{scores.min():.4f}",
+        "utmos_max": f"{scores.max():.4f}",
+        "spk_sim_mean": f"{sims.mean():.4f}" if sims.size else "",
+        "spk_sim_std": f"{sims.std():.4f}" if sims.size else "",
+        "spk_sim_min": f"{sims.min():.4f}" if sims.size else "",
+        "n_sentences": len(scores),
+    }
+
+    prev_best = best_mean_so_far(metrics_csv)
+    append_metrics(metrics_csv, row)
+    _LOGGER.info("epoch %d: utmos=%.4f±%.4f n=%d", epoch, scores.mean(),
+                 scores.std(), len(scores))
+
+    if prev_best is None or scores.mean() > prev_best:
+        dest = output_dir / "samples" / f"epoch{epoch}"
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(tmp, dest)
+        _LOGGER.info("new best epoch %d (mean=%.4f); wavs kept at %s",
+                     epoch, scores.mean(), dest)
+    shutil.rmtree(tmp, ignore_errors=True)
+    return True
+
+
+@click.command()
+@click.option('--train-dir', required=True, type=click.Path(exists=True, file_okay=False), help='Training directory watched for epoch=*.ckpt checkpoints')
+@click.option('--config', 'config_path', required=True, type=click.Path(exists=True, dir_okay=False), help='config.json produced by preprocessing')
+@click.option('--sentences', 'sentences_path', required=True, type=click.Path(exists=True, dir_okay=False), help='Held-out sentences, one per line')
+@click.option('--output-dir', required=True, type=click.Path(file_okay=False), help='Where metrics.csv, perutt/ and samples/ are written')
+@click.option('--speaker-ref-dir', type=click.Path(exists=True, file_okay=False), default=None, help='Directory of reference wavs of the target speaker (optional; enables speaker similarity)')
+@click.option('--num-ref-wavs', type=int, default=60, help='Number of largest reference wavs averaged into the speaker centroid (default: 60)')
+@click.option('--poll', type=float, default=60.0, help='Seconds between checkpoint scans (default: 60)')
+@click.option('--once', is_flag=True, help='Single pass then exit')
+@click.option('--dry-run', is_flag=True, help='Load config, phonemize and encode the sentences, no synthesis')
+@click.option('--noise-scale', type=float, default=None, help='Override inference noise_scale from config')
+@click.option('--length-scale', type=float, default=None, help='Override inference length_scale from config')
+@click.option('--noise-w', type=float, default=None, help='Override inference noise_w from config')
+@click.option('--seed', type=int, default=1234, help='Random seed (default: 1234)')
+def main(train_dir, config_path, sentences_path, output_dir, speaker_ref_dir,
+         num_ref_wavs, poll, once, dry_run, noise_scale, length_scale,
+         noise_w, seed):
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s")
+    torch.manual_seed(seed)
+
+    train_dir = Path(train_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    sentences = read_sentences(sentences_path)
+    if not sentences:
+        raise click.ClickException(f"no sentences in {sentences_path}")
+    _LOGGER.info("%d held-out sentences", len(sentences))
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+    ph, tokenizer, lang, sample_rate, scales = build_encoder(
+        config, noise_scale, length_scale, noise_w)
+    _LOGGER.info("lang=%s sample_rate=%d scales=%s vocab=%d", lang,
+                 sample_rate, scales, len(config.get("phoneme_id_map", {})))
+
+    if dry_run:
+        for i, text in enumerate(sentences):
+            phonemes, ids = text_to_ids(text, ph, tokenizer, lang)
+            _LOGGER.info("utt%02d ids=%d phon=%d | %s", i, len(ids),
+                         len(phonemes), text[:40])
+        _LOGGER.info("dry-run OK: config loaded, all sentences encoded")
+        return
+
+    predictor = load_utmos()
+    emb, ref = load_speaker_reference(speaker_ref_dir, num_ref_wavs) \
+        if speaker_ref_dir else (None, None)
+    if speaker_ref_dir is None:
+        _LOGGER.warning("--speaker-ref-dir not given; scoring UTMOS only")
+
+    metrics_csv = output_dir / "metrics.csv"
+    while True:
+        try:
+            done = done_epochs(metrics_csv)
+            ckpts = find_checkpoints(train_dir)
+            todo = sorted(e for e in ckpts if e not in done)
+            if not todo:
+                _LOGGER.info("no new checkpoints (done=%d, found=%d)",
+                             len(done), len(ckpts))
+            for epoch in todo:
+                evaluate_checkpoint(ckpts[epoch], epoch, sentences, ph,
+                                    tokenizer, lang, sample_rate, scales,
+                                    predictor, emb, ref, output_dir)
+        except Exception:
+            _LOGGER.exception("scan iteration failed; continuing")
+        if once:
+            break
+        time.sleep(poll)
+
+
+if __name__ == "__main__":
+    main()

--- a/phoonnx_train/eval_utils.py
+++ b/phoonnx_train/eval_utils.py
@@ -1,0 +1,118 @@
+"""Torch-free helpers for the checkpoint evaluation loop.
+
+Checkpoint discovery, epoch/step parsing, metrics.csv bookkeeping and the
+partial-write guard live here so they can be imported (and tested) without
+torch installed.
+"""
+import csv
+import re
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Set
+
+METRICS_HEADER = ["epoch", "step", "checkpoint", "utmos_mean", "utmos_std",
+                  "utmos_min", "utmos_max", "spk_sim_mean", "spk_sim_std",
+                  "spk_sim_min", "n_sentences"]
+
+CKPT_RE = re.compile(r"epoch=(\d+)")
+STEP_RE = re.compile(r"step=(\d+)")
+
+
+def parse_epoch(name: str) -> Optional[int]:
+    """Epoch number from a checkpoint filename, or None if absent."""
+    m = CKPT_RE.search(name)
+    return int(m.group(1)) if m else None
+
+
+def parse_step(name: str) -> int:
+    """Step number from a checkpoint filename, or -1 if absent."""
+    m = STEP_RE.search(name)
+    return int(m.group(1)) if m else -1
+
+
+def find_checkpoints(train_dir: Path) -> Dict[int, Path]:
+    """All epoch=*.ckpt under train_dir as {epoch: path}.
+
+    When several files share an epoch number the newest (highest mtime) wins.
+    """
+    out: Dict[int, Path] = {}
+    for p in Path(train_dir).rglob("epoch=*.ckpt"):
+        ep = parse_epoch(p.name)
+        if ep is None:
+            continue
+        if ep not in out or p.stat().st_mtime > out[ep].stat().st_mtime:
+            out[ep] = p
+    return out
+
+
+def done_epochs(metrics_csv: Path) -> Set[int]:
+    """Epochs already recorded in metrics.csv (malformed rows are skipped)."""
+    metrics_csv = Path(metrics_csv)
+    if not metrics_csv.exists():
+        return set()
+    done: Set[int] = set()
+    with open(metrics_csv, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            try:
+                done.add(int(row["epoch"]))
+            except (KeyError, TypeError, ValueError):
+                pass
+    return done
+
+
+def best_mean_so_far(metrics_csv: Path) -> Optional[float]:
+    """Highest utmos_mean recorded in metrics.csv, or None."""
+    metrics_csv = Path(metrics_csv)
+    if not metrics_csv.exists():
+        return None
+    best: Optional[float] = None
+    with open(metrics_csv, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            try:
+                m = float(row["utmos_mean"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if best is None or m > best:
+                best = m
+    return best
+
+
+def append_metrics(metrics_csv: Path, row: Dict[str, object]) -> None:
+    """Append one summary row, writing the header on first use."""
+    metrics_csv = Path(metrics_csv)
+    new = not metrics_csv.exists()
+    with open(metrics_csv, "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new:
+            w.writerow(METRICS_HEADER)
+        w.writerow([row.get(k, "") for k in METRICS_HEADER])
+
+
+def read_sentences(path: Path) -> List[str]:
+    """Non-empty stripped lines of a sentences file."""
+    return [line.strip() for line in
+            Path(path).read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def size_stable(path: Path, wait: float = 5.0, tries: int = 6,
+                sleep=time.sleep) -> bool:
+    """Wait until file size stops changing (guards against partial writes)."""
+    path = Path(path)
+    last = -1
+    for _ in range(max(1, tries)):
+        try:
+            s = path.stat().st_size
+        except FileNotFoundError:
+            return False
+        if s == last and s > 0:
+            return True
+        last = s
+        sleep(wait)
+    return False
+
+
+def largest_wavs(ref_dir: Path, n: int) -> Sequence[Path]:
+    """The n largest .wav files in ref_dir (longer clips give steadier
+    speaker embeddings)."""
+    return sorted(Path(ref_dir).glob("*.wav"),
+                  key=lambda p: p.stat().st_size, reverse=True)[:n]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,12 @@ train = [
     "pytorch-lightning<2.0",
     "torch>=1.11.0,<2",
 ]
+train-eval = [
+    "speechmos",
+    "torchaudio",
+    "soundfile",
+    "speakeronnx",
+]
 ar = ["epitran", "arbtok"]
 ca = ["epitran"]
 gl = ["pycotovia>=0.1.0"]

--- a/tests/test_eval_loop.py
+++ b/tests/test_eval_loop.py
@@ -1,0 +1,206 @@
+"""Tests for the torch-free helpers behind the checkpoint evaluation loop.
+
+phoonnx_train.eval_utils is loaded by file path so the suite runs without
+torch installed (the eval loop itself needs torch, but its bookkeeping does
+not).
+"""
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_UTILS = Path(__file__).parent.parent / "phoonnx_train" / "eval_utils.py"
+spec = importlib.util.spec_from_file_location("eval_utils", _UTILS)
+eval_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(eval_utils)
+
+
+class TestParseNames(unittest.TestCase):
+    def test_parse_epoch(self):
+        self.assertEqual(eval_utils.parse_epoch("epoch=12-step=3400.ckpt"), 12)
+        self.assertEqual(eval_utils.parse_epoch("epoch=0.ckpt"), 0)
+        self.assertEqual(eval_utils.parse_epoch("epoch=007.ckpt"), 7)
+
+    def test_parse_epoch_missing(self):
+        self.assertIsNone(eval_utils.parse_epoch("last.ckpt"))
+        self.assertIsNone(eval_utils.parse_epoch("epoch=.ckpt"))
+        self.assertIsNone(eval_utils.parse_epoch("epoch=-3.ckpt"))
+        self.assertIsNone(eval_utils.parse_epoch(""))
+
+    def test_parse_step(self):
+        self.assertEqual(eval_utils.parse_step("epoch=1-step=250.ckpt"), 250)
+        self.assertEqual(eval_utils.parse_step("epoch=1.ckpt"), -1)
+        self.assertEqual(eval_utils.parse_step("step=abc.ckpt"), -1)
+
+
+class TestFindCheckpoints(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _touch(self, rel, mtime=None):
+        p = self.dir / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"x")
+        if mtime is not None:
+            os.utime(p, (mtime, mtime))
+        return p
+
+    def test_finds_nested_and_ignores_no_epoch(self):
+        a = self._touch("lightning_logs/version_0/checkpoints/epoch=3-step=9.ckpt")
+        self._touch("lightning_logs/version_0/checkpoints/last.ckpt")
+        self._touch("notes.txt")
+        found = eval_utils.find_checkpoints(self.dir)
+        self.assertEqual(found, {3: a})
+
+    def test_duplicate_epoch_highest_mtime_wins(self):
+        self._touch("v0/epoch=5-step=100.ckpt", mtime=1000)
+        newer = self._touch("v1/epoch=5-step=200.ckpt", mtime=2000)
+        found = eval_utils.find_checkpoints(self.dir)
+        self.assertEqual(found[5], newer)
+
+    def test_empty_dir(self):
+        self.assertEqual(eval_utils.find_checkpoints(self.dir), {})
+
+
+class TestMetricsCsv(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.csv = Path(self.tmp.name) / "metrics.csv"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _row(self, epoch, mean):
+        return {"epoch": epoch, "step": 1, "checkpoint": f"e{epoch}.ckpt",
+                "utmos_mean": f"{mean:.4f}", "utmos_std": "0.1",
+                "utmos_min": "1.0", "utmos_max": "5.0", "spk_sim_mean": "",
+                "spk_sim_std": "", "spk_sim_min": "", "n_sentences": 10}
+
+    def test_missing_file(self):
+        self.assertEqual(eval_utils.done_epochs(self.csv), set())
+        self.assertIsNone(eval_utils.best_mean_so_far(self.csv))
+
+    def test_append_roundtrip_idempotency(self):
+        eval_utils.append_metrics(self.csv, self._row(0, 2.5))
+        eval_utils.append_metrics(self.csv, self._row(4, 3.1))
+        self.assertEqual(eval_utils.done_epochs(self.csv), {0, 4})
+        self.assertAlmostEqual(eval_utils.best_mean_so_far(self.csv), 3.1)
+        # header written exactly once
+        lines = self.csv.read_text().strip().splitlines()
+        self.assertEqual(len(lines), 3)
+        self.assertTrue(lines[0].startswith("epoch,step,checkpoint"))
+
+    def test_missing_columns_padded_empty(self):
+        eval_utils.append_metrics(self.csv, {"epoch": 1, "utmos_mean": "2.0"})
+        line = self.csv.read_text().strip().splitlines()[1]
+        self.assertEqual(len(line.split(",")),
+                         len(eval_utils.METRICS_HEADER))
+
+    def test_malformed_rows_skipped(self):
+        self.csv.write_text(
+            "epoch,step,checkpoint,utmos_mean,utmos_std,utmos_min,utmos_max,"
+            "spk_sim_mean,spk_sim_std,spk_sim_min,n_sentences\n"
+            "1,10,a.ckpt,3.5,0.1,3,4,,,,10\n"
+            "garbage,x,b.ckpt,not-a-float,,,,,,,\n"
+            "3,30,c.ckpt,2.9,0.1,2,3,,,,10\n"
+            ",,,\n"
+            "5\n")
+        self.assertEqual(eval_utils.done_epochs(self.csv), {1, 3, 5})
+        self.assertAlmostEqual(eval_utils.best_mean_so_far(self.csv), 3.5)
+
+    def test_headerless_garbage_file(self):
+        self.csv.write_text("complete nonsense\nwithout,any,header\n")
+        self.assertEqual(eval_utils.done_epochs(self.csv), set())
+        self.assertIsNone(eval_utils.best_mean_so_far(self.csv))
+
+    def test_empty_file(self):
+        self.csv.write_text("")
+        self.assertEqual(eval_utils.done_epochs(self.csv), set())
+        self.assertIsNone(eval_utils.best_mean_so_far(self.csv))
+
+
+class TestReadSentences(unittest.TestCase):
+    def test_strips_and_drops_blanks(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "s.txt"
+            p.write_text("  hello \n\n\t\nworld\n   \n", encoding="utf-8")
+            self.assertEqual(eval_utils.read_sentences(p), ["hello", "world"])
+
+    def test_empty_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "s.txt"
+            p.write_text("", encoding="utf-8")
+            self.assertEqual(eval_utils.read_sentences(p), [])
+
+
+class TestSizeStable(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "ckpt"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_missing_file(self):
+        self.assertFalse(eval_utils.size_stable(self.path, wait=0,
+                                                sleep=lambda _: None))
+
+    def test_stable_file(self):
+        self.path.write_bytes(b"abc")
+        calls = []
+        self.assertTrue(eval_utils.size_stable(self.path, wait=0,
+                                               sleep=calls.append))
+        self.assertEqual(len(calls), 1)  # one sleep to confirm stability
+
+    def test_empty_file_never_stable(self):
+        self.path.write_bytes(b"")
+        self.assertFalse(eval_utils.size_stable(self.path, wait=0, tries=3,
+                                                sleep=lambda _: None))
+
+    def test_growing_file_unstable(self):
+        self.path.write_bytes(b"a")
+
+        def grow(_):
+            with open(self.path, "ab") as f:
+                f.write(b"a")
+
+        self.assertFalse(eval_utils.size_stable(self.path, wait=0, tries=4,
+                                                sleep=grow))
+
+    def test_file_deleted_mid_wait(self):
+        self.path.write_bytes(b"a")
+
+        def grow_then_delete(_):
+            if self.path.exists():
+                with open(self.path, "ab") as f:
+                    f.write(b"bb")  # keep it unstable, then remove
+                self.path.unlink()
+
+        self.assertFalse(eval_utils.size_stable(self.path, wait=0, tries=5,
+                                                sleep=grow_then_delete))
+
+
+class TestLargestWavs(unittest.TestCase):
+    def test_orders_by_size_and_caps_n(self):
+        with tempfile.TemporaryDirectory() as d:
+            dp = Path(d)
+            (dp / "small.wav").write_bytes(b"a")
+            (dp / "big.wav").write_bytes(b"a" * 100)
+            (dp / "mid.wav").write_bytes(b"a" * 10)
+            (dp / "not_audio.txt").write_bytes(b"a" * 1000)
+            top2 = eval_utils.largest_wavs(dp, 2)
+            self.assertEqual([p.name for p in top2], ["big.wav", "mid.wav"])
+            self.assertEqual(eval_utils.largest_wavs(dp, 0), [])
+
+    def test_empty_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(eval_utils.largest_wavs(Path(d), 5), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `phoonnx_train/eval_loop.py`, a checkpoint evaluation loop that runs alongside (or after) VITS training:

- Watches `--train-dir` for new lightning checkpoints (`epoch=*.ckpt`), waiting for each file to finish writing before loading it.
- Synthesizes a fixed set of held-out sentences (`--sentences`) on CPU, using the exact preprocess text encoding: `normalize` -> phonemizer from the dataset `config.json` (`phoneme_type`/`alphabet`/`phonemizer_model`) -> `TTSTokenizer.from_phoonnx_config`.
- Scores every clip with **UTMOS** (SpeechMOS `utmos22_strong`) and, optionally, **speaker similarity** (cosine vs a centroid embedding built from the `--num-ref-wavs` largest wavs in `--speaker-ref-dir`, via `speakeronnx`). Speaker similarity degrades gracefully: if `speakeronnx` is missing or no reference wavs are given, only UTMOS is scored and the similarity columns are left empty.
- Appends one summary row per epoch to `metrics.csv`, writes per-utterance scores to `perutt/epoch<N>.csv`, and keeps the wavs of the best epoch so far under `samples/`.
- Idempotent: scored epochs are read back from `metrics.csv` on start and skipped; ordering is by epoch number parsed from the filename. Supports `--once`, `--poll`, `--dry-run`, and `--noise-scale`/`--length-scale`/`--noise-w` overrides.

## Structure

- `phoonnx_train/eval_utils.py`: torch-free bookkeeping (checkpoint discovery, epoch/step parsing, metrics.csv read/append/idempotency, size-stability wait, reference-wav selection) so it is importable and testable without torch.
- `phoonnx_train/eval_loop.py`: the click CLI + synthesis/scoring, requiring the new optional extra `phoonnx[train-eval]` (`speechmos`, `torchaudio`, `soundfile`, `speakeronnx`) on top of `[train]`.
- `tests/test_eval_loop.py`: 21 unit tests over `eval_utils`, including malformed `metrics.csv` rows, duplicate epoch checkpoints (newest wins), checkpoint names without `epoch=`, empty sentence files, and partial-write size instability. Loaded by file path so the suite runs without torch, following `tests/test_monotonic_align.py`.
- `TRAINING.md`: new section documenting usage, both metrics, and the caveat that UTMOS is trained on English/Japanese MOS data — on other languages it is a relative ranker between checkpoints of the same voice, not an absolute score.

## Model usage

Written by Claude Code (Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic evaluation of training checkpoints on held-out sentences.
  * Reports UTMOS and optional speaker-similarity scores.
  * Saves metrics, per-utterance results, and best-performing audio samples.
  * Supports one-time or continuous monitoring, dry runs, polling intervals, and inference-scale overrides.
  * Added optional training-evaluation dependencies.

* **Documentation**
  * Added setup, usage, configuration, and output details for checkpoint evaluation.

* **Tests**
  * Added coverage for checkpoint discovery, metrics tracking, sentence handling, file stability, and reference-audio selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->