### PR TITLE
fix: corpus-only phoneme map option and untrained-symbol warning

### DIFF
--- a/phoonnx/tokenizer.py
+++ b/phoonnx/tokenizer.py
@@ -194,6 +194,27 @@ DEFAULT_BLANK_WORD_TOKEN = " "  # padding between words
 
 STRESS: Set[str] = {"ˈ", "ˌ"}
 
+SPECIAL_TOKENS: Set[str] = {DEFAULT_PAD_TOKEN, DEFAULT_BOS_TOKEN,
+                            DEFAULT_EOS_TOKEN, DEFAULT_BLANK_WORD_TOKEN}
+
+
+def phoneme_map_seed(corpus_phonemes: Set[str], ipa: bool,
+                     include_defaults: bool = True) -> Set[str]:
+    """Symbols a new phoneme map is built from: the corpus symbols, plus the full
+    default IPA table unless include_defaults is False."""
+    syms = set(corpus_phonemes)
+    if ipa and include_defaults:
+        syms.update(DEFAULT_IPA_PHONEME_ID_MAP)
+    return syms
+
+
+def untrained_map_symbols(phoneme_id_map: Mapping[str, Any],
+                          corpus_phonemes: Set[str]) -> List[str]:
+    """Map symbols that never occur in the corpus. Their embeddings receive no
+    gradient during training, so feeding them at inference produces undefined audio."""
+    return sorted(k for k in phoneme_id_map
+                  if k not in corpus_phonemes and k not in SPECIAL_TOKENS)
+
 PUNCTUATION_MAP: Mapping[str, str] = {";": ",", ":": ",", "?": ".", "!": "."}
 """Default punctuation simplification into short (,) and long (.) pauses"""
 

--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 from phoonnx.config import PhonemeType, get_phonemizer, Alphabet
 from phoonnx.phonemizers import Phonemizer
 from phoonnx.tokenizer import TTSTokenizer, DEFAULT_IPA_PHONEME_ID_MAP, DEFAULT_PAD_TOKEN, DEFAULT_BOS_TOKEN, \
+    phoneme_map_seed, untrained_map_symbols, \
     DEFAULT_EOS_TOKEN, DEFAULT_BLANK_WORD_TOKEN
 from phoonnx.util import normalize
 from phoonnx.version import VERSION_STR
@@ -285,6 +286,17 @@ def phonemize_worker(
     help="If training data has more symbols than base model, discard new symbols. (for fine-tuning only)",
 )
 @click.option(
+    "--corpus-only-map",
+    "corpus_only_map",
+    is_flag=True,
+    default=False,
+    help="Build the phoneme map only from symbols present in the corpus, instead of "
+         "seeding it with the full default IPA table. Symbols outside the map fail at "
+         "tokenization instead of mapping to embeddings the model never trained. "
+         "Models preprocessed this way can only be fine-tuned from configs with a "
+         "compatible (subset) map.",
+)
+@click.option(
     "-r",
     "--sample-rate",
     "sample_rate",
@@ -393,6 +405,7 @@ def cli(
     language: str,
     prev_config: Path,
     drop_extra_phonemes: bool,
+    corpus_only_map: bool,
     sample_rate: int,
     cache_dir: Optional[Path],
     max_workers: Optional[int],
@@ -555,6 +568,7 @@ def cli(
 
     # --- Build the final phoneme map from the collected phonemes ---
     _LOGGER.info("Building a phoneme map from collected dataset phonemes...")
+    corpus_phonemes: Set[str] = set(all_phonemes)
 
     if prev_config:
         with open(prev_config) as f:
@@ -571,8 +585,9 @@ def cli(
     else:
         prev_num_symbols = MAX_PHONEMES
         final_phoneme_id_map: Dict[str, int] = DEFAULT_SPECIAL_PHONEME_ID_MAP.copy()
-        if phonemizer.alphabet == Alphabet.IPA:
-            all_phonemes.update(DEFAULT_IPA_PHONEME_ID_MAP.keys())
+        all_phonemes = phoneme_map_seed(all_phonemes,
+                                        ipa=phonemizer.alphabet == Alphabet.IPA,
+                                        include_defaults=not corpus_only_map)
 
     # Filter out tokens that are already in the map
     existing_keys: Set[str] = set(final_phoneme_id_map.keys())
@@ -598,6 +613,13 @@ def cli(
             final_phoneme_id_map[pho] = current_id
             current_id += 1
             _LOGGER.debug(f"New phoneme: {pho}")
+
+    unused = untrained_map_symbols(final_phoneme_id_map, corpus_phonemes)
+    if unused:
+        _LOGGER.warning(
+            "%d phoneme map symbols never occur in the corpus and their embeddings will "
+            "not be trained; feeding them at inference produces undefined audio: %s",
+            len(unused), " ".join(unused))
 
     if new_phonemes:
         _LOGGER.info("Final phoneme map contains %d phonemes.", len(final_phoneme_id_map))

--- a/tests/test_phoneme_map.py
+++ b/tests/test_phoneme_map.py
@@ -1,0 +1,57 @@
+"""Tests for phoneme-map seeding and the untrained-symbol audit."""
+import unittest
+
+from phoonnx.tokenizer import (DEFAULT_IPA_PHONEME_ID_MAP, SPECIAL_TOKENS,
+                               phoneme_map_seed, untrained_map_symbols)
+
+
+class TestPhonemeMapSeed(unittest.TestCase):
+    def test_default_ipa_seed_includes_full_table(self):
+        seed = phoneme_map_seed({"a", "b"}, ipa=True)
+        self.assertTrue(set(DEFAULT_IPA_PHONEME_ID_MAP).issubset(seed))
+        self.assertIn("a", seed)
+
+    def test_corpus_only_excludes_digits_and_punctuation(self):
+        corpus = {"a", "ˈ", "tˤ"}
+        seed = phoneme_map_seed(corpus, ipa=True, include_defaults=False)
+        self.assertEqual(seed, corpus)
+        for sym in "0123456789!?.,;:":
+            self.assertNotIn(sym, seed)
+
+    def test_non_ipa_never_adds_defaults(self):
+        seed = phoneme_map_seed({"x"}, ipa=False, include_defaults=True)
+        self.assertEqual(seed, {"x"})
+
+    def test_empty_corpus(self):
+        self.assertEqual(phoneme_map_seed(set(), ipa=False), set())
+        self.assertEqual(phoneme_map_seed(set(), ipa=True, include_defaults=False), set())
+
+    def test_input_not_mutated(self):
+        corpus = {"a"}
+        phoneme_map_seed(corpus, ipa=True)
+        self.assertEqual(corpus, {"a"})
+
+
+class TestUntrainedMapSymbols(unittest.TestCase):
+    def test_flags_symbols_missing_from_corpus(self):
+        pmap = {"_": 0, "^": 1, "$": 2, " ": 3, "a": 4, "5": 5, "!": 6}
+        self.assertEqual(untrained_map_symbols(pmap, {"a"}), ["!", "5"])
+
+    def test_special_tokens_never_flagged(self):
+        pmap = {t: i for i, t in enumerate(SPECIAL_TOKENS)}
+        self.assertEqual(untrained_map_symbols(pmap, set()), [])
+
+    def test_full_default_map_against_digit_free_corpus(self):
+        corpus = {k for k in DEFAULT_IPA_PHONEME_ID_MAP if k.isalpha()}
+        unused = untrained_map_symbols(DEFAULT_IPA_PHONEME_ID_MAP, corpus)
+        for d in "0123456789":
+            self.assertIn(d, unused)
+        self.assertNotIn("a", unused)
+
+    def test_clean_map_yields_nothing(self):
+        pmap = {"_": 0, "a": 1, "b": 2}
+        self.assertEqual(untrained_map_symbols(pmap, {"a", "b"}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A freshly preprocessed model's phoneme map is seeded with the entire default IPA table, so it inherits symbols the training corpus never produces — including the digits `0–9` and ASCII punctuation. Those map entries point at embeddings that receive no gradient during training; if raw digits or punctuation reach the tokenizer at inference, the model synthesizes undefined audio instead of failing, and nothing warns the user at any stage.

## Changes

- `preprocess.py --corpus-only-map`: build the phoneme map strictly from symbols observed in the corpus (plus the special tokens). Unmapped symbols then fail at tokenization, which forces text normalization to verbalize them — the behavior a trained model can actually honor. Default behavior is unchanged (full default table) since fine-tuning requires map compatibility with the base model.
- preprocess now always logs a warning listing map symbols that never occur in the corpus, so the mismatch is visible instead of silent.
- The seeding and audit logic lives in `phoonnx.tokenizer` (`phoneme_map_seed`, `untrained_map_symbols`, `SPECIAL_TOKENS`) — importable without the training extras.
- `tests/test_phoneme_map.py`: torch-free unit tests covering default and corpus-only seeding, non-IPA alphabets, empty corpora, input immutability, special-token exemption, and the digit case against the real default table.

## Model usage

Written by Claude Code (Fable 5) after root-causing an exported voice whose map contained digit symbols with untrained embeddings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to build phoneme maps using only symbols observed in the training corpus.
  - Added automatic detection of map symbols that do not appear in the corpus.
- **Bug Fixes**
  - Special tokens are now excluded from unused-symbol warnings.
  - Phoneme-map generation more accurately handles IPA defaults and corpus-specific symbols.
- **Documentation**
  - Added coverage for corpus-only mapping, default symbol handling, and unused-symbol detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->