### PR TITLE
Optional espeak-ng shared library route for EspeakPhonemizer

### DIFF
--- a/phoonnx/phonemizers/mul.py
+++ b/phoonnx/phonemizers/mul.py
@@ -1,6 +1,7 @@
 """multilingual phonemizers"""
 
 import json
+import logging
 import os
 import subprocess
 from typing import List, Dict, Optional, Sequence
@@ -12,6 +13,8 @@ import requests
 from phoonnx.config import Alphabet
 from phoonnx.phonemizers.base import BasePhonemizer
 from phoonnx.providers import ProviderSpec, make_session
+
+LOG = logging.getLogger(__name__)
 
 
 class EspeakError(Exception):
@@ -303,23 +306,95 @@ class EspeakPhonemizer(BasePhonemizer):
                     'kaa', 'jbo', 'eo', 'uz', 'nci', 'vi-vn-x-south', 'el', 'pl', 'grc', ]
 
     _binary_available: Optional[bool] = None
+    _library_available: Optional[bool] = None
 
-    def __init__(self, prefer_espyak: bool = False):
+    def __init__(self, prefer_espyak: bool = False, use_library: bool = True):
         """
         Args:
             prefer_espyak: Use the pure-Python espyak G2P even when the
                 espeak-ng binary is installed. When False, espyak is only
                 used as a fallback if the binary is missing.
+            use_library: Call espeak-ng through its shared library instead of
+                spawning a subprocess, when the optional `phonemizer` package
+                is installed. Same engine, same phonemes, without the ~80ms
+                process startup per call. Falls back to the subprocess when
+                unavailable.
         """
         super().__init__(Alphabet.IPA)
         self.prefer_espyak = prefer_espyak
+        self.use_library = use_library
         self._espyak_g2p: dict = {}
+        self._library_backends: dict = {}
+        self._library_failed: set = set()
 
     def _espyak_phonemize(self, text: str, lang: str) -> str:
         from espyak import G2P
         if lang not in self._espyak_g2p:
             self._espyak_g2p[lang] = G2P(lang)
         return self._espyak_g2p[lang].phonemize(text)
+
+    @classmethod
+    def _locate_library(cls) -> Optional[str]:
+        """Best effort lookup of the espeak-ng shared library.
+
+        phonemizer finds it by itself where the loader can (Linux, macOS, and
+        Windows installs that are on PATH). On Windows the default installer
+        puts it in Program Files, which is not searched, so the usual
+        locations are probed as well. PHONEMIZER_ESPEAK_LIBRARY overrides
+        everything, as it does in phonemizer itself.
+        """
+        env = os.environ.get("PHONEMIZER_ESPEAK_LIBRARY")
+        if env and os.path.isfile(env):
+            return env
+
+        import sys
+        if sys.platform == "win32":
+            candidates = [
+                os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"),
+                             "eSpeak NG", "libespeak-ng.dll"),
+                os.path.join(os.environ.get("ProgramFiles(x86)",
+                                            r"C:\Program Files (x86)"),
+                             "eSpeak NG", "libespeak-ng.dll"),
+            ]
+            for path in candidates:
+                if os.path.isfile(path):
+                    return path
+        return None
+
+    @classmethod
+    def _has_library(cls) -> bool:
+        """True if the optional `phonemizer` package and the espeak-ng shared
+        library are both available."""
+        if cls._library_available is None:
+            cls._library_available = False
+            try:
+                from phonemizer.backend import EspeakBackend
+                from phonemizer.backend.espeak.wrapper import EspeakWrapper
+
+                if not EspeakBackend.is_available():
+                    located = cls._locate_library()
+                    if located:
+                        EspeakWrapper.set_library(located)
+                cls._library_available = EspeakBackend.is_available()
+            except Exception as e:
+                LOG.debug("espeak-ng shared library unavailable: %s", e)
+        return cls._library_available
+
+    def _library_phonemize(self, text: str, lang: str) -> str:
+        """Phonemize through the espeak-ng shared library.
+
+        The backend instance is kept per language: building one initializes
+        the espeak library, which costs ~200ms, while reusing it brings a
+        call down to well under a millisecond.
+        """
+        from phonemizer.backend import EspeakBackend
+        from phonemizer.separator import Separator
+
+        if lang not in self._library_backends:
+            self._library_backends[lang] = EspeakBackend(
+                lang, preserve_punctuation=False, with_stress=True)
+        return self._library_backends[lang].phonemize(
+            [text], separator=Separator(phone="", word=" "), strip=True)[0]
 
     @classmethod
     def _has_binary(cls) -> bool:
@@ -406,16 +481,37 @@ class EspeakPhonemizer(BasePhonemizer):
 
     def phonemize_string(self, text: str, lang: str) -> str:
         lang = self.get_lang(lang)
-        if self.prefer_espyak or not self._has_binary():
+        if self.prefer_espyak or not (self._has_binary() or self._has_library()):
             try:
                 return self._espyak_phonemize(text, lang)
             except ImportError:
-                if not self._has_binary():
+                if not (self._has_binary() or self._has_library()):
                     raise EspeakError(
                         "espeak-ng binary not found and espyak is not installed. "
                         "Install espeak-ng or `pip install espyak` for the "
                         "pure-Python fallback."
                     )
+
+        # Preferred route: the espeak-ng shared library. Same engine as the
+        # subprocess below, without paying process startup on every call.
+        # Languages that the library cannot load (a voice may be missing, or
+        # shadowed by an mbrola definition without mbrola installed) are
+        # remembered so the failure is paid once rather than on every call.
+        if (self.use_library and self._has_library()
+                and lang not in self._library_failed):
+            try:
+                return self._library_phonemize(text, lang)
+            except Exception as e:
+                self._library_failed.add(lang)
+                if not self._has_binary():
+                    raise EspeakError(
+                        f"espeak-ng shared library failed for language "
+                        f"'{lang}' ({e}) and the espeak-ng binary is not "
+                        f"available as a fallback."
+                    )
+                LOG.info("espeak-ng library cannot handle language '%s' (%s), "
+                         "using the subprocess for it", lang, e)
+
         return self._run_espeak_command(
             ['-q', '-x', '--ipa', '-v', lang],
             input_text=text

--- a/phoonnx/phonemizers/mul.py
+++ b/phoonnx/phonemizers/mul.py
@@ -334,6 +334,17 @@ class EspeakPhonemizer(BasePhonemizer):
         return self._espyak_g2p[lang].phonemize(text)
 
     @classmethod
+    def reset_availability_cache(cls) -> None:
+        """Forget what was detected about espeak-ng's availability.
+
+        Both the binary and the shared library are probed once and the answer
+        is cached on the class. Call this if the environment changed, or from
+        tests that patch the detection.
+        """
+        cls._binary_available = None
+        cls._library_available = None
+
+    @classmethod
     def _locate_library(cls) -> Optional[str]:
         """Best effort lookup of the espeak-ng shared library.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ test = [
     "g2p_barranquenho",
     "mwl_phonemizer",
 ]
-espeak = ["espyak>=0.0.2a1"]
+# espeak-ng phonemization extras. `phonemizer` enables the shared library
+# route (same espeak-ng, without a subprocess per call); espyak is the
+# pure-Python fallback for systems without espeak-ng at all.
+espeak = ["espyak>=0.0.2a1", "phonemizer"]
 train = [
     "librosa>=0.9.2,<1",
     "numpy>=1.19.0,<2",
@@ -102,6 +105,7 @@ all = [
     "pykakasi==2.3.0", "spacy-pkuseg",
     "soundfile", "scipy",
     "orthography2ipa", "arbtok", "euskaphone", "g2p_barranquenho", "mwl_phonemizer",
+    "phonemizer",
 ]
 
 [tool.setuptools.dynamic]

--- a/test/test_espyak_fallback.py
+++ b/test/test_espyak_fallback.py
@@ -1,5 +1,6 @@
-"""EspeakPhonemizer falls back to the pure-Python espyak G2P when the
-espeak-ng binary is unavailable, and can be forced to prefer it."""
+"""EspeakPhonemizer prefers the espeak-ng shared library, falls back to the
+espeak-ng subprocess, and finally to the pure-Python espyak G2P. It can also
+be forced to prefer espyak."""
 import unittest
 from unittest.mock import patch
 
@@ -8,10 +9,10 @@ from phoonnx.phonemizers.mul import EspeakPhonemizer, EspeakError
 
 class TestEspyakFallback(unittest.TestCase):
     def setUp(self):
-        EspeakPhonemizer._binary_available = None
+        EspeakPhonemizer.reset_availability_cache()
 
     def tearDown(self):
-        EspeakPhonemizer._binary_available = None
+        EspeakPhonemizer.reset_availability_cache()
 
     def test_prefer_espyak_skips_binary(self):
         pho = EspeakPhonemizer(prefer_espyak=True)
@@ -26,16 +27,55 @@ class TestEspyakFallback(unittest.TestCase):
             result = pho.phonemize_string("hallo wereld", "nl")
         self.assertTrue(result.strip())
 
-    def test_binary_used_when_available(self):
+    def test_library_used_when_available(self):
+        """The shared library is preferred over spawning a subprocess."""
         EspeakPhonemizer._binary_available = True
+        EspeakPhonemizer._library_available = True
+        pho = EspeakPhonemizer()
+        with patch.object(EspeakPhonemizer, "_library_phonemize",
+                          return_value="from-library") as lib, \
+                patch.object(EspeakPhonemizer, "_run_espeak_command") as run_cmd:
+            self.assertEqual(pho.phonemize_string("hello", "en"), "from-library")
+            lib.assert_called_once()
+            run_cmd.assert_not_called()
+
+    def test_binary_used_when_library_unavailable(self):
+        """Without the library, the subprocess is used as before."""
+        EspeakPhonemizer._binary_available = True
+        EspeakPhonemizer._library_available = False
         pho = EspeakPhonemizer()
         with patch.object(EspeakPhonemizer, "_run_espeak_command",
                           return_value="mocked") as run_cmd:
             self.assertEqual(pho.phonemize_string("hello", "en"), "mocked")
             run_cmd.assert_called_once()
 
-    def test_error_when_neither_available(self):
+    def test_binary_used_when_library_opted_out(self):
+        """use_library=False keeps the original subprocess behaviour."""
+        EspeakPhonemizer._binary_available = True
+        EspeakPhonemizer._library_available = True
+        pho = EspeakPhonemizer(use_library=False)
+        with patch.object(EspeakPhonemizer, "_run_espeak_command",
+                          return_value="mocked") as run_cmd:
+            self.assertEqual(pho.phonemize_string("hello", "en"), "mocked")
+            run_cmd.assert_called_once()
+
+    def test_library_failure_falls_back_to_binary(self):
+        """A language the library cannot load still gets phonemized."""
+        EspeakPhonemizer._binary_available = True
+        EspeakPhonemizer._library_available = True
+        pho = EspeakPhonemizer()
+        with patch.object(EspeakPhonemizer, "_library_phonemize",
+                          side_effect=RuntimeError("failed to load voice")), \
+                patch.object(EspeakPhonemizer, "_run_espeak_command",
+                             return_value="mocked") as run_cmd:
+            self.assertEqual(pho.phonemize_string("hello", "en"), "mocked")
+            run_cmd.assert_called_once()
+            # the failure is remembered, so the library is not retried
+            self.assertIn(pho.get_lang("en"), pho._library_failed)
+
+    def test_error_when_nothing_available(self):
         with patch("shutil.which", return_value=None), \
+                patch.object(EspeakPhonemizer, "_has_library", return_value=False), \
                 patch.object(EspeakPhonemizer, "_espyak_phonemize",
                              side_effect=ImportError("no espyak")):
             pho = EspeakPhonemizer()
@@ -47,6 +87,15 @@ class TestEspyakFallback(unittest.TestCase):
         pho.phonemize_string("one", "en")
         pho.phonemize_string("two", "en")
         self.assertEqual(len(pho._espyak_g2p), 1)
+
+    def test_backend_instances_cached_per_lang(self):
+        """Backends are expensive to build, so they are reused per language."""
+        if not EspeakPhonemizer._has_library():
+            self.skipTest("espeak-ng shared library not available")
+        pho = EspeakPhonemizer()
+        pho.phonemize_string("one", "en")
+        pho.phonemize_string("two", "en")
+        self.assertEqual(len(pho._library_backends), 1)
 
     def test_matches_binary_output_shape(self):
         # dialect resolution goes through get_lang (en-gb -> en-gb-x-rp)


### PR DESCRIPTION
Optional espeak-ng shared library route for EspeakPhonemizer

## Problem

`EspeakPhonemizer` spawns an `espeak-ng` subprocess per call. The
phonemization itself takes microseconds; process startup takes most of the
time and dominates short utterances.

Measured on Windows, Python 3.12, espeak-ng 1.52, phonemizing single words:

```
per call: 150 ms
```

That is the case that matters most for a screen reader: pressing a key and
waiting for a short label to be spoken. Through the NVDA add-on the cost is
paid on every keystroke.

## Change

espeak-ng ships a shared library alongside the binary. Calling it directly
skips process startup entirely. Same engine, same voices, same data files,
same version: only the call mechanism differs.

This adds that route, used when the optional `phonemizer` package is
installed, with the existing subprocess kept as the fallback:

1. shared library, if `phonemizer` is installed and the library loads
2. `espeak-ng` subprocess (current behaviour)
3. espyak (unchanged, still last)

```
subprocess:  150 ms per call
library:     0.031 ms per call
```

Nothing is required of users who do not install the extra: without
`phonemizer` the code path is exactly what it is today. `use_library=False`
opts out explicitly.

The backend instance is kept per language, mirroring how `_espyak_g2p`
already caches espyak's G2P in this class. Building one initializes the
espeak library (~200 ms); reusing it brings a call well under a millisecond.
This is the whole reason the route is fast, and worth stating plainly:
calling `phonemizer.phonemize()` naively, without holding on to the backend,
measures **slower** than the subprocess (284 ms vs 158 ms per call), because
it rebuilds the backend every time.

## Correctness

Compared against the current subprocess route across 39 cases: 18 single
words, 7 phrases, 14 languages. All 39 produce the same phonemes.

End to end through a VITS voice (lessac-high, noise scales at 0 for
determinism), the synthesized audio is **bit identical** for all 8 test
phrases. Not close: identical samples.

Two caveats, both handled by falling back rather than failing:

- espeak resolves some language codes to mbrola voices when mbrola voice
  definitions are present but mbrola itself is not installed. On my machine
  `fr` and `cs` hit this and fall back to the subprocess. The failure is
  remembered per language, so it is paid once rather than on every call, and
  a language that falls back is no slower than it is today.
- espeak's CLI splits its output on clause boundaries into separate lines;
  the library returns a single line. The phoneme sequence is the same.
  Newlines are not in `phoneme_id_map` and never reach the model, which is
  why the audio comes out identical.

On Windows the library lives in Program Files, which the loader does not
search, so the usual install locations are probed when phonemizer cannot
find it by itself. `PHONEMIZER_ESPEAK_LIBRARY` overrides this, as in
phonemizer.

## Tests

Two existing tests described the old preference order and are updated to the
new one, keeping their intent. Four tests are added for behaviour that had no
coverage: opting out, library-failure fallback, per-language backend reuse,
and the error path with all three routes disabled.

```
baseline (upstream/dev):  50 failed, 349 passed, 9 skipped
with this branch:         50 failed, 353 passed, 9 skipped
```

Same 50 failures in both runs, all from optional language packages that are
not installed here (arbtok, euskaphone, pycotovia, mwl, o2ipa) plus espyak.
No regressions; the four extra passes are the new tests.

`reset_availability_cache()` is added because availability was cached on the
class with no way to clear it. That leaked state between tests, and gave
callers no way to re-probe after the environment changed.

## A note on espyak

While measuring, I compared espyak against espeak-ng directly, since it is
currently the fallback. Same 12 sentences, same languages:

```
espyak identical to espeak-ng: 1/12
```

Four languages raise `FileNotFoundError` on missing rule data. Of those that
do run, the output differs in ways that are not cosmetic:

```
nl  "Het document"   espeak: hə tˌoːkymˈɛnt      espyak: hət dˌoːkymˈɛnt
pl  "jest"           espeak: jɛzd                espyak: jɛst
ru  "Privet, mir!"   espeak: (en)pɹˈɪvɪt(ru)     espyak: zʌpitˈɑja vˈoskɨ
```

The Russian case is not a near miss; it is different words. Because espyak
only runs when nothing else is available, a user in that situation gets
wrong pronunciation with no indication anything went wrong. The espyak tests
in this repo also fail on the currently published build, on missing
`dictsource` data.

I have left espyak exactly where it is in this PR, since it is your call, not
mine. But now that there is a fallback that is correct by construction, it
seems worth asking whether espyak still earns its place. Happy to remove it
in a follow-up if you agree, or to leave it alone.

## About the phonemizer dependency

Worth flagging before you weigh this up: `pip install phonemizer` currently
pulls in 15 packages, because it depends on `segments` unconditionally, which
drags in csvw, rdflib, jsonschema, babel and language-tags. The espeak
backend needs none of it. For a bundled screen reader add-on that is real
weight for a feature nobody uses.

I have opened three PRs upstream at bootphon/phonemizer to address what I ran
into while measuring this:

- [#211](https://github.com/bootphon/phonemizer/pull/211) makes `segments`
  optional, taking a default install from 15 packages to 5
- [#212](https://github.com/bootphon/phonemizer/pull/212) caches backend
  instances in `phonemize()`, so the naive call is not slower than a
  subprocess
- [#213](https://github.com/bootphon/phonemizer/pull/213) adds a custom
  espeak data path, so espeak data can be bundled rather than assumed
  installed system-wide (cherry-picked from thewh1teagle/phonemizer-fork
  with authorship preserved, not my work)

None of them are required for this PR. This branch depends on plain
`phonemizer` from PyPI and works with it as published today; #212 in
particular is redundant here, since this code holds its own backend
instances. If #211 lands, the extra simply gets lighter. If it does not,
the dependency weight above is what you are signing up for, and that is a
fair reason to say no.

Anyone who wants the lighter install before then can point at
`git+https://github.com/aradix85/phonemizer.git@all`, but I would not
suggest phoonnx depend on a fork, and this PR does not.

## Possible follow-up: batching the subprocess route

Not included here, but worth noting for whoever needs the subprocess path to
be faster: `espeak-ng` accepts multiple lines in one invocation and returns
one line of phonemes per input line. Phonemizing 8 sentences that way was
9.1x faster than 8 separate calls (918 ms vs 101 ms), with identical output.

Taking advantage of it would mean `phonemize_string` accepting a list, which
touches every phonemizer in `mul.py`, so it belongs in its own change. With
the library route the question is somewhat moot: at 0.03 ms per call it is
already faster than a batched subprocess.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared-library support for espeak-ng phonemization, with subprocess fallback.
  * Added automatic backend selection based on availability and language support.
  * Added an option to use the pure-Python phonemizer or disable shared-library usage.
  * Improved reuse of initialized phonemization backends.

* **Bug Fixes**
  * Failed backend initialization is now remembered to avoid repeated delays.
  * Clear errors are reported when no phonemization backend is available.

* **Chores**
  * Updated optional dependencies to include shared-library phonemization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->