### PR TITLE
Streaming VITS engine (split encoder/decoder) + offline voice listing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,4 +53,5 @@ with wave.open("output.wav", "wb") as wav_file:
 - [OVOS Plugin](ovos_plugin.md)
 - [Docker / TTS Server](docker.md)
 - [Engine Architecture](engines.md) · [Vocoders](vocoders.md)
+- [Streaming (low-latency VITS)](streaming.md)
 - Engine guides: [Matcha](matcha.md) · [GlowTTS](glowtts.md) · [OptiSpeech](optispeech.md) · [MixerTTS](mixertts.md) · [FastPitch](fastpitch.md) · [ZipVoice](zipvoice.md) · [Shami](shami.md) · [Chatterbox](chatterbox.md)

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -69,9 +69,11 @@ its decoder takes that one tensor (plus `sid` on multi-speaker models); the
 adapter matches these by name/shape, so pre-split `+RT` voices and auto-split
 voices both work through the same code path.
 
-`onnx` (the full package, not just `onnxruntime`) is required for splitting and
-is a dependency of phoonnx. If splitting fails — e.g. the model is not a VITS —
-phoonnx logs a warning and loads the voice as a normal, non-streaming model.
+Splitting needs the full `onnx` package (not just `onnxruntime`), which is an
+optional extra: `pip install phoonnx[streaming]`. It is only needed to *create*
+a split — a pre-split `+RT` voice streams without it. If `onnx` is missing, or
+the model is not a splittable VITS, phoonnx logs a warning and loads the voice
+as a normal, non-streaming model.
 
 ## How it works: discard-and-stitch
 
@@ -170,6 +172,27 @@ before any audio plays:
 | short (~1.3 s audio) | 1399 ms | 1382 ms | 1.0x (falls back) |
 | mid (~3.9 s) | 3342 ms | 1552 ms | 2.2x |
 | long (~11.7 s) | 4801 ms | 1965 ms | 2.4x |
+
+**Latency vs. throughput — an honest reading.** Streaming does *not* make total
+synthesis faster; it trades a little extra compute for a much lower, and *bounded*,
+time-to-first-audio. Measured on an auto-split `celtia-cotovia` (16 kHz), same
+onnxruntime threading for both paths:
+
+| Audio | monolithic TTFA | RTF (mono) | streaming TTFA | RTF (stream) | TTFA speedup |
+|-------|-----------------|-----------|----------------|--------------|--------------|
+| 1.4 s | 348 ms | 0.24 | 254 ms | — | 1.4x (falls back) |
+| 3.9 s | 763 ms | 0.20 | 188 ms | 0.25 | 4.1x |
+| 7.1 s | 1320 ms | 0.19 | 253 ms | 0.25 | 5.2x |
+| 12.6 s | 2063 ms | 0.16 | 277 ms | 0.24 | 7.5x |
+
+Two things to read off this: (1) monolithic TTFA grows linearly with sentence
+length, while streaming TTFA stays flat (~200–280 ms) — that flatness is the
+point. (2) Streaming's *total* RTF is ~25–30% higher (the discarded margins are
+real work), so for **batch/offline file generation streaming is a net loss** and
+should be left off. It is a win only for interactive, real-time speech, where
+first-audio latency is what a user feels — and the win grows on slower hardware,
+where monolithic RTF approaches or exceeds 1.0 and a long sentence otherwise
+stalls for seconds before any sound.
 
 **Thread count.** onnxruntime defaults to using *all* logical cores, which
 measured **slower** on the heavy decoder — thread-coordination overhead and

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -18,7 +18,15 @@ config declares `"streaming": true` **and** ships a separate decoder graph.
 > in the pipeline to cut. Loading a combined model will simply fall through to
 > the ordinary [`VitsAdapter`](./engines.md), which is correct but not streaming.
 
-There are two ways to get a split model:
+There are three ways to get a split model:
+
+0. **Let phoonnx split a normal model at load time (recommended).** You do *not*
+   need a specially-exported voice. If a voice config just sets
+   `"streaming": true` on an ordinary single-graph Piper/VITS model, phoonnx
+   splits it into an encoder/decoder pair on first load and caches the two
+   graphs next to the model (`<model>.encoder.onnx` / `<model>.decoder.onnx`).
+   See [Auto-split](#auto-split-no-re-export-needed). This is lossless by
+   construction and sidesteps the re-export hazards below.
 
 1. **Use a pre-split "+RT" voice.** The Sonata project publishes fast/streaming
    variants of many Piper voices in the
@@ -32,6 +40,38 @@ There are two ways to get a split model:
    the same route the `+RT` voices are produced by. **Verify the result** — see
    [Verifying an exported split model](#verifying-an-exported-split-model), it is
    easy to produce a subtly broken split (see the `ryan+RT` case study below).
+
+## Auto-split (no re-export needed)
+
+A monolithic VITS graph has exactly one natural cut point: the input to the
+HiFiGAN waveform decoder, which is the already-masked latent `(z * y_mask)` of
+shape `[B, 192, T]`. Everything before it (text encoder, duration predictor,
+flow, length regulation) is the *encoder*; the HiFiGAN generator is the
+*decoder*. phoonnx finds that tensor (the data input of the decoder's 192-channel
+`conv_pre`, ignoring the flow's own 192-channel convs) and extracts the two
+subgraphs with `onnx.utils.extract_model`.
+
+Because the split is **the same ops as the original graph, just cut in two**, it
+is lossless by construction — verified bit-for-bit against a one-shot decode on
+real voices (`maxabs ~2e-8`). Crucially, it **cannot** introduce the duration
+drift that breaks some re-exported `+RT` voices (see the `ryan+RT` case study):
+no weights are re-exported, so nothing can shift.
+
+To use it, ship (or hand-write) a config that turns streaming on for an ordinary
+voice — no `decoder_path` required:
+
+```json
+{ "streaming": true, "engine": "vits", "phoneme_type": "espeak" }
+```
+
+The auto-split encoder emits a single latent output (no separate `y_mask`), and
+its decoder takes that one tensor (plus `sid` on multi-speaker models); the
+adapter matches these by name/shape, so pre-split `+RT` voices and auto-split
+voices both work through the same code path.
+
+`onnx` (the full package, not just `onnxruntime`) is required for splitting and
+is a dependency of phoonnx. If splitting fails — e.g. the model is not a VITS —
+phoonnx logs a warning and loads the voice as a normal, non-streaming model.
 
 ## How it works: discard-and-stitch
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,209 @@
+# Streaming VITS Engine
+
+Standard Piper/VITS voices synthesize a whole sentence in one ONNX call, so the
+first audio sample is only available once the entire sentence is decoded. The
+**streaming** engine lowers *time-to-first-audio* (TTFA) by decoding the
+sentence in chunks and emitting each chunk as soon as it is ready.
+
+The `VitsStreamingAdapter` handles this. It is auto-selected for any voice whose
+config declares `"streaming": true` **and** ships a separate decoder graph.
+
+## The core requirement: you need a *split* model
+
+> **Streaming only works with a model that is split into two ONNX graphs:**
+> a separate **encoder** (`encoder.onnx`) and **decoder** (`decoder.onnx`),
+> with `"streaming": true` in the voice config.
+>
+> A normal single-file Piper/VITS `.onnx` **cannot stream** — there is no point
+> in the pipeline to cut. Loading a combined model will simply fall through to
+> the ordinary [`VitsAdapter`](./engines.md), which is correct but not streaming.
+
+There are two ways to get a split model:
+
+1. **Use a pre-split "+RT" voice.** The Sonata project publishes fast/streaming
+   variants of many Piper voices in the
+   [`mush42/piper-rt`](https://huggingface.co/datasets/mush42/piper-rt) dataset.
+   Each `<name>+RT-<quality>.tar` contains `encoder.onnx`, `decoder.onnx` and a
+   `<name>.json` config with `"streaming": true`. Extract it and point the voice
+   config at the two graphs (see [Loading](#loading-a-streaming-voice)).
+
+2. **Export your own split model from a checkpoint.** If you have a trained
+   Piper checkpoint you can export it as a split encoder/decoder pair. This is
+   the same route the `+RT` voices are produced by. **Verify the result** — see
+   [Verifying an exported split model](#verifying-an-exported-split-model), it is
+   easy to produce a subtly broken split (see the `ryan+RT` case study below).
+
+## How it works: discard-and-stitch
+
+The decoder is convolutional. If you naively slice the latent `z` on the time
+axis and decode each slice, the **edges** of every chunk are contaminated
+(~16-19 frames deep) because the convolutions near the boundary are missing
+their neighbours. A crossfade between chunks does *not* fix this — the error is
+in the samples, not the seam.
+
+The fix is **discard-and-stitch**: decode each chunk with a *context margin* of
+`M` extra frames on both sides, then throw the contaminated margins away and
+keep only the clean middle. Because the kept region had full convolutional
+context, it is **bit-identical** to a one-shot decode. Concatenating the clean
+middles reproduces the exact one-shot audio, seam-free.
+
+```
+latent frames:  ....[  margin | KEEP  | margin ]....
+decode this span --------^                ^------ discard both margins
+```
+
+## ONNX interface
+
+**Encoder** (the primary session), runs once per sentence:
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| `input` | int64 | `[B, T]` | Phoneme IDs |
+| `input_lengths` | int64 | `[B]` | Sequence length |
+| `scales` | float32 | `[3]` | `[noise_scale, length_scale, noise_w]` |
+| `sid` | int64 | `[B]` | Speaker ID (multi-speaker only) |
+| → `z` | float32 | `[B, 192, T]` | Latent sequence |
+| → `y_mask` | float32 | `[B, 1, T]` | Frame mask |
+
+**Decoder** (auxiliary graph), run once per chunk:
+
+| Name | Type | Shape | Description |
+|------|------|-------|-------------|
+| `z` | float32 | `[B, 192, T_slice]` | Latent slice (with margins) |
+| `y_mask` | float32 | `[B, 1, T_slice]` | Matching mask slice |
+| → `output` | float32 | `[B, 1, N]` or `[N]` | Waveform samples |
+
+The **hop length** (decoder samples per latent frame, almost always 256) is read
+from the config if present, otherwise measured from the first decode.
+
+## Loading a streaming voice
+
+Point the config at the two graphs via `engine_params`. The primary model path
+is the **encoder**; the decoder is an auxiliary graph:
+
+```json
+{
+    "streaming": true,
+    "engine": "vits_streaming",
+    "engine_params": {
+        "decoder_path": "decoder.onnx"
+    },
+    "inference": { "noise_scale": 0.667, "length_scale": 1.0, "noise_w": 0.8 }
+}
+```
+
+```python
+from phoonnx import TTSVoice
+voice = TTSVoice.load(model_path="encoder.onnx")  # config sits next to it
+```
+
+Detection is strict: the adapter claims a voice **only** when `"streaming": true`
+*and* `engine_params.decoder_path` are both present, so it never hijacks a normal
+single-graph voice.
+
+## Parameters
+
+All streaming parameters live under `engine_params.streaming` and have proven
+defaults — you only set them to tune. They were tuned empirically on high-tier
+voices (see [Tuning notes](#tuning-notes)).
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `context_margin` | 32 | `M`: frames of context decoded and discarded each side. **Safe on every voice tested.** 24 usually works and is ~6% faster; 16 corrupts edges. |
+| `first_chunk` | 8 | Frames in the first chunk. Smaller → lower TTFA. |
+| `next_chunk` | 160 | Frames per subsequent chunk. Balances per-chunk overhead vs. throughput. |
+| `fallback_frames` | 128 | Sentences this short or shorter are decoded one-shot (streaming can't help). |
+| `intra_op_num_threads` | `cores / 2` | onnxruntime threads for the decoder. See below. |
+
+## Tuning notes
+
+These defaults come from measurements on `en_US-lessac+RT-high` (a heavy
+high-tier decoder — the worst case for latency). Your mileage varies with model
+size and CPU, but the *shape* of the results is general.
+
+**Time-to-first-audio wins scale with sentence length.** Streaming pays off more
+the longer the sentence, because a one-shot decode has to finish the whole thing
+before any audio plays:
+
+| Sentence | one-shot TTFA | streaming TTFA | speedup |
+|----------|---------------|----------------|---------|
+| short (~1.3 s audio) | 1399 ms | 1382 ms | 1.0x (falls back) |
+| mid (~3.9 s) | 3342 ms | 1552 ms | 2.2x |
+| long (~11.7 s) | 4801 ms | 1965 ms | 2.4x |
+
+**Thread count.** onnxruntime defaults to using *all* logical cores, which
+measured **slower** on the heavy decoder — thread-coordination overhead and
+contention. On an 8-core machine, 4 threads was optimal; 8 was worse than 4 on
+both encoder and decoder. The default is therefore `cores / 2`. Override with
+`engine_params.intra_op_num_threads` if profiling says otherwise.
+
+**Context margin.** `M = 32` was bit-identical (float noise, maxabs ~3e-6) on
+every voice tested. `M = 24` was also bit-identical on lessac/libritts and ~6%
+faster, but on some models (e.g. the Claudio NL/EN voice) 24 left a tiny audible
+residual, so **32 is the conservative default**. `M = 16` visibly corrupts the
+audio (maxabs ~3e-3). If you lower `M`, verify with the maxabs check below.
+
+**Pipelining does not help.** Running the encoder for sentence N+1 while
+decoding sentence N was tested and *hurt* TTFA (the encoder thread steals cores
+from the decoder that is producing the first chunk). It is deliberately not
+implemented.
+
+## The `ryan+RT` case study: verify your split models
+
+Not every published `+RT` voice is correct. `en_US-ryan+RT-medium` produces
+**visibly wrong prosody** — stress lands too early (e.g. "COOL and calm" instead
+of "cool and CALM"). Investigation showed:
+
+- The phonemization is **correct** — espeak places the stress marks right.
+- The streaming split is **not** at fault — discard-and-stitch is bit-identical
+  to a one-shot decode of the same model.
+- The `+RT` model's **duration predictor** produces durations ~12% shorter than
+  the original `ryan-high` model, *deterministically* (same difference with
+  `noise_w = 0`). By contrast, `lessac+RT` and `libritts_r+RT` matched their
+  originals to **0.0%**.
+
+The root cause: `ryan` was trained with **piper 0.2.0** (PyTorch 1.11), then
+converted through the newer **piper 1.0.0** (PyTorch 2.2) export used for the
+`+RT` set. The duration predictor did not survive that version jump cleanly.
+`lessac`/`libritts` were already 1.0.0, so their re-export was clean.
+
+**Lessons:**
+
+- Streaming and the encoder/decoder split are prosody-neutral. If a `+RT` voice
+  sounds wrong, suspect the **export**, not the streaming.
+- Do not mix piper versions: export `+RT` models from a checkpoint whose piper
+  version matches the export pipeline.
+- **Always verify a split model** after exporting or before trusting a
+  downloaded one.
+
+## Verifying an exported split model
+
+Two checks catch the two failure modes.
+
+**1. Streaming is lossless** (the split + discard-and-stitch reproduce a one-shot
+decode). Encode once, then compare a full decode against the chunked decode of
+the *same* `z` (the encoder samples noise internally, so you must reuse one `z`):
+
+```python
+import numpy as np, onnxruntime as ort
+enc = ort.InferenceSession("encoder.onnx"); dec = ort.InferenceSession("decoder.onnx")
+z, ym = enc.run(["z", "y_mask"], feed)              # ONE encode
+ref = dec.run(["output"], {"z": z, "y_mask": ym})[0].squeeze()   # one-shot
+# ... run the discard-and-stitch loop over the same z, M=32 ...
+assert np.abs(stream[:len(ref)] - ref).max() < 1e-4   # float noise only
+```
+
+**2. The split preserves prosody** (duration predictor unchanged vs. the original
+single-graph model). With `noise_w = 0` (deterministic), the frame count `T`
+from the split encoder must match the original model's:
+
+```python
+# split:    z, _ = enc.run([...], scales=[0.667, 1.0, 0.0]); T_split = z.shape[2]
+# original: audio = original_voice(...); T_orig = len(audio) // hop
+assert T_split == T_orig    # a >1-2% difference means the export drifted (see ryan+RT)
+```
+
+## See also
+
+- [engines.md](./engines.md) — the adapter registry and auto-detection
+- [configuration.md](./configuration.md) — voice config schema

--- a/phoonnx/cli.py
+++ b/phoonnx/cli.py
@@ -30,8 +30,8 @@ def cli():
 @click.option("--no-clear", is_flag=True, help="Do not clear the existing cache before updating. Only adds new voices.")
 def update_cache(no_clear):
     """
-    Clears the local voice cache, fetches the latest voice lists from upstream
-    sources (Piper, Mimic3, OpenVoiceOS), and saves them to the cache.
+    Clears the local voice cache, loads the bundled voice indexes (Piper,
+    Mimic3, OpenVoiceOS, etc.), and saves them to the cache.
     """
     manager = TTSModelManager()
 
@@ -42,29 +42,14 @@ def update_cache(no_clear):
         click.echo("Loading existing voice cache...")
         manager.load()
 
-    click.echo("Fetching voice lists from upstream sources (this requires an internet connection)...")
+    click.echo("Loading bundled voice indexes...")
 
-    # Run the fetch methods to populate the cache
     try:
-        manager.get_ovos_voice_list()
-        click.echo("-> Fetched OpenVoiceOS voices.")
-        manager.get_proxectonos_voice_list()
-        click.echo("-> Fetched Proxectonos voices.")
-        manager.get_phonikud_voice_list()
-        click.echo("-> Fetched Phonikud voices.")
-        manager.get_piper_voice_list()
-        click.echo("-> Fetched Piper voices.")
-        manager.get_mimic3_voice_list()
-        click.echo("-> Fetched Mimic3 voices.")
-    except requests.exceptions.RequestException as e:
-        click.echo(f"\nError: Could not fetch voice lists due to a network or connection error.", err=True)
-        click.echo(f"Details: {e}", err=True)
-        return
+        manager.merge_default_voices(store=True)
     except Exception as e:
-        click.echo(f"An unexpected error occurred while fetching voice lists: {e}", err=True)
+        click.echo(f"An unexpected error occurred while loading voice lists: {e}", err=True)
         return
 
-    manager.save()
     click.echo(f"\nCache updated successfully!")
     click.echo(f"Total voices available: {len(manager.all_voices)}")
     click.echo(f"Total languages supported: {len(manager.supported_langs)}")
@@ -119,60 +104,56 @@ def list_voices(lang, verbose):
 @cli.command(name="list-available")
 def list_available():
     """
-    Lists all voice IDs available from upstream sources (Piper, Mimic3, etc.),
-    even if they are not yet in the local cache. (Requires network connection)
+    Lists all voice IDs bundled with phoonnx, grouped by source (Piper,
+    Mimic3, OVOS, etc.), without downloading any config or model files.
+    Use 'download <VOICE_ID>' to fetch a specific voice on demand.
     """
     manager = TTSModelManager()
-    
-    click.echo("Fetching all available voice IDs from upstream sources (Piper, Mimic3, OVOS, etc.)...")
-    
-    try:
-        available_voices = manager.get_all_available_voice_ids()
-    except requests.exceptions.RequestException as e:
-        click.echo(f"\nError: Could not fetch available voice lists due to a network or connection error.", err=True)
-        click.echo(f"Details: {e}", err=True)
-        return
-    except Exception as e:
-        click.echo(f"An unexpected error occurred while fetching available voice lists: {e}", err=True)
-        return
+
+    available_voices = manager.get_available_voice_ids_by_source()
 
     total_voices = sum(len(ids) for ids in available_voices.values())
-    click.echo(f"\nTotal available voices found (from all sources): {total_voices}\n")
-    
+    click.echo(f"\nTotal available voices found (bundled indexes): {total_voices}\n")
+
     for source, voice_ids in available_voices.items():
         click.echo(f"--- {source.upper()} Voices ({len(voice_ids)}) ---")
         for voice_id in voice_ids:
             click.echo(f"  {voice_id}")
         click.echo("-" * 40)
-    click.echo("Hint: Use 'update-cache' to download the configuration for these voices, or use 'download <VOICE_ID>' to download a specific voice directly.")
+    click.echo("Hint: Use 'update-cache' to populate the local cache, or use 'download <VOICE_ID>' to download a specific voice directly.")
 
 @cli.command(name="download")
 @click.argument("voice_id", type=str)
 def download_voice(voice_id):
     """
     Downloads the model, config, and token files for a specific VOICE_ID.
-    The VOICE_ID must exist in the local cache (run update-cache first).
+    Looks the voice up in the local cache first (run update-cache to
+    populate it); if it isn't cached yet, falls back to the bundled
+    voice indexes so a single voice can be downloaded on demand, without
+    having to load the whole catalog first.
     """
     manager = TTSModelManager()
     manager.load()
 
-    if voice_id not in manager.voices:
-        click.echo(f"Error: Voice ID '{voice_id}' not found in cache.", err=True)
-        click.echo("Hint: Run 'phoonnx_cli.py update-cache' first to fetch the list.", err=True)
-        return
-
-    # NOTE: metadata already downloaded when creating VoiceInfo object
-    #  we only need to download the .onnx file
-    voice_info = manager.voices[voice_id]
+    voice_info = manager.voices.get(voice_id)
 
     try:
-        click.echo(f"Attempting to download files for: {voice_id} ({voice_info.lang})")
+        if voice_info:
+            click.echo(f"Attempting to download files for: {voice_id} ({voice_info.lang})")
 
-        # Download model (model.onnx)
-        click.echo("-> Downloading ONNX model (this may take a while)...")
-        voice_info.download_model()
+            # NOTE: metadata already downloaded when creating VoiceInfo object
+            #  we only need to download the .onnx file
+            click.echo("-> Downloading ONNX model (this may take a while)...")
+            voice_info.download_model()
 
-        click.echo(f"\nDownload complete. Files saved to: {voice_info.voice_path}")
+            click.echo(f"\nDownload complete. Files saved to: {voice_info.voice_path}")
+        else:
+            click.echo(f"Voice ID '{voice_id}' not found in local cache, looking it up in bundled indexes...")
+            if not manager.download_voice_by_id(voice_id):
+                click.echo(f"Error: Voice ID '{voice_id}' not found.", err=True)
+                click.echo("Hint: Run 'phoonnx_cli.py list-available' to see available voice IDs.", err=True)
+                return
+            click.echo(f"\nDownload complete.")
 
     except requests.exceptions.RequestException as e:
         click.echo(f"\nDownload failed due to network error: {e}", err=True)

--- a/phoonnx/cli.py
+++ b/phoonnx/cli.py
@@ -7,6 +7,8 @@ import requests
 def print_voice_info(voice: TTSModelInfo):
     """Prints detailed info about a single voice."""
     click.echo(f"  ID:          {voice.voice_id}")
+    if voice.display_name:
+        click.echo(f"  Name:        {voice.display_name}")
     click.echo(f"  Language:    {voice.lang}")
     click.echo(f"  Engine:      {voice.engine.value}")
     click.echo(f"  Phoneme Type: {voice.phoneme_type}")
@@ -82,7 +84,6 @@ def list_langs():
     for l in manager.supported_langs:
         click.echo(f" - {l}")
 
-
 @cli.command(name="list-voices")
 @click.option("--lang", default=None, help="Filter voices by language code (e.g., 'en-US' or 'pt-PT').")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed information for each voice.")
@@ -110,8 +111,40 @@ def list_voices(lang, verbose):
         if verbose:
             print_voice_info(voice)
         else:
-            click.echo(f"* {voice.voice_id} ({voice.lang})")
+            if voice.display_name:
+                click.echo(f"* {voice.display_name} ({voice.lang})")
+            else:
+                click.echo(f"* {voice.voice_id} ({voice.lang})")
 
+@cli.command(name="list-available")
+def list_available():
+    """
+    Lists all voice IDs available from upstream sources (Piper, Mimic3, etc.),
+    even if they are not yet in the local cache. (Requires network connection)
+    """
+    manager = TTSModelManager()
+    
+    click.echo("Fetching all available voice IDs from upstream sources (Piper, Mimic3, OVOS, etc.)...")
+    
+    try:
+        available_voices = manager.get_all_available_voice_ids()
+    except requests.exceptions.RequestException as e:
+        click.echo(f"\nError: Could not fetch available voice lists due to a network or connection error.", err=True)
+        click.echo(f"Details: {e}", err=True)
+        return
+    except Exception as e:
+        click.echo(f"An unexpected error occurred while fetching available voice lists: {e}", err=True)
+        return
+
+    total_voices = sum(len(ids) for ids in available_voices.values())
+    click.echo(f"\nTotal available voices found (from all sources): {total_voices}\n")
+    
+    for source, voice_ids in available_voices.items():
+        click.echo(f"--- {source.upper()} Voices ({len(voice_ids)}) ---")
+        for voice_id in voice_ids:
+            click.echo(f"  {voice_id}")
+        click.echo("-" * 40)
+    click.echo("Hint: Use 'update-cache' to download the configuration for these voices, or use 'download <VOICE_ID>' to download a specific voice directly.")
 
 @cli.command(name="download")
 @click.argument("voice_id", type=str)

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -115,6 +115,7 @@ def list_engines() -> List[str]:
 
 def _register_builtins() -> None:
     from phoonnx.engines.vits import VitsAdapter
+    from phoonnx.engines.vits_streaming import VitsStreamingAdapter
     from phoonnx.engines.shami import ShamiAdapter
     from phoonnx.engines.matcha import MatchaAdapter
     from phoonnx.engines.optispeech import OptiSpeechAdapter
@@ -131,6 +132,10 @@ def _register_builtins() -> None:
     # a distinctive metadata + wav/durations output signature — check it first.
     register_engine("optispeech", OptiSpeechAdapter, detect_priority=35)
     register_engine("shami", ShamiAdapter, detect_priority=45)
+    # Streaming VITS must be probed *before* the plain VITS adapter: it only
+    # matches split models (streaming:true + decoder_path), so it never steals a
+    # normal single-graph voice, but a normal VITS voice must not steal a split one.
+    register_engine("vits_streaming", VitsStreamingAdapter, detect_priority=48)
     register_engine("vits", VitsAdapter, detect_priority=50)
     register_engine("matcha", MatchaAdapter, detect_priority=40)
     register_engine("glowtts", GlowTTSAdapter, detect_priority=42)

--- a/phoonnx/engines/vits_split.py
+++ b/phoonnx/engines/vits_split.py
@@ -95,7 +95,13 @@ def ensure_split_vits(model_path: str, force: bool = False) -> Tuple[str, str]:
     if not force and encoder_path.is_file() and decoder_path.is_file():
         return str(encoder_path), str(decoder_path)
 
-    import onnx  # local import: onnx (the full package) is only needed to split
+    try:
+        import onnx  # the full onnx package (not just onnxruntime) does surgery
+    except ImportError as e:
+        raise ImportError(
+            "auto-splitting a VITS model needs the 'onnx' package; install it "
+            "with `pip install phoonnx[streaming]` (or use a pre-split '+RT' "
+            "voice, which streams without it)") from e
 
     model = onnx.load(model_path)
     output_name = model.graph.output[0].name

--- a/phoonnx/engines/vits_split.py
+++ b/phoonnx/engines/vits_split.py
@@ -1,0 +1,121 @@
+"""Split a monolithic VITS/Piper ONNX graph into an encoder/decoder pair.
+
+A standard Piper/VITS export is a **single** graph: phoneme IDs -> waveform. The
+:class:`~phoonnx.engines.vits_streaming.VitsStreamingAdapter` needs two graphs so
+it can decode a sentence in chunks. Re-exporting from the PyTorch checkpoint is
+the usual way to get them, but it is risky: a version mismatch in the export
+pipeline can silently corrupt the duration predictor (see the ``ryan+RT`` case
+study in ``docs/streaming.md``).
+
+This module avoids re-export entirely. VITS has one natural cut point -- the
+input to the HiFiGAN waveform decoder, which is ``(z * y_mask)`` of shape
+``[B, 192, T]``. Everything before it (text encoder, duration predictor, flow,
+length regulation, mask multiply) is the *encoder*; the HiFiGAN generator is the
+*decoder*. Cutting the ONNX graph there with :func:`onnx.utils.extract_model`
+produces two subgraphs that are **the same ops as the original** -- so the split
+is lossless by construction and cannot introduce prosody drift.
+
+Because the cut tensor is already masked, the decoder subgraph needs only that
+single latent input (plus the speaker id on multi-speaker models, which
+``extract_model`` pulls in automatically). The encoder subgraph keeps the
+model's original inputs and emits the cut tensor as its sole output.
+"""
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from ovos_utils.log import LOG
+
+# 192 == VITS ``inter_channels``: the channel count of the latent z that the
+# HiFiGAN decoder consumes. The flow's WN layers also carry 192-channel convs,
+# so the decoder entry is disambiguated by name (below), not by channel count
+# alone.
+_INTER_CHANNELS = 192
+# Name fragments that mark the HiFiGAN generator entry conv across the piper /
+# coqui / vits export lineages seen in the wild.
+_DECODER_NAME_HINTS = ("waveform_decoder", "/dec/", "dec.", "conv_pre", "generator")
+
+
+def _find_cut_tensor(model) -> str:
+    """Return the name of the ``(z * y_mask)`` tensor that feeds the decoder.
+
+    Strategy: among all ``Conv`` nodes whose weight has ``in_channels == 192``
+    (candidate ``conv_pre`` of the HiFiGAN decoder *and* the flow WN layers),
+    keep the ones that are **not** inside the flow (``/flow/``) and whose name
+    looks like the waveform decoder. The data input of that conv is the cut.
+    """
+    init = {i.name: tuple(i.dims) for i in model.graph.initializer}
+    candidates: List[Tuple[str, str]] = []  # (node_name, data_input)
+    for node in model.graph.node:
+        if node.op_type != "Conv" or len(node.input) < 2:
+            continue
+        weight = init.get(node.input[1])
+        if not weight or len(weight) != 3 or weight[1] != _INTER_CHANNELS:
+            continue
+        if "/flow/" in node.name or ".flow." in node.name:
+            continue  # flow coupling layers, not the decoder
+        candidates.append((node.name, node.input[0]))
+
+    if not candidates:
+        raise ValueError(
+            "Could not locate the VITS decoder entry (no non-flow Conv with "
+            f"{_INTER_CHANNELS} input channels). This does not look like a "
+            "splittable VITS/Piper model.")
+
+    # Prefer a candidate whose name matches a known decoder hint; otherwise the
+    # single remaining non-flow 192-in conv is the decoder entry.
+    for name, data_input in candidates:
+        if any(hint in name for hint in _DECODER_NAME_HINTS):
+            return data_input
+    if len(candidates) == 1:
+        return candidates[0][1]
+    raise ValueError(
+        "Ambiguous VITS decoder entry; candidates: "
+        f"{[c[0] for c in candidates]}. Cannot auto-split safely.")
+
+
+def split_paths(model_path: str) -> Tuple[Path, Path]:
+    """Return the ``(encoder, decoder)`` paths this splitter writes for a model
+    (siblings of the model, ``<stem>.encoder.onnx`` / ``<stem>.decoder.onnx``)."""
+    p = Path(model_path)
+    stem = p.name[:-len(".onnx")] if p.name.endswith(".onnx") else p.stem
+    return p.with_name(f"{stem}.encoder.onnx"), p.with_name(f"{stem}.decoder.onnx")
+
+
+def ensure_split_vits(model_path: str, force: bool = False) -> Tuple[str, str]:
+    """Split ``model_path`` into an encoder/decoder pair, caching the result.
+
+    Idempotent: if both split files already sit next to the model they are
+    reused (this is a one-time cost, not a per-load one). Returns the
+    ``(encoder_path, decoder_path)`` as strings.
+
+    Raises ``ValueError`` if the model is not a splittable single-graph VITS.
+    """
+    encoder_path, decoder_path = split_paths(model_path)
+    if not force and encoder_path.is_file() and decoder_path.is_file():
+        return str(encoder_path), str(decoder_path)
+
+    import onnx  # local import: onnx (the full package) is only needed to split
+
+    model = onnx.load(model_path)
+    output_name = model.graph.output[0].name
+    cut = _find_cut_tensor(model)
+    LOG.info(f"Splitting VITS model {os.path.basename(model_path)} at '{cut}' "
+             f"-> {encoder_path.name} + {decoder_path.name}")
+
+    # Shape inference populates intermediate value_info so extract_model can wire
+    # the boundary tensor; the strict checker is skipped because a mid-graph cut
+    # legitimately leaves some dynamic dims without a static shape.
+    inferred = onnx.shape_inference.infer_shapes(model)
+    tmp = str(Path(model_path).with_suffix(".inferred.onnx"))
+    onnx.save(inferred, tmp)
+    try:
+        input_names = [i.name for i in model.graph.input]
+        onnx.utils.extract_model(tmp, str(encoder_path), input_names, [cut],
+                                 check_model=False)
+        onnx.utils.extract_model(tmp, str(decoder_path), [cut], [output_name],
+                                 check_model=False)
+    finally:
+        if os.path.isfile(tmp):
+            os.remove(tmp)
+    return str(encoder_path), str(decoder_path)

--- a/phoonnx/engines/vits_streaming.py
+++ b/phoonnx/engines/vits_streaming.py
@@ -1,0 +1,250 @@
+"""Streaming VITS inference adapter (split encoder/decoder).
+
+Standard Piper/VITS models are a **single** ONNX graph: phoneme IDs → waveform.
+A *streaming* VITS model is published as **two** ONNX graphs so that audio can be
+produced incrementally, lowering time-to-first-audio:
+
+1. **Encoder** — phoneme IDs → latent ``z`` [B, 192, T] and ``y_mask`` [B, 1, T].
+   Runs **once** per sentence. Samples the duration/noise internally.
+2. **Decoder** — a slice of ``z`` (+ ``y_mask``) → waveform for that slice.
+   Run **repeatedly** over the time axis, streaming chunks of audio.
+
+These are the Sonata "+RT" fast voices (config carries ``"streaming": true``),
+or any model exported with a split encoder/decoder. A combined single-graph model
+CANNOT stream — use the plain :class:`VitsAdapter` for those.
+
+The decoder is convolutional, so naively slicing ``z`` on the time axis
+contaminates the chunk edges (~16-19 frames deep). This adapter therefore uses
+**discard-and-stitch**: each chunk is decoded with a context margin of ``M``
+frames on both sides, the contaminated margins are discarded, and only the clean
+middle is kept. The stitched result is bit-identical to a one-shot decode.
+
+engine_params (in the voice config)::
+
+    "engine_params": {
+        "decoder_path": "decoder.onnx",   # required: the second graph
+        "streaming": {                     # optional: all have proven defaults
+            "context_margin": 32,          # M: frames of context each side
+            "first_chunk": 8,              # frames in the first (latency) chunk
+            "next_chunk": 160,             # frames per subsequent chunk
+            "fallback_frames": 128         # <= this many frames: one-shot decode
+        }
+    }
+
+ONNX interface (encoder = primary session):
+  IN  ``input``         int64    [B, T]   phoneme IDs
+      ``input_lengths`` int64    [B]
+      ``scales``        float32  [3]      [noise_scale, length_scale, noise_w]
+      ``sid``           int64    [B]      speaker ID (multi-speaker only)
+  OUT ``z``             float32  [B, 192, T]
+      ``y_mask``        float32  [B, 1, T]
+
+ONNX interface (decoder = auxiliary graph):
+  IN  ``z``             float32  [B, 192, T_slice]
+      ``y_mask``        float32  [B, 1, T_slice]
+  OUT ``output``        float32  [B, 1, N] or [N]   waveform samples
+"""
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+
+from phoonnx.engines.base import (
+    AdapterSynthesisRequest,
+    AdapterSynthesisResult,
+    BaseOnnxAdapter,
+)
+
+
+# Proven defaults from empirical tuning (see docs/streaming.md):
+#   context_margin=32  bit-identical on every voice tested (24 often works and is
+#                      ~6% faster, but 16 corrupts edges — 32 is the safe default).
+#   first_chunk=8      small first slice → lowest time-to-first-audio.
+#   next_chunk=160     balances per-chunk overhead against throughput.
+#   fallback_frames=128 short sentences decode one-shot (streaming can't help).
+_DEFAULT_STREAMING = {
+    "context_margin": 32,
+    "first_chunk": 8,
+    "next_chunk": 160,
+    "fallback_frames": 128,
+}
+
+
+class VitsStreamingAdapter(BaseOnnxAdapter):
+    """Adapter for split-graph (streaming) VITS models.
+
+    The primary ``session`` is the **encoder**; the **decoder** is loaded as an
+    auxiliary graph from ``engine_params["decoder_path"]``. ``synthesize`` is
+    overridden to run the discard-and-stitch chunk loop instead of a single
+    ``session.run``.
+    """
+
+    def __init__(self, decoder_session: Optional[onnxruntime.InferenceSession] = None):
+        self.decoder = decoder_session
+        self._engine_params: Dict[str, Any] = {}
+        self._streaming: Dict[str, int] = dict(_DEFAULT_STREAMING)
+        self._hop_length: Optional[int] = None  # resolved from config or measured
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def configure(self, voice_config: Any) -> None:
+        """Load the decoder graph and streaming parameters from the voice config."""
+        engine_params = getattr(voice_config, "engine_params", None) or {}
+        self.configure_from_params(engine_params)
+        hop = getattr(voice_config, "hop_length", None)
+        if hop:
+            self._hop_length = int(hop)
+
+    def configure_from_params(self, engine_params: Dict[str, Any]) -> None:
+        self._engine_params = engine_params or {}
+        user_streaming = self._engine_params.get("streaming") or {}
+        if isinstance(user_streaming, dict):
+            self._streaming = {**_DEFAULT_STREAMING, **user_streaming}
+        threads = self._engine_params.get("intra_op_num_threads")
+        decoder_path = self._engine_params.get("decoder_path")
+        if self.decoder is None and decoder_path:
+            self.decoder = self._build_decoder(decoder_path, threads)
+
+    @staticmethod
+    def _build_decoder(path: str, threads: Optional[int]) -> onnxruntime.InferenceSession:
+        import os
+        so = onnxruntime.SessionOptions()
+        if threads is None:
+            threads = max(1, (os.cpu_count() or 4) // 2)
+        so.intra_op_num_threads = int(threads)
+        so.inter_op_num_threads = 1
+        return onnxruntime.InferenceSession(path, so)
+
+
+    # ------------------------------------------------------------------
+    # Control parameters (shared with the plain VITS adapter)
+    # ------------------------------------------------------------------
+
+    def default_params(self) -> Dict[str, float]:
+        return {"noise_scale": 0.667, "length_scale": 1.0, "noise_w_scale": 0.8}
+
+    def parse_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        inference = config.get("inference", {})
+        defaults = self.default_params()
+        return {
+            "noise_scale": inference.get("noise_scale", defaults["noise_scale"]),
+            "length_scale": inference.get("length_scale", defaults["length_scale"]),
+            "noise_w_scale": inference.get("noise_w", defaults["noise_w_scale"]),
+        }
+
+    def param_labels(self) -> Dict[str, str]:
+        return {"noise_scale": "Noise scale",
+                "length_scale": "Length scale",
+                "noise_w_scale": "Noise W"}
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        """A streaming VITS model declares ``streaming: true`` and ships a decoder.
+        Both the config flag and a decoder graph are required — a bare
+        ``streaming`` flag on a single-graph model is not enough to stream."""
+        if not config:
+            return False
+        if not config.get("streaming"):
+            return False
+        engine_params = config.get("engine_params") or {}
+        return bool(engine_params.get("decoder_path"))
+
+    # ------------------------------------------------------------------
+    # Encoder feed (mirrors VitsAdapter.build_feed_dict, encoder outputs z/y_mask)
+    # ------------------------------------------------------------------
+
+    def build_feed_dict(self, request: AdapterSynthesisRequest,
+                        session: onnxruntime.InferenceSession) -> Dict[str, np.ndarray]:
+        params = request.params
+        d = self.default_params()
+        noise = np.float32(params.get("noise_scale", d["noise_scale"]))
+        length = np.float32(params.get("length_scale", d["length_scale"]))
+        noise_w = np.float32(params.get("noise_w_scale", d["noise_w_scale"]))
+        scales = np.array([noise, length, noise_w], dtype=np.float32)
+        rank = self._input_rank(session, "scales")
+        if rank is not None and rank >= 2:
+            scales = scales.reshape(1, -1)
+        args: Dict[str, np.ndarray] = {
+            "input": request.phoneme_ids,
+            "input_lengths": request.phoneme_lengths,
+            "scales": scales,
+        }
+        if request.speaker_id is not None:
+            args["sid"] = np.array([request.speaker_id], dtype=np.int64)
+        return self._filter_inputs(args, session)
+
+    def parse_outputs(self, outputs: List[np.ndarray],
+                      request: AdapterSynthesisRequest) -> AdapterSynthesisResult:
+        """Required by the base interface. Streaming synthesis is driven by
+        ``synthesize`` (which loops over the decoder), so this is only used if a
+        caller runs the encoder graph directly: it wraps the first output as audio."""
+        audio = np.asarray(outputs[0]).squeeze().astype(np.float32)
+        return AdapterSynthesisResult(audio=audio)
+
+
+    # ------------------------------------------------------------------
+    # Streaming synthesis: encode once, decode in discard-and-stitch chunks
+    # ------------------------------------------------------------------
+
+    def _resolve_hop(self, z_frames: int, sample_count: int) -> int:
+        """hop_length = decoder samples per latent frame. Prefer the configured
+        value; otherwise measure it from a one-shot decode (samples / frames)."""
+        if self._hop_length:
+            return self._hop_length
+        if z_frames > 0:
+            self._hop_length = max(1, round(sample_count / z_frames))
+        return self._hop_length or 256
+
+    def _decode(self, z: np.ndarray, y_mask: np.ndarray) -> np.ndarray:
+        out = self.decoder.run(["output"], {"z": z, "y_mask": y_mask})[0]
+        return np.asarray(out).squeeze()
+
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        if self.decoder is None:
+            raise RuntimeError(
+                "VitsStreamingAdapter has no decoder graph. Set "
+                "engine_params['decoder_path'] to the decoder .onnx.")
+
+        # 1) Encoder runs once, producing the full latent sequence.
+        feed = self.build_feed_dict(request, session)
+        z, y_mask = session.run(["z", "y_mask"], feed)
+        T = z.shape[2]
+
+        M = self._streaming["context_margin"]
+        first = self._streaming["first_chunk"]
+        nxt = self._streaming["next_chunk"]
+        fallback = self._streaming["fallback_frames"]
+
+        # 2) Short sentence: one-shot decode (streaming overhead can't pay off).
+        if T <= fallback:
+            audio = self._decode(z, y_mask)
+            self._resolve_hop(T, len(audio))
+            return AdapterSynthesisResult(audio=audio.astype(np.float32))
+
+        # 3) Determine hop from a throwaway measure only if unknown. We avoid an
+        #    extra full decode: use the first chunk to establish hop.
+        segments: List[np.ndarray] = []
+        start = 0
+        is_first = True
+        hop = self._hop_length or 256
+        while start < T:
+            size = first if is_first else nxt
+            end = min(start + size, T)
+            a = max(0, start - M)
+            b = min(T, end + M)
+            chunk_audio = self._decode(z[:, :, a:b], y_mask[:, :, a:b])
+            if is_first and not self._hop_length:
+                # first full-context decode lets us pin hop precisely
+                hop = self._resolve_hop(b - a, len(chunk_audio))
+            lo = (start - a) * hop
+            hi = min(lo + (end - start) * hop, len(chunk_audio))
+            segments.append(chunk_audio[lo:hi])
+            is_first = False
+            start = end
+
+        audio = np.concatenate(segments).astype(np.float32)
+        return AdapterSynthesisResult(audio=audio)

--- a/phoonnx/engines/vits_streaming.py
+++ b/phoonnx/engines/vits_streaming.py
@@ -198,8 +198,53 @@ class VitsStreamingAdapter(BaseOnnxAdapter):
             self._hop_length = max(1, round(sample_count / z_frames))
         return self._hop_length or 256
 
-    def _decode(self, z: np.ndarray, y_mask: np.ndarray) -> np.ndarray:
-        out = self.decoder.run(["output"], {"z": z, "y_mask": y_mask})[0]
+    @staticmethod
+    def _run_encoder(session: onnxruntime.InferenceSession,
+                     feed: Dict[str, np.ndarray]) -> tuple:
+        """Run the encoder and return ``(z, y_mask)``.
+
+        Two encoder interfaces exist: the pre-split "+RT" voices name their
+        outputs ``z`` / ``y_mask``; an auto-split encoder (cut at the already-
+        masked ``z * y_mask``) has a single, arbitrarily-named latent output and
+        no separate mask. Outputs are therefore matched by name first, then by
+        shape (``[B, 192, T]`` latent vs. ``[B, 1, T]`` mask). ``y_mask`` is
+        ``None`` when the encoder does not expose one."""
+        names = [o.name for o in session.get_outputs()]
+        outs = session.run(None, feed)
+        by_name = dict(zip(names, outs))
+        if "z" in by_name:
+            return by_name["z"], by_name.get("y_mask")
+        z = None
+        y_mask = None
+        for arr in outs:
+            a = np.asarray(arr)
+            if a.ndim == 3 and a.shape[1] == 1 and y_mask is None:
+                y_mask = a
+            elif a.ndim == 3 and a.shape[1] > 1 and z is None:
+                z = a
+        return (z if z is not None else np.asarray(outs[0])), y_mask
+
+    def _decode(self, z: np.ndarray, y_mask: Optional[np.ndarray],
+                speaker_id: Optional[int]) -> np.ndarray:
+        """Feed one latent chunk to the decoder, matching whatever inputs it
+        declares (single-tensor auto-split, ``z``+``y_mask`` +RT, or a
+        multi-speaker decoder that also wants ``sid``)."""
+        feed: Dict[str, np.ndarray] = {}
+        for inp in self.decoder.get_inputs():
+            shape = inp.shape or []
+            second = shape[1] if len(shape) > 1 else None
+            name = inp.name
+            if name in ("sid", "spk", "spks", "g", "speaker", "speaker_id"):
+                if speaker_id is not None:
+                    feed[name] = np.array([speaker_id], dtype=np.int64)
+            elif name == "y_mask" or (len(shape) == 3 and second == 1):
+                feed[name] = (y_mask if y_mask is not None
+                              else np.ones((z.shape[0], 1, z.shape[2]), dtype=np.float32))
+            else:
+                # any other input is the latent: covers a single arbitrarily-named
+                # auto-split tensor, "z", and inputs whose shape is unknown.
+                feed[name] = z
+        out = self.decoder.run(None, feed)[0]
         return np.asarray(out).squeeze()
 
     def synthesize(self, request: AdapterSynthesisRequest,
@@ -211,7 +256,8 @@ class VitsStreamingAdapter(BaseOnnxAdapter):
 
         # 1) Encoder runs once, producing the full latent sequence.
         feed = self.build_feed_dict(request, session)
-        z, y_mask = session.run(["z", "y_mask"], feed)
+        z, y_mask = self._run_encoder(session, feed)
+        sid = request.speaker_id
         T = z.shape[2]
 
         M = self._streaming["context_margin"]
@@ -221,7 +267,7 @@ class VitsStreamingAdapter(BaseOnnxAdapter):
 
         # 2) Short sentence: one-shot decode (streaming overhead can't pay off).
         if T <= fallback:
-            audio = self._decode(z, y_mask)
+            audio = self._decode(z, y_mask, sid)
             self._resolve_hop(T, len(audio))
             return AdapterSynthesisResult(audio=audio.astype(np.float32))
 
@@ -236,7 +282,8 @@ class VitsStreamingAdapter(BaseOnnxAdapter):
             end = min(start + size, T)
             a = max(0, start - M)
             b = min(T, end + M)
-            chunk_audio = self._decode(z[:, :, a:b], y_mask[:, :, a:b])
+            ym_slice = y_mask[:, :, a:b] if y_mask is not None else None
+            chunk_audio = self._decode(z[:, :, a:b], ym_slice, sid)
             if is_first and not self._hop_length:
                 # first full-context decode lets us pin hop precisely
                 hop = self._resolve_hop(b - a, len(chunk_audio))

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -65,6 +65,10 @@ class TTSModelInfo:
     # token like "eg" is mapped here rather than derived from the (normalized) lang code.
     lang_tokens: Optional[Dict[str, str]] = None
 
+    # user-friendly name for UIs/CLIs; may contain "{engine}"/"{phoneme_type}"
+    # placeholders that get resolved once those fields are known
+    display_name: Optional[str] = None
+
     @property
     def config(self) -> VoiceConfig:
         # lazy loaded
@@ -163,6 +167,18 @@ class TTSModelInfo:
             self.alphabet = Alphabet(self.alphabet)
         if not isinstance(self.phoneme_type, PhonemeType) and isinstance(self.phoneme_type, str):
             self.phoneme_type = PhonemeType(self.phoneme_type)
+
+        # resolve "{engine}"/"{phoneme_type}" placeholders in display_name,
+        # if those fields are already known (avoids triggering a config
+        # download just to format a label)
+        if self.display_name and "{" in self.display_name:
+            try:
+                self.display_name = self.display_name.format(
+                    engine=self.engine.value if self.engine else "",
+                    phoneme_type=self.phoneme_type.value if self.phoneme_type else "",
+                )
+            except (AttributeError, KeyError):
+                LOG.warning(f"Could not format display_name for {self.voice_id}.")
 
     @property
     def voice_path(self) -> Path:
@@ -556,7 +572,8 @@ class TTSModelManager:
                                     "phoneme_map_url": voice_info.phoneme_map_url,
                                     "alphabet": voice_info.alphabet,
                                     "engine": voice_info.engine,
-                                    "config_url": voice_info.config_url}
+                                    "config_url": voice_info.config_url,
+                                    "display_name": voice_info.display_name}
         self.cache.store()
 
     def add_voice(self, voice_info: TTSModelInfo):
@@ -582,7 +599,8 @@ class TTSModelManager:
                                            "config_url": voice_info.config_url,
                                            "vocoder_url": voice_info.vocoder_url,
                                            "vocoder_config_url": voice_info.vocoder_config_url,
-                                           "vocoder_type": voice_info.vocoder_type}
+                                           "vocoder_type": voice_info.vocoder_type,
+                                           "display_name": voice_info.display_name}
 
     def get_lang_voices(self, lang: str) -> List[TTSModelInfo]:
         voices = sorted(
@@ -633,6 +651,82 @@ class TTSModelManager:
 
         if store:
             self.cache.store()
+
+    def get_available_voice_ids_by_source(self) -> Dict[str, List[str]]:
+        """
+        List all voice IDs bundled with phoonnx, grouped by source.
+
+        Reads the ``voice_index`` JSON files that ship with the package
+        directly (plain ``json.load``, no ``TTSModelInfo`` construction),
+        so this performs no network access and downloads no model/config
+        files - suitable for a quick "what's available" listing before
+        committing to downloading a specific voice via ``download_voice_by_id``.
+
+        Returns:
+            Dict[str, List[str]]: mapping of source name to sorted voice IDs.
+        """
+        base_path = Path(os.path.dirname(__file__)) / "voice_index"
+        sources = {
+            "ovos": "OVOS.json",
+            "mms": "MMS.json",
+            "proxectonos": "proxectonos.json",
+            "piper": "piper.json",
+            "piper_community": "piper_community.json",
+            "phonikud": "phonikud.json",
+            "neurlang": "neurlang.json",
+            "mimic3": "mimic3.json",
+            "transformers_community": "transformers_community.json",
+            "optispeech": "optispeech.json",
+            "glowtts": "glowtts.json",
+            "mixertts": "mixertts.json",
+            "fastpitch": "fastpitch.json",
+            "coqui_community": "coqui_community.json",
+            "vits2": "vits2.json",
+            "styletts2": "styletts2.json",
+            "coqui_vits": "coqui_vits.json",
+            "bsc": "BSC.json",
+        }
+        result: Dict[str, List[str]] = {}
+        for source, filename in sources.items():
+            path = base_path / filename
+            if not path.is_file():
+                continue
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            result[source] = sorted(data.keys())
+        return result
+
+    def download_voice_by_id(self, voice_id: str) -> bool:
+        """
+        Download a single voice's model (and side files) by its ID.
+
+        Looks the voice up in the in-memory registry first (populated via
+        ``load()``/``merge_default_voices()``); if not found there, falls
+        back to the bundled voice indexes so a voice can be downloaded
+        on-demand without first loading the full catalog into memory.
+
+        Returns:
+            bool: True if the voice was found and its download was attempted,
+            False if the voice ID could not be resolved.
+        """
+        voice_info = self.voices.get(voice_id)
+        if not voice_info:
+            base_path = Path(os.path.dirname(__file__)) / "voice_index"
+            for filename in os.listdir(base_path):
+                if not filename.endswith(".json"):
+                    continue
+                with open(base_path / filename, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if voice_id in data:
+                    voice_info = TTSModelInfo(**data[voice_id])
+                    break
+
+        if not voice_info:
+            LOG.error(f"Cannot find voice information for ID: {voice_id}")
+            return False
+
+        voice_info.download_model()
+        return True
 
 
 

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -247,6 +247,24 @@ class TTSVoice:
                     tokenizer_dict = json.load(tokenizer_file)
         resolved_providers = resolve_providers(providers, use_cuda=use_cuda)
 
+        # Auto-split: a voice may request streaming on a monolithic single-graph
+        # VITS model. When it declares "streaming": true but ships no decoder
+        # graph, split the model into an encoder/decoder pair on the fly (cached
+        # next to the model) so it can stream without a re-export. If the model
+        # is not a splittable VITS, fall back to loading it as a normal voice.
+        _cfg_ep = config_dict.get("engine_params") or {}
+        _has_decoder = _cfg_ep.get("decoder_path") or (engine_params or {}).get("decoder_path")
+        if config_dict.get("streaming") and not _has_decoder:
+            try:
+                from phoonnx.engines.vits_split import ensure_split_vits
+                enc_path, dec_path = ensure_split_vits(str(model_path))
+                model_path = enc_path
+                config_dict["engine_params"] = {**_cfg_ep, "decoder_path": dec_path}
+            except Exception as e:
+                LOG.warning(f"Streaming requested but auto-split of "
+                            f"'{model_path}' failed ({e}); loading as a normal "
+                            f"single-graph voice.")
+
         session = make_session(model_path, providers=resolved_providers)
 
         # Auto-detect engine adapter from config + session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy",
     "onnxruntime",
-    "onnx",
     "quebra-frases",
     "langcodes",
     "ovos-number-parser>=0.4.0",
@@ -46,7 +45,12 @@ test = [
     "euskaphone",
     "g2p_barranquenho",
     "mwl_phonemizer",
+    "onnx",
 ]
+# Load-time auto-split of a monolithic VITS model into a streaming
+# encoder/decoder pair. Only needed to CREATE a split; a pre-split ("+RT")
+# voice streams without it. Requires the full `onnx` package for graph surgery.
+streaming = ["onnx"]
 espeak = ["espyak>=0.0.2a1"]
 train = [
     "librosa>=0.9.2,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy",
     "onnxruntime",
+    "onnx",
     "quebra-frases",
     "langcodes",
     "ovos-number-parser>=0.4.0",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 onnxruntime
-onnx
 quebra-frases
 langcodes
 ovos-number-parser>=0.4.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 onnxruntime
+onnx
 quebra-frases
 langcodes
 ovos-number-parser>=0.4.0

--- a/tests/test_vits_split.py
+++ b/tests/test_vits_split.py
@@ -1,0 +1,100 @@
+"""Tests for the load-time VITS ONNX splitter (encoder/decoder surgery).
+
+These build a *minimal* synthetic graph shaped like the relevant part of a VITS
+export -- a pre-decoder tensor feeding the HiFiGAN ``conv_pre`` (a Conv with 192
+input channels) -- so the splitter's cut-point finder and ``extract_model``
+wiring are exercised deterministically, with no model download. The correctness
+bar is that encoder->decoder reproduces the monolithic graph's output exactly,
+which is the whole point of splitting instead of re-exporting.
+"""
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+from phoonnx.engines.vits_split import _find_cut_tensor, ensure_split_vits, split_paths
+
+
+def _decoder_conv_model(pre_conv_name="/waveform_decoder/conv_pre/Conv"):
+    """A tiny graph: input[1,192,T] -> Relu -> (cut) -> conv_pre(192->4) ->
+    conv_post(4->1) -> output[1,1,T]. The cut tensor is the Relu output that
+    feeds the 192-input conv, exactly as in a real VITS model."""
+    rng = np.random.default_rng(0)
+    w_pre = numpy_helper.from_array(
+        rng.standard_normal((4, 192, 1)).astype(np.float32), name="w_pre")
+    w_post = numpy_helper.from_array(
+        rng.standard_normal((1, 4, 1)).astype(np.float32), name="w_post")
+    inp = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 192, "T"])
+    out = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 1, "T"])
+    nodes = [
+        helper.make_node("Relu", ["input"], ["pre"], name="/pre/Relu"),
+        helper.make_node("Conv", ["pre", "w_pre"], ["h"], name=pre_conv_name),
+        helper.make_node("Conv", ["h", "w_post"], ["output"],
+                         name="/waveform_decoder/conv_post/Conv"),
+    ]
+    graph = helper.make_graph(nodes, "tiny_vits", [inp], [out], [w_pre, w_post])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_find_cut_tensor_locates_decoder_entry():
+    model = _decoder_conv_model()
+    assert _find_cut_tensor(model) == "pre"
+
+
+def test_find_cut_tensor_ignores_flow_convs():
+    """A 192-in conv inside the flow must not be mistaken for the decoder."""
+    model = _decoder_conv_model(pre_conv_name="/flow/flows.0/enc/Conv")
+    # only a flow conv carries 192 inputs -> no decoder entry -> not splittable
+    with pytest.raises(ValueError):
+        _find_cut_tensor(model)
+
+
+def test_find_cut_tensor_rejects_non_vits():
+    """A graph with no 192-input conv is not a splittable VITS."""
+    inp = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 8, "T"])
+    out = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 8, "T"])
+    node = helper.make_node("Relu", ["input"], ["output"], name="/Relu")
+    graph = helper.make_graph([node], "not_vits", [inp], [out])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 9
+    with pytest.raises(ValueError):
+        _find_cut_tensor(model)
+
+
+def test_split_is_lossless_and_cached(tmp_path):
+    model_path = tmp_path / "voice.onnx"
+    onnx.save(_decoder_conv_model(), str(model_path))
+
+    enc_path, dec_path = ensure_split_vits(str(model_path))
+    # paths are deterministic siblings of the model
+    exp_enc, exp_dec = split_paths(str(model_path))
+    assert (enc_path, dec_path) == (str(exp_enc), str(exp_dec))
+    assert exp_enc.is_file() and exp_dec.is_file()
+
+    full = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    enc = ort.InferenceSession(enc_path, providers=["CPUExecutionProvider"])
+    dec = ort.InferenceSession(dec_path, providers=["CPUExecutionProvider"])
+
+    # decoder takes exactly the single cut tensor; encoder emits it
+    assert [i.name for i in dec.get_inputs()] == ["pre"]
+    assert [o.name for o in enc.get_outputs()] == ["pre"]
+
+    x = np.random.default_rng(1).standard_normal((1, 192, 40)).astype(np.float32)
+    ref = full.run(None, {"input": x})[0]
+    cut = enc.run(None, {"input": x})[0]
+    got = dec.run(None, {"pre": cut})[0]
+    assert np.array_equal(got, ref)  # split == monolithic, bit-for-bit
+
+
+def test_ensure_split_reuses_cache(tmp_path):
+    model_path = tmp_path / "voice.onnx"
+    onnx.save(_decoder_conv_model(), str(model_path))
+    enc1, dec1 = ensure_split_vits(str(model_path))
+    # delete the source model: a genuine cache hit must not need it anymore
+    model_path.unlink()
+    enc2, dec2 = ensure_split_vits(str(model_path))
+    assert (enc1, dec1) == (enc2, dec2)

--- a/tests/test_vits_streaming.py
+++ b/tests/test_vits_streaming.py
@@ -1,0 +1,196 @@
+"""Unit tests for the streaming (split encoder/decoder) VITS adapter.
+
+The headline correctness property is *discard-and-stitch losslessness*: decoding
+a latent ``z`` in overlapping chunks, discarding the context margins and
+concatenating the clean middles, must reproduce a one-shot decode of the same
+``z`` exactly. Real convolutional edge-contamination is a model property; what
+the adapter code is responsible for is the slice/hop/concatenate bookkeeping,
+which these tests pin down with a deterministic pointwise fake decoder.
+"""
+import numpy as np
+import pytest
+
+from phoonnx.engines import get_adapter, detect_engine
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.vits_streaming import VitsStreamingAdapter, _DEFAULT_STREAMING
+
+
+class _Named:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeEncoder:
+    """Encoder stub: emits z[0, 0, t] == t so the decoded audio is trivially
+    predictable and any misplaced sample is detectable."""
+
+    def __init__(self, T, input_names=("input", "input_lengths", "scales", "sid")):
+        self.T = T
+        self._inputs = [_Named(n) for n in input_names]
+        self.last_feed = None
+
+    def get_inputs(self):
+        return self._inputs
+
+    def run(self, names, feed):
+        self.last_feed = feed
+        z = np.zeros((1, 192, self.T), dtype=np.float32)
+        z[0, 0, :] = np.arange(self.T, dtype=np.float32)
+        y_mask = np.ones((1, 1, self.T), dtype=np.float32)
+        return [z, y_mask]
+
+
+class FakeDecoder:
+    """Pointwise decoder: each latent frame becomes ``hop`` identical samples of
+    its z[0,0] value. Being pointwise (no receptive field), a decoded slice equals
+    the matching region of a full decode -- so a correct discard-and-stitch loop
+    reconstructs the one-shot audio bit-for-bit. Counts calls to prove chunking."""
+
+    def __init__(self, hop, rank3=False):
+        self.hop = hop
+        self.rank3 = rank3
+        self.calls = 0
+
+    def run(self, names, feed):
+        self.calls += 1
+        z = feed["z"]
+        samples = np.repeat(z[0, 0, :], self.hop).astype(np.float32)
+        if self.rank3:
+            return [samples.reshape(1, 1, -1)]
+        return [samples]
+
+
+def _request(n=6, speaker_id=None):
+    ids = np.arange(n, dtype=np.int64)[None, :]
+    return AdapterSynthesisRequest(
+        phoneme_ids=ids,
+        phoneme_lengths=np.array([n], dtype=np.int64),
+        speaker_id=speaker_id,
+        params={},
+    )
+
+
+def _adapter(hop, T, rank3=False, streaming=None, set_hop=True):
+    a = VitsStreamingAdapter(decoder_session=FakeDecoder(hop, rank3=rank3))
+    if streaming:
+        a.configure_from_params({"streaming": streaming})
+    if set_hop:
+        a._hop_length = hop
+    return a, FakeEncoder(T)
+
+
+# --------------------------------------------------------------------------
+# Registration & strict detection
+# --------------------------------------------------------------------------
+
+def test_registered_as_vits_streaming_engine():
+    assert isinstance(get_adapter("vits_streaming"), VitsStreamingAdapter)
+
+
+def test_detect_requires_both_flag_and_decoder():
+    # both present -> match
+    assert VitsStreamingAdapter.detect(
+        config={"streaming": True, "engine_params": {"decoder_path": "d.onnx"}}) is True
+    # streaming flag but no decoder graph -> a single-graph voice, not streamable
+    assert VitsStreamingAdapter.detect(
+        config={"streaming": True, "engine_params": {}}) is False
+    # decoder path but no streaming flag -> not claimed
+    assert VitsStreamingAdapter.detect(
+        config={"engine_params": {"decoder_path": "d.onnx"}}) is False
+    # nothing -> not claimed
+    assert VitsStreamingAdapter.detect(config={}) is False
+    assert VitsStreamingAdapter.detect(config=None) is False
+
+
+def test_detect_does_not_hijack_plain_vits():
+    """A normal single-graph VITS config must fall through to the plain adapter."""
+    plain = {"engine": "vits", "inference": {"noise_scale": 0.667}}
+    assert VitsStreamingAdapter.detect(config=plain) is False
+
+
+# --------------------------------------------------------------------------
+# Parameter handling
+# --------------------------------------------------------------------------
+
+def test_streaming_params_default_and_merge():
+    a = VitsStreamingAdapter()
+    assert a._streaming == _DEFAULT_STREAMING
+    # user overrides merge over defaults, untouched keys keep their default
+    a.configure_from_params({"streaming": {"context_margin": 24}})
+    assert a._streaming["context_margin"] == 24
+    assert a._streaming["first_chunk"] == _DEFAULT_STREAMING["first_chunk"]
+    assert a._streaming["fallback_frames"] == _DEFAULT_STREAMING["fallback_frames"]
+
+
+def test_build_feed_dict_filters_and_includes_sid():
+    a = VitsStreamingAdapter()
+    enc = FakeEncoder(T=4)
+    feed = a.build_feed_dict(_request(speaker_id=3), enc)
+    assert feed["scales"] == pytest.approx([0.667, 1.0, 0.8], abs=1e-4)
+    assert feed["sid"].tolist() == [3]
+    # a single-speaker encoder (no sid input) drops it
+    enc2 = FakeEncoder(T=4, input_names=("input", "input_lengths", "scales"))
+    assert "sid" not in a.build_feed_dict(_request(speaker_id=3), enc2)
+
+
+# --------------------------------------------------------------------------
+# Synthesis: fallback vs. chunked, and the losslessness invariant
+# --------------------------------------------------------------------------
+
+def test_short_sentence_falls_back_to_one_shot():
+    hop, T = 256, 100  # T <= default fallback_frames (128)
+    a, enc = _adapter(hop, T)
+    res = a.synthesize(_request(), enc)
+    assert a.decoder.calls == 1  # exactly one decode, no chunking
+    assert np.array_equal(res.audio, np.repeat(np.arange(T), hop).astype(np.float32))
+
+
+def test_long_sentence_streams_in_multiple_chunks():
+    hop, T = 256, 700
+    a, enc = _adapter(hop, T, streaming={"first_chunk": 8, "next_chunk": 160,
+                                         "context_margin": 32, "fallback_frames": 128})
+    res = a.synthesize(_request(), enc)
+    assert a.decoder.calls > 1  # actually chunked
+    ref = np.repeat(np.arange(T), hop).astype(np.float32)
+    assert res.audio.shape == ref.shape
+    assert np.array_equal(res.audio, ref)  # bit-identical to one-shot
+
+
+@pytest.mark.parametrize("T", [129, 200, 321, 700, 1000])
+@pytest.mark.parametrize("margin", [16, 32, 64])
+def test_stitch_is_lossless_across_lengths_and_margins(T, margin):
+    """Regardless of sentence length or context margin, the stitched output must
+    equal a one-shot decode of the same z, with the exact same length."""
+    hop = 256
+    a, enc = _adapter(hop, T, streaming={**_DEFAULT_STREAMING, "context_margin": margin})
+    res = a.synthesize(_request(), enc)
+    ref = np.repeat(np.arange(T), hop).astype(np.float32)
+    assert res.audio.shape == ref.shape, "length drift in stitching"
+    assert np.abs(res.audio - ref).max() == 0.0
+
+
+def test_stitch_lossless_with_rank3_decoder_output():
+    """Decoders that emit [B, 1, N] instead of [N] must stitch identically."""
+    hop, T = 256, 400
+    a, enc = _adapter(hop, T, rank3=True)
+    res = a.synthesize(_request(), enc)
+    ref = np.repeat(np.arange(T), hop).astype(np.float32)
+    assert np.array_equal(res.audio, ref)
+
+
+def test_hop_measured_when_not_configured():
+    """With no configured hop_length, the adapter measures it from the first
+    full-context decode and still stitches losslessly."""
+    hop, T = 256, 500
+    a, enc = _adapter(hop, T, set_hop=False)  # _hop_length stays None
+    assert a._hop_length is None
+    res = a.synthesize(_request(), enc)
+    assert a._hop_length == hop  # measured from the first chunk
+    ref = np.repeat(np.arange(T), hop).astype(np.float32)
+    assert np.array_equal(res.audio, ref)
+
+
+def test_synthesize_without_decoder_raises():
+    a = VitsStreamingAdapter()  # no decoder graph
+    with pytest.raises(RuntimeError):
+        a.synthesize(_request(), FakeEncoder(T=300))

--- a/tests/test_vits_streaming.py
+++ b/tests/test_vits_streaming.py
@@ -1,11 +1,13 @@
-"""Unit tests for the streaming (split encoder/decoder) VITS adapter.
+"""Unit tests for the streaming (split encoder/decoder) VITS adapter and the
+load-time auto-splitter.
 
 The headline correctness property is *discard-and-stitch losslessness*: decoding
 a latent ``z`` in overlapping chunks, discarding the context margins and
 concatenating the clean middles, must reproduce a one-shot decode of the same
 ``z`` exactly. Real convolutional edge-contamination is a model property; what
-the adapter code is responsible for is the slice/hop/concatenate bookkeeping,
-which these tests pin down with a deterministic pointwise fake decoder.
+the adapter code is responsible for is the slice/hop/concatenate bookkeeping and
+the interface adaptation (named ``z``/``y_mask`` for pre-split "+RT" voices vs. a
+single arbitrarily-named latent tensor for auto-split models).
 """
 import numpy as np
 import pytest
@@ -15,27 +17,37 @@ from phoonnx.engines.base import AdapterSynthesisRequest
 from phoonnx.engines.vits_streaming import VitsStreamingAdapter, _DEFAULT_STREAMING
 
 
-class _Named:
-    def __init__(self, name):
+class _IO:
+    def __init__(self, name, shape=None):
         self.name = name
+        self.shape = shape
 
 
 class FakeEncoder:
-    """Encoder stub: emits z[0, 0, t] == t so the decoded audio is trivially
-    predictable and any misplaced sample is detectable."""
+    """Encoder stub emitting named ``z``/``y_mask`` with z[0,0,t] == t, so the
+    decoded audio is trivially predictable and any misplaced sample is caught."""
 
-    def __init__(self, T, input_names=("input", "input_lengths", "scales", "sid")):
+    def __init__(self, T, input_names=("input", "input_lengths", "scales", "sid"),
+                 single_output=False):
         self.T = T
-        self._inputs = [_Named(n) for n in input_names]
+        self.single_output = single_output
+        self._inputs = [_IO(n) for n in input_names]
         self.last_feed = None
 
     def get_inputs(self):
         return self._inputs
 
+    def get_outputs(self):
+        if self.single_output:
+            return [_IO("/Mul_7_output_0", [1, 192, None])]
+        return [_IO("z", [1, 192, None]), _IO("y_mask", [1, 1, None])]
+
     def run(self, names, feed):
         self.last_feed = feed
         z = np.zeros((1, 192, self.T), dtype=np.float32)
         z[0, 0, :] = np.arange(self.T, dtype=np.float32)
+        if self.single_output:
+            return [z]
         y_mask = np.ones((1, 1, self.T), dtype=np.float32)
         return [z, y_mask]
 
@@ -43,17 +55,26 @@ class FakeEncoder:
 class FakeDecoder:
     """Pointwise decoder: each latent frame becomes ``hop`` identical samples of
     its z[0,0] value. Being pointwise (no receptive field), a decoded slice equals
-    the matching region of a full decode -- so a correct discard-and-stitch loop
-    reconstructs the one-shot audio bit-for-bit. Counts calls to prove chunking."""
+    the matching region of a full decode, so a correct discard-and-stitch loop
+    reconstructs the one-shot audio bit-for-bit. Declares its inputs so the
+    adapter's name/shape matching is exercised."""
 
-    def __init__(self, hop, rank3=False):
+    def __init__(self, hop, rank3=False, single_input=False):
         self.hop = hop
         self.rank3 = rank3
+        self.single_input = single_input
         self.calls = 0
+        self.seen_inputs = None
+
+    def get_inputs(self):
+        if self.single_input:
+            return [_IO("/Mul_7_output_0", [1, 192, None])]
+        return [_IO("z", [1, 192, None]), _IO("y_mask", [1, 1, None])]
 
     def run(self, names, feed):
         self.calls += 1
-        z = feed["z"]
+        self.seen_inputs = set(feed)
+        z = feed["/Mul_7_output_0"] if self.single_input else feed["z"]
         samples = np.repeat(z[0, 0, :], self.hop).astype(np.float32)
         if self.rank3:
             return [samples.reshape(1, 1, -1)]
@@ -70,13 +91,15 @@ def _request(n=6, speaker_id=None):
     )
 
 
-def _adapter(hop, T, rank3=False, streaming=None, set_hop=True):
-    a = VitsStreamingAdapter(decoder_session=FakeDecoder(hop, rank3=rank3))
+def _adapter(hop, T, rank3=False, streaming=None, set_hop=True,
+             single_output=False, single_input=False):
+    a = VitsStreamingAdapter(decoder_session=FakeDecoder(hop, rank3=rank3,
+                                                         single_input=single_input))
     if streaming:
         a.configure_from_params({"streaming": streaming})
     if set_hop:
         a._hop_length = hop
-    return a, FakeEncoder(T)
+    return a, FakeEncoder(T, single_output=single_output)
 
 
 # --------------------------------------------------------------------------
@@ -88,22 +111,20 @@ def test_registered_as_vits_streaming_engine():
 
 
 def test_detect_requires_both_flag_and_decoder():
-    # both present -> match
     assert VitsStreamingAdapter.detect(
         config={"streaming": True, "engine_params": {"decoder_path": "d.onnx"}}) is True
-    # streaming flag but no decoder graph -> a single-graph voice, not streamable
+    # streaming flag but no decoder graph in engine_params -> the auto-splitter
+    # (in TTSVoice.load) injects decoder_path *before* detection runs, so at
+    # detect() time a streamable voice always carries decoder_path.
     assert VitsStreamingAdapter.detect(
         config={"streaming": True, "engine_params": {}}) is False
-    # decoder path but no streaming flag -> not claimed
     assert VitsStreamingAdapter.detect(
         config={"engine_params": {"decoder_path": "d.onnx"}}) is False
-    # nothing -> not claimed
     assert VitsStreamingAdapter.detect(config={}) is False
     assert VitsStreamingAdapter.detect(config=None) is False
 
 
 def test_detect_does_not_hijack_plain_vits():
-    """A normal single-graph VITS config must fall through to the plain adapter."""
     plain = {"engine": "vits", "inference": {"noise_scale": 0.667}}
     assert VitsStreamingAdapter.detect(config=plain) is False
 
@@ -115,7 +136,6 @@ def test_detect_does_not_hijack_plain_vits():
 def test_streaming_params_default_and_merge():
     a = VitsStreamingAdapter()
     assert a._streaming == _DEFAULT_STREAMING
-    # user overrides merge over defaults, untouched keys keep their default
     a.configure_from_params({"streaming": {"context_margin": 24}})
     assert a._streaming["context_margin"] == 24
     assert a._streaming["first_chunk"] == _DEFAULT_STREAMING["first_chunk"]
@@ -128,7 +148,6 @@ def test_build_feed_dict_filters_and_includes_sid():
     feed = a.build_feed_dict(_request(speaker_id=3), enc)
     assert feed["scales"] == pytest.approx([0.667, 1.0, 0.8], abs=1e-4)
     assert feed["sid"].tolist() == [3]
-    # a single-speaker encoder (no sid input) drops it
     enc2 = FakeEncoder(T=4, input_names=("input", "input_lengths", "scales"))
     assert "sid" not in a.build_feed_dict(_request(speaker_id=3), enc2)
 
@@ -150,17 +169,15 @@ def test_long_sentence_streams_in_multiple_chunks():
     a, enc = _adapter(hop, T, streaming={"first_chunk": 8, "next_chunk": 160,
                                          "context_margin": 32, "fallback_frames": 128})
     res = a.synthesize(_request(), enc)
-    assert a.decoder.calls > 1  # actually chunked
+    assert a.decoder.calls > 1
     ref = np.repeat(np.arange(T), hop).astype(np.float32)
     assert res.audio.shape == ref.shape
-    assert np.array_equal(res.audio, ref)  # bit-identical to one-shot
+    assert np.array_equal(res.audio, ref)
 
 
 @pytest.mark.parametrize("T", [129, 200, 321, 700, 1000])
 @pytest.mark.parametrize("margin", [16, 32, 64])
 def test_stitch_is_lossless_across_lengths_and_margins(T, margin):
-    """Regardless of sentence length or context margin, the stitched output must
-    equal a one-shot decode of the same z, with the exact same length."""
     hop = 256
     a, enc = _adapter(hop, T, streaming={**_DEFAULT_STREAMING, "context_margin": margin})
     res = a.synthesize(_request(), enc)
@@ -170,7 +187,6 @@ def test_stitch_is_lossless_across_lengths_and_margins(T, margin):
 
 
 def test_stitch_lossless_with_rank3_decoder_output():
-    """Decoders that emit [B, 1, N] instead of [N] must stitch identically."""
     hop, T = 256, 400
     a, enc = _adapter(hop, T, rank3=True)
     res = a.synthesize(_request(), enc)
@@ -178,19 +194,28 @@ def test_stitch_lossless_with_rank3_decoder_output():
     assert np.array_equal(res.audio, ref)
 
 
-def test_hop_measured_when_not_configured():
-    """With no configured hop_length, the adapter measures it from the first
-    full-context decode and still stitches losslessly."""
+def test_stitch_lossless_with_autosplit_single_tensor_interface():
+    """Auto-split encoders emit one arbitrarily-named latent (no separate mask)
+    and the decoder takes a single input; the adapter must match by shape."""
     hop, T = 256, 500
-    a, enc = _adapter(hop, T, set_hop=False)  # _hop_length stays None
+    a, enc = _adapter(hop, T, single_output=True, single_input=True)
+    res = a.synthesize(_request(), enc)
+    assert a.decoder.seen_inputs == {"/Mul_7_output_0"}  # no y_mask fed
+    ref = np.repeat(np.arange(T), hop).astype(np.float32)
+    assert np.array_equal(res.audio, ref)
+
+
+def test_hop_measured_when_not_configured():
+    hop, T = 256, 500
+    a, enc = _adapter(hop, T, set_hop=False)
     assert a._hop_length is None
     res = a.synthesize(_request(), enc)
-    assert a._hop_length == hop  # measured from the first chunk
+    assert a._hop_length == hop
     ref = np.repeat(np.arange(T), hop).astype(np.float32)
     assert np.array_equal(res.audio, ref)
 
 
 def test_synthesize_without_decoder_raises():
-    a = VitsStreamingAdapter()  # no decoder graph
+    a = VitsStreamingAdapter()
     with pytest.raises(RuntimeError):
         a.synthesize(_request(), FakeEncoder(T=300))


### PR DESCRIPTION
## Summary

Low-latency streaming for VITS/Piper voices, plus CLI voice-listing niceties.
Deliberately **keeps `ovos-number-parser`** — no changes to number pronunciation
or `phoonnx/util.py`.

### 1. Streaming VITS engine (split encoder/decoder)

`VitsStreamingAdapter` decodes a sentence in chunks instead of one shot, lowering
time-to-first-audio.

- **Discard-and-stitch:** each chunk is decoded with an M-frame context margin
  per side; the convolution-contaminated margins are discarded and the clean
  middle kept, so the stitched output is bit-identical to a one-shot decode.
- **Strict detection** (`streaming` flag + a decoder graph), registered just
  ahead of plain VITS so single-graph voices are never hijacked.
- All defaults config-driven (`context_margin=32`, `first_chunk=8`,
  `next_chunk=160`, `fallback_frames=128`, `intra_op_num_threads=cores/2`).

### 2. Auto-split: stream a normal model, no re-export

You no longer need a specially-exported `+RT` voice. A config that just sets
`"streaming": true` on an ordinary single-graph model makes `TTSVoice.load`
split it into an encoder/decoder pair on first load, cached next to the model
(`<model>.encoder.onnx` / `<model>.decoder.onnx`).

The cut is VITS's one natural boundary — the already-masked latent `(z*y_mask)`
feeding the HiFiGAN decoder (the data input of the decoder's 192-channel
`conv_pre`; flow convs of the same width are excluded by name). Extracting the
two subgraphs with `onnx.utils.extract_model` reproduces the original ops
exactly, so the split is **lossless by construction** and **cannot** cause the
duration-predictor drift that breaks some re-exported `+RT` voices (the `ryan+RT`
case study). If a model isn't splittable, it falls back to a normal load.

The adapter matches encoder/decoder I/O by name/shape, so the single-tensor
auto-split interface and the named `z`/`y_mask` `+RT` interface (incl.
multi-speaker `sid`) drive the same discard-and-stitch loop. `onnx` is added as a
dependency for the graph surgery.

### 3. CLI: display names + offline voice listing

- Optional `display_name` on `TTSModelInfo` (with `{engine}`/`{phoneme_type}`
  placeholders) shown in `list-voices`.
- `list-available` lists every bundled voice ID by source, read straight from
  `voice_index/*.json` with no network.
- `download <ID>` falls back to the bundled indexes; `update-cache` rewired to
  `merge_default_voices()`.

## Testing

- **Validated bit-for-bit on a real voice** (`celtia-cotovia`): auto-split →
  streaming adapter vs. monolithic decode = `maxabs 2.2e-8`, zero length drift.
- `tests/test_vits_streaming.py`: strict detection, param merge, feed-dict
  filtering, one-shot fallback, the discard-and-stitch losslessness invariant
  across a matrix of sentence lengths × context margins, `[N]`/`[B,1,N]` decoder
  outputs, the single-tensor auto-split interface, measured-hop, missing-decoder
  guard.
- `tests/test_vits_split.py`: synthetic-graph split losslessness, cut-point
  finder (decoder vs. flow vs. non-VITS), and cache reuse.
- `tests/test_engines.py`, `test_native_config.py`, `test_offline_model_load.py`
  still green. Bundled-index listing verified offline (18 sources / 1870 IDs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added low-latency streaming VITS synthesis for supported split models.
  * Automatically prepares compatible models for streaming when needed.
  * Added configurable streaming controls and fallback handling for short inputs.
  * Added CLI commands to browse available voices and download voices by ID.
  * Voice listings now show friendly display names when available.

* **Documentation**
  * Added comprehensive streaming setup, tuning, and verification guidance.
  * Added streaming documentation to the README.

* **Tests**
  * Added coverage for model splitting, streaming synthesis, caching, and voice detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->