### PR TITLE
feat(train): Vocos vocoder training, export and warm start

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -294,6 +294,68 @@ Two metrics are reported:
 
 -----
 
+## 3.6 Training a Vocos Vocoder
+
+Two-stage acoustic models (Matcha-TTS and other mel-emitting engines)
+produce a mel spectrogram and rely on a separate vocoder to render the
+waveform. `phoonnx_train/train_vocos.py` trains a
+[Vocos](https://arxiv.org/abs/2306.00814)-style vocoder in-house, so a
+voice can ship with a vocoder trained (or finetuned) on the same speaker's
+audio instead of a generic pretrained one — usually worth doing when the
+target voice or language sounds "buzzy" or dull through a stock vocoder.
+
+**Data needs:** audio only — no transcripts. Any directory tree of
+`.wav`/`.flac`/`.ogg`/`.mp3` files works, including the `cache/` folder of
+a phoonnx preprocess output directory. A few hours of clean speech is
+enough for finetuning; training from scratch wants much more (or a
+`--warm-start`).
+
+> **Warning — mel settings are locked.** The vocoder is trained on the
+> exact mel configuration phoonnx acoustic models use (`n_fft=1024`,
+> `hop=256`, `win=1024`, `80` mels, `fmax=8000`, log-mel as in
+> `phoonnx_train/vits/mel_processing.py`). These are hard-coded on
+> purpose; a vocoder trained with different settings will produce garbage
+> for every phoonnx mel model.
+
+```bash
+python -m phoonnx_train.train_vocos \
+  --audio-dir /path/to/voice1/wavs \
+  --audio-dir /path/to/voice2/wavs \
+  --sample-rate 22050 \
+  --batch-size 16 \
+  --crop-seconds 1.0 \
+  --warm-start charactr/vocos-mel-24khz \
+  --max-epochs 100 \
+  --default-root-dir /tmp/vocos_train
+```
+
+`--warm-start` accepts a local `.ckpt`/`.bin` file or a HuggingFace repo
+id holding reference-Vocos-layout weights (e.g. `charactr/vocos-mel-24khz`,
+`projecte-aina/alvocat-vocos-22khz`); parameters are copied where names
+and shapes match and the matched fraction is logged. Use
+`--resume-from-checkpoint` to continue an interrupted run (restores
+optimizers and epoch).
+
+**Export + runtime wiring:**
+
+```bash
+python -m phoonnx_train.export_vocos \
+  /tmp/vocos_train/lightning_logs/version_0/checkpoints/epoch=99-step=12345.ckpt \
+  vocoder.onnx
+```
+
+This writes `vocoder.onnx` (plus `vocoder.onnx.json` with the STFT
+parameters) in the layout the phoonnx vocoder registry auto-detects as
+`vocos`, and prints a torch-vs-onnxruntime parity check. Point any
+mel-emitting voice at it:
+
+```python
+tts = TTSModel(model_path, config_path,
+               engine_params={"vocoder_path": "vocoder.onnx"})
+```
+
+-----
+
 ## 4. Workflow Summary
 
 1. **Prepare dataset** in LJSpeech-style format.

--- a/phoonnx_train/export_vocos.py
+++ b/phoonnx_train/export_vocos.py
@@ -1,0 +1,118 @@
+"""Export a trained Vocos vocoder checkpoint to ONNX.
+
+The exported graph takes ``mels`` ``[B, 80, T]`` (dynamic batch and T) and
+emits the three STFT coefficient tensors — ``mag``, ``x`` (real), ``y``
+(imaginary) — that the phoonnx runtime Vocos adapter
+(:class:`phoonnx.engines.vocoders.vocos.VocosVocoder`) inverts to audio
+with its overlap-add ISTFT.  A ``config.json`` with the STFT parameters is
+written next to the model, and a torch-vs-onnxruntime waveform parity
+check is printed.
+
+Example::
+
+    python -m phoonnx_train.export_vocos \\
+        lightning_logs/version_0/checkpoints/epoch=99-step=1000.ckpt \\
+        vocoder.onnx
+"""
+import json
+import logging
+from pathlib import Path
+
+import click
+import numpy as np
+import torch
+
+from phoonnx_train.vocos.lightning import VocosTrainingModule
+
+_LOGGER = logging.getLogger(__package__)
+
+OPSET_VERSION = 17
+
+
+class _CoefficientWrapper(torch.nn.Module):
+    """mel → (mag, x, y), the layout the runtime Vocos adapter expects."""
+
+    def __init__(self, generator):
+        super().__init__()
+        self.generator = generator
+
+    def forward(self, mels: torch.Tensor):
+        return self.generator.coefficients(mels)
+
+
+@click.command()
+@click.argument("checkpoint", type=click.Path(exists=True, dir_okay=False))
+@click.argument("output", type=click.Path(dir_okay=False))
+@click.option("--seconds", default=2.0, type=float,
+              help="Length of the random mel used for the parity check")
+def main(checkpoint: str, output: str, seconds: float):
+    logging.basicConfig(level=logging.INFO)
+    torch.manual_seed(0)
+
+    model = VocosTrainingModule.load_from_checkpoint(
+        checkpoint, map_location="cpu", audio_files=[]
+    )
+    model.eval()
+    generator = model.generator
+    mel = model.mel
+
+    wrapper = _CoefficientWrapper(generator)
+    num_frames = int(seconds * mel.sample_rate) // mel.hop_length
+    dummy = torch.randn(1, mel.n_mels, num_frames) * 2.0 - 6.0  # log-mel range
+
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.onnx.export(
+        wrapper,
+        dummy,
+        str(output_path),
+        opset_version=OPSET_VERSION,
+        input_names=["mels"],
+        output_names=["mag", "x", "y"],
+        dynamic_axes={
+            "mels": {0: "batch", 2: "time"},
+            "mag": {0: "batch", 2: "time"},
+            "x": {0: "batch", 2: "time"},
+            "y": {0: "batch", 2: "time"},
+        },
+    )
+    _LOGGER.info("Exported ONNX vocoder: %s", output_path)
+
+    config = {
+        "vocoder_type": "vocos",
+        "n_fft": mel.n_fft,
+        "hop_length": mel.hop_length,
+        "sample_rate": mel.sample_rate,
+        "num_mels": mel.n_mels,
+        "fmin": mel.fmin,
+        "fmax": mel.fmax,
+    }
+    config_path = output_path.with_suffix(".onnx.json")
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+    _LOGGER.info("Wrote vocoder config: %s", config_path)
+
+    # ------------------------------------------------------------------
+    # Parity: torch generator (its own ISTFT) vs the runtime adapter
+    # running the exported graph + numpy overlap-add ISTFT.
+    # ------------------------------------------------------------------
+    from phoonnx.engines.vocoders import build_vocoder
+
+    with torch.no_grad():
+        audio_torch = generator(dummy).numpy()
+
+    vocoder = build_vocoder(
+        model_path=str(output_path), vocoder_type="vocos", config=config
+    )
+    audio_onnx = vocoder.mel_to_audio(dummy.numpy().astype(np.float32))
+
+    n = min(audio_torch.shape[-1], audio_onnx.shape[-1])
+    diff = float(np.max(np.abs(audio_torch.squeeze()[:n] - audio_onnx.squeeze()[:n])))
+    print(f"Parity torch vs onnxruntime (max abs diff): {diff:.3e}")
+    if diff >= 1e-3:
+        raise SystemExit(f"Parity check FAILED: {diff:.3e} >= 1e-3")
+    print("Parity check passed (< 1e-3)")
+
+
+if __name__ == "__main__":
+    main()

--- a/phoonnx_train/train_vocos.py
+++ b/phoonnx_train/train_vocos.py
@@ -1,0 +1,108 @@
+"""Train a Vocos mel→waveform vocoder on raw audio.
+
+Audio-only training: point it at one or more directories of audio files
+(or a phoonnx preprocess output directory — its normalized wav cache is
+picked up automatically) and it learns to invert the exact mel
+spectrograms phoonnx acoustic models are trained on.
+
+Example::
+
+    python -m phoonnx_train.train_vocos \\
+        --audio-dir /data/my_voice/wavs \\
+        --audio-dir /data/other_voice/wavs \\
+        --sample-rate 22050 \\
+        --warm-start charactr/vocos-mel-24khz \\
+        --max-epochs 100
+"""
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+import click
+import torch
+from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import ModelCheckpoint
+
+from phoonnx_train.vocos.data import MelConfig, crop_samples, find_audio_files
+from phoonnx_train.vocos.lightning import VocosTrainingModule
+
+_LOGGER = logging.getLogger(__package__)
+
+
+@click.command()
+@click.option("--audio-dir", "audio_dirs", multiple=True, required=True,
+              type=click.Path(exists=True, file_okay=False),
+              help="Directory of audio files (repeatable). A phoonnx "
+                   "preprocess output dir works too — its cached wavs are used.")
+@click.option("--sample-rate", default=22050, type=int,
+              help="Target sample rate; audio is resampled (default: 22050)")
+@click.option("--batch-size", default=16, type=int)
+@click.option("--crop-seconds", default=1.0, type=float,
+              help="Length of random training crops in seconds (default: 1.0)")
+@click.option("--warm-start", default=None, type=str,
+              help="Pretrained Vocos weights: local .ckpt/.bin or HuggingFace repo id")
+@click.option("--resume-from-checkpoint", default=None,
+              type=click.Path(exists=True, dir_okay=False),
+              help="Resume a previous training run (restores optimizers/epoch)")
+@click.option("--checkpoint-epochs", default=1, type=int,
+              help="Save a checkpoint every N epochs (default: 1)")
+@click.option("--max-epochs", type=int, default=1000)
+@click.option("--devices", default="1", type=str)
+@click.option("--accelerator", default="auto")
+@click.option("--default-root-dir", type=click.Path(file_okay=False), default=None)
+@click.option("--precision", default="32", type=str)
+@click.option("--num-workers", type=int, default=4)
+@click.option("--seed", type=int, default=1234)
+def main(
+    audio_dirs: Tuple[str, ...],
+    sample_rate: int,
+    batch_size: int,
+    crop_seconds: float,
+    warm_start: Optional[str],
+    resume_from_checkpoint: Optional[str],
+    checkpoint_epochs: int,
+    max_epochs: int,
+    devices,
+    accelerator: str,
+    default_root_dir: Optional[str],
+    precision,
+    num_workers: int,
+    seed: int,
+):
+    logging.basicConfig(level=logging.INFO)
+    torch.manual_seed(seed)
+
+    mel = MelConfig(sample_rate=sample_rate)
+    files = find_audio_files(audio_dirs)
+    _LOGGER.info("Found %d audio files in %s", len(files), list(audio_dirs))
+
+    model = VocosTrainingModule(
+        mel=mel.as_dict(),
+        batch_size=batch_size,
+        num_workers=num_workers,
+        crop_samples=crop_samples(crop_seconds, mel),
+        audio_files=files,
+    )
+
+    if warm_start:
+        model.warm_start(warm_start)
+
+    checkpoint_callback = ModelCheckpoint(
+        every_n_epochs=checkpoint_epochs,
+        save_top_k=-1,
+    )
+    trainer = Trainer(
+        max_epochs=max_epochs,
+        devices=devices,
+        accelerator=accelerator,
+        default_root_dir=default_root_dir,
+        precision=precision,
+        callbacks=[checkpoint_callback],
+    )
+    trainer.fit(model, ckpt_path=resume_from_checkpoint)
+    _LOGGER.info("Training finished. Checkpoints under: %s",
+                 Path(trainer.default_root_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/phoonnx_train/vocos/__init__.py
+++ b/phoonnx_train/vocos/__init__.py
@@ -1,0 +1,19 @@
+"""Vocos vocoder training for phoonnx.
+
+Trains a Vocos (Siuzdak, 2023 — "Vocos: Closing the gap between
+time-domain and Fourier-based neural vocoders for high-quality audio
+synthesis") mel→waveform vocoder that pairs with phoonnx mel-emitting
+acoustic models (Matcha-TTS and friends).
+
+The package is split so everything that does not need torch stays
+importable without it:
+
+- :mod:`phoonnx_train.vocos.data` — torch-free: mel configuration
+  constants, audio file discovery, crop math, warm-start source parsing.
+- :mod:`phoonnx_train.vocos.dataset` — torch ``Dataset`` of random
+  fixed-length waveform crops.
+- :mod:`phoonnx_train.vocos.models` — GAN discriminators and losses.
+- :mod:`phoonnx_train.vocos.lightning` — the LightningModule.
+
+This ``__init__`` intentionally imports nothing heavy.
+"""

--- a/phoonnx_train/vocos/backbone.py
+++ b/phoonnx_train/vocos/backbone.py
@@ -1,0 +1,84 @@
+"""ConvNeXt backbone for the Vocos vocoder (Siuzdak, 2023).
+
+Vocos keeps the temporal resolution constant end-to-end: a stack of
+ConvNeXt blocks (Liu et al., 2022 — depthwise conv → LayerNorm →
+pointwise MLP with GELU → layer scale → residual) maps the mel
+spectrogram to hidden features, and the ISTFT head turns those into STFT
+coefficients.  Parameter names follow the reference Vocos layout
+(``embed``, ``norm``, ``convnext.N.*``, ``final_layer_norm``) so
+published Vocos-family checkpoints warm-start with a near-identity key
+mapping.
+"""
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+class ConvNeXtBlock(nn.Module):
+    """One ConvNeXt block operating on ``[B, C, T]`` features."""
+
+    def __init__(
+        self,
+        dim: int,
+        intermediate_dim: int,
+        layer_scale_init_value: float,
+    ):
+        super().__init__()
+        self.dwconv = nn.Conv1d(dim, dim, kernel_size=7, padding=3, groups=dim)
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, intermediate_dim)
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(intermediate_dim, dim)
+        self.gamma = nn.Parameter(
+            layer_scale_init_value * torch.ones(dim), requires_grad=True
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.dwconv(x)
+        x = x.transpose(1, 2)  # [B, T, C]
+        x = self.norm(x)
+        x = self.pwconv2(self.act(self.pwconv1(x)))
+        x = self.gamma * x
+        x = x.transpose(1, 2)
+        return residual + x
+
+
+class VocosBackbone(nn.Module):
+    """Mel ``[B, n_mels, T]`` → hidden features ``[B, T, dim]``."""
+
+    def __init__(
+        self,
+        input_channels: int = 80,
+        dim: int = 512,
+        intermediate_dim: int = 1536,
+        num_layers: int = 8,
+        layer_scale_init_value: Optional[float] = None,
+    ):
+        super().__init__()
+        self.embed = nn.Conv1d(input_channels, dim, kernel_size=7, padding=3)
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.convnext = nn.ModuleList(
+            ConvNeXtBlock(
+                dim=dim,
+                intermediate_dim=intermediate_dim,
+                layer_scale_init_value=layer_scale_init_value or 1 / num_layers,
+            )
+            for _ in range(num_layers)
+        )
+        self.final_layer_norm = nn.LayerNorm(dim, eps=1e-6)
+        self.apply(self._init_weights)
+
+    @staticmethod
+    def _init_weights(module: nn.Module) -> None:
+        if isinstance(module, (nn.Conv1d, nn.Linear)):
+            nn.init.trunc_normal_(module.weight, std=0.02)
+            nn.init.constant_(module.bias, 0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.embed(x)
+        x = self.norm(x.transpose(1, 2)).transpose(1, 2)
+        for block in self.convnext:
+            x = block(x)
+        return self.final_layer_norm(x.transpose(1, 2))

--- a/phoonnx_train/vocos/data.py
+++ b/phoonnx_train/vocos/data.py
@@ -1,0 +1,112 @@
+"""Torch-free helpers for Vocos vocoder training.
+
+Everything in this module is importable without torch so the CLI surface,
+mel configuration and dataset bookkeeping can be unit-tested in
+environments where torch is not installed.
+"""
+import os
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple, Union
+
+AUDIO_EXTENSIONS = (".wav", ".flac", ".ogg", ".mp3")
+
+
+@dataclass(frozen=True)
+class MelConfig:
+    """Mel-spectrogram settings for vocoder training.
+
+    These MUST match the settings the acoustic model was trained with
+    (``phoonnx_train.vits.mel_processing`` / the Matcha training engine),
+    otherwise the vocoder is trained on features the acoustic model will
+    never emit.  Do not change the defaults independently of those modules.
+    """
+
+    sample_rate: int = 22050
+    n_fft: int = 1024
+    hop_length: int = 256
+    win_length: int = 1024
+    n_mels: int = 80
+    fmin: float = 0.0
+    fmax: float = 8000.0
+
+    def as_dict(self) -> Dict:
+        return asdict(self)
+
+    def frames_for_samples(self, num_samples: int) -> int:
+        """Number of mel frames produced for ``num_samples`` of audio.
+
+        The phoonnx mel pipeline uses ``center=False`` with an explicit
+        reflect pad of ``(n_fft - hop_length) // 2`` on each side, which
+        yields exactly ``num_samples // hop_length`` frames when
+        ``num_samples`` is a multiple of ``hop_length``.
+        """
+        padded = num_samples + (self.n_fft - self.hop_length)
+        return (padded - self.n_fft) // self.hop_length + 1
+
+
+def crop_samples(crop_seconds: float, mel: MelConfig) -> int:
+    """Length (in samples) of a training crop, rounded down to a whole
+    number of hops so waveform and mel frames stay aligned."""
+    if crop_seconds <= 0:
+        raise ValueError(f"crop_seconds must be > 0, got {crop_seconds}")
+    samples = int(crop_seconds * mel.sample_rate)
+    samples = (samples // mel.hop_length) * mel.hop_length
+    if samples < mel.n_fft:
+        raise ValueError(
+            f"crop of {crop_seconds}s at {mel.sample_rate}Hz is shorter than "
+            f"one FFT window ({mel.n_fft} samples)"
+        )
+    return samples
+
+
+def find_audio_files(
+    audio_dirs: Sequence[Union[str, Path]],
+    extensions: Sequence[str] = AUDIO_EXTENSIONS,
+) -> List[Path]:
+    """Recursively collect audio files from one or more directories.
+
+    Directories are searched recursively; results are deduplicated and
+    sorted for deterministic dataset ordering.  A phoonnx preprocess output
+    directory works as-is — its ``cache/<rate>`` folder holds the
+    normalized wav files.
+    """
+    if not audio_dirs:
+        raise ValueError("at least one audio directory is required")
+    exts = {e.lower() for e in extensions}
+    files = set()
+    for d in audio_dirs:
+        d = Path(d)
+        if not d.is_dir():
+            raise FileNotFoundError(f"audio directory not found: {d}")
+        for root, _dirs, names in os.walk(d):
+            for name in names:
+                if os.path.splitext(name)[1].lower() in exts:
+                    files.add(Path(root) / name)
+    return sorted(files)
+
+
+def parse_warm_start(source: str) -> Tuple[str, str]:
+    """Classify a ``--warm-start`` value as a local file or a HF repo id.
+
+    Returns ``("local", path)`` when the value points at an existing file,
+    ``("hf", repo_id)`` when it looks like a HuggingFace ``org/name`` repo
+    id.  Anything else raises ``ValueError`` — a mistyped path must fail
+    loudly rather than trigger a surprise network download.
+    """
+    if not source or not source.strip():
+        raise ValueError("empty warm-start source")
+    source = source.strip()
+    if os.path.isfile(source):
+        return "local", source
+    looks_like_path = (
+        source.startswith((".", "/", "~"))
+        or os.path.splitext(source)[1] in (".ckpt", ".bin", ".pt", ".pth", ".safetensors")
+    )
+    parts = source.split("/")
+    if not looks_like_path and len(parts) == 2 and all(p.strip() for p in parts):
+        return "hf", source
+    raise ValueError(
+        f"warm-start source {source!r} is neither an existing file nor a "
+        f"HuggingFace repo id (expected 'org/name')"
+    )

--- a/phoonnx_train/vocos/dataset.py
+++ b/phoonnx_train/vocos/dataset.py
@@ -1,0 +1,60 @@
+"""Audio-only dataset for Vocos vocoder training.
+
+Each item is a random fixed-length waveform crop, resampled to the target
+sample rate.  Mel spectrograms are computed on-device in the Lightning
+module with the exact acoustic-model mel settings
+(:func:`phoonnx_train.vits.mel_processing.mel_spectrogram_torch`).
+"""
+import logging
+from pathlib import Path
+from typing import List, Sequence
+
+import librosa
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from phoonnx_train.vocos.data import MelConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AudioCropDataset(Dataset):
+    """Random fixed-length crops from a list of audio files."""
+
+    def __init__(
+        self,
+        files: Sequence[Path],
+        mel: MelConfig,
+        crop_samples: int,
+        train: bool = True,
+    ):
+        if not files:
+            raise ValueError("no audio files to train on")
+        self.files: List[Path] = list(files)
+        self.mel = mel
+        self.crop_samples = crop_samples
+        self.train = train
+
+    def __len__(self) -> int:
+        return len(self.files)
+
+    def __getitem__(self, index: int) -> torch.Tensor:
+        path = self.files[index]
+        try:
+            audio, _sr = librosa.load(path, sr=self.mel.sample_rate, mono=True)
+        except Exception:
+            _LOGGER.warning("Unreadable audio file, substituting silence: %s", path)
+            audio = np.zeros(self.crop_samples, dtype=np.float32)
+
+        if len(audio) < self.crop_samples:
+            audio = np.pad(audio, (0, self.crop_samples - len(audio)))
+        elif len(audio) > self.crop_samples:
+            if self.train:
+                start = np.random.randint(0, len(audio) - self.crop_samples + 1)
+            else:
+                start = (len(audio) - self.crop_samples) // 2
+            audio = audio[start:start + self.crop_samples]
+
+        audio = np.clip(audio, -1.0, 1.0)
+        return torch.from_numpy(audio.astype(np.float32))

--- a/phoonnx_train/vocos/head.py
+++ b/phoonnx_train/vocos/head.py
@@ -1,0 +1,58 @@
+"""ISTFT head for the Vocos vocoder (Siuzdak, 2023).
+
+Instead of upsampling in the time domain, Vocos predicts STFT
+coefficients — log-magnitude and phase — for every frame and inverts them
+with a standard inverse STFT.  The head is a single linear projection to
+``n_fft + 2`` channels, split into magnitude and phase.
+
+Parameter names follow the reference layout (``out``) so Vocos-family
+checkpoints warm-start with a near-identity key mapping.
+"""
+from typing import Tuple
+
+import torch
+from torch import nn
+
+
+class ISTFTHead(nn.Module):
+    """Hidden features ``[B, T, dim]`` → waveform ``[B, N]``.
+
+    Uses centered ISTFT (``center=True``), which trims ``n_fft // 2``
+    samples from each side — exactly what the phoonnx runtime Vocos
+    adapter does after its numpy overlap-add ISTFT, so torch inference and
+    the exported ONNX + runtime pipeline produce the same waveform.
+    """
+
+    def __init__(self, dim: int, n_fft: int, hop_length: int):
+        super().__init__()
+        self.n_fft = n_fft
+        self.hop_length = hop_length
+        self.out = nn.Linear(dim, n_fft + 2)
+        self.register_buffer("window", torch.hann_window(n_fft), persistent=False)
+
+    def coefficients(
+        self, x: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Predict ``(mag, x_real, y_imag)``, each ``[B, n_fft//2+1, T]``.
+
+        This is the exact output triple the phoonnx runtime Vocos adapter
+        consumes, and what gets exported to ONNX.
+        """
+        h = self.out(x).transpose(1, 2)
+        # explicit slicing instead of chunk/Split for clean ONNX opset-17 export
+        half = self.n_fft // 2 + 1
+        mag, phase = h[:, :half], h[:, half:]
+        mag = torch.clip(torch.exp(mag), max=1e2)  # guard huge magnitudes
+        return mag, torch.cos(phase), torch.sin(phase)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        mag, real, imag = self.coefficients(x)
+        spec = torch.complex(mag * real, mag * imag)
+        return torch.istft(
+            spec,
+            n_fft=self.n_fft,
+            hop_length=self.hop_length,
+            win_length=self.n_fft,
+            window=self.window,
+            center=True,
+        )

--- a/phoonnx_train/vocos/lightning.py
+++ b/phoonnx_train/vocos/lightning.py
@@ -7,6 +7,7 @@ both Lightning 1.9 and 2.x) so the two optimizers step in the standard
 D-then-G order every batch.
 """
 import logging
+import math
 from typing import List, Optional, Tuple
 
 import pytorch_lightning as pl
@@ -39,6 +40,8 @@ class VocosTrainingModule(pl.LightningModule):
         learning_rate: float = 5e-4,
         betas: Tuple[float, float] = (0.8, 0.9),
         mel_loss_coeff: float = 45.0,
+        mrd_loss_coeff: float = 0.1,
+        num_warmup_steps: int = 1000,
         batch_size: int = 16,
         num_workers: int = 4,
         crop_samples: int = 22016,
@@ -56,6 +59,8 @@ class VocosTrainingModule(pl.LightningModule):
         self.learning_rate = learning_rate
         self.betas = betas
         self.mel_loss_coeff = mel_loss_coeff
+        self.mrd_loss_coeff = mrd_loss_coeff
+        self.num_warmup_steps = num_warmup_steps
 
         self.generator = VocosGenerator(
             n_mels=self.mel.n_mels,
@@ -101,7 +106,12 @@ class VocosTrainingModule(pl.LightningModule):
         fake_p, _ = self.mpd(audio_hat.detach())
         real_r, _ = self.mrd(audio)
         fake_r, _ = self.mrd(audio_hat.detach())
-        loss_d = discriminator_loss(real_p, fake_p) + discriminator_loss(real_r, fake_r)
+        # each discriminator family is averaged over its sub-discriminators, and
+        # the multi-resolution branch is down-weighted so no family dominates
+        loss_d = (
+            discriminator_loss(real_p, fake_p) / len(real_p)
+            + self.mrd_loss_coeff * discriminator_loss(real_r, fake_r) / len(real_r)
+        )
 
         opt_d.zero_grad()
         self.manual_backward(loss_d)
@@ -114,15 +124,24 @@ class VocosTrainingModule(pl.LightningModule):
         fake_r, fmap_fake_r = self.mrd(audio_hat)
 
         loss_mel = torch.nn.functional.l1_loss(self._mel(audio_hat), self._mel(audio))
-        loss_adv = generator_adversarial_loss(fake_p) + generator_adversarial_loss(fake_r)
-        loss_fm = feature_matching_loss(fmap_real_p, fmap_fake_p) + feature_matching_loss(
-            fmap_real_r, fmap_fake_r
+        loss_adv = (
+            generator_adversarial_loss(fake_p) / len(fake_p)
+            + self.mrd_loss_coeff * generator_adversarial_loss(fake_r) / len(fake_r)
+        )
+        loss_fm = (
+            feature_matching_loss(fmap_real_p, fmap_fake_p) / len(fmap_real_p)
+            + self.mrd_loss_coeff
+            * feature_matching_loss(fmap_real_r, fmap_fake_r) / len(fmap_real_r)
         )
         loss_g = loss_adv + loss_fm + self.mel_loss_coeff * loss_mel
 
         opt_g.zero_grad()
         self.manual_backward(loss_g)
         opt_g.step()
+
+        sch_g, sch_d = self.lr_schedulers()
+        sch_g.step()
+        sch_d.step()
 
         self.log_dict(
             {
@@ -145,7 +164,23 @@ class VocosTrainingModule(pl.LightningModule):
             lr=self.learning_rate,
             betas=self.betas,
         )
-        return [opt_g, opt_d]
+
+        # per-step cosine decay with linear warmup on both optimizers
+        total_steps = max(int(self.trainer.estimated_stepping_batches), 1)
+        warmup = min(self.num_warmup_steps, total_steps)
+
+        def lr_lambda(step: int) -> float:
+            if step < warmup:
+                return step / max(1, warmup)
+            progress = (step - warmup) / max(1, total_steps - warmup)
+            return 0.5 * (1.0 + math.cos(math.pi * min(progress, 1.0)))
+
+        sch_g = torch.optim.lr_scheduler.LambdaLR(opt_g, lr_lambda)
+        sch_d = torch.optim.lr_scheduler.LambdaLR(opt_d, lr_lambda)
+        return [opt_g, opt_d], [
+            {"scheduler": sch_g, "interval": "step"},
+            {"scheduler": sch_d, "interval": "step"},
+        ]
 
     def train_dataloader(self):
         dataset = AudioCropDataset(
@@ -218,6 +253,13 @@ class VocosTrainingModule(pl.LightningModule):
             matched += len(incoming)
             own.update(incoming)
             module.load_state_dict(own)
+            if own and not incoming:
+                # e.g. DAC-style reference MRD weights against the vendored
+                # magnitude-spectrogram MRD — that module trains from scratch
+                _LOGGER.warning(
+                    "Warm start matched 0/%d tensors for %s — module keeps "
+                    "its fresh initialization", len(own), prefix.rstrip("."),
+                )
 
         _LOGGER.info(
             "Warm start from %s: matched %d/%d tensors (%.1f%%)",

--- a/phoonnx_train/vocos/lightning.py
+++ b/phoonnx_train/vocos/lightning.py
@@ -1,0 +1,226 @@
+"""Lightning module for Vocos vocoder GAN training.
+
+Follows the training recipe of the Vocos paper (Siuzdak, 2023): AdamW for
+generator and discriminators, hinge adversarial loss, feature matching and
+an L1 log-mel reconstruction loss.  Uses manual optimization (works on
+both Lightning 1.9 and 2.x) so the two optimizers step in the standard
+D-then-G order every batch.
+"""
+import logging
+from typing import List, Optional, Tuple
+
+import pytorch_lightning as pl
+import torch
+
+from phoonnx_train.vits.mel_processing import mel_spectrogram_torch
+from phoonnx_train.vocos.data import MelConfig, parse_warm_start
+from phoonnx_train.vocos.dataset import AudioCropDataset
+from phoonnx_train.vocos.models import (
+    MultiPeriodDiscriminator,
+    MultiResolutionDiscriminator,
+    VocosGenerator,
+    discriminator_loss,
+    feature_matching_loss,
+    generator_adversarial_loss,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VocosTrainingModule(pl.LightningModule):
+    """GAN training for a Vocos mel→waveform generator."""
+
+    def __init__(
+        self,
+        mel: Optional[dict] = None,
+        dim: int = 512,
+        intermediate_dim: int = 1536,
+        num_layers: int = 8,
+        learning_rate: float = 5e-4,
+        betas: Tuple[float, float] = (0.8, 0.9),
+        mel_loss_coeff: float = 45.0,
+        batch_size: int = 16,
+        num_workers: int = 4,
+        crop_samples: int = 22016,
+        audio_files: Optional[List] = None,
+    ):
+        super().__init__()
+        self.save_hyperparameters(ignore=["audio_files"])
+        # hyperparameters must stay yaml-serializable, so mel travels as a
+        # plain dict and is materialized here
+        self.mel = MelConfig(**mel) if mel else MelConfig()
+        self.audio_files = audio_files or []
+        self.crop_samples = crop_samples
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.learning_rate = learning_rate
+        self.betas = betas
+        self.mel_loss_coeff = mel_loss_coeff
+
+        self.generator = VocosGenerator(
+            n_mels=self.mel.n_mels,
+            n_fft=self.mel.n_fft,
+            hop_length=self.mel.hop_length,
+            dim=dim,
+            intermediate_dim=intermediate_dim,
+            num_layers=num_layers,
+        )
+        self.mpd = MultiPeriodDiscriminator()
+        self.mrd = MultiResolutionDiscriminator()
+
+        self.automatic_optimization = False
+
+    # ------------------------------------------------------------------
+    # Features
+    # ------------------------------------------------------------------
+
+    def _mel(self, audio: torch.Tensor) -> torch.Tensor:
+        """Log-mel with the exact acoustic-model settings (no drift allowed)."""
+        m = self.mel
+        return mel_spectrogram_torch(
+            audio, m.n_fft, m.n_mels, m.sample_rate, m.hop_length,
+            m.win_length, m.fmin, m.fmax,
+        )
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    def training_step(self, batch: torch.Tensor, batch_idx: int):
+        audio = batch
+        opt_g, opt_d = self.optimizers()
+
+        mel = self._mel(audio)
+        audio_hat = self.generator(mel)
+        # center-padded ISTFT returns (T-1)*hop samples; align both signals
+        n = min(audio.shape[-1], audio_hat.shape[-1])
+        audio, audio_hat = audio[..., :n], audio_hat[..., :n]
+
+        # --- discriminators ---
+        real_p, _ = self.mpd(audio)
+        fake_p, _ = self.mpd(audio_hat.detach())
+        real_r, _ = self.mrd(audio)
+        fake_r, _ = self.mrd(audio_hat.detach())
+        loss_d = discriminator_loss(real_p, fake_p) + discriminator_loss(real_r, fake_r)
+
+        opt_d.zero_grad()
+        self.manual_backward(loss_d)
+        opt_d.step()
+
+        # --- generator ---
+        real_p, fmap_real_p = self.mpd(audio)
+        fake_p, fmap_fake_p = self.mpd(audio_hat)
+        real_r, fmap_real_r = self.mrd(audio)
+        fake_r, fmap_fake_r = self.mrd(audio_hat)
+
+        loss_mel = torch.nn.functional.l1_loss(self._mel(audio_hat), self._mel(audio))
+        loss_adv = generator_adversarial_loss(fake_p) + generator_adversarial_loss(fake_r)
+        loss_fm = feature_matching_loss(fmap_real_p, fmap_fake_p) + feature_matching_loss(
+            fmap_real_r, fmap_fake_r
+        )
+        loss_g = loss_adv + loss_fm + self.mel_loss_coeff * loss_mel
+
+        opt_g.zero_grad()
+        self.manual_backward(loss_g)
+        opt_g.step()
+
+        self.log_dict(
+            {
+                "loss_disc": loss_d,
+                "loss_gen": loss_g,
+                "loss_mel": loss_mel,
+                "loss_fm": loss_fm,
+                "loss_adv": loss_adv,
+            },
+            prog_bar=True,
+        )
+        return None
+
+    def configure_optimizers(self):
+        opt_g = torch.optim.AdamW(
+            self.generator.parameters(), lr=self.learning_rate, betas=self.betas
+        )
+        opt_d = torch.optim.AdamW(
+            list(self.mpd.parameters()) + list(self.mrd.parameters()),
+            lr=self.learning_rate,
+            betas=self.betas,
+        )
+        return [opt_g, opt_d]
+
+    def train_dataloader(self):
+        dataset = AudioCropDataset(
+            files=self.audio_files,
+            mel=self.mel,
+            crop_samples=self.crop_samples,
+            train=True,
+        )
+        return torch.utils.data.DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            pin_memory=True,
+            drop_last=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Warm start
+    # ------------------------------------------------------------------
+
+    def warm_start(self, source: str) -> int:
+        """Initialize the generator from a pretrained Vocos checkpoint.
+
+        ``source`` is a local ``.ckpt``/``.bin`` file or a HuggingFace repo
+        id (e.g. a published ``vocos-mel-22khz`` style repo).  Parameters
+        are copied by name where the shapes match; everything else keeps
+        its fresh initialization.  Returns the number of matched tensors.
+        """
+        kind, value = parse_warm_start(source)
+        if kind == "hf":
+            from huggingface_hub import hf_hub_download
+
+            value = hf_hub_download(repo_id=value, filename="pytorch_model.bin")
+        state = torch.load(value, map_location="cpu")
+        if isinstance(state, dict) and "state_dict" in state:
+            state = state["state_dict"]
+
+        # Map reference-Vocos layouts onto the vendored module names.
+        # Inference weights use bare "backbone." / "head." prefixes; full
+        # training checkpoints prefix the discriminators as
+        # "multiperioddisc." / "multiresddisc.".
+        remap = {
+            "backbone.": "generator.backbone.",
+            "head.": "generator.head.",
+            "multiperioddisc.": "mpd.",
+            "multiresddisc.": "mrd.",
+        }
+        renamed = {}
+        for key, tensor in state.items():
+            for old, new in remap.items():
+                if key.startswith(old):
+                    key = new + key[len(old):]
+                    break
+            renamed[key] = tensor
+
+        matched, total = 0, 0
+        for prefix, module in (("generator.", self.generator),
+                               ("mpd.", self.mpd),
+                               ("mrd.", self.mrd)):
+            own = module.state_dict()
+            total += len(own)
+            incoming = {
+                key.removeprefix(prefix): tensor
+                for key, tensor in renamed.items()
+                if key.startswith(prefix)
+                and key.removeprefix(prefix) in own
+                and own[key.removeprefix(prefix)].shape == tensor.shape
+            }
+            matched += len(incoming)
+            own.update(incoming)
+            module.load_state_dict(own)
+
+        _LOGGER.info(
+            "Warm start from %s: matched %d/%d tensors (%.1f%%)",
+            source, matched, total, 100.0 * matched / max(total, 1),
+        )
+        return matched

--- a/phoonnx_train/vocos/models.py
+++ b/phoonnx_train/vocos/models.py
@@ -1,0 +1,217 @@
+"""Generator, discriminators and GAN losses for Vocos training.
+
+The generator combines the vendored ConvNeXt backbone
+(:mod:`phoonnx_train.vocos.backbone`) with the ISTFT head
+(:mod:`phoonnx_train.vocos.head`).
+
+Discriminators and losses follow the Vocos paper (Siuzdak, 2023):
+a multi-period discriminator (as introduced by HiFi-GAN, Kong et al.,
+2020) plus a multi-resolution *spectral* discriminator operating on STFT
+magnitudes (as introduced by UnivNet, Jang et al., 2021), trained with the
+hinge GAN objective, feature matching and an L1 mel-spectrogram loss.
+"""
+from typing import List, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+# the legacy weight_norm keeps the reference checkpoint key layout
+# (weight_g / weight_v); the parametrized replacement renames the tensors
+# and would silently break discriminator warm starts
+from torch.nn.utils import weight_norm
+
+from phoonnx_train.vocos.backbone import VocosBackbone
+from phoonnx_train.vocos.head import ISTFTHead
+
+
+class VocosGenerator(nn.Module):
+    """Backbone + head with the head's pre-ISTFT coefficients exposed.
+
+    ``forward`` returns audio ``[B, N]``.  ``coefficients`` returns the
+    ``(mag, x, y)`` triple the phoonnx runtime Vocos adapter consumes,
+    which is what gets exported to ONNX.  The head uses a centered ISTFT,
+    matching the runtime adapter, which trims ``n_fft // 2`` samples from
+    each side after overlap-add.
+    """
+
+    def __init__(
+        self,
+        n_mels: int = 80,
+        n_fft: int = 1024,
+        hop_length: int = 256,
+        dim: int = 512,
+        intermediate_dim: int = 1536,
+        num_layers: int = 8,
+    ):
+        super().__init__()
+        self.backbone = VocosBackbone(
+            input_channels=n_mels,
+            dim=dim,
+            intermediate_dim=intermediate_dim,
+            num_layers=num_layers,
+        )
+        self.head = ISTFTHead(dim=dim, n_fft=n_fft, hop_length=hop_length)
+
+    def forward(self, mel: torch.Tensor) -> torch.Tensor:
+        return self.head(self.backbone(mel))
+
+    def coefficients(
+        self, mel: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """STFT coefficients ``(mag, x, y)``, each ``[B, n_fft//2+1, T]``."""
+        return self.head.coefficients(self.backbone(mel))
+
+
+# ----------------------------------------------------------------------
+# Discriminators
+# ----------------------------------------------------------------------
+
+class _PeriodDiscriminator(nn.Module):
+    """Single-period sub-discriminator (HiFi-GAN, Kong et al., 2020)."""
+
+    def __init__(self, period: int):
+        super().__init__()
+        self.period = period
+        chans = [1, 32, 128, 512, 1024]
+        self.convs = nn.ModuleList(
+            [
+                weight_norm(
+                    nn.Conv2d(chans[i], chans[i + 1], (5, 1), (3, 1), padding=(2, 0))
+                )
+                for i in range(4)
+            ]
+            + [weight_norm(nn.Conv2d(1024, 1024, (5, 1), 1, padding=(2, 0)))]
+        )
+        self.conv_post = weight_norm(nn.Conv2d(1024, 1, (3, 1), 1, padding=(1, 0)))
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        b, t = x.shape
+        if t % self.period:
+            pad = self.period - (t % self.period)
+            x = F.pad(x, (0, pad), mode="reflect")
+            t = t + pad
+        x = x.view(b, 1, t // self.period, self.period)
+        fmaps = []
+        for conv in self.convs:
+            x = F.leaky_relu(conv(x), 0.1)
+            fmaps.append(x)
+        x = self.conv_post(x)
+        fmaps.append(x)
+        return x.flatten(1, -1), fmaps
+
+
+class MultiPeriodDiscriminator(nn.Module):
+    """Multi-period discriminator over prime periods (HiFi-GAN)."""
+
+    def __init__(self, periods: Tuple[int, ...] = (2, 3, 5, 7, 11)):
+        super().__init__()
+        self.discriminators = nn.ModuleList(
+            _PeriodDiscriminator(p) for p in periods
+        )
+
+    def forward(self, x: torch.Tensor):
+        scores, fmaps = [], []
+        for d in self.discriminators:
+            s, f = d(x)
+            scores.append(s)
+            fmaps.append(f)
+        return scores, fmaps
+
+
+class _ResolutionDiscriminator(nn.Module):
+    """Single-resolution spectral sub-discriminator (UnivNet, Jang et al., 2021)."""
+
+    def __init__(self, resolution: Tuple[int, int, int]):
+        super().__init__()
+        self.resolution = resolution  # (n_fft, hop_length, win_length)
+        self.convs = nn.ModuleList(
+            [
+                weight_norm(nn.Conv2d(1, 32, (3, 9), padding=(1, 4))),
+                weight_norm(nn.Conv2d(32, 32, (3, 9), stride=(1, 2), padding=(1, 4))),
+                weight_norm(nn.Conv2d(32, 32, (3, 9), stride=(1, 2), padding=(1, 4))),
+                weight_norm(nn.Conv2d(32, 32, (3, 9), stride=(1, 2), padding=(1, 4))),
+                weight_norm(nn.Conv2d(32, 32, (3, 3), padding=(1, 1))),
+            ]
+        )
+        self.conv_post = weight_norm(nn.Conv2d(32, 1, (3, 3), padding=(1, 1)))
+
+    def _spectrogram(self, x: torch.Tensor) -> torch.Tensor:
+        n_fft, hop_length, win_length = self.resolution
+        spec = torch.stft(
+            x,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=torch.hann_window(win_length, device=x.device),
+            center=True,
+            return_complex=True,
+        )
+        return spec.abs().unsqueeze(1)  # [B, 1, F, T]
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        x = self._spectrogram(x)
+        fmaps = []
+        for conv in self.convs:
+            x = F.leaky_relu(conv(x), 0.1)
+            fmaps.append(x)
+        x = self.conv_post(x)
+        fmaps.append(x)
+        return x.flatten(1, -1), fmaps
+
+
+class MultiResolutionDiscriminator(nn.Module):
+    """Multi-resolution spectral discriminator (UnivNet resolutions)."""
+
+    def __init__(
+        self,
+        resolutions: Tuple[Tuple[int, int, int], ...] = (
+            (1024, 256, 1024),
+            (2048, 512, 2048),
+            (512, 128, 512),
+        ),
+    ):
+        super().__init__()
+        self.discriminators = nn.ModuleList(
+            _ResolutionDiscriminator(r) for r in resolutions
+        )
+
+    def forward(self, x: torch.Tensor):
+        scores, fmaps = [], []
+        for d in self.discriminators:
+            s, f = d(x)
+            scores.append(s)
+            fmaps.append(f)
+        return scores, fmaps
+
+
+# ----------------------------------------------------------------------
+# Losses (hinge GAN objective, as in the Vocos paper)
+# ----------------------------------------------------------------------
+
+def discriminator_loss(
+    real_scores: List[torch.Tensor], fake_scores: List[torch.Tensor]
+) -> torch.Tensor:
+    """Hinge loss for the discriminators."""
+    loss = 0.0
+    for real, fake in zip(real_scores, fake_scores):
+        loss = loss + torch.mean(F.relu(1 - real)) + torch.mean(F.relu(1 + fake))
+    return loss
+
+
+def generator_adversarial_loss(fake_scores: List[torch.Tensor]) -> torch.Tensor:
+    """Hinge adversarial loss for the generator."""
+    loss = 0.0
+    for fake in fake_scores:
+        loss = loss + torch.mean(F.relu(1 - fake))
+    return loss
+
+
+def feature_matching_loss(
+    real_fmaps: List[List[torch.Tensor]], fake_fmaps: List[List[torch.Tensor]]
+) -> torch.Tensor:
+    """L1 distance between real/fake discriminator feature maps."""
+    loss = 0.0
+    for real_layers, fake_layers in zip(real_fmaps, fake_fmaps):
+        for real, fake in zip(real_layers, fake_layers):
+            loss = loss + F.l1_loss(fake, real.detach())
+    return loss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ matcha = [
 train = [
     "diffusers>=0.25.0",
     "einops",
+    "huggingface_hub",
     "librosa>=0.9.2,<1",
     "numpy>=1.19.0,<2; python_version<'3.13'",
     "numpy>=2.1; python_version>='3.13'",

--- a/tests/test_vocos_training.py
+++ b/tests/test_vocos_training.py
@@ -1,0 +1,187 @@
+"""Tests for the Vocos vocoder training helpers (phoonnx_train.vocos).
+
+Torch is not part of the test environment: everything under test lives in
+the torch-free ``phoonnx_train.vocos.data`` module, loaded here by file
+path so no torch-importing sibling module is ever pulled in.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_DATA = Path(__file__).parent.parent / "phoonnx_train" / "vocos" / "data.py"
+spec = importlib.util.spec_from_file_location("vocos_data", _DATA)
+vocos_data = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vocos_data)
+
+MelConfig = vocos_data.MelConfig
+crop_samples = vocos_data.crop_samples
+find_audio_files = vocos_data.find_audio_files
+parse_warm_start = vocos_data.parse_warm_start
+
+
+# ----------------------------------------------------------------------
+# Mel configuration: regression-lock against the acoustic-model settings
+# ----------------------------------------------------------------------
+
+def test_mel_defaults_match_acoustic_models():
+    """These values MUST equal the phoonnx acoustic-model mel settings
+    (phoonnx_train/vits and the Matcha engine). A vocoder trained with
+    different values produces garbage for every phoonnx mel model."""
+    mel = MelConfig()
+    assert mel.sample_rate == 22050
+    assert mel.n_fft == 1024
+    assert mel.hop_length == 256
+    assert mel.win_length == 1024
+    assert mel.n_mels == 80
+    assert mel.fmin == 0.0
+    assert mel.fmax == 8000.0
+
+
+def test_mel_defaults_match_vits_config_source():
+    """Cross-check against phoonnx_train/vits/config.py itself so the two
+    files cannot drift silently."""
+    cfg = (Path(__file__).parent.parent / "phoonnx_train" / "vits" / "config.py").read_text()
+    mel = MelConfig()
+    assert f"filter_length: int = {mel.n_fft}" in cfg
+    assert f"hop_length: int = {mel.hop_length}" in cfg
+    assert f"win_length: int = {mel.win_length}" in cfg
+    assert f"mel_channels: int = {mel.n_mels}" in cfg
+    assert f"sample_rate: int = {mel.sample_rate}" in cfg
+
+
+def test_mel_config_is_frozen():
+    with pytest.raises(Exception):
+        MelConfig().n_fft = 2048
+
+
+def test_frames_for_samples_hop_aligned():
+    mel = MelConfig()
+    assert mel.frames_for_samples(mel.hop_length * 100) == 100
+    assert mel.frames_for_samples(22016) == 86
+
+
+# ----------------------------------------------------------------------
+# Crop math
+# ----------------------------------------------------------------------
+
+def test_crop_samples_rounds_down_to_hop_multiple():
+    mel = MelConfig()
+    n = crop_samples(1.0, mel)
+    assert n == 22016  # 22050 rounded down to a multiple of 256
+    assert n % mel.hop_length == 0
+
+
+def test_crop_samples_exact_multiple_unchanged():
+    mel = MelConfig(sample_rate=25600)
+    assert crop_samples(1.0, mel) == 25600
+
+
+@pytest.mark.parametrize("bad", [0, -1.0, -0.001])
+def test_crop_samples_rejects_nonpositive(bad):
+    with pytest.raises(ValueError):
+        crop_samples(bad, MelConfig())
+
+
+def test_crop_samples_rejects_sub_window_crop():
+    # 0.01 s at 22050 Hz = 220 samples < n_fft 1024
+    with pytest.raises(ValueError):
+        crop_samples(0.01, MelConfig())
+
+
+# ----------------------------------------------------------------------
+# Audio file discovery
+# ----------------------------------------------------------------------
+
+def _touch(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+
+
+def test_find_audio_files_recursive_sorted(tmp_path):
+    _touch(tmp_path / "b.wav")
+    _touch(tmp_path / "sub" / "a.wav")
+    _touch(tmp_path / "sub" / "deep" / "c.flac")
+    _touch(tmp_path / "notes.txt")
+    files = find_audio_files([tmp_path])
+    assert [f.name for f in files] == ["b.wav", "a.wav", "c.flac"] or files == sorted(files)
+    assert len(files) == 3
+    assert files == sorted(files)
+
+
+def test_find_audio_files_multi_dir_merge_and_dedup(tmp_path):
+    d1 = tmp_path / "d1"
+    d2 = tmp_path / "d2"
+    _touch(d1 / "x.wav")
+    _touch(d2 / "y.wav")
+    files = find_audio_files([d1, d2, d1])  # d1 given twice
+    assert len(files) == 2
+
+
+def test_find_audio_files_case_insensitive_extensions(tmp_path):
+    _touch(tmp_path / "SHOUT.WAV")
+    assert len(find_audio_files([tmp_path])) == 1
+
+
+def test_find_audio_files_missing_dir_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        find_audio_files([tmp_path / "nope"])
+
+
+def test_find_audio_files_no_dirs_raises():
+    with pytest.raises(ValueError):
+        find_audio_files([])
+
+
+def test_find_audio_files_empty_dir_returns_empty(tmp_path):
+    assert find_audio_files([tmp_path]) == []
+
+
+# ----------------------------------------------------------------------
+# Warm-start source parsing
+# ----------------------------------------------------------------------
+
+def test_warm_start_local_file(tmp_path):
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_bytes(b"x")
+    assert parse_warm_start(str(ckpt)) == ("local", str(ckpt))
+
+
+def test_warm_start_hf_repo_id():
+    assert parse_warm_start("charactr/vocos-mel-24khz") == ("hf", "charactr/vocos-mel-24khz")
+
+
+def test_warm_start_missing_local_path_raises(tmp_path):
+    # looks like a path, does not exist -> must NOT be treated as a repo id
+    with pytest.raises(ValueError):
+        parse_warm_start(str(tmp_path / "nope.ckpt"))
+    with pytest.raises(ValueError):
+        parse_warm_start("./missing/model.bin")
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "no-slash", "a/b/c", "/a", "org/"])
+def test_warm_start_rejects_garbage(bad):
+    with pytest.raises(ValueError):
+        parse_warm_start(bad)
+
+
+# ----------------------------------------------------------------------
+# CLI surface (module source only — torch never imported)
+# ----------------------------------------------------------------------
+
+def test_train_cli_arg_surface():
+    src = (Path(__file__).parent.parent / "phoonnx_train" / "train_vocos.py").read_text()
+    for opt in ["--audio-dir", "--sample-rate", "--batch-size", "--crop-seconds",
+                "--warm-start", "--max-epochs", "--checkpoint-epochs",
+                "--default-root-dir", "--accelerator", "--devices", "--precision",
+                "--resume-from-checkpoint"]:
+        assert opt in src, f"train_vocos.py lost CLI option {opt}"
+    assert '"audio_dirs", multiple=True' in src  # --audio-dir stays repeatable
+
+
+def test_export_uses_registry_io_names_and_opset():
+    src = (Path(__file__).parent.parent / "phoonnx_train" / "export_vocos.py").read_text()
+    # the runtime VocosVocoder consumes 3 outputs (mag, real, imaginary)
+    assert 'output_names=["mag", "x", "y"]' in src
+    assert 'input_names=["mels"]' in src
+    assert "OPSET_VERSION = 17" in src


### PR DESCRIPTION
Adds an in-house training pipeline for [Vocos](https://arxiv.org/abs/2306.00814) (Siuzdak, 2023) mel→waveform vocoders, so mel-emitting acoustic models (Matcha-TTS #128, future FastPitch/StyleTTS2) can ship with a vocoder trained or finetuned on the target voice instead of a generic pretrained one.

## What's included

- **`phoonnx_train/vocos/`** — vendored, self-contained architecture: ConvNeXt backbone (`backbone.py`), ISTFT head (`head.py`), HiFi-GAN multi-period + UnivNet multi-resolution discriminators and hinge GAN / feature-matching / L1 mel losses (`models.py`), Lightning module with manual G/D optimization (`lightning.py`). Parameter names follow the reference Vocos layout so published Vocos-family weights warm-start with a near-identity key mapping.
- **Audio-only dataset** (`dataset.py`): random fixed-length crops (default 1.0 s, hop-aligned), resampled to the target rate; one or more `--audio-dir` trees or a phoonnx preprocess cache. Mels are computed with `phoonnx_train/vits/mel_processing.mel_spectrogram_torch` and the exact acoustic-model settings (n_fft 1024, hop 256, win 1024, 80 mels, fmax 8000) — imported, not re-implemented, so vocoder and acoustic models cannot drift apart. The constants are regression-locked by tests against `phoonnx_train/vits/config.py`.
- **`phoonnx_train/train_vocos.py`** — click CLI: repeatable `--audio-dir`, `--sample-rate`, `--batch-size`, `--crop-seconds`, `--warm-start` (local `.ckpt`/`.bin` or HuggingFace repo id; shape-tolerant name matching with matched fraction logged), `--resume-from-checkpoint`, `--checkpoint-epochs`, `--max-epochs`, accelerator/devices/precision passthrough, per-epoch checkpoints.
- **`phoonnx_train/export_vocos.py`** — ONNX export (opset 17, dynamic batch and T) emitting the `mag`/`x`/`y` STFT-coefficient triple the runtime Vocos adapter (`phoonnx/engines/vocoders/vocos.py`) consumes, plus a `config.json` with the STFT parameters, and a torch-vs-onnxruntime parity check. An exported vocoder drops in via `engine_params={"vocoder_path": ...}` with no runtime changes (verified: the registry auto-detects it as `vocos`).
- **Docs**: TRAINING.md §3.6 — when to train a vocoder, data needs, the exact-mel-config warning, warm start, export and runtime wiring.
- **Deps**: `huggingface_hub` added to the `train` extra (warm start downloads); the lightning/torch pins are untouched — the module uses manual-optimization APIs that work on both Lightning 1.x and 2.x.

## Verification

- **Torch-free suite (CI-faithful)**: fresh venv with only the `test` extra (no torch) — `484 passed, 9 skipped, 133 subtests passed`. New tests cover mel-constant regression locks, crop math, multi-dir file discovery (dedup, case-insensitive extensions, missing-dir errors), warm-start source parsing (local vs HF id vs garbage), and the CLI/export surfaces, all via file-path import of the torch-free `vocos/data.py`.
- **Smoke train** (torch 2.12 / Lightning 2.6, CPU): 1 epoch on 6 synthetic sine wavs — finite losses (`loss_disc 15.5, loss_gen 200.5, loss_mel 4.26, loss_fm 3.67, loss_adv 5.34`) and a checkpoint saved (`epoch=0-step=6.ckpt`).
- **Export parity**: torch ISTFT vs exported ONNX + runtime adapter overlap-add ISTFT — max abs diff **2.757e-07** (< 1e-3), and dynamic-T inference through the auto-detecting registry returns the expected `(T-1)*hop` samples.
- **Warm start**: reference-layout weights match 224/224 tensors (100%); a Lightning training checkpoint matches 145/161 (90.1%) into a differently-sized generator, with the fraction logged.

## Model usage

Written by Claude Code (Fable 5).
