### PR TITLE
fix(train): port VITS trainer to Lightning 2 + matcha gradient clip

### DIFF
--- a/phoonnx_train/engines/base.py
+++ b/phoonnx_train/engines/base.py
@@ -120,6 +120,17 @@ class BaseTrainingEngine(ABC):
         """
         return {}
 
+    def trainer_kwargs(self) -> Dict[str, Any]:
+        """
+        Extra keyword arguments for the ``pytorch_lightning.Trainer``
+        used with this engine (e.g. ``gradient_clip_val``).
+
+        Default is empty.  Engines whose LightningModule uses manual
+        optimization must NOT return ``gradient_clip_val`` here —
+        Lightning rejects a global clip with manual optimization.
+        """
+        return {}
+
     def extra_cli_options(self) -> List[Any]:
         """
         Return additional ``click.option`` decorators that should be

--- a/phoonnx_train/engines/matcha.py
+++ b/phoonnx_train/engines/matcha.py
@@ -204,6 +204,12 @@ def _build_model_kwargs(mcfg: MatchaEngineConfig) -> Dict[str, Any]:
 
 class MatchaTrainingEngine(BaseTrainingEngine):
 
+    def trainer_kwargs(self) -> Dict[str, Any]:
+        # Upstream Matcha-TTS trains with gradient clipping at 5.0
+        # (configs/trainer/default.yaml).  Safe here: MatchaTTS uses
+        # automatic optimization.
+        return {"gradient_clip_val": 5.0}
+
     # ------------------------------------------------------------------
     # Required
     # ------------------------------------------------------------------

--- a/phoonnx_train/engines/vits.py
+++ b/phoonnx_train/engines/vits.py
@@ -63,11 +63,18 @@ class VitsTrainingEngine(BaseTrainingEngine):
         """Build a VitsModel LightningModule from *config*."""
         from phoonnx_train.vits.lightning import VitsModel
 
+        # The VITS dataset loader expects jsonl *files*; the CLI passes the
+        # pre-processed dataset *directory* — map dirs to their dataset.jsonl.
+        dataset_files = [
+            Path(p) / "dataset.jsonl" if Path(p).is_dir() else Path(p)
+            for p in dataset_paths
+        ]
+
         return VitsModel(
             num_symbols=config.num_symbols,
             num_speakers=config.num_speakers,
             sample_rate=config.sample_rate,
-            dataset=[str(p) for p in dataset_paths],
+            dataset=[str(p) for p in dataset_files],
             **config.extra,
             **kwargs,
         )
@@ -147,6 +154,12 @@ class VitsTrainingEngine(BaseTrainingEngine):
             dummy_input = (*dummy_input, sid)
 
         output_path = output_dir / f"{checkpoint_path.name}.onnx"
+        export_kwargs = {}
+        if torch.__version__ >= "2.5":
+            # torch >= 2.9 defaults to the dynamo exporter, which cannot
+            # trace the VITS rational-quadratic-spline flows — keep the
+            # legacy TorchScript exporter (piper lineage).
+            export_kwargs["dynamo"] = False
         torch.onnx.export(
             model=model_g,
             args=dummy_input,
@@ -156,6 +169,7 @@ class VitsTrainingEngine(BaseTrainingEngine):
             input_names=input_names,
             output_names=output_names,
             dynamic_axes=dynamic_axes,
+            **export_kwargs,
         )
 
         # Metadata

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -159,6 +159,7 @@ def main(
         default_root_dir=default_root_dir,
         precision=precision,
         callbacks=[checkpoint_callback],
+        **training_engine.trainer_kwargs(),
     )
     _LOGGER.info("Training started!")
     trainer.fit(model)

--- a/phoonnx_train/vits/lightning.py
+++ b/phoonnx_train/vits/lightning.py
@@ -78,6 +78,10 @@ class VitsModel(pl.LightningModule):
         super().__init__()
         self.save_hyperparameters()
 
+        # GAN training with two optimizers requires manual optimization
+        # under pytorch-lightning >= 2.0
+        self.automatic_optimization = False
+
         if (self.hparams.num_speakers > 1) and (self.hparams.gin_channels <= 0):
             # Default gin_channels for multi-speaker model
             self.hparams.gin_channels = 512
@@ -198,12 +202,30 @@ class VitsModel(pl.LightningModule):
             batch_size=self.hparams.batch_size,
         )
 
-    def training_step(self, batch: Batch, batch_idx: int, optimizer_idx: int):
-        if optimizer_idx == 0:
-            return self.training_step_g(batch)
+    def training_step(self, batch: Batch, batch_idx: int):
+        # Manual optimization (pytorch-lightning >= 2.0): run the generator
+        # and discriminator steps in the same order the old
+        # ``optimizer_idx`` branches did.
+        opt_g, opt_d = self.optimizers()
 
-        if optimizer_idx == 1:
-            return self.training_step_d(batch)
+        # Generator
+        loss_g = self.training_step_g(batch)
+        opt_g.zero_grad()
+        self.manual_backward(loss_g)
+        opt_g.step()
+
+        # Discriminator (uses y / y_hat saved by training_step_g)
+        loss_d = self.training_step_d(batch)
+        opt_d.zero_grad()
+        self.manual_backward(loss_d)
+        opt_d.step()
+
+    def on_train_epoch_end(self):
+        # With manual optimization Lightning no longer steps the
+        # schedulers; step both ExponentialLR schedulers once per epoch,
+        # matching the old automatic-optimization behaviour.
+        for scheduler in self.lr_schedulers():
+            scheduler.step()
 
     def training_step_g(self, batch: Batch):
         x, x_lengths, y, _, spec, spec_lengths, speaker_ids = (


### PR DESCRIPTION
The VITS `LightningModule` used the Lightning-1.x `optimizer_idx` signature and could not train under the project's pinned `pytorch-lightning>=2.0`. Ports it to manual optimization (generator-then-discriminator order preserved, discriminator on detached `y_hat`, ExponentialLR schedulers stepped per epoch), fixes `--engine vits` dataset-directory handling, pins the legacy ONNX exporter for the spline flow, and adds a `trainer_kwargs()` engine hook that delivers Matcha's `gradient_clip_val=5.0`.

CPU smoke on a synthetic prep dataset: 3-epoch train, resume-from-checkpoint, ONNX export, and onnxruntime inference (finite audio) all pass. Checkpoint layout is unchanged, so existing published voices load unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)