### PR TITLE
feat: opt-in validation audio-sample logging

### DIFF
--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -63,6 +63,9 @@ def _validate_engine(ctx, param, value):
 @click.option('--batch-size', type=int, default=16)
 @click.option('--validation-split', type=float, default=0.1)
 @click.option('--num-workers', type=int, default=4)
+@click.option('--log-audio-samples/--no-log-audio-samples', default=False,
+              help='Log synthesized validation audio samples to the logger '
+                   'each epoch (requires a TensorBoard logger)')
 @click.option('--discard-encoder', is_flag=True, default=False)
 def main(
     dataset_dir: str,
@@ -80,6 +83,7 @@ def main(
     batch_size: int,
     validation_split: float,
     num_workers: int,
+    log_audio_samples: bool,
     discard_encoder: bool,
 ):
     logging.basicConfig(level=logging.DEBUG)
@@ -140,6 +144,7 @@ def main(
             batch_size=batch_size,
             validation_split=validation_split,
             num_workers=num_workers,
+            log_audio_samples=log_audio_samples,
         ),
     )
     model = training_engine.create_model(

--- a/phoonnx_train/vits/lightning.py
+++ b/phoonnx_train/vits/lightning.py
@@ -86,6 +86,7 @@ class VitsModel(pl.LightningModule):
         num_test_examples: int = 5,
         validation_split: float = 0.1,
         max_phoneme_ids: Optional[int] = None,
+        log_audio_samples: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -373,38 +374,49 @@ class VitsModel(pl.LightningModule):
         val_loss = self.training_step_g(batch) + self.training_step_d(batch)
         self.log("val_loss", val_loss)
 
-        # Generate audio examples
-        for utt_idx, test_utt in enumerate(self._test_dataset):
-            text = test_utt.phoneme_ids.unsqueeze(0).to(self.device)
-            text_lengths = torch.LongTensor([len(test_utt.phoneme_ids)]).to(self.device)
-            scales = [0.667, 1.0, 0.8]
-            sid = (
-                test_utt.speaker_id.to(self.device)
-                if test_utt.speaker_id is not None
-                else None
-            )
-            speaker_embedding = (
-                test_utt.d_vector.unsqueeze(0).to(self.device)
-                if test_utt.d_vector is not None
-                else None
-            )
-            lid = (
-                test_utt.language_id.to(self.device)
-                if test_utt.language_id is not None
-                else None
-            )
-            test_audio = self(
-                text, text_lengths, scales, sid=sid,
-                speaker_embedding=speaker_embedding, lid=lid,
-            ).detach()
+        # Synthesize the held-out test utterances and log them as audio, once
+        # per epoch (batch_idx == 0). Opt-in via ``log_audio_samples`` and
+        # skipped unless the active logger's experiment supports ``add_audio``:
+        # TensorBoardLogger does, CSVLogger (a common choice) does not, and
+        # calling it there would raise. When disabled this whole loop — full
+        # generator inference whose result would otherwise be discarded — is
+        # skipped.
+        if (
+            self.hparams.log_audio_samples
+            and batch_idx == 0
+            and hasattr(self.logger.experiment, "add_audio")
+        ):
+            for utt_idx, test_utt in enumerate(self._test_dataset):
+                text = test_utt.phoneme_ids.unsqueeze(0).to(self.device)
+                text_lengths = torch.LongTensor([len(test_utt.phoneme_ids)]).to(self.device)
+                scales = [0.667, 1.0, 0.8]
+                sid = (
+                    test_utt.speaker_id.to(self.device)
+                    if test_utt.speaker_id is not None
+                    else None
+                )
+                speaker_embedding = (
+                    test_utt.d_vector.unsqueeze(0).to(self.device)
+                    if test_utt.d_vector is not None
+                    else None
+                )
+                lid = (
+                    test_utt.language_id.to(self.device)
+                    if test_utt.language_id is not None
+                    else None
+                )
+                test_audio = self(
+                    text, text_lengths, scales, sid=sid,
+                    speaker_embedding=speaker_embedding, lid=lid,
+                ).detach()
 
-            # Scale to make louder in [-1, 1]
-            test_audio = test_audio * (1.0 / max(0.01, abs(test_audio.max())))
+                # Scale to make louder in [-1, 1]
+                test_audio = test_audio * (1.0 / max(0.01, abs(test_audio.max())))
 
-            tag = test_utt.text or str(utt_idx)
-           # self.logger.experiment.add_audio(
-           #     tag, test_audio, sample_rate=self.hparams.sample_rate
-           # )
+                tag = test_utt.text or str(utt_idx)
+                self.logger.experiment.add_audio(
+                    tag, test_audio, sample_rate=self.hparams.sample_rate
+                )
 
         return val_loss
 
@@ -440,6 +452,12 @@ class VitsModel(pl.LightningModule):
         parser.add_argument("--batch-size", type=int, required=True)
         parser.add_argument("--validation-split", type=float, default=0.1)
         parser.add_argument("--num-test-examples", type=int, default=5)
+        parser.add_argument(
+            "--log-audio-samples",
+            action="store_true",
+            help="Log synthesized validation audio samples to the logger each "
+                 "epoch (requires a TensorBoard logger)",
+        )
         parser.add_argument(
             "--max-phoneme-ids",
             type=int,

--- a/tests/test_vits_audio_logging.py
+++ b/tests/test_vits_audio_logging.py
@@ -1,0 +1,137 @@
+"""Tests for the opt-in validation audio-sample logging guard in VitsModel.
+
+Constructing a real ``VitsModel`` builds a full SynthesizerTrn and needs a real
+dataset + batch, so the guarded logic in ``validation_step`` is exercised in
+isolation: a lightweight harness borrows the *real* ``VitsModel.validation_step``
+function (so the actual guard code runs), while the heavy collaborators
+(loss steps, forward synthesis, ``self.log``) are stubbed. This lets the three
+guard branches be driven deterministically with no model, dataset, or GPU.
+"""
+import types
+
+import torch
+
+from phoonnx_train.vits.lightning import VitsModel
+
+
+class _FakeUtt:
+    """Minimal stand-in for a dataset utterance."""
+
+    def __init__(self, phoneme_ids, text):
+        self.phoneme_ids = torch.tensor(phoneme_ids, dtype=torch.long)
+        self.text = text
+        self.speaker_id = None
+        self.d_vector = None
+        self.language_id = None
+
+
+class _Harness:
+    """Borrows the real validation_step; stubs everything it depends on."""
+
+    # the code under test, unmodified
+    validation_step = VitsModel.validation_step
+
+    def __init__(self, logger, dataset, log_audio_samples):
+        self.logger = logger
+        self._test_dataset = dataset
+        self.device = torch.device("cpu")
+        self.hparams = types.SimpleNamespace(
+            sample_rate=22050,
+            log_audio_samples=log_audio_samples,
+        )
+        self.synth_count = 0
+        self.logged_val_loss = None
+
+    # stubbed heavy collaborators
+    def training_step_g(self, batch):
+        return torch.tensor(1.0)
+
+    def training_step_d(self, batch):
+        return torch.tensor(0.5)
+
+    def log(self, name, value):
+        if name == "val_loss":
+            self.logged_val_loss = value
+
+    def __call__(self, text, text_lengths, scales, sid=None,
+                 speaker_embedding=None, lid=None):
+        # stand-in for generator inference; a non-zero tensor so the loudness
+        # scaling in validation_step is exercised without a div-by-zero
+        self.synth_count += 1
+        return torch.tensor([[[0.1, -0.2, 0.3, -0.4]]])
+
+
+class _RecordingExperiment:
+    """A logger.experiment that supports add_audio (like TensorBoard)."""
+
+    def __init__(self):
+        self.calls = []
+
+    def add_audio(self, tag, audio, sample_rate):
+        self.calls.append((tag, sample_rate))
+
+
+class _RecordingLogger:
+    def __init__(self):
+        self.experiment = _RecordingExperiment()
+
+
+class _NoAudioLogger:
+    """A logger whose experiment has no add_audio (like CSVLogger)."""
+
+    def __init__(self):
+        self.experiment = types.SimpleNamespace()  # deliberately no add_audio
+
+
+def _dataset():
+    return [_FakeUtt([1, 2, 3], "hello"), _FakeUtt([4, 5], "world")]
+
+
+def test_disabled_does_not_synthesize_or_log():
+    """Default (flag off): no synthesis, no add_audio, even at batch_idx 0."""
+    logger = _RecordingLogger()
+    h = _Harness(logger, _dataset(), log_audio_samples=False)
+
+    out = h.validation_step(batch=object(), batch_idx=0)
+
+    assert h.synth_count == 0  # zero wasted generator inference
+    assert logger.experiment.calls == []
+    assert h.logged_val_loss is not None  # normal path still ran
+    assert float(out) == 1.5
+
+
+def test_enabled_without_add_audio_does_not_raise_or_log():
+    """Flag on but logger lacks add_audio (CSVLogger): guard skips the loop."""
+    logger = _NoAudioLogger()
+    h = _Harness(logger, _dataset(), log_audio_samples=True)
+
+    # must not raise AttributeError despite add_audio being absent
+    out = h.validation_step(batch=object(), batch_idx=0)
+
+    assert h.synth_count == 0  # nothing synthesized when it cannot be logged
+    assert float(out) == 1.5
+
+
+def test_enabled_with_add_audio_logs_once_per_epoch():
+    """Flag on + TensorBoard-like logger: add_audio called for each utt."""
+    logger = _RecordingLogger()
+    dataset = _dataset()
+    h = _Harness(logger, dataset, log_audio_samples=True)
+
+    h.validation_step(batch=object(), batch_idx=0)
+
+    assert h.synth_count == len(dataset)
+    tags = [c[0] for c in logger.experiment.calls]
+    assert tags == ["hello", "world"]
+    assert all(c[1] == 22050 for c in logger.experiment.calls)
+
+
+def test_enabled_skips_non_first_batch():
+    """Only batch_idx == 0 logs; later validation batches must not."""
+    logger = _RecordingLogger()
+    h = _Harness(logger, _dataset(), log_audio_samples=True)
+
+    h.validation_step(batch=object(), batch_idx=1)
+
+    assert h.synth_count == 0
+    assert logger.experiment.calls == []


### PR DESCRIPTION
## What

Adds an opt-in `--log-audio-samples` flag that re-enables logging of
synthesized validation audio samples for VITS training.

## Why

`VitsModel.validation_step` synthesized the held-out test utterances on
every call but threw the result away — the `add_audio` logging call was
commented out, leaving full generator inference running purely as dead
compute. Three problems kept it disabled:

- **Wasted inference** — the synthesis loop ran but nothing was logged.
- **Logger crash** — `add_audio` only exists on a TensorBoard logger's
  `experiment`. `CSVLogger`, a common choice, has no such method and
  would raise `AttributeError`.
- **Per-batch, not per-epoch** — the loop sat in `validation_step` with
  no batch guard, so it fired once per validation *batch*, multiplying
  the waste.

## Change

- New `--log-audio-samples/--no-log-audio-samples` CLI flag in
  `train.py` (default off), threaded into the model hparams the same way
  as the other training knobs; mirrored as `--log-audio-samples` in
  `add_model_specific_args`.
- New `log_audio_samples` constructor param on `VitsModel` (default
  `False`), saved into hparams.
- The synthesis + `add_audio` loop now runs only when the flag is on,
  on the first validation batch (`batch_idx == 0`), and when the active
  logger's `experiment` actually has `add_audio`. When disabled — the
  default — the loop is skipped entirely, so behavior is unchanged and
  no inference is wasted.

## Tests

`tests/test_vits_audio_logging.py` drives the guard in isolation with
lightweight fakes (no model, dataset, or GPU):

- flag off → no synthesis and no `add_audio`;
- flag on + a logger without `add_audio` (CSVLogger-like) → no raise,
  no synthesis;
- flag on + a TensorBoard-like logger → `add_audio` called per utterance
  on `batch_idx == 0`, and not called on `batch_idx == 1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to log synthesized validation audio samples during training.
  * Audio logging occurs once per epoch when supported by the active logging system.
  * Added command-line controls to enable or disable validation audio logging.

* **Bug Fixes**
  * Prevented audio logging attempts when the selected logger does not support audio.

* **Tests**
  * Added coverage for enabled, disabled, unsupported-logger, and batch-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->