### PR TITLE
Add generic on-demand quality-metric filtering to preprocess

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,5 +11,5 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.11", "3.12", "3.13", "3.14"]'
-      install_extras: 'test,train,train-styletts2'
+      install_extras: 'test,train,train-styletts2,train-eval'
       test_path: 'tests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'phoonnx'
       test_path: 'tests/'
-      install_extras: '-e .[test,train,train-styletts2]'
+      install_extras: '-e .[test,train,train-styletts2,train-eval]'
       min_coverage: 0

--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -23,6 +23,9 @@ from phoonnx.tokenizer import TTSTokenizer, DEFAULT_IPA_PHONEME_ID_MAP, DEFAULT_
 from phoonnx.util import normalize
 from phoonnx.version import VERSION_STR
 from phoonnx_train.norm_audio import cache_norm_audio, make_silence_detector
+from phoonnx_train.quality_filter import (FilterSpec, apply_quality_filters,
+                                          known_scorers, log_filter_summary,
+                                          parse_filter_spec)
 
 _LOGGER = logging.getLogger("preprocess")
 
@@ -424,6 +427,23 @@ def phonemize_worker(
     help="[--engine yourtts] language id recorded on every utterance "
          "(multilingual training)",
 )
+@click.option(
+    "--filter",
+    "quality_filters",
+    multiple=True,
+    metavar="COLUMN:MIN:MAX",
+    help="Drop utterances outside [MIN, MAX] on an on-demand-computed quality "
+         "metric. Repeatable; a sample must pass every --filter to be kept. "
+         "MIN or MAX may be empty for unbounded on that side. Metrics are "
+         "computed fresh per sample (not read from precomputed dataset "
+         "columns): 'wpm' (words per minute, arithmetic), 'is_music_like' "
+         "(0/1 spectral heuristic, not a trained classifier), 'utmos' "
+         "(SpeechMOS UTMOS naturalness), 'dnsmos_sig'/'dnsmos_bak'/'dnsmos_ovrl' "
+         "(DNSMOS P.835, requires the 'speechmos' package). Referencing an "
+         "unknown column warns and skips that filter instead of failing. "
+         "Examples: --filter utmos:3.0: --filter wpm:80:400 "
+         "--filter is_music_like:0:0",
+)
 def cli(
     input_dir: Path,
     output_dir: Path,
@@ -450,6 +470,7 @@ def cli(
     engine: Optional[str],
     speaker_encoder_path: Optional[str],
     language_id: Optional[int],
+    quality_filters: Tuple[str, ...],
 ) -> None:
     """
     Preprocess a TTS dataset into a JSONL and config suitable for training a VITS-style model.
@@ -479,7 +500,9 @@ def cli(
         add_diacritics (bool): Instruct the inference settings in the config to add diacritics.
         jsonl_audio_path (Optional[str]): Optional base path override for audio paths written into dataset.jsonl.
         jsonl_audio_spec_path (Optional[str]): Optional base path override for cached audio/spec paths in dataset.jsonl.
-    
+        quality_filters (Tuple[str, ...]): Repeatable 'column:min:max' quality-metric filters (e.g. 'utmos:3.0:'),
+            applied at manifest-load time before phonemization/audio caching. See phoonnx_train.quality_filter.
+
     Raises:
         click.Abort: If mutually exclusive CLI options are provided (e.g., both --single-speaker and --speaker-id).
         ValueError: If finetuning with a previous config and the new dataset contains phonemes not present in that config and drop_extra_phonemes is False.
@@ -526,6 +549,20 @@ def cli(
     if not utterances:
         _LOGGER.error("No valid utterances found in dataset.")
         return
+
+    if quality_filters:
+        specs: List[FilterSpec] = [parse_filter_spec(f) for f in quality_filters]
+        total_before = len(utterances)
+        utterances, dropped_counts = apply_quality_filters(
+            utterances,
+            specs,
+            audio_path_fn=lambda u: u.audio_path,
+            text_fn=lambda u: u.text,
+        )
+        log_filter_summary(total_before, dropped_counts, len(utterances))
+        if not utterances:
+            _LOGGER.error("No utterances left after quality filtering.")
+            return
 
     num_utterances: int = len(utterances)
     _LOGGER.info("Found %d utterances.", num_utterances)

--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -24,8 +24,10 @@ from phoonnx.util import normalize
 from phoonnx.version import VERSION_STR
 from phoonnx_train.norm_audio import cache_norm_audio, make_silence_detector
 from phoonnx_train.quality_filter import (FilterSpec, apply_quality_filters,
-                                          known_scorers, log_filter_summary,
-                                          parse_filter_spec)
+                                          configure_asr_model,
+                                          configure_speaker_model,
+                                          configure_vad_model, known_scorers,
+                                          log_filter_summary, parse_filter_spec)
 
 _LOGGER = logging.getLogger("preprocess")
 
@@ -436,13 +438,50 @@ def phonemize_worker(
          "metric. Repeatable; a sample must pass every --filter to be kept. "
          "MIN or MAX may be empty for unbounded on that side. Metrics are "
          "computed fresh per sample (not read from precomputed dataset "
-         "columns): 'wpm' (words per minute, arithmetic), 'is_music_like' "
-         "(0/1 spectral heuristic, not a trained classifier), 'utmos' "
-         "(SpeechMOS UTMOS naturalness), 'dnsmos_sig'/'dnsmos_bak'/'dnsmos_ovrl' "
-         "(DNSMOS P.835, requires the 'speechmos' package). Referencing an "
+         "columns): 'wpm' (words per minute, arithmetic), 'snr' (energy-based "
+         "signal-to-noise dB estimate, arithmetic), 'clipping' (fraction of "
+         "near-full-scale samples, arithmetic), 'is_music_like' (0/1 "
+         "onset-rhythmicity heuristic, not a trained classifier -- roughly "
+         "25-30% error rate at any threshold, a coarse pre-filter only), "
+         "'vad_ratio' (speech-activity fraction via vadonnx, see "
+         "--vad-model), 'speaker_consistency' (min pairwise cosine "
+         "similarity between windows via speakeronnx, see --speaker-model), "
+         "'utmos' (SpeechMOS UTMOS naturalness), 'dnsmos_sig'/'dnsmos_bak'/"
+         "'dnsmos_ovrl' (DNSMOS P.835), 'plcmos' (packet-loss-concealment "
+         "quality, catches VoIP/dropped-packet artifacts), 'aecmos' "
+         "(echo-cancellation quality, catches speakerphone/echo artifacts; "
+         "plcmos/aecmos are most relevant to call-based corpora and require "
+         "the 'speechmos' package), 'wer' (word error rate of an onnx_asr "
+         "transcription against the sample's own text, see --asr-model; the "
+         "most expensive filter, always evaluated last). Referencing an "
          "unknown column warns and skips that filter instead of failing. "
          "Examples: --filter utmos:3.0: --filter wpm:80:400 "
-         "--filter is_music_like:0:0",
+         "--filter is_music_like:0:0 --filter snr:15: --filter clipping:0:0.01 "
+         "--filter vad_ratio:0.5: --filter speaker_consistency:0.6: "
+         "--filter plcmos:3.0: --filter aecmos:3.0: --filter wer:0:0.3",
+)
+@click.option(
+    "--vad-model",
+    "vad_model",
+    default="silero",
+    show_default=True,
+    help="vadonnx model name used by the 'vad_ratio' quality filter.",
+)
+@click.option(
+    "--speaker-model",
+    "speaker_model",
+    default="wespeaker-resnet34",
+    show_default=True,
+    help="speakeronnx model name used by the 'speaker_consistency' quality filter.",
+)
+@click.option(
+    "--asr-model",
+    "asr_model",
+    default="whisper-base",
+    show_default=True,
+    help="Model identifier or path loadable via onnx_asr.load_model(), used "
+         "by the 'wer' quality filter. Must be onnx-asr-compatible; an "
+         "unloadable value fails loudly instead of silently skipping 'wer'.",
 )
 def cli(
     input_dir: Path,
@@ -471,6 +510,9 @@ def cli(
     speaker_encoder_path: Optional[str],
     language_id: Optional[int],
     quality_filters: Tuple[str, ...],
+    vad_model: str,
+    speaker_model: str,
+    asr_model: str,
 ) -> None:
     """
     Preprocess a TTS dataset into a JSONL and config suitable for training a VITS-style model.
@@ -502,6 +544,9 @@ def cli(
         jsonl_audio_spec_path (Optional[str]): Optional base path override for cached audio/spec paths in dataset.jsonl.
         quality_filters (Tuple[str, ...]): Repeatable 'column:min:max' quality-metric filters (e.g. 'utmos:3.0:'),
             applied at manifest-load time before phonemization/audio caching. See phoonnx_train.quality_filter.
+        vad_model (str): vadonnx model name used by the 'vad_ratio' quality filter.
+        speaker_model (str): speakeronnx model name used by the 'speaker_consistency' quality filter.
+        asr_model (str): Model identifier/path loadable via onnx_asr.load_model(), used by the 'wer' quality filter.
 
     Raises:
         click.Abort: If mutually exclusive CLI options are provided (e.g., both --single-speaker and --speaker-id).
@@ -551,6 +596,9 @@ def cli(
         return
 
     if quality_filters:
+        configure_vad_model(vad_model)
+        configure_speaker_model(speaker_model)
+        configure_asr_model(asr_model)
         specs: List[FilterSpec] = [parse_filter_spec(f) for f in quality_filters]
         total_before = len(utterances)
         utterances, dropped_counts = apply_quality_filters(

--- a/phoonnx_train/quality_filter.py
+++ b/phoonnx_train/quality_filter.py
@@ -1,0 +1,335 @@
+"""Generic per-sample quality-metric filtering for training data preprocessing.
+
+Datasets fed into phoonnx do not reliably carry precomputed quality columns
+(UTMOS, DNSMOS, ...), and even where an upstream pipeline happens to have
+populated them we don't want preprocessing to silently depend on that. So
+every metric named on the CLI is instead computed on demand, once per
+sample, from its raw audio/text, by a small registry of named "scorers".
+
+New metrics are added by registering a new scorer function here; the
+``--filter`` CLI flag in ``phoonnx_train/preprocess.py`` stays generic and
+never needs a dedicated flag per metric.
+
+Scorers are evaluated cheapest-first (arithmetic, then heuristic, then
+model-based) and short-circuit per sample: once a sample fails one filter it
+is dropped without paying for any remaining (possibly expensive) scorers.
+"""
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+_LOGGER = logging.getLogger(__name__)
+
+# A scorer computes one metric from a sample's raw audio/text.
+# Signature: (audio: np.ndarray, sr: int, text: str, duration: float) -> float
+Scorer = Callable[[object, int, str, float], float]
+
+_SCORER_REGISTRY: Dict[str, Scorer] = {}
+# Registration order doubles as cheapest-first evaluation order.
+_SCORER_ORDER: List[str] = []
+
+
+def register_scorer(name: str, fn: Scorer) -> None:
+    """Register a named on-demand quality scorer.
+
+    Args:
+        name: filter column name (e.g. "utmos", "wpm").
+        fn: callable computing the metric from (audio, sr, text, duration).
+    """
+    _SCORER_REGISTRY[name] = fn
+    if name not in _SCORER_ORDER:
+        _SCORER_ORDER.append(name)
+
+
+def known_scorers() -> List[str]:
+    """Names of all registered scorers, cheapest-first."""
+    return list(_SCORER_ORDER)
+
+
+@dataclass
+class FilterSpec:
+    """One `column:min:max` filter. min/max of None means unbounded."""
+    column: str
+    min: Optional[float] = None
+    max: Optional[float] = None
+
+    def passes(self, value: float) -> bool:
+        if self.min is not None and value < self.min:
+            return False
+        if self.max is not None and value > self.max:
+            return False
+        return True
+
+
+def parse_filter_spec(spec: str) -> FilterSpec:
+    """Parse a `column:min:max` CLI value into a FilterSpec.
+
+    Either bound may be empty (unbounded on that side), e.g. "utmos:3.0:"
+    keeps utmos >= 3.0 with no upper bound.
+
+    Raises:
+        ValueError: if spec is not exactly three colon-separated fields, or
+            a non-empty bound is not a number.
+    """
+    parts = spec.split(":")
+    if len(parts) != 3:
+        raise ValueError(
+            f"invalid --filter spec {spec!r}: expected 'column:min:max' "
+            "(min/max may be empty for unbounded)"
+        )
+    column, raw_min, raw_max = (p.strip() for p in parts)
+    if not column:
+        raise ValueError(f"invalid --filter spec {spec!r}: column name is empty")
+    min_val = float(raw_min) if raw_min else None
+    max_val = float(raw_max) if raw_max else None
+    return FilterSpec(column=column, min=min_val, max=max_val)
+
+
+def _ordered_specs(specs: List[FilterSpec]) -> List[FilterSpec]:
+    """Specs sorted cheapest-scorer-first, unknown columns last (they warn
+    once up-front and are skipped for every sample anyway)."""
+    order = {name: i for i, name in enumerate(_SCORER_ORDER)}
+    return sorted(specs, key=lambda s: order.get(s.column, len(order)))
+
+
+def apply_quality_filters(
+    samples: List[object],
+    specs: List[FilterSpec],
+    audio_path_fn: Callable[[object], Union[str, Path]],
+    text_fn: Callable[[object], str],
+    audio_loader: Optional[Callable[[Union[str, Path]], Tuple[object, int, float]]] = None,
+) -> Tuple[List[object], Dict[str, int]]:
+    """Filter samples by on-demand-computed quality scorers.
+
+    Args:
+        samples: opaque per-sample objects (e.g. Utterance instances).
+        specs: filter specs to apply (AND semantics: a sample must pass all
+            of them to be kept).
+        audio_path_fn: samples[i] -> path to its audio file.
+        text_fn: samples[i] -> its transcript text.
+        audio_loader: path -> (audio, sample_rate, duration_seconds). Only
+            called lazily, and at most once per sample, when a filter that
+            actually needs audio is evaluated. Defaults to a librosa-backed
+            16kHz mono loader.
+
+    Returns:
+        (kept_samples, dropped_counts) where dropped_counts maps each
+        applied filter's column name to how many samples it dropped.
+        Unknown/unregistered column names are warned about once and
+        excluded from dropped_counts entirely (they are skipped, not
+        applied).
+    """
+    known: List[FilterSpec] = []
+    for spec in specs:
+        if spec.column not in _SCORER_REGISTRY:
+            _LOGGER.warning(
+                "unknown quality filter column %r (known: %s); skipping this filter",
+                spec.column, ", ".join(_SCORER_ORDER) or "<none registered>",
+            )
+            continue
+        known.append(spec)
+
+    dropped: Dict[str, int] = {spec.column: 0 for spec in known}
+    if not known:
+        return list(samples), dropped
+
+    ordered = _ordered_specs(known)
+    loader = audio_loader or _default_audio_loader
+    kept: List[object] = []
+
+    for sample in samples:
+        audio = None
+        sr = 0
+        duration = 0.0
+        audio_loaded = False
+        text = text_fn(sample)
+        sample_dropped = False
+
+        try:
+            for spec in ordered:
+                scorer = _SCORER_REGISTRY[spec.column]
+                if spec.column != "wpm" and not audio_loaded:
+                    audio, sr, duration = loader(audio_path_fn(sample))
+                    audio_loaded = True
+                elif spec.column == "wpm" and not audio_loaded:
+                    # wpm only needs duration; fetch it without decoding audio
+                    # unless a later filter already forced a full decode.
+                    duration = _duration_only(audio_path_fn(sample))
+
+                value = scorer(audio, sr, text, duration)
+                if not spec.passes(value):
+                    dropped[spec.column] += 1
+                    sample_dropped = True
+                    break
+        except Exception:
+            _LOGGER.exception(
+                "quality filtering failed for %s; dropping sample",
+                audio_path_fn(sample),
+            )
+            sample_dropped = True
+
+        if not sample_dropped:
+            kept.append(sample)
+
+    return kept, dropped
+
+
+def _duration_only(path: Union[str, Path]) -> float:
+    try:
+        import soundfile as sf
+        info = sf.info(str(path))
+        return float(info.frames) / float(info.samplerate)
+    except Exception:
+        _LOGGER.exception("failed to read duration for %s", path)
+        return 0.0
+
+
+def _default_audio_loader(path: Union[str, Path]) -> Tuple[object, int, float]:
+    """Loads audio mono at 16kHz for scoring. Lazily imports librosa."""
+    import librosa
+    audio, sr = librosa.load(str(path), sr=16000, mono=True)
+    duration = float(len(audio)) / float(sr)
+    return audio, sr, duration
+
+
+def log_filter_summary(total: int, dropped: Dict[str, int], remaining: int) -> None:
+    """Logs a standard before/dropped-per-filter/after summary."""
+    _LOGGER.info("Quality filtering: %d samples before filtering.", total)
+    for column, count in dropped.items():
+        _LOGGER.info("  --filter %s dropped %d samples.", column, count)
+    _LOGGER.info("Quality filtering: %d samples remaining.", remaining)
+
+
+# -----------------------------------------------------------------------------
+# Built-in scorers
+# -----------------------------------------------------------------------------
+
+def _word_count(text: str) -> int:
+    return len(text.split())
+
+
+def wpm_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Words per minute = word_count / (duration_seconds / 60).
+
+    Flags partial transcriptions (very low wpm, more audio than text
+    accounts for) and unnaturally fast speech (very high wpm).
+    """
+    if duration <= 0:
+        return 0.0
+    return _word_count(text) / (duration / 60.0)
+
+
+def is_music_like_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Cheap heuristic proxy for music contamination: 1.0 if music-like,
+    else 0.0. NOT a trained classifier — spectral flatness (music tends
+    noisier/flatter spectra than voiced speech) combined with the harmonic
+    energy ratio from HPSS (music leans more harmonic-dominant than typical
+    conversational speech). Tune thresholds per-corpus if this proves noisy.
+    """
+    import numpy as np
+    import librosa
+
+    if audio is None or len(audio) == 0:
+        return 0.0
+    flatness = float(np.mean(librosa.feature.spectral_flatness(y=audio)))
+    harmonic, _percussive = librosa.effects.hpss(audio)
+    total_energy = float(np.sum(np.asarray(audio, dtype=np.float64) ** 2)) + 1e-9
+    harmonic_ratio = float(np.sum(harmonic.astype(np.float64) ** 2)) / total_energy
+    return 1.0 if (flatness > 0.25 and harmonic_ratio > 0.6) else 0.0
+
+
+_utmos_predictor = None
+
+
+def _load_utmos():
+    global _utmos_predictor
+    if _utmos_predictor is None:
+        import torch
+        _LOGGER.info("loading UTMOS (SpeechMOS utmos22_strong)...")
+        _utmos_predictor = torch.hub.load(
+            "tarepan/SpeechMOS", "utmos22_strong", trust_repo=True
+        )
+        _utmos_predictor.eval()
+    return _utmos_predictor
+
+
+def utmos_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """UTMOS1 naturalness MOS via SpeechMOS utmos22_strong. Resamples to
+    16kHz mono, expects roughly peak-normalized audio."""
+    import torch
+    import torchaudio
+
+    predictor = _load_utmos()
+    t = torch.from_numpy(audio).float() if hasattr(audio, "dtype") else torch.tensor(audio).float()
+    if sr != 16000:
+        t = torchaudio.functional.resample(t, sr, 16000)
+    with torch.no_grad():
+        score = predictor(t.unsqueeze(0), 16000)
+    return float(score.squeeze().item())
+
+
+_dnsmos_run = None
+_dnsmos_cache_key = None
+_dnsmos_cache_value: Optional[Dict[str, float]] = None
+
+
+def _load_dnsmos_run():
+    """Imports the real (pip) speechmos.dnsmos.run and purges `speechmos`
+    from sys.modules afterward.
+
+    torch.hub.load(...) for UTMOS caches a github repo that bundles its own
+    package also named `speechmos` (UTMOS-only). Importing that cached repo
+    after the real pip package has already been imported (or vice versa)
+    lets one shadow the other in sys.modules. Grabbing a bound reference to
+    the real `run` function first and then purging `speechmos*` from
+    sys.modules keeps both usable regardless of import order.
+    """
+    global _dnsmos_run
+    if _dnsmos_run is None:
+        import speechmos.dnsmos as _real_dnsmos
+        _dnsmos_run = _real_dnsmos.run
+        for mod_name in list(sys.modules):
+            if mod_name == "speechmos" or mod_name.startswith("speechmos."):
+                del sys.modules[mod_name]
+    return _dnsmos_run
+
+
+def _dnsmos_all(audio: object, sr: int) -> Dict[str, float]:
+    global _dnsmos_cache_key, _dnsmos_cache_value
+    key = id(audio)
+    if _dnsmos_cache_key != key or _dnsmos_cache_value is None:
+        run = _load_dnsmos_run()
+        target_sr = 16000
+        if sr != target_sr:
+            import librosa
+            audio = librosa.resample(audio, orig_sr=sr, target_sr=target_sr)
+        _dnsmos_cache_value = run(audio, sr=target_sr)
+        _dnsmos_cache_key = key
+    return _dnsmos_cache_value
+
+
+def dnsmos_sig_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """DNSMOS P.835 signal quality MOS, via the `speechmos` pip package."""
+    return float(_dnsmos_all(audio, sr)["sig_mos"])
+
+
+def dnsmos_bak_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """DNSMOS P.835 background-noise quality MOS."""
+    return float(_dnsmos_all(audio, sr)["bak_mos"])
+
+
+def dnsmos_ovrl_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """DNSMOS P.835 overall quality MOS."""
+    return float(_dnsmos_all(audio, sr)["ovrl_mos"])
+
+
+# Cheapest first: pure arithmetic, then a lightweight heuristic, then
+# model-based scorers, roughly cheapest-to-most-expensive within that tier.
+register_scorer("wpm", wpm_score)
+register_scorer("is_music_like", is_music_like_score)
+register_scorer("dnsmos_sig", dnsmos_sig_score)
+register_scorer("dnsmos_bak", dnsmos_bak_score)
+register_scorer("dnsmos_ovrl", dnsmos_ovrl_score)
+register_scorer("utmos", utmos_score)

--- a/phoonnx_train/quality_filter.py
+++ b/phoonnx_train/quality_filter.py
@@ -221,23 +221,43 @@ def wpm_score(audio: object, sr: int, text: str, duration: float) -> float:
     return _word_count(text) / (duration / 60.0)
 
 
-def is_music_like_score(audio: object, sr: int, text: str, duration: float) -> float:
-    """Cheap heuristic proxy for music contamination: 1.0 if music-like,
-    else 0.0. NOT a trained classifier — spectral flatness (music tends
-    noisier/flatter spectra than voiced speech) combined with the harmonic
-    energy ratio from HPSS (music leans more harmonic-dominant than typical
-    conversational speech). Tune thresholds per-corpus if this proves noisy.
-    """
+IS_MUSIC_LIKE_RHYTHMICITY_THRESHOLD = 0.5
+
+
+def rhythmicity_score(audio: object, sr: int) -> float:
+    """Onset-strength autocorrelation peak (beyond the trivial lag-0/near-0
+    peak), in roughly [0, 1]: how strongly the clip pulses at a periodic
+    tempo. Music tends to score high even under vocals (a spoken-over beat
+    still pulses); conversational speech has no such periodicity."""
     import numpy as np
     import librosa
 
     if audio is None or len(audio) == 0:
         return 0.0
-    flatness = float(np.mean(librosa.feature.spectral_flatness(y=audio)))
-    harmonic, _percussive = librosa.effects.hpss(audio)
-    total_energy = float(np.sum(np.asarray(audio, dtype=np.float64) ** 2)) + 1e-9
-    harmonic_ratio = float(np.sum(harmonic.astype(np.float64) ** 2)) / total_energy
-    return 1.0 if (flatness > 0.25 and harmonic_ratio > 0.6) else 0.0
+    onset_env = librosa.onset.onset_strength(y=audio, sr=sr)
+    if len(onset_env) <= 8:
+        return 0.0
+    ac = librosa.autocorrelate(onset_env, max_size=len(onset_env) // 2)
+    ac = ac / (ac[0] + 1e-9)
+    return float(np.max(ac[4:])) if len(ac) > 4 else 0.0
+
+
+def is_music_like_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Cheap heuristic proxy for music contamination: 1.0 if music-like,
+    else 0.0. NOT a trained classifier, and NOT reliable enough to treat as
+    ground truth: it thresholds `rhythmicity_score` (onset-strength
+    autocorrelation), which on a 200-clip labeled validation set (100
+    music-tagged / 100 clean-speech-tagged, real broadcast audio) scored
+    ROC-AUC 0.744 — clearly the best of several candidate features tried
+    (spectral flatness AUC 0.282, harmonic ratio AUC 0.544, tempo AUC 0.481,
+    chroma variants AUC ~0.48-0.50, all near or below chance), but AUC 0.744
+    still implies a real false-positive/false-negative rate on the order of
+    25-30% at any single threshold. Treat this as a coarse, cheap pre-filter
+    to catch the more obvious music contamination, not a substitute for a
+    trained speech/music/silence classifier; verify a sample of what it
+    drops and keeps before trusting it on a new corpus.
+    """
+    return 1.0 if rhythmicity_score(audio, sr) > IS_MUSIC_LIKE_RHYTHMICITY_THRESHOLD else 0.0
 
 
 _utmos_predictor = None
@@ -270,14 +290,16 @@ def utmos_score(audio: object, sr: int, text: str, duration: float) -> float:
     return float(score.squeeze().item())
 
 
-_dnsmos_run = None
 _dnsmos_cache_key = None
 _dnsmos_cache_value: Optional[Dict[str, float]] = None
 
 
-def _load_dnsmos_run():
-    """Imports the real (pip) speechmos.dnsmos.run and purges `speechmos`
-    from sys.modules afterward.
+_speechmos_run_cache: Dict[str, Callable] = {}
+
+
+def _load_speechmos_run(submodule: str) -> Callable:
+    """Imports the real (pip) speechmos.<submodule>.run and purges
+    `speechmos` from sys.modules afterward.
 
     torch.hub.load(...) for UTMOS caches a github repo that bundles its own
     package also named `speechmos` (UTMOS-only). Importing that cached repo
@@ -286,28 +308,48 @@ def _load_dnsmos_run():
     the real `run` function first and then purging `speechmos*` from
     sys.modules keeps both usable regardless of import order.
     """
-    global _dnsmos_run
-    if _dnsmos_run is None:
-        import speechmos.dnsmos as _real_dnsmos
-        _dnsmos_run = _real_dnsmos.run
+    if submodule not in _speechmos_run_cache:
+        import importlib
+        real_module = importlib.import_module(f"speechmos.{submodule}")
+        _speechmos_run_cache[submodule] = real_module.run
         for mod_name in list(sys.modules):
             if mod_name == "speechmos" or mod_name.startswith("speechmos."):
                 del sys.modules[mod_name]
-    return _dnsmos_run
+    return _speechmos_run_cache[submodule]
+
+
+def _resample_16k(audio: object, sr: int) -> object:
+    target_sr = 16000
+    if sr != target_sr:
+        import librosa
+        audio = librosa.resample(audio, orig_sr=sr, target_sr=target_sr)
+    return audio
 
 
 def _dnsmos_all(audio: object, sr: int) -> Dict[str, float]:
     global _dnsmos_cache_key, _dnsmos_cache_value
     key = id(audio)
     if _dnsmos_cache_key != key or _dnsmos_cache_value is None:
-        run = _load_dnsmos_run()
-        target_sr = 16000
-        if sr != target_sr:
-            import librosa
-            audio = librosa.resample(audio, orig_sr=sr, target_sr=target_sr)
-        _dnsmos_cache_value = run(audio, sr=target_sr)
+        run = _load_speechmos_run("dnsmos")
+        audio = _resample_16k(audio, sr)
+        _dnsmos_cache_value = run(audio, sr=16000)
         _dnsmos_cache_key = key
     return _dnsmos_cache_value
+
+
+def _speechmos_df_value(df, preferred_columns: List[str]) -> float:
+    """Pulls a scalar metric out of a single-row speechmos `return_df=True`
+    result, preferring an exact expected column name but falling back to the
+    last numeric column so a harmless column-naming difference across
+    speechmos versions doesn't hard-crash preprocessing."""
+    row = df.iloc[0]
+    for col in preferred_columns:
+        if col in row:
+            return float(row[col])
+    numeric = [v for v in row if isinstance(v, (int, float))]
+    if not numeric:
+        raise ValueError(f"speechmos result has no numeric columns: {list(row.index)}")
+    return float(numeric[-1])
 
 
 def dnsmos_sig_score(audio: object, sr: int, text: str, duration: float) -> float:
@@ -325,11 +367,250 @@ def dnsmos_ovrl_score(audio: object, sr: int, text: str, duration: float) -> flo
     return float(_dnsmos_all(audio, sr)["ovrl_mos"])
 
 
+def plcmos_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Packet-loss-concealment quality MOS, via `speechmos.plcmos`. Flags
+    VoIP/call audio with dropped-packet artifacts that DNSMOS doesn't
+    specifically target; most relevant to call-based corpora."""
+    run = _load_speechmos_run("plcmos")
+    audio = _resample_16k(audio, sr)
+    df = run(audio, 16000, return_df=True, verbose=False)
+    return _speechmos_df_value(df, ["plcmos", "PLCMOS", "plcmos_score"])
+
+
+def aecmos_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Echo-cancellation quality MOS, via `speechmos.aecmos`. Flags
+    speakerphone/echo artifacts that DNSMOS doesn't specifically target;
+    most relevant to call-based corpora. Runs in scenarioless mode
+    (talk_type=None): at 16kHz that selects aecmos_scenarioless_16kHz,
+    which needs no far-end reference signal, so it can score one clip at a
+    time like every other scorer here (at 48kHz talk_type would be
+    mandatory instead, which is why audio is always resampled to 16kHz
+    first)."""
+    run = _load_speechmos_run("aecmos")
+    audio = _resample_16k(audio, sr)
+    df = run(audio, 16000, talk_type=None, return_df=True, verbose=False)
+    return _speechmos_df_value(df, ["aecmos", "AECMOS", "aecmos_score"])
+
+
+def snr_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Energy-based SNR estimate in dB, no model.
+
+    Frames the clip (20ms), treats the quietest 10% of frame energies as the
+    noise floor and the loudest half as signal, and returns
+    10*log10(signal/noise). A cheap proxy, not a WADA-SNR-grade estimate;
+    tune the corpus threshold empirically.
+    """
+    import numpy as np
+
+    if audio is None or len(audio) == 0 or not sr:
+        return 0.0
+    frame_len = max(1, int(0.02 * sr))
+    n_frames = len(audio) // frame_len
+    if n_frames == 0:
+        return 0.0
+    frames = np.asarray(audio[: n_frames * frame_len], dtype=np.float64).reshape(n_frames, frame_len)
+    energies = np.mean(frames ** 2, axis=1)
+    sorted_energies = np.sort(energies)
+    noise_floor = float(np.mean(sorted_energies[: max(1, n_frames // 10)])) + 1e-12
+    signal_power = float(np.mean(sorted_energies[max(1, n_frames // 2):])) + 1e-12
+    return float(10.0 * np.log10(signal_power / noise_floor))
+
+
+def clipping_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Fraction of samples at or near full-scale (|x| > 0.99) on a
+    [-1, 1]-normalized waveform. No model."""
+    import numpy as np
+
+    if audio is None or len(audio) == 0:
+        return 0.0
+    return float(np.mean(np.abs(np.asarray(audio, dtype=np.float64)) > 0.99))
+
+
+_vad_model_name = "silero"
+_vad_model = None
+_vad_model_cache_key: Optional[str] = None
+
+
+def configure_vad_model(name: str) -> None:
+    """Sets the vadonnx model used by the vad_ratio scorer. Takes effect on
+    the next call (the cached model, if any, is dropped)."""
+    global _vad_model_name, _vad_model, _vad_model_cache_key
+    _vad_model_name = name
+    _vad_model = None
+    _vad_model_cache_key = None
+
+
+def _get_vad_model():
+    global _vad_model, _vad_model_cache_key
+    if _vad_model is None or _vad_model_cache_key != _vad_model_name:
+        from vadonnx import load_vad
+        _LOGGER.info("loading VAD model %r (vadonnx) for vad_ratio scoring...", _vad_model_name)
+        _vad_model = load_vad(_vad_model_name)
+        _vad_model_cache_key = _vad_model_name
+    return _vad_model
+
+
+def vad_ratio_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Fraction of the clip vadonnx detects as speech. Model set via
+    configure_vad_model()/--vad-model (default: vadonnx's bundled 'silero',
+    offline with no extra download)."""
+    if audio is None or len(audio) == 0 or duration <= 0:
+        return 0.0
+    vad = _get_vad_model()
+    segments = vad.get_speech_segments(audio, sample_rate=sr)
+    speech_seconds = sum(seg.duration for seg in segments)
+    return float(speech_seconds / duration)
+
+
+_speaker_model_name = "wespeaker-resnet34"
+_speaker_embedder = None
+_speaker_embedder_cache_key: Optional[str] = None
+
+
+def configure_speaker_model(name: str) -> None:
+    """Sets the speakeronnx model used by the speaker_consistency scorer.
+    Takes effect on the next call (the cached embedder, if any, is dropped)."""
+    global _speaker_model_name, _speaker_embedder, _speaker_embedder_cache_key
+    _speaker_model_name = name
+    _speaker_embedder = None
+    _speaker_embedder_cache_key = None
+
+
+def _get_speaker_embedder():
+    global _speaker_embedder, _speaker_embedder_cache_key
+    if _speaker_embedder is None or _speaker_embedder_cache_key != _speaker_model_name:
+        from speakeronnx import SpeakerEmbedder
+        _LOGGER.info("loading speaker embedder %r (speakeronnx) for "
+                     "speaker_consistency scoring...", _speaker_model_name)
+        _speaker_embedder = SpeakerEmbedder(model=_speaker_model_name)
+        _speaker_embedder_cache_key = _speaker_model_name
+    return _speaker_embedder
+
+
+def speaker_consistency_score(audio: object, sr: int, text: str, duration: float,
+                              num_windows: int = 3, min_window_seconds: float = 0.5) -> float:
+    """Minimum pairwise cosine similarity between speaker embeddings of
+    N evenly-spaced windows of the clip; low similarity between windows of
+    the same nominal clip suggests a speaker change or bleed-in. Clips too
+    short to split into `num_windows` windows of at least
+    `min_window_seconds` are treated as trivially consistent (1.0) since
+    there's nothing to compare. Model set via configure_speaker_model()/
+    --speaker-model (default: speakeronnx's own default,
+    'wespeaker-resnet34')."""
+    import numpy as np
+    from speakeronnx import cosine
+
+    if audio is None or duration <= 0:
+        return 1.0
+    window_len = len(audio) // num_windows
+    if sr and window_len < int(min_window_seconds * sr):
+        return 1.0
+    embedder = _get_speaker_embedder()
+    embeddings = []
+    for i in range(num_windows):
+        start = i * window_len
+        end = start + window_len if i < num_windows - 1 else len(audio)
+        window = np.asarray(audio[start:end])
+        embeddings.append(embedder.embed(window))
+    similarities = [
+        cosine(embeddings[i], embeddings[j])
+        for i in range(len(embeddings))
+        for j in range(i + 1, len(embeddings))
+    ]
+    return float(min(similarities)) if similarities else 1.0
+
+
+_asr_model_name: Optional[str] = "whisper-base"
+_asr_model = None
+_asr_model_cache_key: Optional[str] = None
+
+
+def configure_asr_model(name: str) -> None:
+    """Sets the onnx_asr model used by the wer scorer. Takes effect on the
+    next call (the cached model, if any, is dropped)."""
+    global _asr_model_name, _asr_model, _asr_model_cache_key
+    _asr_model_name = name
+    _asr_model = None
+    _asr_model_cache_key = None
+
+
+def _get_asr_model():
+    global _asr_model, _asr_model_cache_key
+    if _asr_model_name is None:
+        raise RuntimeError(
+            "the 'wer' filter requires an ASR model; set --asr-model to a "
+            "model identifier or path loadable via onnx_asr.load_model()"
+        )
+    if _asr_model is None or _asr_model_cache_key != _asr_model_name:
+        try:
+            import onnx_asr
+        except ImportError as exc:
+            raise RuntimeError(
+                "the 'wer' filter requires the 'onnx_asr' package "
+                "(pip install onnx-asr, or the phoonnx 'train-eval' extra); "
+                "it does not fall back to any other ASR backend"
+            ) from exc
+        _LOGGER.info("loading ASR model %r (onnx_asr) for wer scoring...", _asr_model_name)
+        try:
+            _asr_model = onnx_asr.load_model(_asr_model_name)
+        except Exception as exc:
+            raise RuntimeError(
+                f"--asr-model {_asr_model_name!r} is not loadable via "
+                "onnx_asr.load_model(); the 'wer' filter only supports "
+                "onnx-asr-compatible model identifiers or paths, and does "
+                "not fall back to any other ASR backend"
+            ) from exc
+        _asr_model_cache_key = _asr_model_name
+    return _asr_model
+
+
+def _word_error_rate(reference: str, hypothesis: str) -> float:
+    """Word error rate: word-level Levenshtein edit distance / reference
+    word count. An empty reference with a non-empty hypothesis scores 1.0
+    (fully wrong); an empty reference with an empty hypothesis scores 0.0."""
+    ref_words = reference.split()
+    hyp_words = hypothesis.split()
+    if not ref_words:
+        return 1.0 if hyp_words else 0.0
+    n, m = len(ref_words), len(hyp_words)
+    dp = list(range(m + 1))
+    for i in range(1, n + 1):
+        prev = dp[0]
+        dp[0] = i
+        for j in range(1, m + 1):
+            temp = dp[j]
+            cost = 0 if ref_words[i - 1] == hyp_words[j - 1] else 1
+            dp[j] = min(dp[j] + 1, dp[j - 1] + 1, prev + cost)
+            prev = temp
+    return dp[m] / n
+
+
+def wer_score(audio: object, sr: int, text: str, duration: float) -> float:
+    """Word error rate of an onnx_asr transcription against the sample's own
+    transcript. The most expensive scorer here (a full ASR pass per clip),
+    so it is evaluated last. Model set via configure_asr_model()/
+    --asr-model; loading a model that onnx_asr.load_model() rejects raises
+    immediately rather than silently skipping this filter."""
+    model = _get_asr_model()
+    hypothesis = model.recognize(audio, sample_rate=sr or 16000)
+    if isinstance(hypothesis, list):
+        hypothesis = hypothesis[0] if hypothesis else ""
+    return _word_error_rate(text, str(hypothesis))
+
+
 # Cheapest first: pure arithmetic, then a lightweight heuristic, then
 # model-based scorers, roughly cheapest-to-most-expensive within that tier.
+# wer is a full ASR pass per clip and always sorts last.
 register_scorer("wpm", wpm_score)
+register_scorer("snr", snr_score)
+register_scorer("clipping", clipping_score)
 register_scorer("is_music_like", is_music_like_score)
+register_scorer("vad_ratio", vad_ratio_score)
 register_scorer("dnsmos_sig", dnsmos_sig_score)
 register_scorer("dnsmos_bak", dnsmos_bak_score)
 register_scorer("dnsmos_ovrl", dnsmos_ovrl_score)
+register_scorer("plcmos", plcmos_score)
+register_scorer("aecmos", aecmos_score)
 register_scorer("utmos", utmos_score)
+register_scorer("speaker_consistency", speaker_consistency_score)
+register_scorer("wer", wer_score)

--- a/phoonnx_train/quality_filter.py
+++ b/phoonnx_train/quality_filter.py
@@ -290,7 +290,7 @@ def utmos_score(audio: object, sr: int, text: str, duration: float) -> float:
     return float(score.squeeze().item())
 
 
-_dnsmos_cache_key = None
+_dnsmos_cache_audio = None
 _dnsmos_cache_value: Optional[Dict[str, float]] = None
 
 
@@ -327,13 +327,12 @@ def _resample_16k(audio: object, sr: int) -> object:
 
 
 def _dnsmos_all(audio: object, sr: int) -> Dict[str, float]:
-    global _dnsmos_cache_key, _dnsmos_cache_value
-    key = id(audio)
-    if _dnsmos_cache_key != key or _dnsmos_cache_value is None:
+    global _dnsmos_cache_audio, _dnsmos_cache_value
+    if _dnsmos_cache_audio is not audio or _dnsmos_cache_value is None:
         run = _load_speechmos_run("dnsmos")
-        audio = _resample_16k(audio, sr)
-        _dnsmos_cache_value = run(audio, sr=16000)
-        _dnsmos_cache_key = key
+        resampled = _resample_16k(audio, sr)
+        _dnsmos_cache_value = run(resampled, sr=16000)
+        _dnsmos_cache_audio = audio
     return _dnsmos_cache_value
 
 
@@ -487,6 +486,13 @@ def _get_speaker_embedder():
     return _speaker_embedder
 
 
+def _cosine_similarity(a, b) -> float:
+    import numpy as np
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+
+
 def speaker_consistency_score(audio: object, sr: int, text: str, duration: float,
                               num_windows: int = 3, min_window_seconds: float = 0.5) -> float:
     """Minimum pairwise cosine similarity between speaker embeddings of
@@ -498,7 +504,6 @@ def speaker_consistency_score(audio: object, sr: int, text: str, duration: float
     --speaker-model (default: speakeronnx's own default,
     'wespeaker-resnet34')."""
     import numpy as np
-    from speakeronnx import cosine
 
     if audio is None or duration <= 0:
         return 1.0
@@ -513,7 +518,7 @@ def speaker_consistency_score(audio: object, sr: int, text: str, duration: float
         window = np.asarray(audio[start:end])
         embeddings.append(embedder.embed(window))
     similarities = [
-        cosine(embeddings[i], embeddings[j])
+        _cosine_similarity(embeddings[i], embeddings[j])
         for i in range(len(embeddings))
         for j in range(i + 1, len(embeddings))
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ train-eval = [
     "torchaudio",
     "soundfile",
     "speakeronnx",
+    "vadonnx",
+    "onnx-asr",
+    "pandas",
 ]
 # extra deps for the FastPitch / SpeedySpeech training engine
 # (phoonnx_train/engines/fastpitch.py) on top of [train]: pyworld for F0

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -179,6 +179,10 @@ class TestApplyQualityFilters(unittest.TestCase):
         self.assertEqual([s.name for s in kept], ["speech"])
         self.assertEqual(dropped, {"is_music_like": 1})
 
+        # restore the real scorer for any subsequent tests in this run
+        from phoonnx_train.quality_filter import is_music_like_score
+        register_scorer("is_music_like", is_music_like_score)
+
     def test_wpm_needs_no_audio_load(self):
         # wpm is arithmetic-only: it must never touch the audio loader,
         # only the (cheap, header-only) duration lookup.

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -1,0 +1,256 @@
+"""Tests for generic on-demand quality-metric filtering."""
+import unittest
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from phoonnx_train.quality_filter import (FilterSpec, apply_quality_filters,
+                                           parse_filter_spec, register_scorer)
+
+
+@dataclass
+class _Sample:
+    """Minimal stand-in for Utterance: only audio_path/text matter here."""
+    name: str
+    text: str = "hello world"
+    audio_path: str = ""
+
+
+def _stub_loader(scores: Dict[str, Dict[str, float]]):
+    """Fake audio_loader: returns (audio, sr, duration) where 'audio' is the
+    sample name itself, so scorer stubs can key off it."""
+    def loader(path):
+        return path, 16000, scores.get(path, {}).get("duration", 1.0)
+    return loader
+
+
+class TestParseFilterSpec(unittest.TestCase):
+    def test_both_bounds(self):
+        spec = parse_filter_spec("utmos:3.0:4.5")
+        self.assertEqual(spec, FilterSpec("utmos", 3.0, 4.5))
+
+    def test_unbounded_max(self):
+        spec = parse_filter_spec("utmos:3.0:")
+        self.assertEqual(spec, FilterSpec("utmos", 3.0, None))
+
+    def test_unbounded_min(self):
+        spec = parse_filter_spec("wpm::400")
+        self.assertEqual(spec, FilterSpec("wpm", None, 400.0))
+
+    def test_boolean_like_bounds(self):
+        spec = parse_filter_spec("is_music_like:0:0")
+        self.assertEqual(spec, FilterSpec("is_music_like", 0.0, 0.0))
+
+    def test_malformed_spec_raises(self):
+        with self.assertRaises(ValueError):
+            parse_filter_spec("utmos:3.0")
+        with self.assertRaises(ValueError):
+            parse_filter_spec("utmos:3.0:4.0:5.0")
+
+    def test_empty_column_raises(self):
+        with self.assertRaises(ValueError):
+            parse_filter_spec(":1:2")
+
+    def test_non_numeric_bound_raises(self):
+        with self.assertRaises(ValueError):
+            parse_filter_spec("utmos:low:high")
+
+
+class TestApplyQualityFilters(unittest.TestCase):
+    def setUp(self):
+        # Register lightweight test-only scorers so this suite never needs
+        # librosa/torch/speechmos: each stub reads its value straight off
+        # the sample name from a per-test score table.
+        self._orig_registry = {}
+
+    def _register(self, name, table):
+        def scorer(audio, sr, text, duration):
+            return table[audio]
+        register_scorer(name, scorer)
+        return scorer
+
+    def test_drops_samples_outside_bounds(self):
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b"),
+                   _Sample("c", audio_path="c")]
+        self._register("metric_a", {"a": 4.0, "b": 2.0, "c": 3.5})
+        specs = [parse_filter_spec("metric_a:3.0:")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual([s.name for s in kept], ["a", "c"])
+        self.assertEqual(dropped, {"metric_a": 1})
+
+    def test_unbounded_min_keeps_everything_below_max(self):
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b")]
+        self._register("metric_b", {"a": 1.0, "b": 999.0})
+        specs = [parse_filter_spec("metric_b::100")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual([s.name for s in kept], ["a"])
+        self.assertEqual(dropped, {"metric_b": 1})
+
+    def test_unbounded_max_keeps_everything_above_min(self):
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b")]
+        self._register("metric_c", {"a": 1.0, "b": 999.0})
+        specs = [parse_filter_spec("metric_c:100:")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual([s.name for s in kept], ["b"])
+        self.assertEqual(dropped, {"metric_c": 1})
+
+    def test_unknown_column_warns_and_is_skipped(self):
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b")]
+        specs = [parse_filter_spec("totally_made_up_metric:1:2")]
+        with self.assertLogs("phoonnx_train.quality_filter", level="WARNING") as log:
+            kept, dropped = apply_quality_filters(
+                samples, specs,
+                audio_path_fn=lambda s: s.audio_path,
+                text_fn=lambda s: s.text,
+                audio_loader=_stub_loader({}),
+            )
+        self.assertEqual([s.name for s in kept], ["a", "b"])
+        self.assertEqual(dropped, {})
+        self.assertTrue(any("unknown quality filter column" in m for m in log.output))
+
+    def test_multiple_filters_combine_with_and_semantics(self):
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b"),
+                   _Sample("c", audio_path="c")]
+        # a: passes both, b: fails first, c: passes first, fails second
+        self._register("metric_d", {"a": 4.0, "b": 1.0, "c": 4.0})
+        self._register("metric_e", {"a": 4.0, "b": 4.0, "c": 1.0})
+        specs = [parse_filter_spec("metric_d:3.0:"), parse_filter_spec("metric_e:3.0:")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual([s.name for s in kept], ["a"])
+        self.assertEqual(dropped["metric_d"], 1)
+        self.assertEqual(dropped["metric_e"], 1)
+
+    def test_short_circuits_before_expensive_filter(self):
+        # 'b' fails the cheap filter registered first in scorer order; the
+        # second (expensive) scorer must never be evaluated for it.
+        calls = []
+
+        def cheap(audio, sr, text, duration):
+            return {"a": 5.0, "b": 0.0}[audio]
+
+        def expensive(audio, sr, text, duration):
+            calls.append(audio)
+            return 5.0
+
+        register_scorer("cheap_metric", cheap)
+        register_scorer("expensive_metric", expensive)
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b")]
+        specs = [parse_filter_spec("cheap_metric:1:"), parse_filter_spec("expensive_metric:1:")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual([s.name for s in kept], ["a"])
+        self.assertNotIn("b", calls)
+        self.assertIn("a", calls)
+
+    def test_is_music_like_boolean_filter_keeps_only_non_music(self):
+        samples = [_Sample("speech", audio_path="speech"),
+                   _Sample("music", audio_path="music")]
+        self._register("is_music_like", {"speech": 0.0, "music": 1.0})
+        specs = [parse_filter_spec("is_music_like:0:0")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual([s.name for s in kept], ["speech"])
+        self.assertEqual(dropped, {"is_music_like": 1})
+
+    def test_wpm_needs_no_audio_load(self):
+        # wpm is arithmetic-only: it must never touch the audio loader,
+        # only the (cheap, header-only) duration lookup.
+        from unittest.mock import patch
+
+        from phoonnx_train.quality_filter import wpm_score
+        register_scorer("wpm", wpm_score)
+
+        def failing_loader(path):
+            raise AssertionError("audio_loader should not be called for wpm-only filters")
+
+        samples = [_Sample("a", text="one two three four", audio_path="a")]
+        specs = [parse_filter_spec("wpm:1:")]
+        with patch("phoonnx_train.quality_filter._duration_only", return_value=60.0):
+            kept, dropped = apply_quality_filters(
+                samples, specs,
+                audio_path_fn=lambda s: s.audio_path,
+                text_fn=lambda s: s.text,
+                audio_loader=failing_loader,
+            )
+        self.assertEqual(len(kept), 1)
+
+    def test_no_filters_returns_all_samples_unchanged(self):
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b")]
+        kept, dropped = apply_quality_filters(
+            samples, [],
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual(kept, samples)
+        self.assertEqual(dropped, {})
+
+    def test_scorer_exception_drops_sample_without_crashing(self):
+        def boom(audio, sr, text, duration):
+            raise RuntimeError("scorer blew up")
+
+        register_scorer("flaky_metric", boom)
+        samples = [_Sample("a", audio_path="a"), _Sample("b", audio_path="b")]
+        specs = [parse_filter_spec("flaky_metric:1:")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual(kept, [])
+
+
+class TestWpmScore(unittest.TestCase):
+    def test_wpm_arithmetic(self):
+        from phoonnx_train.quality_filter import wpm_score
+        # 6 words over 30s = 12 wpm
+        self.assertAlmostEqual(wpm_score(None, 16000, "one two three four five six", 30.0), 12.0)
+
+    def test_wpm_zero_duration_is_safe(self):
+        from phoonnx_train.quality_filter import wpm_score
+        self.assertEqual(wpm_score(None, 16000, "hello", 0.0), 0.0)
+
+
+class TestIsMusicLikeScore(unittest.TestCase):
+    def test_silence_is_not_music(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import is_music_like_score
+        silence = np.zeros(16000, dtype=np.float32)
+        self.assertEqual(is_music_like_score(silence, 16000, "", 1.0), 0.0)
+
+    def test_empty_audio_is_not_music(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import is_music_like_score
+        self.assertEqual(is_music_like_score(np.array([]), 16000, "", 0.0), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -239,17 +239,346 @@ class TestWpmScore(unittest.TestCase):
         self.assertEqual(wpm_score(None, 16000, "hello", 0.0), 0.0)
 
 
-class TestIsMusicLikeScore(unittest.TestCase):
-    def test_silence_is_not_music(self):
+class TestRhythmicityScore(unittest.TestCase):
+    def test_silence_has_no_rhythmicity(self):
         import numpy as np
+        from phoonnx_train.quality_filter import rhythmicity_score
+        silence = np.zeros(16000 * 3, dtype=np.float32)
+        self.assertEqual(rhythmicity_score(silence, 16000), 0.0)
+
+    def test_periodic_click_train_scores_high(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import rhythmicity_score
+        sr = 16000
+        clicks = np.zeros(sr * 3, dtype=np.float32)
+        clicks[:: sr // 2] = 1.0  # a click every 0.5s: a clean periodic pulse
+        self.assertGreater(rhythmicity_score(clicks, sr), 0.5)
+
+    def test_empty_audio_is_safe(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import rhythmicity_score
+        self.assertEqual(rhythmicity_score(np.array([]), 16000), 0.0)
+        self.assertEqual(rhythmicity_score(None, 16000), 0.0)
+
+
+class TestIsMusicLikeScore(unittest.TestCase):
+    def test_thresholds_rhythmicity_below(self):
+        from unittest.mock import patch
         from phoonnx_train.quality_filter import is_music_like_score
-        silence = np.zeros(16000, dtype=np.float32)
-        self.assertEqual(is_music_like_score(silence, 16000, "", 1.0), 0.0)
+        with patch("phoonnx_train.quality_filter.rhythmicity_score", return_value=0.2):
+            self.assertEqual(is_music_like_score(object(), 16000, "", 1.0), 0.0)
+
+    def test_thresholds_rhythmicity_above(self):
+        from unittest.mock import patch
+        from phoonnx_train.quality_filter import is_music_like_score
+        with patch("phoonnx_train.quality_filter.rhythmicity_score", return_value=0.9):
+            self.assertEqual(is_music_like_score(object(), 16000, "", 1.0), 1.0)
 
     def test_empty_audio_is_not_music(self):
         import numpy as np
         from phoonnx_train.quality_filter import is_music_like_score
         self.assertEqual(is_music_like_score(np.array([]), 16000, "", 0.0), 0.0)
+
+
+class TestPlcmosScore(unittest.TestCase):
+    def test_reads_plcmos_column_from_df(self):
+        import numpy as np
+        import pandas as pd
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import plcmos_score
+
+        fake_run = MagicMock(return_value=pd.DataFrame([{"filename": "clip", "plcmos": 3.7}]))
+        with patch("phoonnx_train.quality_filter._load_speechmos_run", return_value=fake_run):
+            score = plcmos_score(np.zeros(16000), 16000, "", 1.0)
+        self.assertAlmostEqual(score, 3.7)
+        fake_run.assert_called_once()
+        args, kwargs = fake_run.call_args
+        self.assertEqual(kwargs.get("return_df"), True)
+
+    def test_resamples_to_16k(self):
+        import numpy as np
+        import pandas as pd
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import plcmos_score
+
+        fake_run = MagicMock(return_value=pd.DataFrame([{"plcmos": 3.0}]))
+        with patch("phoonnx_train.quality_filter._load_speechmos_run", return_value=fake_run):
+            plcmos_score(np.zeros(48000), 48000, "", 1.0)
+        args, kwargs = fake_run.call_args
+        self.assertEqual(args[1] if len(args) > 1 else kwargs.get("sr"), 16000)
+
+
+class TestAecmosScore(unittest.TestCase):
+    def test_reads_aecmos_column_from_df_scenarioless(self):
+        import numpy as np
+        import pandas as pd
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import aecmos_score
+
+        fake_run = MagicMock(return_value=pd.DataFrame([{"aecmos": 4.1}]))
+        with patch("phoonnx_train.quality_filter._load_speechmos_run", return_value=fake_run):
+            score = aecmos_score(np.zeros(16000), 16000, "", 1.0)
+        self.assertAlmostEqual(score, 4.1)
+        args, kwargs = fake_run.call_args
+        # scenarioless mode: talk_type must stay None so no far-end
+        # reference signal is required to score a single clip
+        self.assertIsNone(kwargs.get("talk_type"))
+
+
+class TestSpeechmosDfValue(unittest.TestCase):
+    def test_falls_back_to_last_numeric_column_on_name_mismatch(self):
+        import pandas as pd
+        from phoonnx_train.quality_filter import _speechmos_df_value
+        df = pd.DataFrame([{"filename": "clip.wav", "some_other_mos_name": 2.5}])
+        self.assertAlmostEqual(_speechmos_df_value(df, ["plcmos"]), 2.5)
+
+    def test_raises_when_no_numeric_columns(self):
+        import pandas as pd
+        from phoonnx_train.quality_filter import _speechmos_df_value
+        df = pd.DataFrame([{"filename": "clip.wav"}])
+        with self.assertRaises(ValueError):
+            _speechmos_df_value(df, ["plcmos"])
+
+
+class TestSnrScore(unittest.TestCase):
+    def test_loud_signal_over_silence_scores_high(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import snr_score
+        sr = 16000
+        t = np.linspace(0, 1.0, sr, endpoint=False)
+        # half the clip near-silent, half a strong tone: clear separation
+        # between the noise-floor tier and the signal tier.
+        loud = 0.9 * np.sin(2 * np.pi * 440 * t)
+        quiet = 1e-4 * np.sin(2 * np.pi * 440 * t)
+        audio = np.concatenate([quiet, loud]).astype(np.float32)
+        score = snr_score(audio, sr, "", 2.0)
+        self.assertGreater(score, 20.0)
+
+    def test_uniform_signal_scores_near_zero_db(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import snr_score
+        sr = 16000
+        t = np.linspace(0, 1.0, sr, endpoint=False)
+        audio = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        score = snr_score(audio, sr, "", 1.0)
+        self.assertLess(score, 5.0)
+
+    def test_empty_audio_is_safe(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import snr_score
+        self.assertEqual(snr_score(np.array([]), 16000, "", 0.0), 0.0)
+        self.assertEqual(snr_score(None, 16000, "", 0.0), 0.0)
+        self.assertEqual(snr_score(np.zeros(100), 0, "", 0.0), 0.0)
+
+
+class TestClippingScore(unittest.TestCase):
+    def test_fraction_of_near_full_scale_samples(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import clipping_score
+        audio = np.array([0.0, 0.5, 1.0, -1.0, 0.995, -0.2] * 10, dtype=np.float32)
+        score = clipping_score(audio, 16000, "", 1.0)
+        # 3 of 6 repeated values (1.0, -1.0, 0.995) exceed the 0.99 threshold
+        self.assertAlmostEqual(score, 3 / 6)
+
+    def test_no_clipping(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import clipping_score
+        audio = np.full(1000, 0.1, dtype=np.float32)
+        self.assertEqual(clipping_score(audio, 16000, "", 1.0), 0.0)
+
+    def test_empty_audio_is_safe(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import clipping_score
+        self.assertEqual(clipping_score(np.array([]), 16000, "", 0.0), 0.0)
+        self.assertEqual(clipping_score(None, 16000, "", 0.0), 0.0)
+
+
+class TestVadRatioScore(unittest.TestCase):
+    def test_ratio_from_mocked_segments(self):
+        import numpy as np
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import configure_vad_model, vad_ratio_score
+
+        seg_a = MagicMock(duration=1.0)
+        seg_b = MagicMock(duration=1.5)
+        fake_vad = MagicMock()
+        fake_vad.get_speech_segments.return_value = [seg_a, seg_b]
+
+        configure_vad_model("fake-model")
+        with patch("phoonnx_train.quality_filter._get_vad_model", return_value=fake_vad):
+            score = vad_ratio_score(np.zeros(16000 * 5), 16000, "", 5.0)
+        self.assertAlmostEqual(score, 2.5 / 5.0)
+        fake_vad.get_speech_segments.assert_called_once()
+
+    def test_empty_audio_is_safe(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import vad_ratio_score
+        self.assertEqual(vad_ratio_score(np.array([]), 16000, "", 0.0), 0.0)
+        self.assertEqual(vad_ratio_score(np.zeros(100), 16000, "", 0.0), 0.0)
+
+    def test_configure_vad_model_invalidates_cache(self):
+        from phoonnx_train import quality_filter as qf
+        qf.configure_vad_model("model-a")
+        self.assertIsNone(qf._vad_model)
+        qf._vad_model = object()
+        qf._vad_model_cache_key = "model-a"
+        qf.configure_vad_model("model-b")
+        self.assertIsNone(qf._vad_model)
+        self.assertIsNone(qf._vad_model_cache_key)
+
+
+class TestSpeakerConsistencyScore(unittest.TestCase):
+    def test_similar_windows_score_high(self):
+        import numpy as np
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import (configure_speaker_model,
+                                                   speaker_consistency_score)
+
+        same_vec = np.array([1.0, 0.0, 0.0])
+        fake_embedder = MagicMock()
+        fake_embedder.embed.return_value = same_vec
+
+        configure_speaker_model("fake-model")
+        audio = np.zeros(16000 * 6, dtype=np.float32)
+        with patch("phoonnx_train.quality_filter._get_speaker_embedder", return_value=fake_embedder):
+            score = speaker_consistency_score(audio, 16000, "", 6.0, num_windows=3)
+        self.assertAlmostEqual(score, 1.0)
+
+    def test_dissimilar_windows_score_low(self):
+        import numpy as np
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import (configure_speaker_model,
+                                                   speaker_consistency_score)
+
+        vectors = [np.array([1.0, 0.0]), np.array([0.0, 1.0]), np.array([1.0, 0.0])]
+        fake_embedder = MagicMock()
+        fake_embedder.embed.side_effect = vectors
+
+        configure_speaker_model("fake-model")
+        audio = np.zeros(16000 * 6, dtype=np.float32)
+        with patch("phoonnx_train.quality_filter._get_speaker_embedder", return_value=fake_embedder):
+            score = speaker_consistency_score(audio, 16000, "", 6.0, num_windows=3)
+        # minimum pairwise similarity is between orthogonal windows 0 and 1
+        self.assertAlmostEqual(score, 0.0, places=6)
+
+    def test_too_short_clip_is_trivially_consistent(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import speaker_consistency_score
+        audio = np.zeros(100, dtype=np.float32)  # far too short to window
+        score = speaker_consistency_score(audio, 16000, "", 100 / 16000, num_windows=3)
+        self.assertEqual(score, 1.0)
+
+    def test_zero_duration_is_trivially_consistent(self):
+        import numpy as np
+        from phoonnx_train.quality_filter import speaker_consistency_score
+        self.assertEqual(speaker_consistency_score(np.array([]), 16000, "", 0.0), 1.0)
+
+
+class TestWerScore(unittest.TestCase):
+    def test_word_error_rate_arithmetic(self):
+        from phoonnx_train.quality_filter import _word_error_rate
+        self.assertEqual(_word_error_rate("hello world", "hello world"), 0.0)
+        # one substitution out of two reference words
+        self.assertAlmostEqual(_word_error_rate("hello world", "hello there"), 0.5)
+        # one deletion out of two reference words
+        self.assertAlmostEqual(_word_error_rate("hello world", "hello"), 0.5)
+        # one insertion: reference has 2 words, hypothesis adds one
+        self.assertAlmostEqual(_word_error_rate("hello world", "hello big world"), 0.5)
+
+    def test_empty_reference_edge_cases(self):
+        from phoonnx_train.quality_filter import _word_error_rate
+        self.assertEqual(_word_error_rate("", ""), 0.0)
+        self.assertEqual(_word_error_rate("", "unexpected words"), 1.0)
+
+    def test_wer_score_uses_mocked_asr_model(self):
+        import numpy as np
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import configure_asr_model, wer_score
+
+        fake_model = MagicMock()
+        fake_model.recognize.return_value = "hello world"
+
+        configure_asr_model("fake-asr-model")
+        with patch("phoonnx_train.quality_filter._get_asr_model", return_value=fake_model):
+            score = wer_score(np.zeros(16000), 16000, "hello world", 1.0)
+        self.assertEqual(score, 0.0)
+
+    def test_bad_asr_model_fails_loudly_not_silently(self):
+        # onnx_asr is a real dependency here; a model name it does not
+        # recognize must raise, not silently fall back to another backend
+        # or let the 'wer' filter behave as if it were skipped.
+        from phoonnx_train.quality_filter import _get_asr_model, configure_asr_model
+        configure_asr_model("definitely-not-a-real-onnx-asr-model-xyz")
+        with self.assertRaises(RuntimeError) as ctx:
+            _get_asr_model()
+        self.assertIn("onnx_asr", str(ctx.exception))
+
+    def test_wer_requires_asr_model_to_be_configured(self):
+        from phoonnx_train.quality_filter import _get_asr_model, configure_asr_model
+        configure_asr_model(None)
+        with self.assertRaises(RuntimeError):
+            _get_asr_model()
+
+
+class TestScorerOrdering(unittest.TestCase):
+    def test_arithmetic_scorers_precede_model_based_ones(self):
+        from phoonnx_train.quality_filter import known_scorers
+        order = known_scorers()
+        cheap_tier = {"wpm", "snr", "clipping"}
+        model_tier = {"utmos", "dnsmos_sig", "dnsmos_bak", "dnsmos_ovrl",
+                     "plcmos", "aecmos", "vad_ratio", "speaker_consistency"}
+        max_cheap_index = max(order.index(name) for name in cheap_tier)
+        min_model_index = min(order.index(name) for name in model_tier)
+        self.assertLess(max_cheap_index, min_model_index)
+
+    def test_wer_sorts_last(self):
+        # Other tests in this module register their own throwaway scorer
+        # names into the same module-level registry, so assert wer's
+        # position relative to the real production scorers only, not
+        # against the literal tail of the (possibly test-polluted) list.
+        from phoonnx_train.quality_filter import known_scorers
+        order = known_scorers()
+        production_scorers = {"wpm", "snr", "clipping", "is_music_like",
+                              "vad_ratio", "dnsmos_sig", "dnsmos_bak",
+                              "dnsmos_ovrl", "plcmos", "aecmos", "utmos",
+                              "speaker_consistency", "wer"}
+        wer_index = order.index("wer")
+        for name in production_scorers - {"wer"}:
+            self.assertLess(order.index(name), wer_index)
+
+    def test_short_circuits_before_wer(self):
+        # A sample failing a cheap filter must never reach the wer scorer.
+        from unittest.mock import MagicMock, patch
+        from phoonnx_train.quality_filter import configure_asr_model
+
+        def exploding_asr(*a, **k):
+            raise AssertionError("wer scorer should not run for a sample "
+                                 "already dropped by a cheaper filter")
+
+        register_scorer("wer", exploding_asr)
+        configure_asr_model("unused")
+
+        samples = [_Sample("bad", audio_path="bad", text="x")]
+        self._register_wpm_fail("bad")
+        specs = [parse_filter_spec("wpm:1000:"), parse_filter_spec("wer:0:0.1")]
+        kept, dropped = apply_quality_filters(
+            samples, specs,
+            audio_path_fn=lambda s: s.audio_path,
+            text_fn=lambda s: s.text,
+            audio_loader=_stub_loader({}),
+        )
+        self.assertEqual(kept, [])
+        self.assertEqual(dropped["wpm"], 1)
+
+        # restore the real scorers for any subsequent tests in this run
+        from phoonnx_train.quality_filter import wer_score, wpm_score
+        register_scorer("wer", wer_score)
+        register_scorer("wpm", wpm_score)
+
+    def _register_wpm_fail(self, name):
+        def low_wpm(audio, sr, text, duration):
+            return 1.0
+        register_scorer("wpm", low_wpm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds a repeatable `--filter column:min:max` flag to `phoonnx_train.preprocess` that drops utterances failing a bound on a named quality metric, applied at manifest-load time before phonemization/audio caching.
- Metrics are computed on demand per sample from raw audio/text via a small named-scorer registry (`phoonnx_train/quality_filter.py`), not read from precomputed dataset columns:
  - `wpm`, `snr`, `clipping` — pure arithmetic, no model.
  - `is_music_like` — a coarse onset-strength-rhythmicity heuristic (not a trained classifier; documented at ~ROC-AUC 0.744 on a labeled validation set, i.e. a real ~25-30% error rate, not something to trust blindly).
  - `vad_ratio` — speech-activity fraction via a configurable `vadonnx` model (`--vad-model`, default `silero`).
  - `speaker_consistency` — minimum pairwise embedding similarity across windows of a clip via a configurable `speakeronnx` model (`--speaker-model`, default `wespeaker-resnet34`), catching speaker changes/bleed within a clip.
  - `utmos`, `dnsmos_sig`/`dnsmos_bak`/`dnsmos_ovrl`, `plcmos`, `aecmos` — SpeechMOS-family model-based MOS scorers (naturalness, P.835 signal/background/overall, packet-loss-concealment, echo-cancellation; the last two mainly relevant to call-based corpora).
  - `wer` — word error rate of an onnx_asr transcription against the sample's own text, via a configurable, explicitly onnx-asr-compatible model (`--asr-model`, default `whisper-base`); a bad model value fails loudly instead of silently skipping the filter or falling back to another backend.
- Scorers run cheapest-first (arithmetic, then heuristic/light-model, then heavy model-based, with `wer` always last) and short-circuit per sample once one filter fails, so expensive inference is skipped on samples that would be dropped anyway.
- Multiple `--filter` flags combine with AND semantics; an unbounded side (`utmos:3.0:`) is left empty; an unknown filter column warns and is skipped rather than crashing the run; a per-sample scoring failure drops that sample instead of aborting.
- New metrics only need a registered scorer function — no new CLI flag per metric.

## Test plan
- [x] `pytest tests/test_quality_filter.py` (51 tests) — spec parsing, drop/keep bounds, unbounded min/max, unknown-column warn+skip, multi-filter AND semantics, short-circuit ordering (cheap tier before model-based tier, `wer` always last), boolean-like `is_music_like:0:0`, `wpm`/`snr`/`clipping` arithmetic, rhythmicity-based `is_music_like`, `vad_ratio`/`speaker_consistency`/`plcmos`/`aecmos`/`wer` with mocked model calls, and the onnx-asr-compatibility enforcement failing loudly on a bad `--asr-model` value
- [x] Full suite run locally; unrelated pre-existing failures only (missing `espeak` binary, missing `train-styletts2` extras in this environment)
- [x] CI extras updated to include `train-eval` so `vadonnx`/`speakeronnx`/`onnx-asr`/`speechmos`/`pandas` are installed for these tests