### PR TITLE
feat: multi-format dataset loading for preprocess (ljspeech/jsonl/parquet/HF)

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,5 +11,5 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.11", "3.12", "3.13", "3.14"]'
-      install_extras: 'test,train,train-styletts2,train-eval'
+      install_extras: 'test,train,train-styletts2,train-eval,train-data'
       test_path: 'tests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'phoonnx'
       test_path: 'tests/'
-      install_extras: '-e .[test,train,train-styletts2,train-eval]'
+      install_extras: '-e .[test,train,train-styletts2,train-eval,train-data]'
       min_coverage: 0

--- a/phoonnx_train/dataset_loaders.py
+++ b/phoonnx_train/dataset_loaders.py
@@ -1,0 +1,535 @@
+"""Multi-format dataset loading for training preprocessing.
+
+Preprocessing consumes a stream of :class:`Utterance` objects regardless of how
+the dataset is stored on disk. Every supported on-disk shape is loaded by a
+named generator registered here, mirroring the scorer registry in
+``phoonnx_train/quality_filter.py``: a loader takes ``(source, config)`` and
+yields fully-populated :class:`Utterance` objects.
+
+Supported formats (see :func:`detect_format` for auto-detection):
+
+* ``ljspeech`` -- a directory with a pipe-delimited ``metadata.csv`` + ``wav(s)/``.
+* ``jsonl`` -- a ``.jsonl`` file, one JSON object per line.
+* ``parquet`` -- a ``.parquet`` file, a glob of shards, or a directory of shards.
+* ``hf`` -- a Hugging Face ``org/name`` repo id loaded via ``datasets``.
+
+The tabular formats (jsonl/parquet/hf) resolve columns by name with sensible
+fallbacks (see the ``DEFAULT_*_COLUMNS`` tuples) and carry any unmapped columns
+through under :attr:`Utterance.extras`. Hugging Face audio columns (and our own
+parquet shards) frequently hold embedded audio *bytes* rather than a filesystem
+path -- ``path`` is often ``None`` and casting does not inline the bytes -- so
+the loaders read the bytes field explicitly into :attr:`Utterance.audio_bytes`
+and audio-consuming code materializes them on demand via :func:`ensure_audio_path`.
+"""
+import csv
+import dataclasses
+import io
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+from phoonnx.config import Alphabet, PhonemeType
+
+_LOGGER = logging.getLogger("preprocess")
+
+DEFAULT_TEXT_COLUMNS: Tuple[str, ...] = ("text", "sentence", "transcription", "transcript")
+DEFAULT_AUDIO_COLUMNS: Tuple[str, ...] = ("audio",)
+DEFAULT_SPEAKER_COLUMNS: Tuple[str, ...] = ("speaker", "speaker_id")
+DEFAULT_PHONEMES_COLUMNS: Tuple[str, ...] = ()
+DEFAULT_LANG_COLUMNS: Tuple[str, ...] = ()
+
+
+@dataclass
+class Utterance:
+    """Represents a single utterance in the dataset."""
+    text: str
+    audio_path: Path
+    speaker: Optional[str] = None
+    speaker_id: Optional[int] = None
+    phonemes: Optional[List[str]] = None
+    phoneme_ids: Optional[List[int]] = None
+    audio_norm_path: Optional[Path] = None
+    audio_spec_path: Optional[Path] = None
+    # engine-specific extras (e.g. yourtts d_vector_path, language_id;
+    # fastpitch f0_path) merged from TrainingEngine.extra_preprocess
+    d_vector_path: Optional[Path] = None
+    language_id: Optional[int] = None
+    f0_path: Optional[Path] = None
+    # stable identity for cache/spec keying and resume when there is no
+    # filesystem audio path (embedded-bytes rows)
+    row_id: Optional[str] = None
+    # embedded audio bytes (HF/parquet inline audio); decoded on demand
+    audio_bytes: Optional[bytes] = None
+    # True when phonemes came from a dataset column and must not be
+    # re-phonemized, normalized, or case-mangled
+    phonemes_precomputed: bool = False
+    # unmapped source columns, carried through into dataset.jsonl
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    def asdict(self) -> Dict[str, Any]:
+        """Custom asdict to handle Path objects for JSON serialization.
+
+        The embedded audio bytes and the internal precomputed-phonemes flag are
+        dropped: bytes are not JSON serializable and only exist to feed audio
+        processing, and the flag is a processing detail, not training data.
+        """
+        data = dataclasses.asdict(self)
+        data.pop("audio_bytes", None)
+        data.pop("phonemes_precomputed", None)
+        for key, value in data.items():
+            if isinstance(value, Path):
+                data[key] = str(value)
+        return data
+
+
+def get_text_casing(casing: str) -> Callable[[str], str]:
+    """
+    Returns a function to apply text casing based on a string name.
+
+    Args:
+        casing: The name of the casing function ('lower', 'upper', 'casefold', or 'ignore').
+
+    Returns:
+        A callable function (str) -> str.
+    """
+    if casing == "lower":
+        return str.lower
+    if casing == "upper":
+        return str.upper
+    if casing == "casefold":
+        return str.casefold
+    return lambda s: s
+
+
+@dataclass
+class PreprocessorConfig:
+    """Dataclass to hold all runtime configuration, mimicking argparse.Namespace."""
+    input_dir: Path
+    output_dir: Path
+    language: str
+    sample_rate: int
+    cache_dir: Path
+    max_workers: int
+    single_speaker: bool
+    speaker_id: Optional[int]
+    phoneme_type: PhonemeType
+    alphabet: Alphabet
+    phonemizer_model: str
+    text_casing: str
+    dataset_name: Optional[str]
+    audio_quality: Optional[str]
+    skip_audio: bool
+    debug: bool
+    add_diacritics: bool
+    # multi-format loading
+    dataset_format: str = "auto"
+    text_column: Optional[str] = None
+    audio_column: Optional[str] = None
+    speaker_column: Optional[str] = None
+    phonemes_column: Optional[str] = None
+    lang_column: Optional[str] = None
+
+
+# -----------------------------------------------------------------------------
+# Loader registry
+# -----------------------------------------------------------------------------
+Loader = Callable[[str, PreprocessorConfig], Iterable[Utterance]]
+_LOADER_REGISTRY: Dict[str, Loader] = {}
+
+
+def register_loader(name: str, fn: Loader) -> None:
+    """Register a named dataset loader generator.
+
+    Args:
+        name: format name (e.g. "ljspeech", "jsonl", "parquet", "hf").
+        fn: callable ``(source, config) -> Iterable[Utterance]``.
+    """
+    _LOADER_REGISTRY[name] = fn
+
+
+def known_loaders() -> List[str]:
+    """Names of all registered loaders."""
+    return list(_LOADER_REGISTRY)
+
+
+def detect_format(source: str) -> str:
+    """Guess a dataset format from a single input source.
+
+    Rules:
+        * an existing directory with ``metadata.csv`` -> ``ljspeech``.
+        * an existing directory with ``*.parquet`` shards -> ``parquet``.
+        * an existing ``.jsonl`` file -> ``jsonl``.
+        * an existing ``.parquet`` file -> ``parquet``.
+        * a glob pattern (``*?[]``) -> ``parquet`` (shard glob).
+        * an ``org/name`` string that is not an existing path -> ``hf``.
+
+    Raises:
+        ValueError: if the source matches none of the rules.
+    """
+    path = Path(source)
+    if path.exists():
+        if path.is_dir():
+            if (path / "metadata.csv").exists():
+                return "ljspeech"
+            if any(path.glob("*.parquet")):
+                return "parquet"
+            raise ValueError(
+                f"cannot auto-detect dataset format for directory {source!r}: "
+                "no metadata.csv and no .parquet shards found"
+            )
+        if path.suffix == ".jsonl":
+            return "jsonl"
+        if path.suffix == ".parquet":
+            return "parquet"
+        raise ValueError(
+            f"cannot auto-detect dataset format for file {source!r}: "
+            "expected a .jsonl or .parquet file"
+        )
+    if any(ch in source for ch in "*?[]"):
+        return "parquet"
+    if re.fullmatch(r"[\w.-]+/[\w.-]+", source):
+        return "hf"
+    raise ValueError(
+        f"cannot auto-detect dataset format for {source!r}: not an existing "
+        "path, a shard glob, or an 'org/name' Hugging Face repo id"
+    )
+
+
+def load_source(source: str, config: PreprocessorConfig) -> Iterable[Utterance]:
+    """Load one source, dispatching by ``config.dataset_format`` (or auto)."""
+    fmt = config.dataset_format
+    if fmt == "auto":
+        fmt = detect_format(source)
+    if fmt not in _LOADER_REGISTRY:
+        raise ValueError(f"unknown dataset format {fmt!r}; known: {', '.join(known_loaders())}")
+    _LOGGER.info("Loading source %r as format %r", source, fmt)
+    return _LOADER_REGISTRY[fmt](source, config)
+
+
+# -----------------------------------------------------------------------------
+# Column resolution (tabular loaders)
+# -----------------------------------------------------------------------------
+def _resolve_column(keys: Iterable[str], requested: Optional[str],
+                    defaults: Tuple[str, ...], what: str, required: bool = False) -> Optional[str]:
+    """Pick the column name to use for a field.
+
+    An explicitly requested column must exist (else a loud error). Otherwise the
+    first present default is used; if none match and the field is required, fail.
+    """
+    keyset = set(keys)
+    if requested:
+        if requested not in keyset:
+            raise ValueError(
+                f"requested {what} column {requested!r} not found; "
+                f"available columns: {sorted(keyset)}"
+            )
+        return requested
+    for candidate in defaults:
+        if candidate in keyset:
+            return candidate
+    if required:
+        raise ValueError(
+            f"no {what} column found (tried {list(defaults)}); "
+            f"available columns: {sorted(keyset)}; pass an explicit column flag"
+        )
+    return None
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce a source-column value into something json.dump can serialize.
+
+    Passes primitives through, unwraps numpy scalars via ``.item()``, and drops
+    anything else (bytes, arrays, nested audio mappings) by returning ``None``.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if hasattr(value, "item") and not isinstance(value, dict):
+        try:
+            return value.item()
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def _audio_from_value(value: Any) -> Tuple[Optional[str], Optional[bytes]]:
+    """Extract (path, bytes) from a row's audio-column value.
+
+    Handles a plain path string, raw bytes, and the Hugging Face Audio mapping
+    ``{"bytes": ..., "path": ...}`` where ``path`` may be ``None`` and the audio
+    only exists as embedded bytes.
+    """
+    if value is None:
+        return None, None
+    if isinstance(value, (bytes, bytearray)):
+        return None, bytes(value)
+    if isinstance(value, dict):
+        raw = value.get("bytes")
+        return value.get("path"), bytes(raw) if raw is not None else None
+    return str(value), None
+
+
+def _row_utterance(row: Dict[str, Any], cols: Dict[str, Optional[str]],
+                   config: PreprocessorConfig, source: str, index: int) -> Optional[Utterance]:
+    """Build an Utterance from a tabular row given resolved column names."""
+    text = row.get(cols["text"])
+    if text is None or str(text) == "":
+        _LOGGER.warning("Skipping row %d with empty text in %s", index, source)
+        return None
+
+    audio_path, audio_bytes = (None, None)
+    if cols["audio"]:
+        audio_path, audio_bytes = _audio_from_value(row.get(cols["audio"]))
+
+    if not config.skip_audio and audio_path is None and audio_bytes is None:
+        _LOGGER.warning("Skipping row %d with no audio in %s", index, source)
+        return None
+
+    speaker = None
+    if not config.single_speaker and cols["speaker"]:
+        raw_speaker = row.get(cols["speaker"])
+        speaker = str(raw_speaker) if raw_speaker is not None and str(raw_speaker) != "" else None
+
+    phonemes = None
+    precomputed = False
+    if cols["phonemes"]:
+        raw_ph = row.get(cols["phonemes"])
+        if raw_ph is not None and str(raw_ph).strip():
+            phonemes = str(raw_ph).split()
+            precomputed = True
+
+    row_id = str(audio_path) if audio_path else f"{source}#{index}"
+
+    # The lang column is intentionally left in extras (carried through into
+    # dataset.jsonl) rather than consumed here.
+    mapped = {cols[k] for k in ("text", "audio", "speaker", "phonemes") if cols[k]}
+    extras = {k: _jsonable(v) for k, v in row.items() if k not in mapped}
+    extras = {k: v for k, v in extras.items() if v is not None}
+
+    return Utterance(
+        text=str(text),
+        audio_path=Path(audio_path) if audio_path else Path(""),
+        speaker=speaker,
+        speaker_id=config.speaker_id,
+        phonemes=phonemes,
+        phonemes_precomputed=precomputed,
+        row_id=row_id,
+        audio_bytes=audio_bytes,
+        extras=extras,
+    )
+
+
+def _resolve_columns(keys: Iterable[str], config: PreprocessorConfig) -> Dict[str, Optional[str]]:
+    keys = list(keys)
+    return {
+        "text": _resolve_column(keys, config.text_column, DEFAULT_TEXT_COLUMNS, "text", required=True),
+        "audio": _resolve_column(keys, config.audio_column, DEFAULT_AUDIO_COLUMNS, "audio"),
+        "speaker": _resolve_column(keys, config.speaker_column, DEFAULT_SPEAKER_COLUMNS, "speaker"),
+        "phonemes": _resolve_column(keys, config.phonemes_column, DEFAULT_PHONEMES_COLUMNS, "phonemes"),
+        "lang": _resolve_column(keys, config.lang_column, DEFAULT_LANG_COLUMNS, "lang"),
+    }
+
+
+# -----------------------------------------------------------------------------
+# Loaders
+# -----------------------------------------------------------------------------
+def ljspeech_loader(source: str, config: PreprocessorConfig) -> Iterable[Utterance]:
+    """
+    Generator for LJSpeech-style dataset.
+    Loads metadata and resolves audio file paths.
+
+    Args:
+        source: dataset directory containing ``metadata.csv`` and ``wav(s)/``.
+        config: The configuration object containing dataset parameters.
+
+    Yields:
+        Utterance: A fully populated Utterance object.
+    """
+    dataset_dir = Path(source)
+    metadata_path = dataset_dir / "metadata.csv"
+    if not metadata_path.exists():
+        _LOGGER.error(f"Missing metadata file: {metadata_path}")
+        return
+
+    wav_dirs: List[Path] = [dataset_dir / "wav", dataset_dir / "wavs"]
+
+    with open(metadata_path, "r", encoding="utf-8") as csv_file:
+        reader = csv.reader(csv_file, delimiter="|")
+        for row in reader:
+            if len(row) < 2:
+                _LOGGER.warning(f"Skipping malformed row: {row}")
+                continue
+
+            filename: str = row[0]
+            text: str = row[-1]
+            speaker: Optional[str] = None
+
+            if not config.single_speaker and len(row) > 2:
+                speaker = row[1]
+            else:
+                speaker = None
+
+            wav_path: Optional[Path] = None
+            for wav_dir in wav_dirs:
+                potential_paths: List[Path] = [
+                    wav_dir / filename,
+                    wav_dir / f"{filename}.wav",
+                    wav_dir / f"{filename.lstrip('0')}.wav"
+                ]
+                for path in potential_paths:
+                    if path.exists():
+                        wav_path = path
+                        break
+                if wav_path:
+                    break
+
+            if not config.skip_audio and not wav_path:
+                _LOGGER.warning("Missing audio file for filename: %s", filename)
+                continue
+
+            if not config.skip_audio and wav_path and wav_path.stat().st_size == 0:
+                _LOGGER.warning("Empty audio file: %s", wav_path)
+                continue
+
+            yield Utterance(
+                text=text,
+                audio_path=wav_path or Path(""),  # Use empty path if skipping audio, should not be used
+                speaker=speaker,
+                speaker_id=config.speaker_id,
+                row_id=str(wav_path) if wav_path else filename,
+            )
+
+
+def jsonl_loader(source: str, config: PreprocessorConfig) -> Iterable[Utterance]:
+    """Generator for a JSON-lines dataset (one JSON object per line).
+
+    Columns are resolved from the first non-empty row and applied to all rows;
+    malformed lines are logged and skipped rather than aborting the load.
+    """
+    cols: Optional[Dict[str, Optional[str]]] = None
+    with open(source, "r", encoding="utf-8") as handle:
+        for index, line in enumerate(handle):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                _LOGGER.warning("Skipping malformed JSON on line %d in %s", index, source)
+                continue
+            if not isinstance(row, dict):
+                _LOGGER.warning("Skipping non-object JSON on line %d in %s", index, source)
+                continue
+            if cols is None:
+                cols = _resolve_columns(row.keys(), config)
+            utt = _row_utterance(row, cols, config, source, index)
+            if utt is not None:
+                yield utt
+
+
+def _iter_parquet_paths(source: str) -> List[Path]:
+    path = Path(source)
+    if path.is_dir():
+        return sorted(path.glob("*.parquet"))
+    if any(ch in source for ch in "*?[]"):
+        from glob import glob
+        return sorted(Path(p) for p in glob(source))
+    return [path]
+
+
+def parquet_loader(source: str, config: PreprocessorConfig) -> Iterable[Utterance]:
+    """Generator for a parquet file, a glob of shards, or a directory of shards.
+
+    Reads with pandas (pyarrow backend). Audio may be a path string or embedded
+    bytes (our own shards inline audio bytes to stay under HF's per-dir file cap).
+    """
+    import pandas as pd
+
+    shards = _iter_parquet_paths(source)
+    if not shards:
+        _LOGGER.error("No parquet shards found for %s", source)
+        return
+
+    cols: Optional[Dict[str, Optional[str]]] = None
+    index = 0
+    for shard in shards:
+        frame = pd.read_parquet(shard)
+        if cols is None:
+            cols = _resolve_columns(frame.columns, config)
+        for record in frame.to_dict(orient="records"):
+            utt = _row_utterance(record, cols, config, source, index)
+            index += 1
+            if utt is not None:
+                yield utt
+
+
+def hf_loader(source: str, config: PreprocessorConfig) -> Iterable[Utterance]:
+    """Generator for a Hugging Face dataset given an ``org/name`` repo id.
+
+    Audio columns are cast to ``Audio(decode=False)`` so the embedded bytes are
+    read explicitly (decoding/casting does not inline bytes, and ``path`` is
+    frequently ``None`` for byte-backed audio).
+    """
+    import datasets
+
+    loaded = datasets.load_dataset(source)
+    splits = loaded.values() if isinstance(loaded, datasets.DatasetDict) else [loaded]
+
+    index = 0
+    for split in splits:
+        audio_col = _resolve_column(split.column_names, config.audio_column,
+                                    DEFAULT_AUDIO_COLUMNS, "audio")
+        if audio_col and isinstance(split.features.get(audio_col), datasets.Audio):
+            split = split.cast_column(audio_col, datasets.Audio(decode=False))
+        cols = _resolve_columns(split.column_names, config)
+        for record in split:
+            utt = _row_utterance(record, cols, config, source, index)
+            index += 1
+            if utt is not None:
+                yield utt
+
+
+register_loader("ljspeech", ljspeech_loader)
+register_loader("jsonl", jsonl_loader)
+register_loader("parquet", parquet_loader)
+register_loader("hf", hf_loader)
+
+
+# -----------------------------------------------------------------------------
+# Embedded-bytes audio materialization
+# -----------------------------------------------------------------------------
+def ensure_audio_path(utt: Utterance, cache_dir: Union[str, Path]) -> Path:
+    """Return a filesystem audio path for an utterance, decoding embedded bytes.
+
+    Path-backed utterances return their path unchanged (byte-identical to the
+    existing flow). Byte-backed utterances have their audio decoded via
+    soundfile and written once to ``<cache_dir>/audio/<row_id>.wav``; the path
+    is cached on the utterance so repeated calls are cheap.
+
+    Raises:
+        soundfile.LibsndfileError / RuntimeError: if the embedded bytes cannot
+            be decoded (corrupt audio), so callers can drop the sample loudly.
+    """
+    if str(utt.audio_path) not in ("", "."):
+        return Path(utt.audio_path)
+    if utt.audio_bytes is None:
+        raise RuntimeError(f"utterance {utt.row_id!r} has neither an audio path nor audio bytes")
+
+    import soundfile as sf
+
+    key = utt.row_id or sha256(utt.audio_bytes).hexdigest()
+    safe = sha256(key.encode("utf-8")).hexdigest()
+    out = Path(cache_dir) / "audio" / f"{safe}.wav"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if not out.exists():
+        data, sr = sf.read(io.BytesIO(utt.audio_bytes))
+        tmp = out.with_name(out.name + ".tmp")
+        sf.write(tmp, data, sr, format="WAV")
+        tmp.rename(out)
+    utt.audio_path = out
+    return out

--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
-import csv
-import dataclasses
 import itertools
 import json
 import logging
 import os
 from collections import Counter
-from dataclasses import dataclass
 from multiprocessing import JoinableQueue, Process, Queue
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple, Any, Set, Union, Callable
@@ -22,6 +19,9 @@ from phoonnx.tokenizer import TTSTokenizer, DEFAULT_IPA_PHONEME_ID_MAP, DEFAULT_
     DEFAULT_EOS_TOKEN, DEFAULT_BLANK_WORD_TOKEN
 from phoonnx.util import normalize
 from phoonnx.version import VERSION_STR
+from phoonnx_train.dataset_loaders import (PreprocessorConfig, Utterance,
+                                           ensure_audio_path, get_text_casing,
+                                           known_loaders, load_source)
 from phoonnx_train.norm_audio import cache_norm_audio, make_silence_detector
 from phoonnx_train.quality_filter import (FilterSpec, apply_quality_filters,
                                           configure_asr_model,
@@ -41,32 +41,6 @@ DEFAULT_SPECIAL_PHONEME_ID_MAP: Dict[str, int] = {
 MAX_PHONEMES = 256
 # -----------------------------------------------------------------------------
 
-@dataclass
-class Utterance:
-    """Represents a single utterance in the dataset."""
-    text: str
-    audio_path: Path
-    speaker: Optional[str] = None
-    speaker_id: Optional[int] = None
-    phonemes: Optional[List[str]] = None
-    phoneme_ids: Optional[List[int]] = None
-    audio_norm_path: Optional[Path] = None
-    audio_spec_path: Optional[Path] = None
-    # engine-specific extras (e.g. yourtts d_vector_path, language_id;
-    # fastpitch f0_path) merged from TrainingEngine.extra_preprocess
-    d_vector_path: Optional[Path] = None
-    language_id: Optional[int] = None
-    f0_path: Optional[Path] = None
-
-    def asdict(self) -> Dict[str, Any]:
-        """Custom asdict to handle Path objects for JSON serialization."""
-        data = dataclasses.asdict(self)
-        for key, value in data.items():
-            if isinstance(value, Path):
-                data[key] = str(value)
-        return data
-
-
 class PathEncoder(json.JSONEncoder):
     """JSON encoder for Path objects."""
 
@@ -83,113 +57,6 @@ class PathEncoder(json.JSONEncoder):
         if isinstance(o, Path):
             return str(o)
         return super().default(o)
-
-
-def get_text_casing(casing: str) -> Callable[[str], str]:
-    """
-    Returns a function to apply text casing based on a string name.
-
-    Args:
-        casing: The name of the casing function ('lower', 'upper', 'casefold', or 'ignore').
-
-    Returns:
-        A callable function (str) -> str.
-    """
-    if casing == "lower":
-        return str.lower
-    if casing == "upper":
-        return str.upper
-    if casing == "casefold":
-        return str.casefold
-    return lambda s: s
-
-
-@dataclass
-class PreprocessorConfig:
-    """Dataclass to hold all runtime configuration, mimicking argparse.Namespace."""
-    input_dir: Path
-    output_dir: Path
-    language: str
-    sample_rate: int
-    cache_dir: Path
-    max_workers: int
-    single_speaker: bool
-    speaker_id: Optional[int]
-    phoneme_type: PhonemeType
-    alphabet: Alphabet
-    phonemizer_model: str
-    text_casing: str
-    dataset_name: Optional[str]
-    audio_quality: Optional[str]
-    skip_audio: bool
-    debug: bool
-    add_diacritics: bool
-
-
-def ljspeech_dataset(config: PreprocessorConfig) -> Iterable[Utterance]:
-    """
-    Generator for LJSpeech-style dataset.
-    Loads metadata and resolves audio file paths.
-
-    Args:
-        config: The configuration object containing dataset parameters.
-
-    Yields:
-        Utterance: A fully populated Utterance object.
-    """
-    dataset_dir = config.input_dir
-    metadata_path = dataset_dir / "metadata.csv"
-    if not metadata_path.exists():
-        _LOGGER.error(f"Missing metadata file: {metadata_path}")
-        return
-
-    wav_dirs: List[Path] = [dataset_dir / "wav", dataset_dir / "wavs"]
-
-    with open(metadata_path, "r", encoding="utf-8") as csv_file:
-        reader = csv.reader(csv_file, delimiter="|")
-        for row in reader:
-            if len(row) < 2:
-                _LOGGER.warning(f"Skipping malformed row: {row}")
-                continue
-
-            filename: str = row[0]
-            text: str = row[-1]
-            speaker: Optional[str] = None
-
-            if not config.single_speaker and len(row) > 2:
-                speaker = row[1]
-            else:
-                speaker = None
-
-            wav_path: Optional[Path] = None
-            for wav_dir in wav_dirs:
-                potential_paths: List[Path] = [
-                    wav_dir / filename,
-                    wav_dir / f"{filename}.wav",
-                    wav_dir / f"{filename.lstrip('0')}.wav"
-                ]
-                for path in potential_paths:
-                    if path.exists():
-                        wav_path = path
-                        break
-                if wav_path:
-                    break
-
-            if not config.skip_audio and not wav_path:
-                _LOGGER.warning("Missing audio file for filename: %s", filename)
-                continue
-
-            if not config.skip_audio and wav_path and wav_path.stat().st_size == 0:
-                _LOGGER.warning("Empty audio file: %s", wav_path)
-                continue
-
-            # Ensure wav_path is Path or None, and is never accessed if skip_audio is true
-            yield Utterance(
-                text=text,
-                audio_path=wav_path or Path(""), # Use empty path if skipping audio, should not be used
-                speaker=speaker,
-                speaker_id=config.speaker_id,
-            )
 
 
 def phonemize_worker(
@@ -221,23 +88,30 @@ def phonemize_worker(
 
             for utt in utterance_batch:
                 try:
-                    # Normalize text (case, numbers, etc.)
-                    utterance: str = casing(normalize(utt.text, config.language))
+                    if utt.phonemes_precomputed:
+                        # Phonemes come verbatim from a dataset column: use them
+                        # as-is, never normalized or case-mangled.
+                        if not utt.phonemes:
+                            raise RuntimeError("empty precomputed phonemes")
+                    else:
+                        # Normalize text (case, numbers, etc.)
+                        utterance: str = casing(normalize(utt.text, config.language))
 
-                    # Add diacritics
-                    if config.add_diacritics:
-                        utterance = phonemizer.add_diacritics(utterance, config.language)
+                        # Add diacritics
+                        if config.add_diacritics:
+                            utterance = phonemizer.add_diacritics(utterance, config.language)
 
-                    # Phonemize the text
-                    utt.phonemes = [p for p in phonemizer.phonemize_to_list(utterance, config.language)
-                                    if p != "\n"] # HACK: not sure where this is coming from
-                    if not utt.phonemes:
-                        raise RuntimeError(f"Phonemes not found for '{utterance}'")
+                        # Phonemize the text
+                        utt.phonemes = [p for p in phonemizer.phonemize_to_list(utterance, config.language)
+                                        if p != "\n"] # HACK: not sure where this is coming from
+                        if not utt.phonemes:
+                            raise RuntimeError(f"Phonemes not found for '{utterance}'")
 
                     # Process audio if not skipping
                     if not config.skip_audio:
+                        audio_path = ensure_audio_path(utt, config.cache_dir)
                         utt.audio_norm_path, utt.audio_spec_path = cache_norm_audio(
-                            utt.audio_path,
+                            audio_path,
                             config.cache_dir,
                             silence_detector,
                             config.sample_rate,
@@ -260,11 +134,60 @@ def phonemize_worker(
 @click.option(
     "-i",
     "--input-dir",
-    "input_dir",
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    "input_sources",
+    multiple=True,
     required=True,
-    help="Directory with audio dataset (e.g., containing metadata.csv and wavs/)",
+    help="Dataset source. Repeatable (or comma-separated) to merge multiple "
+         "datasets; per-source speaker ids are namespaced to avoid collisions. "
+         "A source may be an LJSpeech-style directory (metadata.csv + wav(s)/), "
+         "a .jsonl file, a .parquet file / shard glob / directory of shards, or "
+         "a Hugging Face 'org/name' repo id (see --dataset-format).",
 )
+@click.option(
+    "--dataset-format",
+    "dataset_format",
+    type=click.Choice(["auto", "ljspeech", "jsonl", "parquet", "hf"]),
+    default="auto",
+    show_default=True,
+    help="Input format. 'auto' detects from each source: a directory with "
+         "metadata.csv -> ljspeech; a .jsonl file -> jsonl; a .parquet file, "
+         "shard glob, or directory of shards -> parquet; an 'org/name' string "
+         "that is not an existing path -> hf.",
+)
+@click.option("--text-column", "text_column", default=None,
+              help="Column holding transcript text (jsonl/parquet/hf). "
+                   "Default: first of text, sentence, transcription, transcript.")
+@click.option("--audio-column", "audio_column", default=None,
+              help="Column holding audio path or embedded bytes "
+                   "(jsonl/parquet/hf). Default: audio.")
+@click.option("--speaker-column", "speaker_column", default=None,
+              help="Column holding the speaker label (jsonl/parquet/hf). "
+                   "Default: first of speaker, speaker_id.")
+@click.option("--phonemes-column", "phonemes_column", default=None,
+              help="Opt-in: column holding precomputed, whitespace-separated "
+                   "phoneme symbols (jsonl/parquet/hf). Rows with a non-empty "
+                   "value skip phonemization and are used verbatim; their "
+                   "symbols are validated against the final phoneme map.")
+@click.option("--lang-column", "lang_column", default=None,
+              help="Column holding a per-row language code (jsonl/parquet/hf). "
+                   "Carried through into dataset.jsonl extras. Default: unset.")
+@click.option("--resume", "resume", is_flag=True,
+              help="Skip rows already present (by row_id/audio path) in an "
+                   "existing output dataset.jsonl and append only new rows. "
+                   "Writes are atomic (temp file + rename).")
+@click.option("--metrics-out", "metrics_out", type=click.Path(dir_okay=False, path_type=Path),
+              default=None,
+              help="Write every computed --filter metric value per row_id to "
+                   "this parquet sidecar during filtering.")
+@click.option("--metrics-in", "metrics_in", type=click.Path(exists=True, dir_okay=False, path_type=Path),
+              default=None,
+              help="Read a previously written metrics sidecar; with "
+                   "--filter-from-columns its values are preferred over "
+                   "recomputation.")
+@click.option("--filter-from-columns", "filter_from_columns", is_flag=True,
+              help="Make --filter prefer a per-row value from a dataset column "
+                   "of the same name (or from --metrics-in) before computing it "
+                   "on demand.")
 @click.option(
     "-o",
     "--output-dir",
@@ -484,7 +407,17 @@ def phonemize_worker(
          "unloadable value fails loudly instead of silently skipping 'wer'.",
 )
 def cli(
-    input_dir: Path,
+    input_sources: Tuple[str, ...],
+    dataset_format: str,
+    text_column: Optional[str],
+    audio_column: Optional[str],
+    speaker_column: Optional[str],
+    phonemes_column: Optional[str],
+    lang_column: Optional[str],
+    resume: bool,
+    metrics_out: Optional[Path],
+    metrics_in: Optional[Path],
+    filter_from_columns: bool,
     output_dir: Path,
     language: str,
     prev_config: Path,
@@ -552,9 +485,12 @@ def cli(
         click.Abort: If mutually exclusive CLI options are provided (e.g., both --single-speaker and --speaker-id).
         ValueError: If finetuning with a previous config and the new dataset contains phonemes not present in that config and drop_extra_phonemes is False.
     """
+    # Split any comma-separated sources into a flat list.
+    sources: List[str] = [s.strip() for spec in input_sources for s in spec.split(",") if s.strip()]
+
     # Create a config object from click arguments for easier passing
     config = PreprocessorConfig(
-        input_dir=input_dir,
+        input_dir=Path(sources[0]) if sources else Path(""),
         output_dir=output_dir,
         language=language,
         sample_rate=sample_rate,
@@ -571,6 +507,12 @@ def cli(
         skip_audio=skip_audio,
         debug=debug,
         add_diacritics=add_diacritics,
+        dataset_format=dataset_format,
+        text_column=text_column,
+        audio_column=audio_column,
+        speaker_column=speaker_column,
+        phonemes_column=phonemes_column,
+        lang_column=lang_column,
     )
 
     # Setup logging
@@ -588,12 +530,40 @@ def cli(
     config.output_dir.mkdir(parents=True, exist_ok=True)
     config.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    # Load all utterances from the dataset
-    _LOGGER.info("Loading utterances from dataset...")
-    utterances: List[Utterance] = list(ljspeech_dataset(config))
+    # Load all utterances, merging multiple sources. When more than one source
+    # is given, speaker labels are namespaced by source ("<tag>:<speaker>") so
+    # identical speaker ids across datasets do not collide.
+    _LOGGER.info("Loading utterances from %d source(s)...", len(sources))
+    utterances: List[Utterance] = []
+    for src_index, source in enumerate(sources):
+        source_tag = Path(source).stem or Path(source).name or source
+        source_speakers: Set[str] = set()
+        for utt in load_source(source, config):
+            if len(sources) > 1 and utt.speaker is not None:
+                source_speakers.add(utt.speaker)
+                utt.speaker = f"{source_tag}:{utt.speaker}"
+            utterances.append(utt)
+        if len(sources) > 1 and source_speakers:
+            _LOGGER.info("Source %r speakers namespaced as %s", source,
+                         ", ".join(f"{source_tag}:{s}" for s in sorted(source_speakers)))
+
     if not utterances:
         _LOGGER.error("No valid utterances found in dataset.")
         return
+
+    # Resume: skip rows already written to an existing dataset.jsonl.
+    dataset_path = config.output_dir / "dataset.jsonl"
+    resume_rows: List[Dict[str, Any]] = []
+    if resume and dataset_path.exists():
+        resume_rows = _read_jsonl(dataset_path)
+        done_keys = {_row_key(r) for r in resume_rows}
+        kept = [u for u in utterances if _utt_key(u) not in done_keys]
+        _LOGGER.info("Resume: %d rows already done, %d new rows to process.",
+                     len(resume_rows), len(kept))
+        utterances = kept
+        if not utterances:
+            _LOGGER.info("Resume: nothing new to process.")
+            return
 
     if quality_filters:
         configure_vad_model(vad_model)
@@ -601,13 +571,40 @@ def cli(
         configure_asr_model(asr_model)
         specs: List[FilterSpec] = [parse_filter_spec(f) for f in quality_filters]
         total_before = len(utterances)
+
+        sidecar: Dict[str, Dict[str, float]] = {}
+        if metrics_in:
+            sidecar = _read_metrics_sidecar(metrics_in)
+
+        value_source = None
+        if filter_from_columns:
+            def value_source(utt: Utterance, column: str) -> Optional[float]:
+                if column in utt.extras and utt.extras[column] is not None:
+                    try:
+                        return float(utt.extras[column])
+                    except (TypeError, ValueError):
+                        return None
+                return sidecar.get(utt.row_id or "", {}).get(column)
+
+        recorded: Dict[str, Dict[str, float]] = {}
+        metrics_sink = None
+        if metrics_out:
+            def metrics_sink(row_id: str, column: str, value: float) -> None:
+                recorded.setdefault(row_id, {})[column] = value
+
         utterances, dropped_counts = apply_quality_filters(
             utterances,
             specs,
-            audio_path_fn=lambda u: u.audio_path,
+            audio_path_fn=lambda u: ensure_audio_path(u, config.cache_dir),
             text_fn=lambda u: u.text,
+            id_fn=lambda u: u.row_id or str(u.audio_path),
+            value_source=value_source,
+            metrics_sink=metrics_sink,
         )
         log_filter_summary(total_before, dropped_counts, len(utterances))
+        if metrics_out and recorded:
+            _write_metrics_sidecar(metrics_out, recorded)
+            _LOGGER.info("Wrote metrics sidecar for %d rows to %s", len(recorded), metrics_out)
         if not utterances:
             _LOGGER.error("No utterances left after quality filtering.")
             return
@@ -663,25 +660,39 @@ def cli(
     for _ in range(config.max_workers):
         task_queue.put(None)
 
-    # Collect results from the queue with a progress bar
+    # Collect results from the queue with a progress bar. Phonemes read from a
+    # dataset column (precomputed) never expand the phoneme map: they are kept
+    # aside and validated against the final map so a mismatched inventory fails
+    # loudly instead of silently growing the vocab.
     processed_utterances: List[Utterance] = []
     all_phonemes: Set[str] = set()
+    precomputed_symbols: Set[str] = set()
+    num_from_column: int = 0
+    num_phonemized: int = 0
     for _ in tqdm(range(task_count), desc="Processing utterances"):
         result: Tuple[Optional[Utterance], Set[str]] = result_queue.get()
         utt, unique_phonemes = result
         if utt is not None:
             processed_utterances.append(utt)
-            all_phonemes.update(unique_phonemes)
+            if utt.phonemes_precomputed:
+                precomputed_symbols.update(unique_phonemes)
+                num_from_column += 1
+            else:
+                all_phonemes.update(unique_phonemes)
+                num_phonemized += 1
 
     # Wait for workers to finish
     task_queue.join()
     for proc in processes:
         proc.join()
 
+    if phonemes_column:
+        _LOGGER.info("Phoneme source split: %d rows from column %r, %d phonemized.",
+                     num_from_column, phonemes_column, num_phonemized)
 
     # --- Build the final phoneme map from the collected phonemes ---
     _LOGGER.info("Building a phoneme map from collected dataset phonemes...")
-    corpus_phonemes: Set[str] = set(all_phonemes)
+    corpus_phonemes: Set[str] = set(all_phonemes) | precomputed_symbols
 
     if prev_config:
         with open(prev_config) as f:
@@ -737,6 +748,17 @@ def cli(
     if new_phonemes:
         _LOGGER.info("Final phoneme map contains %d phonemes.", len(final_phoneme_id_map))
 
+    # Precomputed (column) phonemes must already be representable in the final
+    # map; a mismatched inventory fails loudly instead of expanding the vocab.
+    if precomputed_symbols:
+        missing = sorted(precomputed_symbols - set(final_phoneme_id_map))
+        if missing:
+            raise ValueError(
+                f"precomputed phonemes from column {phonemes_column!r} contain "
+                f"{len(missing)} symbol(s) absent from the final phoneme map: "
+                f"{' '.join(missing)}"
+            )
+
     # --- Write the final config.json ---
     _LOGGER.info("Writing dataset config...")
     audio_quality = config.audio_quality or config.output_dir.name
@@ -763,16 +785,27 @@ def cli(
         "phoonnx_version": VERSION_STR,
     }
 
-    with open(config.output_dir / "config.json", "w", encoding="utf-8") as config_file:
+    config_tmp = config.output_dir / "config.json.tmp"
+    with open(config_tmp, "w", encoding="utf-8") as config_file:
         json.dump(config_data, config_file, ensure_ascii=False, indent=2)
+    config_tmp.rename(config.output_dir / "config.json")
 
     # --- Apply final phoneme IDs and write dataset.jsonl ---
+    # Writes go to a temp file and are atomically renamed into place so an
+    # interrupted run never leaves a half-written manifest. With --resume the
+    # already-processed rows are re-emitted first, then the new rows appended.
     _LOGGER.info("Writing dataset.jsonl...")
     valid_utterances_count: int = 0
 
     tokenizer = TTSTokenizer.from_phoonnx_config(config_data)
 
-    with open(config.output_dir / "dataset.jsonl", "w", encoding="utf-8") as dataset_file:
+    dataset_tmp = config.output_dir / "dataset.jsonl.tmp"
+    with open(dataset_tmp, "w", encoding="utf-8") as dataset_file:
+        for row in resume_rows:
+            json.dump(row, dataset_file, ensure_ascii=False, cls=PathEncoder)
+            print("", file=dataset_file)
+            valid_utterances_count += 1
+
         training_engine = None
         engine_kwargs = {}
         if engine:
@@ -838,10 +871,57 @@ def cli(
             print("", file=dataset_file)
             valid_utterances_count += 1
 
+    dataset_tmp.rename(config.output_dir / "dataset.jsonl")
     _LOGGER.info("Preprocessing complete. Wrote %d valid utterances to dataset.jsonl.", valid_utterances_count)
 
 
 # -----------------------------------------------------------------------------
+
+def _row_key(row: Dict[str, Any]) -> str:
+    """Resume identity for an existing dataset.jsonl row: row_id or audio path."""
+    return str(row.get("row_id") or row.get("audio_path") or "")
+
+
+def _utt_key(utt: Utterance) -> str:
+    """Resume identity for a freshly loaded utterance: row_id or audio path."""
+    return str(utt.row_id or utt.audio_path or "")
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    """Read existing dataset.jsonl rows, tolerating a truncated final line."""
+    rows: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                _LOGGER.warning("Ignoring truncated/malformed row while resuming: %.60s", line)
+    return rows
+
+
+def _read_metrics_sidecar(path: Path) -> Dict[str, Dict[str, float]]:
+    """Load a metrics parquet sidecar into {row_id: {column: value}}."""
+    import pandas as pd
+    frame = pd.read_parquet(path)
+    out: Dict[str, Dict[str, float]] = {}
+    for record in frame.to_dict(orient="records"):
+        row_id = str(record.get("row_id", ""))
+        out[row_id] = {k: float(v) for k, v in record.items()
+                       if k != "row_id" and v is not None and not pd.isna(v)}
+    return out
+
+
+def _write_metrics_sidecar(path: Path, recorded: Dict[str, Dict[str, float]]) -> None:
+    """Write per-row computed metric values to a parquet sidecar (atomic)."""
+    import pandas as pd
+    rows = [{"row_id": row_id, **values} for row_id, values in recorded.items()]
+    tmp = Path(str(path) + ".tmp")
+    pd.DataFrame(rows).to_parquet(tmp)
+    tmp.rename(path)
+
 
 def batched(iterable: Iterable[Any], n: int) -> Iterable[List[Any]]:
     """

--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -174,7 +174,9 @@ def phonemize_worker(
 @click.option("--resume", "resume", is_flag=True,
               help="Skip rows already present (by row_id/audio path) in an "
                    "existing output dataset.jsonl and append only new rows. "
-                   "Writes are atomic (temp file + rename).")
+                   "Writes are atomic (temp file + rename). Incompatible with "
+                   "--corpus-only-map, which cannot be reconstructed from "
+                   "already-written rows.")
 @click.option("--metrics-out", "metrics_out", type=click.Path(dir_okay=False, path_type=Path),
               default=None,
               help="Write every computed --filter metric value per row_id to "
@@ -525,6 +527,15 @@ def cli(
     if config.single_speaker and (config.speaker_id is not None):
         _LOGGER.fatal("--single-speaker and --speaker-id cannot both be provided")
         raise click.Abort()
+
+    if resume and corpus_only_map:
+        raise click.UsageError(
+            "--resume cannot be combined with --corpus-only-map: resuming "
+            "reprocesses only new rows, so it cannot reconstruct a corpus-only "
+            "phoneme map from the already-written rows (symbols occurring only "
+            "in those rows would be lost). Rerun without --resume, or without "
+            "--corpus-only-map."
+        )
 
     # Create directories
     config.output_dir.mkdir(parents=True, exist_ok=True)

--- a/phoonnx_train/quality_filter.py
+++ b/phoonnx_train/quality_filter.py
@@ -100,6 +100,9 @@ def apply_quality_filters(
     audio_path_fn: Callable[[object], Union[str, Path]],
     text_fn: Callable[[object], str],
     audio_loader: Optional[Callable[[Union[str, Path]], Tuple[object, int, float]]] = None,
+    id_fn: Optional[Callable[[object], str]] = None,
+    value_source: Optional[Callable[[object, str], Optional[float]]] = None,
+    metrics_sink: Optional[Callable[[str, str, float], None]] = None,
 ) -> Tuple[List[object], Dict[str, int]]:
     """Filter samples by on-demand-computed quality scorers.
 
@@ -113,6 +116,14 @@ def apply_quality_filters(
             called lazily, and at most once per sample, when a filter that
             actually needs audio is evaluated. Defaults to a librosa-backed
             16kHz mono loader.
+        id_fn: samples[i] -> stable row id, used only to key values passed to
+            ``metrics_sink``. Defaults to ``str(audio_path_fn(sample))``.
+        value_source: (sample, column) -> a precomputed metric value to use
+            instead of running the scorer, or ``None`` to compute on demand.
+            A source that satisfies every needed metric avoids decoding audio.
+        metrics_sink: called ``(row_id, column, value)`` for every metric value
+            evaluated for a sample (computed or sourced), before the pass/fail
+            decision. Used to persist a metrics sidecar.
 
     Returns:
         (kept_samples, dropped_counts) where dropped_counts maps each
@@ -146,19 +157,25 @@ def apply_quality_filters(
         audio_loaded = False
         text = text_fn(sample)
         sample_dropped = False
+        row_id = id_fn(sample) if id_fn else str(audio_path_fn(sample))
 
         try:
             for spec in ordered:
-                scorer = _SCORER_REGISTRY[spec.column]
-                if spec.column != "wpm" and not audio_loaded:
-                    audio, sr, duration = loader(audio_path_fn(sample))
-                    audio_loaded = True
-                elif spec.column == "wpm" and not audio_loaded:
-                    # wpm only needs duration; fetch it without decoding audio
-                    # unless a later filter already forced a full decode.
-                    duration = _duration_only(audio_path_fn(sample))
+                value = value_source(sample, spec.column) if value_source else None
+                if value is None:
+                    scorer = _SCORER_REGISTRY[spec.column]
+                    if spec.column != "wpm" and not audio_loaded:
+                        audio, sr, duration = loader(audio_path_fn(sample))
+                        audio_loaded = True
+                    elif spec.column == "wpm" and not audio_loaded:
+                        # wpm only needs duration; fetch it without decoding
+                        # audio unless a later filter forced a full decode.
+                        duration = _duration_only(audio_path_fn(sample))
+                    value = scorer(audio, sr, text, duration)
 
-                value = scorer(audio, sr, text, duration)
+                if metrics_sink is not None:
+                    metrics_sink(row_id, spec.column, float(value))
+
                 if not spec.passes(value):
                     dropped[spec.column] += 1
                     sample_dropped = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,14 @@ train-eval = [
     "onnx-asr",
     "pandas",
 ]
+# multi-format dataset loading for preprocessing (jsonl/parquet/HF repos with
+# embedded audio bytes) and the metrics sidecar
+train-data = [
+    "pandas",
+    "pyarrow",
+    "datasets",
+    "soundfile",
+]
 # extra deps for the FastPitch / SpeedySpeech training engine
 # (phoonnx_train/engines/fastpitch.py) on top of [train]: pyworld for F0
 # (pitch) extraction in extra_preprocess. librosa is already in [train].

--- a/tests/test_dataset_loaders.py
+++ b/tests/test_dataset_loaders.py
@@ -393,6 +393,31 @@ class TestPreprocessIntegration(unittest.TestCase):
             lines2 = [json.loads(x) for x in (out / "dataset.jsonl").read_text().splitlines() if x]
             self.assertEqual(len(lines2), 3)
 
+    def test_resume_with_corpus_only_map_is_rejected(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            a = tmp / "a.jsonl"
+            self._jsonl(a, [{"text": "hi", "audio": "a.wav", "phon": "h i"}])
+            out = tmp / "out"
+            base = ["-i", str(a), "-o", str(out), "-l", "en",
+                    "--skip-audio", "--phonemes-column", "phon"]
+
+            # both flags together -> loud usage error (exit 2), nothing written
+            both = self._invoke(base + ["--resume", "--corpus-only-map"])
+            self.assertEqual(both.exit_code, 2)
+            self.assertIn("--corpus-only-map", both.output)
+            self.assertFalse((out / "dataset.jsonl").exists())
+
+            # --resume alone still works
+            self.assertEqual(self._invoke(base + ["--resume"]).exit_code, 0)
+
+            # --corpus-only-map alone still works (phonemizing builds the map)
+            with TemporaryDirectory() as tmp2:
+                out2 = Path(tmp2) / "out"
+                ok = self._invoke(["-i", str(a), "-o", str(out2), "-l", "en",
+                                   "--skip-audio", "--corpus-only-map"])
+                self.assertEqual(ok.exit_code, 0, ok.output)
+
     def test_mismatched_precomputed_phonemes_fail_loudly(self):
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)

--- a/tests/test_dataset_loaders.py
+++ b/tests/test_dataset_loaders.py
@@ -1,0 +1,411 @@
+"""Tests for multi-format dataset loading and its preprocessing integration."""
+import io
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import numpy as np
+import soundfile as sf
+
+from phoonnx_train.dataset_loaders import (PreprocessorConfig, Utterance,
+                                           _audio_from_value, _jsonable,
+                                           detect_format, ensure_audio_path,
+                                           jsonl_loader, known_loaders,
+                                           load_source, parquet_loader)
+from phoonnx.config import Alphabet, PhonemeType
+
+
+def _wav_bytes(seconds: float = 0.2, sr: int = 16000) -> bytes:
+    tone = 0.1 * np.sin(2 * np.pi * 220 * np.linspace(0, seconds, int(sr * seconds), endpoint=False))
+    buf = io.BytesIO()
+    sf.write(buf, tone.astype(np.float32), sr, format="WAV")
+    return buf.getvalue()
+
+
+def _config(tmp: str, **overrides) -> PreprocessorConfig:
+    base = dict(
+        input_dir=Path(tmp), output_dir=Path(tmp), language="en", sample_rate=16000,
+        cache_dir=Path(tmp) / "cache", max_workers=1, single_speaker=False,
+        speaker_id=None, phoneme_type=PhonemeType.ESPEAK, alphabet=Alphabet.IPA,
+        phonemizer_model="", text_casing="ignore", dataset_name=None,
+        audio_quality=None, skip_audio=False, debug=False, add_diacritics=False,
+    )
+    base.update(overrides)
+    return PreprocessorConfig(**base)
+
+
+class TestDetectFormat(unittest.TestCase):
+    def test_ljspeech_dir(self):
+        with TemporaryDirectory() as tmp:
+            (Path(tmp) / "metadata.csv").write_text("a|hi\n")
+            self.assertEqual(detect_format(tmp), "ljspeech")
+
+    def test_jsonl_file(self):
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text("{}\n")
+            self.assertEqual(detect_format(str(p)), "jsonl")
+
+    def test_parquet_file_and_dir_and_glob(self):
+        import pandas as pd
+        with TemporaryDirectory() as tmp:
+            shard = Path(tmp) / "part-0.parquet"
+            pd.DataFrame({"text": ["hi"]}).to_parquet(shard)
+            self.assertEqual(detect_format(str(shard)), "parquet")
+            self.assertEqual(detect_format(tmp), "parquet")
+            self.assertEqual(detect_format(str(Path(tmp) / "*.parquet")), "parquet")
+
+    def test_hf_repo_id(self):
+        self.assertEqual(detect_format("org/some-dataset"), "hf")
+
+    def test_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            detect_format("not a path or repo")
+        with TemporaryDirectory() as tmp:
+            # existing dir with neither metadata.csv nor parquet shards
+            with self.assertRaises(ValueError):
+                detect_format(tmp)
+
+    def test_all_formats_registered(self):
+        self.assertEqual(set(known_loaders()), {"ljspeech", "jsonl", "parquet", "hf"})
+
+
+class TestAudioFromValue(unittest.TestCase):
+    def test_path_string(self):
+        self.assertEqual(_audio_from_value("a.wav"), ("a.wav", None))
+
+    def test_raw_bytes(self):
+        self.assertEqual(_audio_from_value(b"xyz"), (None, b"xyz"))
+
+    def test_hf_mapping_with_null_path(self):
+        # the embedded-bytes case: path is None, bytes carry the audio
+        self.assertEqual(_audio_from_value({"bytes": b"xyz", "path": None}), (None, b"xyz"))
+
+    def test_hf_mapping_with_path_only(self):
+        self.assertEqual(_audio_from_value({"bytes": None, "path": "a.wav"}), ("a.wav", None))
+
+    def test_none(self):
+        self.assertEqual(_audio_from_value(None), (None, None))
+
+
+class TestJsonable(unittest.TestCase):
+    def test_numpy_scalar_unwrapped(self):
+        self.assertEqual(_jsonable(np.int64(5)), 5)
+
+    def test_bytes_dropped(self):
+        self.assertIsNone(_jsonable(b"raw"))
+
+    def test_primitives_passthrough(self):
+        self.assertEqual(_jsonable("x"), "x")
+        self.assertEqual(_jsonable([1, np.float32(2.0)]), [1, 2.0])
+
+
+class TestUtteranceAsdict(unittest.TestCase):
+    def test_drops_bytes_and_flag_keeps_extras(self):
+        utt = Utterance(text="hi", audio_path=Path("a.wav"), audio_bytes=b"raw",
+                        phonemes_precomputed=True, row_id="r1", extras={"lang": "en"})
+        data = utt.asdict()
+        self.assertNotIn("audio_bytes", data)
+        self.assertNotIn("phonemes_precomputed", data)
+        self.assertEqual(data["row_id"], "r1")
+        self.assertEqual(data["extras"], {"lang": "en"})
+        self.assertEqual(data["audio_path"], "a.wav")
+        # the whole thing must be JSON-serializable
+        json.dumps(data)
+
+
+class TestJsonlLoader(unittest.TestCase):
+    def _write(self, tmp, rows):
+        p = Path(tmp) / "data.jsonl"
+        with open(p, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+        return str(p)
+
+    def test_reads_rows_with_default_columns(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"text": "hello", "audio": "a.wav", "speaker": "s1"}])
+            utts = list(jsonl_loader(src, _config(tmp)))
+            self.assertEqual(len(utts), 1)
+            self.assertEqual(utts[0].text, "hello")
+            self.assertEqual(utts[0].speaker, "s1")
+            self.assertEqual(str(utts[0].audio_path), "a.wav")
+
+    def test_alternate_text_column_fallback(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"sentence": "hi there", "audio": "a.wav"}])
+            utts = list(jsonl_loader(src, _config(tmp)))
+            self.assertEqual(utts[0].text, "hi there")
+
+    def test_explicit_missing_column_raises(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"text": "hi", "audio": "a.wav"}])
+            with self.assertRaises(ValueError):
+                list(jsonl_loader(src, _config(tmp, text_column="nope")))
+
+    def test_missing_text_skips_row(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"text": "", "audio": "a.wav"},
+                                    {"text": "ok", "audio": "b.wav"}])
+            utts = list(jsonl_loader(src, _config(tmp)))
+            self.assertEqual([u.text for u in utts], ["ok"])
+
+    def test_missing_audio_skips_unless_skip_audio(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"text": "hi"}])
+            self.assertEqual(list(jsonl_loader(src, _config(tmp))), [])
+            utts = list(jsonl_loader(src, _config(tmp, skip_audio=True)))
+            self.assertEqual(len(utts), 1)
+
+    def test_malformed_json_line_skipped(self):
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.jsonl"
+            p.write_text('{"text": "ok", "audio": "a.wav"}\nnot json\n{bad}\n')
+            utts = list(jsonl_loader(str(p), _config(tmp)))
+            self.assertEqual([u.text for u in utts], ["ok"])
+
+    def test_precomputed_phonemes_split_on_whitespace(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"text": "hi", "audio": "a.wav", "phon": "h a i"},
+                                    {"text": "bye", "audio": "b.wav", "phon": ""}])
+            utts = list(jsonl_loader(src, _config(tmp, phonemes_column="phon")))
+            self.assertEqual(utts[0].phonemes, ["h", "a", "i"])
+            self.assertTrue(utts[0].phonemes_precomputed)
+            # empty phonemes cell falls back to the phonemizer
+            self.assertIsNone(utts[1].phonemes)
+            self.assertFalse(utts[1].phonemes_precomputed)
+
+    def test_unmapped_and_lang_columns_go_to_extras(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"text": "hi", "audio": "a.wav",
+                                     "lang": "en", "dataset": "x"}])
+            utts = list(jsonl_loader(src, _config(tmp, lang_column="lang")))
+            self.assertEqual(utts[0].extras.get("lang"), "en")
+            self.assertEqual(utts[0].extras.get("dataset"), "x")
+
+    def test_single_speaker_ignores_speaker_column(self):
+        with TemporaryDirectory() as tmp:
+            src = self._write(tmp, [{"text": "hi", "audio": "a.wav", "speaker": "s1"}])
+            utts = list(jsonl_loader(src, _config(tmp, single_speaker=True)))
+            self.assertIsNone(utts[0].speaker)
+
+
+class TestParquetLoader(unittest.TestCase):
+    def test_reads_shards_in_directory(self):
+        import pandas as pd
+        with TemporaryDirectory() as tmp:
+            pd.DataFrame({"text": ["a", "b"], "audio": ["a.wav", "b.wav"]}).to_parquet(
+                Path(tmp) / "part-0.parquet")
+            pd.DataFrame({"text": ["c"], "audio": ["c.wav"]}).to_parquet(
+                Path(tmp) / "part-1.parquet")
+            utts = list(parquet_loader(tmp, _config(tmp)))
+            self.assertEqual(sorted(u.text for u in utts), ["a", "b", "c"])
+
+    def test_embedded_bytes_row(self):
+        import pandas as pd
+        with TemporaryDirectory() as tmp:
+            wav = _wav_bytes()
+            df = pd.DataFrame({"text": ["hi"], "audio": [{"bytes": wav, "path": None}]})
+            df.to_parquet(Path(tmp) / "d.parquet")
+            utts = list(parquet_loader(str(Path(tmp) / "d.parquet"), _config(tmp)))
+            self.assertEqual(len(utts), 1)
+            self.assertEqual(utts[0].audio_bytes, wav)
+            self.assertIn(str(utts[0].audio_path), ("", "."))
+            self.assertTrue(utts[0].row_id)
+
+    def test_missing_audio_column_in_shard(self):
+        import pandas as pd
+        with TemporaryDirectory() as tmp:
+            # no audio column at all; without skip_audio every row drops
+            pd.DataFrame({"text": ["a", "b"]}).to_parquet(Path(tmp) / "d.parquet")
+            self.assertEqual(list(parquet_loader(str(Path(tmp) / "d.parquet"), _config(tmp))), [])
+            kept = list(parquet_loader(str(Path(tmp) / "d.parquet"), _config(tmp, skip_audio=True)))
+            self.assertEqual(len(kept), 2)
+
+
+class TestEnsureAudioPath(unittest.TestCase):
+    def test_path_backed_returns_path_unchanged(self):
+        utt = Utterance(text="x", audio_path=Path("/some/a.wav"))
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(ensure_audio_path(utt, tmp), Path("/some/a.wav"))
+
+    def test_bytes_materialized_to_wav(self):
+        wav = _wav_bytes()
+        utt = Utterance(text="x", audio_path=Path(""), audio_bytes=wav, row_id="r1")
+        with TemporaryDirectory() as tmp:
+            out = ensure_audio_path(utt, tmp)
+            self.assertTrue(out.exists())
+            self.assertEqual(out.suffix, ".wav")
+            data, sr = sf.read(str(out))
+            self.assertGreater(len(data), 0)
+            # second call is cached on the utterance
+            self.assertEqual(ensure_audio_path(utt, tmp), out)
+
+    def test_corrupt_bytes_raise(self):
+        utt = Utterance(text="x", audio_path=Path(""), audio_bytes=b"not audio at all", row_id="r2")
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(Exception):
+                ensure_audio_path(utt, tmp)
+
+    def test_no_path_and_no_bytes_raises(self):
+        utt = Utterance(text="x", audio_path=Path(""), row_id="r3")
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError):
+                ensure_audio_path(utt, tmp)
+
+
+class TestHfLoader(unittest.TestCase):
+    def test_reads_embedded_audio_bytes(self):
+        import datasets
+
+        wav = _wav_bytes()
+        # A plain struct column carrying embedded bytes (our parquet shards look
+        # like this); no Audio feature so datasets never tries to encode/decode.
+        ds = datasets.Dataset.from_dict(
+            {"audio": [{"bytes": wav, "path": None}], "text": ["hello"]},
+        )
+        with TemporaryDirectory() as tmp:
+            with patch("datasets.load_dataset", return_value=ds):
+                from phoonnx_train.dataset_loaders import hf_loader
+                utts = list(hf_loader("org/name", _config(tmp)))
+        self.assertEqual(len(utts), 1)
+        self.assertEqual(utts[0].text, "hello")
+        self.assertIsNotNone(utts[0].audio_bytes)
+
+
+class TestQualityFilterExtensions(unittest.TestCase):
+    def test_metrics_sink_records_and_value_source_avoids_compute(self):
+        from phoonnx_train.quality_filter import (apply_quality_filters,
+                                                   parse_filter_spec, register_scorer)
+
+        computed = []
+
+        def scorer(audio, sr, text, duration):
+            computed.append(text)
+            return 9.9
+
+        register_scorer("metric_x", scorer)
+        s1 = Utterance(text="a", audio_path=Path("a.wav"), row_id="a", extras={"metric_x": 5.0})
+        s2 = Utterance(text="b", audio_path=Path("b.wav"), row_id="b", extras={})
+
+        recorded = {}
+
+        def sink(row_id, column, value):
+            recorded.setdefault(row_id, {})[column] = value
+
+        def value_source(sample, column):
+            v = sample.extras.get(column)
+            return float(v) if v is not None else None
+
+        kept, dropped = apply_quality_filters(
+            [s1, s2], [parse_filter_spec("metric_x:3.0:")],
+            audio_path_fn=lambda u: u.audio_path,
+            text_fn=lambda u: u.text,
+            audio_loader=lambda p: (None, 16000, 1.0),
+            id_fn=lambda u: u.row_id,
+            value_source=value_source,
+            metrics_sink=sink,
+        )
+        # s1 sourced from column (never computed); s2 computed via scorer
+        self.assertEqual(computed, ["b"])
+        self.assertEqual([u.row_id for u in kept], ["a", "b"])
+        self.assertEqual(recorded["a"]["metric_x"], 5.0)
+        self.assertEqual(recorded["b"]["metric_x"], 9.9)
+
+
+class TestMetricsSidecarRoundtrip(unittest.TestCase):
+    def test_write_then_read(self):
+        from phoonnx_train.preprocess import (_read_metrics_sidecar,
+                                              _write_metrics_sidecar)
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "metrics.parquet"
+            _write_metrics_sidecar(path, {"r1": {"wpm": 120.0}, "r2": {"wpm": 80.0}})
+            back = _read_metrics_sidecar(path)
+            self.assertEqual(back["r1"]["wpm"], 120.0)
+            self.assertEqual(back["r2"]["wpm"], 80.0)
+
+
+class TestResumeHelpers(unittest.TestCase):
+    def test_read_jsonl_tolerates_truncated_final_line(self):
+        from phoonnx_train.preprocess import _read_jsonl, _row_key, _utt_key
+        with TemporaryDirectory() as tmp:
+            p = Path(tmp) / "dataset.jsonl"
+            # a valid row, then a half-written (truncated) final line
+            p.write_text('{"row_id": "r1", "audio_path": "a.wav"}\n{"row_id": "r2", "aud')
+            rows = _read_jsonl(p)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(_row_key(rows[0]), "r1")
+            self.assertEqual(_utt_key(Utterance(text="x", audio_path=Path("a.wav"), row_id="r2")), "r2")
+
+
+class TestPreprocessIntegration(unittest.TestCase):
+    """End-to-end cli over jsonl sources with precomputed phonemes + skip_audio,
+    covering multi-source speaker namespacing and --resume."""
+
+    class _DummyPhonemizer:
+        alphabet = Alphabet.IPA
+
+        def phonemize_to_list(self, text, lang):
+            return list(text.replace(" ", ""))
+
+        def add_diacritics(self, text, lang):
+            return text
+
+    def _jsonl(self, path, rows):
+        with open(path, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+    def _invoke(self, args):
+        import click.testing
+        from phoonnx_train import preprocess
+        with patch.object(preprocess, "get_phonemizer", return_value=self._DummyPhonemizer()):
+            return click.testing.CliRunner().invoke(preprocess.cli, args, catch_exceptions=False)
+
+    def test_multi_source_speaker_namespacing_and_resume(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            a = tmp / "a.jsonl"
+            b = tmp / "b.jsonl"
+            # both sources reuse speaker id "0" -> must be namespaced apart
+            self._jsonl(a, [{"text": "hi", "audio": "a.wav", "speaker": "0", "phon": "h i"}])
+            self._jsonl(b, [{"text": "no", "audio": "b.wav", "speaker": "0", "phon": "n o"}])
+            out = tmp / "out"
+            args = ["-i", str(a), "-i", str(b), "-o", str(out), "-l", "en",
+                    "--skip-audio", "--phonemes-column", "phon"]
+            result = self._invoke(args)
+            self.assertEqual(result.exit_code, 0, result.output)
+
+            config = json.loads((out / "config.json").read_text())
+            self.assertEqual(config["num_speakers"], 2)
+            self.assertEqual(set(config["speaker_id_map"]), {"a:0", "b:0"})
+
+            lines = [json.loads(x) for x in (out / "dataset.jsonl").read_text().splitlines() if x]
+            self.assertEqual(len(lines), 2)
+
+            # resume: add a third row in a new source; only it is processed/appended
+            c = tmp / "c.jsonl"
+            self._jsonl(c, [{"text": "yo", "audio": "c.wav", "speaker": "0", "phon": "i o"}])
+            result2 = self._invoke(args + ["-i", str(c), "--resume"])
+            self.assertEqual(result2.exit_code, 0, result2.output)
+            lines2 = [json.loads(x) for x in (out / "dataset.jsonl").read_text().splitlines() if x]
+            self.assertEqual(len(lines2), 3)
+
+    def test_mismatched_precomputed_phonemes_fail_loudly(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            a = tmp / "a.jsonl"
+            # 'ZZZ' is not a valid IPA symbol in the default map
+            self._jsonl(a, [{"text": "hi", "audio": "a.wav", "phon": "h ZZZ"}])
+            out = tmp / "out"
+            args = ["-i", str(a), "-o", str(out), "-l", "en", "--corpus-only-map",
+                    "--skip-audio", "--phonemes-column", "phon"]
+            with self.assertRaises(ValueError) as ctx:
+                self._invoke(args)
+            self.assertIn("ZZZ", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Multi-format dataset loading for preprocessing

`phoonnx_train/preprocess.py` previously loaded exactly one dataset shape
(LJSpeech: `metadata.csv` + `wavs/`). This adds a loader registry so the same
`Utterance` pipeline (phonemize workers, quality filters, `dataset.jsonl`
writer) can consume several formats.

### Loader registry & auto-detection
New module `phoonnx_train/dataset_loaders.py` holds named loader generators
(mirroring the scorer registry in `quality_filter.py`). `--dataset-format
{auto,ljspeech,jsonl,parquet,hf}` (default `auto`). Auto-detection per source:

- directory with `metadata.csv` -> `ljspeech`
- `.jsonl` file -> `jsonl`
- `.parquet` file, shard glob, or directory of shards -> `parquet`
- `org/name` string that is not an existing path -> `hf` (`datasets.load_dataset`)

The LJSpeech loader moved behind the registry with unchanged behavior.

### Column mapping (jsonl/parquet/hf)
`--text-column`, `--audio-column`, `--speaker-column`, `--phonemes-column`,
`--lang-column`. Defaults: text tried in order `text, sentence, transcription,
transcript`; audio `audio`; speaker `speaker, speaker_id`; lang unset. An
explicitly requested column that is absent fails loudly. Unmapped columns (and
the lang column) pass through into `dataset.jsonl` under an `extras` key.
LJSpeech keeps its positional format.

### Embedded audio bytes
HF audio columns and our own parquet shards frequently inline audio **bytes**
(HF caps 10000 files/dir), with `path` often `None`; casting does not inline
bytes. Loaders read the bytes field explicitly into `Utterance.audio_bytes`
and stamp a stable `Utterance.row_id`. Audio-consuming code
(`cache_norm_audio` call sites, the quality filters' `audio_path_fn`)
materializes bytes on demand by decoding via soundfile to a cached wav keyed by
`row_id`. The path-based flow is byte-identical for existing formats.

### Per-row precomputed phonemes (opt-in)
Only when `--phonemes-column` is given: rows with a non-empty value skip
phonemization and use that value verbatim (whitespace-separated symbols, never
normalized or case-mangled); empty cells fall back to the phonemizer. Used
symbols are validated against the final phoneme map and a mismatch fails loudly
listing the offending symbols (never silently expands the vocab). The
column/phonemized split is logged.

### Metrics sidecar + column-backed filters (opt-in)
`--metrics-out PATH.parquet` writes every computed `--filter` metric per
row_id. `--filter-from-columns` makes `--filter` prefer a per-row value from
(a) a dataset column of the same name or (b) a `--metrics-in PATH.parquet`
sidecar, before computing on demand. Without these flags, behavior is exactly
as today (always compute fresh).

### Resumable preprocessing
`--resume` skips rows already present (by row_id/audio path) in an existing
output `dataset.jsonl` and appends only new rows. `config.json` and
`dataset.jsonl` are written to a temp file and atomically renamed. Without
`--resume`, behavior is unchanged.

### Multiple inputs
`-i/--input-dir` is repeatable (and comma-separated), merging datasets; when
more than one source is given, speaker labels are namespaced per source
(`<tag>:<speaker>`) to avoid id collisions, and the mapping is logged.

### Packaging / CI
New `train-data` extra (`pandas`, `pyarrow`, `datasets`, `soundfile`) added to
`build-tests.yml` and `coverage.yml` install extras.

## Test plan
- [x] `pytest tests/test_dataset_loaders.py tests/test_quality_filter.py -q` green (88 passed)
- [x] format auto-detection incl. unknown/ambiguous -> error
- [x] column resolution: defaults, fallbacks, explicit-missing raises
- [x] jsonl/parquet loaders incl. malformed JSON lines, missing text/audio, missing audio column
- [x] embedded-bytes rows (parquet + HF) and corrupt-bytes decode raises
- [x] precomputed phonemes split/opt-in; mismatched inventory fails loudly
- [x] metrics sidecar roundtrip; value_source avoids recompute; metrics_sink records
- [x] resume tolerates a truncated final jsonl line
- [x] end-to-end cli: multi-source speaker namespacing + `--resume` append
- [x] existing suites still green: `test_yourtts_training`, `test_lang_preprocess`, `test_phoneme_map`
