### PR TITLE
feat: add per-stage TTS latency benchmark script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .pytest_cache/
+bench_results_cpu.json

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,73 @@
+# Benchmarking TTS latency
+
+> This page targets developers who need to reason about synthesis latency —
+> where time goes inside a single `synthesize()` call, and how to compare
+> voices or execution providers. The docs tree is being restructured in a
+> parallel change; this page stays at `docs/benchmarking.md` regardless of
+> where the rest of the tree ends up.
+
+## Running the benchmark
+
+```bash
+python scripts/bench_latency.py MODEL [OPTIONS]
+```
+
+`MODEL` is either a path to a local `.onnx` voice or a voice id downloadable
+through `TTSModelManager` (for example `piper/en_US-amy-low`). Useful options:
+
+- `--config PATH` — voice config JSON, if it doesn't sit next to the model as `MODEL.json`.
+- `--runs N` — number of warm runs to summarize (default 5).
+- `--warmup / --no-warmup` — run one extra untimed pass before the reported cold run.
+- `--text` / `--text-file` — override the built-in 1-sentence and 5-sentence benchmark texts.
+- `--json-out PATH` — write machine-readable results alongside the printed table.
+
+To force a specific ONNX Runtime execution provider, set `PHOONNX_ONNX_PROVIDERS`
+before running, e.g. `PHOONNX_ONNX_PROVIDERS=CPUExecutionProvider` or
+`PHOONNX_ONNX_PROVIDERS=CUDAExecutionProvider,CPUExecutionProvider`. The script
+also reports which providers ONNX Runtime *claims* to have available — that is
+not proof a GPU provider actually initializes; a missing CUDA/cuDNN shared
+library makes ONNX Runtime fall back to CPU silently, so always check the
+`session_create` time and the per-run numbers before trusting a GPU result.
+
+## What the stages mean
+
+Each stage mirrors a step inside `TTSVoice.synthesize()` (see
+`phoonnx/voice.py`), timed with the same public methods synthesis itself
+calls — nothing is patched or mocked in the timed path:
+
+- **config_parse** / **session_create** — loading the voice: parsing its JSON
+  config versus building the ONNX Runtime session. Reported once, cold, since
+  a real deployment loads a voice exactly once and keeps it resident.
+- **cold_warmup_run** — the first `session.run` after session creation, which
+  pays for ONNX Runtime's graph optimization and kernel selection. This cost
+  is paid once per process; every run after it is faster for that reason
+  alone, not because anything about the text changed.
+- **text_normalize** — phonetic-spelling substitution (user pronunciation
+  overrides), when the voice ships an override table.
+- **diacritics** — restoring diacritics (Arabic/Hebrew voices only); zero
+  for voices that don't request it.
+- **phonemize** — turning text into phoneme sequences, one per sentence.
+- **tokenize** — mapping phonemes to the model's integer vocabulary.
+- **session_run_total** — the sum of ONNX Runtime inference calls across all
+  sentences in the text.
+- **postprocess_total** — normalization, volume scaling, and clipping into
+  the final `AudioChunk`.
+
+## TTFA vs RTF
+
+**Time-to-first-audio (TTFA)** is the wall-clock time from calling
+`synthesize()` to receiving the *first* `AudioChunk`. Because `synthesize()`
+phonemizes and tokenizes the whole input text before running inference on the
+first sentence, TTFA for a multi-sentence paragraph is not driven only by that
+first sentence's inference cost — it also carries the cost of phonemizing
+every sentence up front. This is the number that determines how long a user
+waits in a live conversation before hearing anything.
+
+**Real-time factor (RTF)** is total synthesis time divided by the seconds of
+audio produced. An RTF below 1.0 means synthesis runs faster than playback —
+the model can keep up with real-time streaming. RTF says nothing about how
+long the *first* chunk takes to arrive; a voice can have a low RTF and still
+feel slow to start if phonemization of a long text delays the first sentence.
+
+Read them together: TTFA answers "how long until I hear anything," RTF
+answers "can this keep up once it starts."

--- a/scripts/bench_latency.py
+++ b/scripts/bench_latency.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Per-stage TTS latency benchmark.
+
+Mirrors the exact call sequence of ``phoonnx.voice.TTSVoice.synthesize`` and
+times each stage with ``time.perf_counter``, plus the wall-clock time to the
+first yielded ``AudioChunk`` (time-to-first-audio, TTFA) and the total
+synthesis time. No internals are patched: every stage below calls the same
+public methods ``synthesize()`` itself calls, in the same order.
+"""
+import json
+import statistics
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import click
+import numpy as np
+import onnxruntime
+
+from phoonnx.config import SynthesisConfig
+from phoonnx.voice import AudioChunk, TTSVoice
+
+DEFAULT_TEXT_1SENT = "The quick brown fox jumps over the lazy dog."
+DEFAULT_TEXT_5SENT = (
+    "The quick brown fox jumps over the lazy dog. "
+    "A rainbow is a meteorological phenomenon caused by reflection and refraction of light. "
+    "Voice assistants rely on low latency to feel responsive. "
+    "This sentence exists purely to pad out the paragraph for benchmarking. "
+    "Synthesis quality and speed both matter for a good user experience."
+)
+
+
+def timed(fn: Callable[[], Any]) -> tuple:
+    """Run ``fn`` and return ``(result, elapsed_seconds)`` using a monotonic clock."""
+    start = time.perf_counter()
+    result = fn()
+    return result, time.perf_counter() - start
+
+
+def resolve_model(model: str, config: Optional[str]) -> tuple:
+    """Resolve MODEL to a local (model_path, config_path) pair.
+
+    ``model`` may be a filesystem path to a ``.onnx`` file, or a voice id
+    downloadable via ``TTSModelManager`` (e.g. ``piper/en_US-amy-low``).
+    """
+    model_path = Path(model)
+    if model_path.is_file():
+        return str(model_path), config
+
+    import os
+
+    import phoonnx.model_manager as mm
+
+    manager = mm.TTSModelManager()
+    if not manager.download_voice_by_id(model):
+        raise click.ClickException(f"Could not resolve or download voice '{model}'")
+
+    # download_voice_by_id() resolves bundled-index voices without registering
+    # them in manager.voices; look it up the same way it did internally.
+    info = manager.voices.get(model)
+    if info is None:
+        base_path = Path(os.path.dirname(mm.__file__)) / "voice_index"
+        for index_file in base_path.glob("*.json"):
+            data = json.loads(index_file.read_text(encoding="utf-8"))
+            if model in data:
+                info = mm.TTSModelInfo(**data[model])
+                break
+    if info is None:
+        raise click.ClickException(f"Downloaded '{model}' but could not reload its metadata")
+    local_model_path = info.download_model()
+    local_config_path = local_model_path.parent / "model.json"
+    if not local_config_path.is_file():
+        info.download_config()
+    return str(local_model_path), str(local_config_path)
+
+
+def load_voice_timed(model_path: str, config_path: Optional[str]) -> Dict[str, Any]:
+    """Load a voice, separately timing config parse from ONNX session creation.
+
+    Mirrors ``TTSVoice.load`` (see phoonnx/voice.py) rather than calling it as
+    one opaque unit, so config-parse cost and session-creation cost are
+    reported separately.
+    """
+    from phoonnx.config import VoiceConfig
+    from phoonnx.providers import make_session, resolve_providers
+
+    if config_path is None:
+        config_path = f"{model_path}.json"
+
+    def _parse_config():
+        import os
+
+        if os.path.isfile(config_path):
+            with open(config_path, "r", encoding="utf-8") as f:
+                config_dict = json.load(f)
+        else:
+            config_dict = {"phoneme_type": "unicode", "alphabet": "unicode"}
+        return VoiceConfig.from_dict(config_dict), config_dict
+
+    (voice_config, config_dict), t_config_parse = timed(_parse_config)
+
+    resolved_providers = resolve_providers(None, use_cuda=False)
+
+    session, t_session_create = timed(lambda: make_session(model_path, providers=resolved_providers))
+
+    from phoonnx.engines import detect_engine
+
+    adapter = detect_engine(config=config_dict, session=session)
+    voice = TTSVoice(config=voice_config, session=session, adapter=adapter)
+
+    return {
+        "voice": voice,
+        "t_config_parse": t_config_parse,
+        "t_session_create": t_session_create,
+    }
+
+
+def warmup_session(voice: TTSVoice, text: str = "hi") -> float:
+    """Run one throwaway synthesis pass and time the ONNX session's cold
+    ``session.run`` (graph optimization / kernel selection happens here)."""
+    _, elapsed = timed(lambda: list(voice.synthesize(text)))
+    return elapsed
+
+
+def bench_stages(voice: TTSVoice, text: str, syn_config: SynthesisConfig) -> Dict[str, Any]:
+    """Time each stage of the synthesize() pipeline honestly, by calling the
+    same public methods in the same order voice.synthesize() does."""
+    stages: Dict[str, float] = {}
+
+    working_text = text
+    if voice.phonetic_spellings and syn_config.enable_phonetic_spellings:
+        working_text, stages["text_normalize"] = timed(
+            lambda: voice.phonetic_spellings.apply(working_text)
+        )
+    else:
+        stages["text_normalize"] = 0.0
+
+    do_diacritics = syn_config.add_diacritics
+    if do_diacritics is None:
+        do_diacritics = voice.config.add_diacritics
+    if do_diacritics:
+        diacritizer_model = syn_config.diacritizer_model or voice.config.diacritizer_model
+        working_text, stages["diacritics"] = timed(
+            lambda: voice.phonemizer.add_diacritics(
+                working_text, voice.config.lang_code, model=diacritizer_model
+            )
+        )
+    else:
+        stages["diacritics"] = 0.0
+
+    sentence_phonemes, stages["phonemize"] = timed(lambda: voice.phonemize(working_text))
+
+    all_ids, stages["tokenize"] = timed(
+        lambda: [voice.phonemes_to_ids(p) for p in sentence_phonemes if p]
+    )
+
+    run_times: List[float] = []
+    post_times: List[float] = []
+    audio_seconds = 0.0
+    for phoneme_ids in all_ids:
+        if not phoneme_ids:
+            continue
+        audio, run_elapsed = timed(lambda: voice.phoneme_ids_to_audio(phoneme_ids, syn_config))
+        run_times.append(run_elapsed)
+
+        def _postprocess():
+            a = audio
+            if syn_config.normalize_audio:
+                max_val = np.max(np.abs(a))
+                a = np.zeros_like(a) if max_val < 1e-8 else a / max_val
+            if syn_config.volume != 1.0:
+                a = a * syn_config.volume
+            a = np.clip(a, -1.0, 1.0).astype(np.float32)
+            return AudioChunk(sample_rate=voice.config.sample_rate, sample_width=2, sample_channels=1,
+                               audio_float_array=a)
+
+        chunk, post_elapsed = timed(_postprocess)
+        post_times.append(post_elapsed)
+        audio_seconds += len(chunk.audio_float_array) / chunk.sample_rate
+
+    stages["session_run_total"] = sum(run_times)
+    stages["session_run_per_sentence"] = run_times
+    stages["postprocess_total"] = sum(post_times)
+    stages["audio_seconds"] = audio_seconds
+    return stages
+
+
+def bench_ttfa(voice: TTSVoice, text: str, syn_config: SynthesisConfig) -> Dict[str, float]:
+    """Wall-clock time from calling synthesize() to the first yielded
+    AudioChunk (TTFA), and total time to exhaust the generator."""
+    start = time.perf_counter()
+    gen = voice.synthesize(text, syn_config=syn_config)
+    first_chunk = next(gen)
+    ttfa = time.perf_counter() - start
+    audio_seconds = len(first_chunk.audio_float_array) / first_chunk.sample_rate
+    for chunk in gen:
+        audio_seconds += len(chunk.audio_float_array) / chunk.sample_rate
+    total = time.perf_counter() - start
+    rtf = total / audio_seconds if audio_seconds > 0 else float("nan")
+    return {"ttfa": ttfa, "total": total, "audio_seconds": audio_seconds, "rtf": rtf}
+
+
+def summarize(values: List[float]) -> Dict[str, float]:
+    if not values:
+        return {"median": float("nan"), "p95": float("nan"), "min": float("nan"), "max": float("nan")}
+    ordered = sorted(values)
+    p95_idx = min(len(ordered) - 1, int(round(0.95 * (len(ordered) - 1))))
+    return {
+        "median": statistics.median(values),
+        "p95": ordered[p95_idx],
+        "min": ordered[0],
+        "max": ordered[-1],
+    }
+
+
+@click.command()
+@click.argument("model")
+@click.option("--config", "config_path", default=None, help="Path to the voice's JSON config (defaults to MODEL + '.json').")
+@click.option("--runs", default=5, show_default=True, help="Number of warm runs to measure (median/p95).")
+@click.option("--warmup/--no-warmup", default=False, show_default=True,
+              help="Run an extra untimed warmup pass before the cold run (the cold run is always reported separately).")
+@click.option("--text", default=None, help="Override both the 1-sentence and 5-sentence benchmark texts (used verbatim for both).")
+@click.option("--text-file", default=None, type=click.Path(exists=True), help="Read benchmark text from a file instead of the built-in defaults.")
+@click.option("--json-out", default=None, type=click.Path(), help="Write machine-readable results as JSON to this path.")
+def main(model, config_path, runs, warmup, text, text_file, json_out):
+    """Measure per-stage TTS latency and time-to-first-audio for MODEL.
+
+    MODEL is a path to a local ONNX voice, or a voice id downloadable via
+    TTSModelManager (e.g. 'piper/en_US-amy-low').
+    """
+    if text_file:
+        text = Path(text_file).read_text(encoding="utf-8").strip()
+
+    text_1sent = text or DEFAULT_TEXT_1SENT
+    text_5sent = text or DEFAULT_TEXT_5SENT
+
+    click.echo(f"Resolving model '{model}'...")
+    model_path, resolved_config_path = resolve_model(model, config_path)
+
+    click.echo("Loading voice (cold)...")
+    load_result = load_voice_timed(model_path, resolved_config_path)
+    voice = load_result["voice"]
+    providers = onnxruntime.get_available_providers()
+
+    if warmup:
+        warmup_session(voice, text_1sent)
+
+    click.echo("Timing cold warmup run (first session.run)...")
+    t_warmup_run = warmup_session(voice, text_1sent)
+
+    syn_config = SynthesisConfig()
+
+    results: Dict[str, Any] = {
+        "model": model,
+        "model_path": model_path,
+        "sample_rate": voice.config.sample_rate,
+        "onnxruntime_providers_available": providers,
+        "load": {
+            "config_parse_s": load_result["t_config_parse"],
+            "session_create_s": load_result["t_session_create"],
+        },
+        "cold_warmup_run_s": t_warmup_run,
+        "runs": runs,
+    }
+
+    for label, sample_text in (("1sentence", text_1sent), ("5sentence", text_5sent)):
+        stage_samples: Dict[str, List[float]] = {}
+        ttfa_samples: List[float] = []
+        total_samples: List[float] = []
+        rtf_samples: List[float] = []
+        audio_seconds = None
+
+        click.echo(f"Benchmarking '{label}' ({runs} warm runs)...")
+        for _ in range(runs):
+            stages = bench_stages(voice, sample_text, syn_config)
+            for key in ("text_normalize", "diacritics", "phonemize", "tokenize",
+                        "session_run_total", "postprocess_total"):
+                stage_samples.setdefault(key, []).append(stages[key])
+            audio_seconds = stages["audio_seconds"]
+
+            ttfa_result = bench_ttfa(voice, sample_text, syn_config)
+            ttfa_samples.append(ttfa_result["ttfa"])
+            total_samples.append(ttfa_result["total"])
+            rtf_samples.append(ttfa_result["rtf"])
+
+        results[label] = {
+            "stages": {k: summarize(v) for k, v in stage_samples.items()},
+            "ttfa": summarize(ttfa_samples),
+            "total": summarize(total_samples),
+            "rtf": summarize(rtf_samples),
+            "audio_seconds": audio_seconds,
+        }
+
+    _print_table(results)
+
+    if json_out:
+        Path(json_out).write_text(json.dumps(results, indent=2), encoding="utf-8")
+        click.echo(f"\nWrote JSON results to {json_out}")
+
+
+def _print_table(results: Dict[str, Any]) -> None:
+    click.echo("\n=== Load (cold, one-shot) ===")
+    click.echo(f"{'stage':<20}{'seconds':>12}")
+    click.echo(f"{'config_parse':<20}{results['load']['config_parse_s']:>12.4f}")
+    click.echo(f"{'session_create':<20}{results['load']['session_create_s']:>12.4f}")
+    click.echo(f"{'cold_warmup_run':<20}{results['cold_warmup_run_s']:>12.4f}")
+
+    for label in ("1sentence", "5sentence"):
+        r = results[label]
+        click.echo(f"\n=== {label} (warm, N={results['runs']}) ===")
+        click.echo(f"{'stage':<24}{'median':>10}{'p95':>10}{'min':>10}{'max':>10}")
+        for stage_name, stats in r["stages"].items():
+            click.echo(
+                f"{stage_name:<24}{stats['median']:>10.4f}{stats['p95']:>10.4f}{stats['min']:>10.4f}{stats['max']:>10.4f}"
+            )
+        for extra in ("ttfa", "total", "rtf"):
+            stats = r[extra]
+            click.echo(
+                f"{extra:<24}{stats['median']:>10.4f}{stats['p95']:>10.4f}{stats['min']:>10.4f}{stats['max']:>10.4f}"
+            )
+        click.echo(f"audio_seconds: {r['audio_seconds']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bench_latency.py
+++ b/tests/test_bench_latency.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/bench_latency.py.
+
+Uses a mocked voice (no ONNX session, no model download) so these run in CI
+without network access or a real model file.
+"""
+import json
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import bench_latency  # noqa: E402
+from phoonnx.config import SynthesisConfig  # noqa: E402
+from phoonnx.voice import AudioChunk  # noqa: E402
+
+
+def _make_mock_voice(sample_rate=16000, add_diacritics=False):
+    voice = MagicMock()
+    voice.config.sample_rate = sample_rate
+    voice.config.add_diacritics = add_diacritics
+    voice.config.diacritizer_model = None
+    voice.config.lang_code = "en-US"
+    voice.phonetic_spellings = None
+    voice.phonemize.return_value = [["h", "i"], ["b", "y", "e"]]
+    voice.phonemes_to_ids.side_effect = lambda phonemes: list(range(len(phonemes)))
+
+    def _synthesize(text, syn_config=None):
+        for _ in range(2):
+            yield AudioChunk(
+                sample_rate=sample_rate, sample_width=2, sample_channels=1,
+                audio_float_array=np.zeros(sample_rate // 4, dtype=np.float32),
+            )
+
+    voice.synthesize.side_effect = _synthesize
+
+    def _phoneme_ids_to_audio(phoneme_ids, syn_config=None, language_ids=None):
+        return np.zeros(sample_rate // 4, dtype=np.float32)
+
+    voice.phoneme_ids_to_audio.side_effect = _phoneme_ids_to_audio
+    return voice
+
+
+class TestModuleImports:
+    def test_bench_module_imports(self):
+        assert hasattr(bench_latency, "main")
+        assert hasattr(bench_latency, "bench_stages")
+        assert hasattr(bench_latency, "bench_ttfa")
+
+
+class TestTimedUtility:
+    def test_timed_returns_result_and_nonnegative_elapsed(self):
+        result, elapsed = bench_latency.timed(lambda: 1 + 1)
+        assert result == 2
+        assert elapsed >= 0.0
+
+    def test_timed_elapsed_is_monotonic_and_reflects_sleep(self):
+        _, elapsed = bench_latency.timed(lambda: time.sleep(0.01))
+        assert elapsed >= 0.01
+
+    def test_timed_propagates_exceptions(self):
+        def _boom():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError):
+            bench_latency.timed(_boom)
+
+
+class TestSummarize:
+    def test_summarize_empty_list_is_nan_not_crash(self):
+        stats = bench_latency.summarize([])
+        assert stats["median"] != stats["median"]  # NaN != NaN
+
+    def test_summarize_single_value(self):
+        stats = bench_latency.summarize([0.5])
+        assert stats["median"] == 0.5
+        assert stats["p95"] == 0.5
+        assert stats["min"] == 0.5
+        assert stats["max"] == 0.5
+
+    def test_summarize_orders_min_max_correctly(self):
+        stats = bench_latency.summarize([0.3, 0.1, 0.2])
+        assert stats["min"] == 0.1
+        assert stats["max"] == 0.3
+
+
+class TestBenchStagesWithMockedVoice:
+    def test_bench_stages_returns_expected_keys(self):
+        voice = _make_mock_voice()
+        stages = bench_latency.bench_stages(voice, "hello there", SynthesisConfig())
+        for key in ("text_normalize", "diacritics", "phonemize", "tokenize",
+                    "session_run_total", "postprocess_total", "audio_seconds"):
+            assert key in stages
+        assert stages["audio_seconds"] > 0
+
+    def test_bench_stages_skips_diacritics_when_not_enabled(self):
+        voice = _make_mock_voice(add_diacritics=False)
+        stages = bench_latency.bench_stages(voice, "hello", SynthesisConfig())
+        assert stages["diacritics"] == 0.0
+        voice.phonemizer.add_diacritics.assert_not_called()
+
+
+class TestBenchTTFAWithMockedVoice:
+    def test_ttfa_is_less_than_or_equal_to_total(self):
+        voice = _make_mock_voice()
+        result = bench_latency.bench_ttfa(voice, "hello there", SynthesisConfig())
+        assert result["ttfa"] <= result["total"]
+        assert result["audio_seconds"] > 0
+        assert result["rtf"] >= 0
+
+    def test_ttfa_handles_zero_audio_without_crashing(self):
+        voice = _make_mock_voice()
+        voice.synthesize.side_effect = lambda text, syn_config=None: iter(
+            [AudioChunk(sample_rate=16000, sample_width=2, sample_channels=1,
+                        audio_float_array=np.zeros(0, dtype=np.float32))]
+        )
+        result = bench_latency.bench_ttfa(voice, "x", SynthesisConfig())
+        assert result["rtf"] != result["rtf"] or result["rtf"] == 0  # nan or 0, never a crash
+
+
+class TestCLI:
+    def test_help_exits_zero(self):
+        runner = CliRunner()
+        result = runner.invoke(bench_latency.main, ["--help"])
+        assert result.exit_code == 0
+        assert "MODEL" in result.output
+
+    def test_missing_model_argument_fails_cleanly(self):
+        runner = CliRunner()
+        result = runner.invoke(bench_latency.main, [])
+        assert result.exit_code != 0
+
+
+class TestJSONSchema:
+    """The JSON schema written by --json-out must stay stable: downstream
+    tooling reads these keys."""
+
+    def _run_with_mocked_voice(self, tmp_path, monkeypatch):
+        voice = _make_mock_voice()
+
+        monkeypatch.setattr(bench_latency, "resolve_model", lambda model, config: ("mock.onnx", None))
+        monkeypatch.setattr(
+            bench_latency, "load_voice_timed",
+            lambda model_path, config_path: {"voice": voice, "t_config_parse": 0.001, "t_session_create": 0.01},
+        )
+        monkeypatch.setattr(bench_latency, "warmup_session", lambda voice, text="hi": 0.02)
+
+        json_out = tmp_path / "results.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            bench_latency.main,
+            ["mock-voice", "--runs", "2", "--json-out", str(json_out)],
+        )
+        assert result.exit_code == 0, result.output
+        return json.loads(json_out.read_text())
+
+    def test_top_level_keys_present(self, tmp_path, monkeypatch):
+        data = self._run_with_mocked_voice(tmp_path, monkeypatch)
+        for key in ("model", "model_path", "sample_rate", "onnxruntime_providers_available",
+                    "load", "cold_warmup_run_s", "runs", "1sentence", "5sentence"):
+            assert key in data
+
+    def test_load_keys_present(self, tmp_path, monkeypatch):
+        data = self._run_with_mocked_voice(tmp_path, monkeypatch)
+        assert "config_parse_s" in data["load"]
+        assert "session_create_s" in data["load"]
+
+    def test_per_text_section_keys_present(self, tmp_path, monkeypatch):
+        data = self._run_with_mocked_voice(tmp_path, monkeypatch)
+        for label in ("1sentence", "5sentence"):
+            section = data[label]
+            for key in ("stages", "ttfa", "total", "rtf", "audio_seconds"):
+                assert key in section
+            for stat_key in ("median", "p95", "min", "max"):
+                assert stat_key in section["ttfa"]
+
+    def test_stage_names_present_in_stages(self, tmp_path, monkeypatch):
+        data = self._run_with_mocked_voice(tmp_path, monkeypatch)
+        stage_names = data["1sentence"]["stages"].keys()
+        for expected in ("text_normalize", "diacritics", "phonemize", "tokenize",
+                         "session_run_total", "postprocess_total"):
+            assert expected in stage_names


### PR DESCRIPTION
## Summary
- Adds `scripts/bench_latency.py`, a CLI that times each stage of `TTSVoice.synthesize()` (config parse, session create, cold warmup `session.run`, phonemize, tokenize, per-sentence `session.run`, post-processing) plus end-to-end time-to-first-audio (TTFA) and real-time factor (RTF), for a 1-sentence and a 5-sentence text.
- Adds `docs/benchmarking.md` explaining how to run it and how to read TTFA vs RTF.
- Adds `tests/test_bench_latency.py` (mocked voice, no network/model download).

## Initial CPU numbers

Voice: `piper/en_US-amy-low` (mainstream low-quality-tier VITS/piper English voice, downloaded via `TTSModelManager`).
Hardware: 11th Gen Intel Core i9-11900H @ 2.50GHz, 16 threads, `PHOONNX_ONNX_PROVIDERS=CPUExecutionProvider`.

Cold, one-shot:

| stage | seconds |
|---|---|
| config_parse | 0.0013 |
| session_create | 0.7419 |
| cold_warmup_run | 0.1210 |

Warm (median / p95 over 5 runs), 1-sentence text (audio: 3.36s):

| stage | median | p95 |
|---|---|---|
| phonemize | 0.0497 | 0.0539 |
| tokenize | 0.0000 | 0.0001 |
| session_run_total | 0.1972 | 0.2076 |
| postprocess_total | 0.0002 | 0.0003 |
| ttfa | 0.2233 | 0.4244 |
| total | 0.2233 | 0.4244 |
| rtf | 0.0674 | 0.1251 |

Warm (median / p95 over 5 runs), 5-sentence text (audio: 22.03s):

| stage | median | p95 |
|---|---|---|
| phonemize | 0.1640 | 0.2579 |
| tokenize | 0.0001 | 0.0002 |
| session_run_total | 1.4934 | 1.7091 |
| postprocess_total | 0.0013 | 0.0024 |
| ttfa | 0.4614 | 0.5615 |
| total | 1.3433 | 2.1794 |
| rtf | 0.0612 | 0.0995 |

`onnxruntime` reports `CUDAExecutionProvider` as available on this machine, but it fails to initialize here (missing `libcublasLt.so.12` — CUDA/cuDNN runtime libraries not present) and silently falls back to CPU, so no separate GPU numbers are reported; the doc calls this failure mode out explicitly.

## Test plan
- [x] `python -m pytest tests/test_bench_latency.py -q -p no:ovoscope` — 17 passed
- [x] `python scripts/bench_latency.py --help`
- [x] Ran full benchmark against a real downloaded voice on CPU (see numbers above)