### PR TITLE
Cache ORT-optimized graphs, add voice warmup, warn on silent provider fallback

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,6 +115,9 @@ or set `PHOONNX_ONNX_PROVIDERS` once for the process. `CPUExecutionProvider` is 
 appended so synthesis keeps working. Full details in the
 [Configuration reference](configuration.md#execution-providers).
 
+Set `PHOONNX_ORT_CACHE_DIR` to cache the optimized ONNX Runtime graph across process
+restarts and reduce cold-start session-creation time.
+
 ## System dependency: espeak-ng
 
 The eSpeak phonemizer can drive the system `espeak-ng` binary directly. Install it from your

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,6 +48,11 @@ auto-detection. `use_cuda=True` is a **deprecated** alias for
 `providers=["CUDAExecutionProvider"]`; prefer `providers`. See the
 [Configuration reference](configuration.md#execution-providers).
 
+Set `PHOONNX_ORT_CACHE_DIR` to a writable directory to cache the ONNX Runtime-optimized graph
+across process restarts, and pass `warmup=True` to `TTSVoice.load` to pay the first-inference
+kernel-selection cost during load instead of on the first `synthesize` call — both cut cold-start
+latency.
+
 ## Synthesizing Speech
 
 ### To a WAV File

--- a/phoonnx/providers.py
+++ b/phoonnx/providers.py
@@ -24,7 +24,9 @@ GPU providers come from the ONNX Runtime build, not from phoonnx: the default
 needs ``onnxruntime-rocm``, ``DirectML`` needs ``onnxruntime-directml``, and
 CUDA needs ``onnxruntime-gpu``.
 """
+import hashlib
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import onnxruntime
@@ -38,6 +40,13 @@ CPU_PROVIDER = "CPUExecutionProvider"
 
 #: Environment variable holding a comma-separated provider list, or ``auto``.
 PROVIDERS_ENV_VAR = "PHOONNX_ONNX_PROVIDERS"
+
+#: Environment variable holding a directory to cache ORT-optimized graphs in.
+#: When set (or a ``cache_dir`` is passed to :func:`make_session`), the
+#: optimized model is written once and every subsequent process load reuses
+#: it instead of re-running graph optimization from the raw model. Unset by
+#: default — behaviour is unchanged unless a caller opts in.
+CACHE_DIR_ENV_VAR = "PHOONNX_ORT_CACHE_DIR"
 
 #: Auto-detection preference order, best first. Only providers the installed
 #: runtime reports as available are kept.
@@ -139,15 +148,114 @@ def resolve_providers(
     return resolved
 
 
+def _cache_key_path(
+        model_path: Any,
+        resolved_providers: Sequence[ProviderSpec],
+        cache_dir: Union[str, Path],
+) -> Path:
+    """Deterministic cache-file path for a (model, provider list) pair.
+
+    The key is cheap to compute (path + size + mtime, no file hashing) but
+    changes whenever the model file, the onnxruntime build, or the provider
+    list changes, so a stale cache is never served silently.
+    """
+    stat = os.stat(model_path)
+    provider_key = ",".join(repr(p) for p in resolved_providers)
+    raw = (
+        f"{os.path.abspath(str(model_path))}|{stat.st_size}|{stat.st_mtime_ns}|"
+        f"{onnxruntime.__version__}|{provider_key}"
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return Path(cache_dir) / f"{digest}.ort_optimized.onnx"
+
+
+def _warn_on_provider_fallback(
+        requested: Sequence[ProviderSpec],
+        session: onnxruntime.InferenceSession,
+) -> None:
+    """Warn when the first requested provider silently fell back to another.
+
+    onnxruntime does not raise when a provider fails to initialize (e.g. a
+    CUDA build advertising ``CUDAExecutionProvider`` while missing a shared
+    library like ``libcublasLt``); it just falls back to the next provider
+    in the list with no log line. This surfaces that so a "GPU" run that is
+    actually running on CPU is not mistaken for one that is not.
+    """
+    if not requested:
+        return
+    try:
+        actual = list(session.get_providers())
+    except Exception:  # pragma: no cover - defensive, ORT always answers
+        return
+    requested_first = _name(requested[0])
+    if requested_first not in actual:
+        LOG.warning(
+            f"requested onnxruntime provider '{requested_first}' is not "
+            f"active for this session; falling back to "
+            f"'{actual[0] if actual else 'unknown'}' (active providers: {actual})"
+        )
+
+
 def make_session(
         model_path: Any,
         providers: Optional[Sequence[ProviderSpec]] = None,
         sess_options: Optional[onnxruntime.SessionOptions] = None,
         use_cuda: bool = False,
+        cache_dir: Optional[Union[str, Path]] = None,
 ) -> onnxruntime.InferenceSession:
-    """Create an ``InferenceSession`` on the resolved execution providers."""
-    return onnxruntime.InferenceSession(
-        str(model_path),
-        sess_options=sess_options or onnxruntime.SessionOptions(),
-        providers=resolve_providers(providers, use_cuda=use_cuda),
+    """
+    Create an ``InferenceSession`` on the resolved execution providers.
+
+    Parameters:
+        cache_dir: Directory to cache the ORT-optimized graph in. When given
+            (or ``PHOONNX_ORT_CACHE_DIR`` is set), the optimized model is
+            written to a deterministic file the first time and every later
+            session for the same model/provider list is created directly
+            from that pre-optimized file with graph optimization disabled,
+            skipping the optimization pass. A stale or corrupt cache file
+            is deleted and the session falls back to a normal load. Default
+            (no env var, no argument): unchanged behaviour.
+    """
+    resolved = resolve_providers(providers, use_cuda=use_cuda)
+    cache_dir = cache_dir if cache_dir is not None else os.environ.get(CACHE_DIR_ENV_VAR)
+
+    if not cache_dir:
+        session = onnxruntime.InferenceSession(
+            str(model_path),
+            sess_options=sess_options or onnxruntime.SessionOptions(),
+            providers=resolved,
+        )
+        _warn_on_provider_fallback(resolved, session)
+        return session
+
+    os.makedirs(cache_dir, exist_ok=True)
+    cache_path = _cache_key_path(model_path, resolved, cache_dir)
+
+    if cache_path.is_file():
+        try:
+            cached_options = onnxruntime.SessionOptions()
+            cached_options.graph_optimization_level = (
+                onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+            )
+            session = onnxruntime.InferenceSession(
+                str(cache_path), sess_options=cached_options, providers=resolved,
+            )
+            _warn_on_provider_fallback(resolved, session)
+            return session
+        except Exception as err:
+            LOG.warning(
+                f"cached optimized model '{cache_path}' failed to load "
+                f"({err}); removing it and rebuilding from '{model_path}'"
+            )
+            try:
+                cache_path.unlink()
+            except OSError:
+                pass
+
+    build_options = sess_options or onnxruntime.SessionOptions()
+    build_options.optimized_model_filepath = str(cache_path)
+    session = onnxruntime.InferenceSession(
+        str(model_path), sess_options=build_options, providers=resolved,
     )
+    _warn_on_provider_fallback(resolved, session)
+    return session

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -194,6 +194,34 @@ class TTSVoice:
         # building its vocoder from config.engine_params).
         self.adapter.configure(self.config)
 
+    def warmup(self) -> None:
+        """
+        Run one throwaway inference to pay ONNX Runtime's first-call kernel
+        selection / graph optimization cost outside the first real request.
+
+        Builds the smallest valid synthesis request (a single phoneme id)
+        and routes it through the adapter's own ``synthesize`` (which calls
+        ``build_feed_dict`` → ``session.run`` → ``parse_outputs``), so it
+        exercises the exact same code path as a real call rather than
+        hand-rolled input names. Adapters that cannot make sense of a
+        minimal input (or that need extra state ``configure`` didn't set
+        up) fail this quietly: warmup is an optimization, not a
+        requirement, so any error is logged at debug level and swallowed.
+        """
+        try:
+            request = AdapterSynthesisRequest(
+                phoneme_ids=np.array([[1]], dtype=np.int64),
+                phoneme_lengths=np.array([1], dtype=np.int64),
+                speaker_id=0,
+                language_id=0,
+                params=dict(self.adapter.default_params()),
+            )
+            self.adapter.synthesize(request, self.session)
+        except Exception as err:
+            LOG.debug(
+                f"warmup skipped for adapter '{type(self.adapter).__name__}': {err}"
+            )
+
     @property
     def tokenizer(self) -> TTSTokenizer:
         """
@@ -217,7 +245,8 @@ class TTSVoice:
             alphabet_str: Optional[str] = None,
             engine_params: Optional[Dict[str, Any]] = None,
             providers: Optional[Sequence[ProviderSpec]] = None,
-            use_cuda: bool = False
+            use_cuda: bool = False,
+            warmup: bool = False,
     ) -> "TTSVoice":
         """
         Load a TTS voice ONNX model and its configuration into a TTSVoice instance.
@@ -237,7 +266,10 @@ class TTSVoice:
                 list also drives the auxiliary graphs an engine loads (vocoders, speaker
                 encoders, ...).
             use_cuda (bool): Deprecated alias for ``providers=["CUDAExecutionProvider"]``.
-        
+            warmup (bool): Run a throwaway inference (see :meth:`TTSVoice.warmup`)
+                before returning, so the first real ``synthesize`` call does not
+                pay ONNX Runtime's first-call kernel-selection cost.
+
         Returns:
             TTSVoice: A TTSVoice instance prepared with the loaded ONNX session and merged configuration.
         """
@@ -303,11 +335,14 @@ class TTSVoice:
             engine_params=engine_params,
         )
 
-        return TTSVoice(
+        voice = TTSVoice(
             config=voice_config,
             session=session,
             adapter=adapter,
         )
+        if warmup:
+            voice.warmup()
+        return voice
 
     def phonemize(self, text: str, lang: Optional[str] = None) -> PhonemizedChunks:
         """

--- a/tests/test_coldstart_warmup_cache.py
+++ b/tests/test_coldstart_warmup_cache.py
@@ -1,0 +1,250 @@
+"""Tests for cold-start latency fixes: ORT-optimized-graph caching, voice
+warmup, and the silent-provider-fallback warning.
+"""
+import logging
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from phoonnx import providers
+from phoonnx.providers import (
+    CACHE_DIR_ENV_VAR,
+    CPU_PROVIDER,
+    make_session,
+)
+
+
+def _build_tiny_onnx_model(path: Path) -> None:
+    """Write a minimal but real single-node ONNX model to *path*."""
+    import onnx
+    from onnx import TensorProto, helper
+
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4])
+    node = helper.make_node("Identity", ["x"], ["y"])
+    graph = helper.make_graph([node], "tiny", [x], [y])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, str(path))
+
+
+class TestOrtOptimizedGraphCache(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.model_path = Path(self.tmpdir.name) / "model.onnx"
+        _build_tiny_onnx_model(self.model_path)
+        self.cache_dir = Path(self.tmpdir.name) / "cache"
+
+        env_patcher = patch.dict(os.environ, {}, clear=False)
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
+        os.environ.pop(CACHE_DIR_ENV_VAR, None)
+
+    def test_no_cache_dir_leaves_behaviour_unchanged(self):
+        session = make_session(self.model_path, providers=[CPU_PROVIDER])
+        self.assertIn(CPU_PROVIDER, session.get_providers())
+        self.assertFalse(self.cache_dir.exists())
+
+    def test_first_load_writes_the_optimized_cache_file(self):
+        make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
+        cached_files = list(self.cache_dir.glob("*.ort_optimized.onnx"))
+        self.assertEqual(len(cached_files), 1)
+
+    def test_second_load_reuses_the_cached_file_without_rewriting_it(self):
+        make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
+        cached_files = list(self.cache_dir.glob("*.ort_optimized.onnx"))
+        self.assertEqual(len(cached_files), 1)
+        cache_path = cached_files[0]
+        mtime_after_first_load = cache_path.stat().st_mtime_ns
+
+        with patch.object(providers.onnxruntime, "InferenceSession",
+                           wraps=providers.onnxruntime.InferenceSession) as spy:
+            session = make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
+
+        # Second load must construct the session directly from the cached
+        # optimized file (with optimization disabled), not from the raw model.
+        (loaded_path, ), kwargs = spy.call_args
+        self.assertEqual(str(loaded_path), str(cache_path))
+        self.assertEqual(
+            kwargs["sess_options"].graph_optimization_level,
+            providers.onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL,
+        )
+        self.assertEqual(cache_path.stat().st_mtime_ns, mtime_after_first_load)
+        self.assertIn(CPU_PROVIDER, session.get_providers())
+
+    def test_env_var_is_honoured_when_no_cache_dir_argument_is_given(self):
+        with patch.dict(os.environ, {CACHE_DIR_ENV_VAR: str(self.cache_dir)}):
+            make_session(self.model_path, providers=[CPU_PROVIDER])
+        self.assertTrue(list(self.cache_dir.glob("*.ort_optimized.onnx")))
+
+    def test_explicit_cache_dir_argument_wins_over_env_var(self):
+        other_dir = Path(self.tmpdir.name) / "other_cache"
+        with patch.dict(os.environ, {CACHE_DIR_ENV_VAR: str(self.cache_dir)}):
+            make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=other_dir)
+        self.assertTrue(list(other_dir.glob("*.ort_optimized.onnx")))
+        self.assertFalse(self.cache_dir.exists())
+
+    def test_corrupt_cache_file_falls_back_and_is_removed(self):
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = providers._cache_key_path(self.model_path, [CPU_PROVIDER], self.cache_dir)
+        cache_path.write_bytes(b"not a valid onnx model")
+        self.assertTrue(cache_path.is_file())
+
+        with patch.object(providers.LOG, "warning") as warn:
+            session = make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
+
+        self.assertTrue(warn.called)
+        warned = " ".join(str(c) for c in warn.call_args_list)
+        self.assertIn("cached optimized model", warned)
+        self.assertIn(CPU_PROVIDER, session.get_providers())
+        # the corrupt bytes were discarded — what's on disk now (if anything)
+        # is a freshly rebuilt, valid optimized model, not the garbage above.
+        if cache_path.is_file():
+            self.assertNotEqual(cache_path.read_bytes(), b"not a valid onnx model")
+
+    def test_cache_key_changes_when_provider_list_changes(self):
+        make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
+        key_a = set(p.name for p in self.cache_dir.glob("*.ort_optimized.onnx"))
+
+        make_session(self.model_path, providers=[("CPUExecutionProvider", {"foo": "bar"})],
+                     cache_dir=self.cache_dir)
+        key_b = set(p.name for p in self.cache_dir.glob("*.ort_optimized.onnx"))
+
+        # Different provider spec -> different cache key -> an extra file, not
+        # a reused/corrupted one.
+        self.assertEqual(len(key_a), 1)
+        self.assertEqual(len(key_b), 2)
+        self.assertTrue(key_a.issubset(key_b))
+
+    def test_cache_key_changes_when_model_file_changes(self):
+        make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
+        first_keys = set(self.cache_dir.glob("*.ort_optimized.onnx"))
+
+        # touch the model so mtime/size differ
+        import time
+        time.sleep(0.01)
+        _build_tiny_onnx_model(self.model_path)
+
+        make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
+        second_keys = set(self.cache_dir.glob("*.ort_optimized.onnx"))
+        self.assertEqual(len(first_keys | second_keys), 2)
+
+
+class TestProviderFallbackWarning(unittest.TestCase):
+    def test_warns_when_requested_provider_is_missing_from_active_session(self):
+        fake_session = MagicMock()
+        fake_session.get_providers.return_value = [CPU_PROVIDER]
+        with patch.object(providers.LOG, "warning") as warn:
+            providers._warn_on_provider_fallback(["CUDAExecutionProvider", CPU_PROVIDER], fake_session)
+        self.assertTrue(warn.called)
+        joined = " ".join(str(c) for c in warn.call_args_list)
+        self.assertIn("CUDAExecutionProvider", joined)
+        self.assertIn(CPU_PROVIDER, joined)
+
+    def test_no_warning_when_requested_provider_is_active(self):
+        fake_session = MagicMock()
+        fake_session.get_providers.return_value = ["CUDAExecutionProvider", CPU_PROVIDER]
+        with patch.object(providers.LOG, "warning") as warn:
+            providers._warn_on_provider_fallback(["CUDAExecutionProvider", CPU_PROVIDER], fake_session)
+        warn.assert_not_called()
+
+    def test_no_crash_when_get_providers_raises(self):
+        fake_session = MagicMock()
+        fake_session.get_providers.side_effect = RuntimeError("boom")
+        # Must not raise.
+        providers._warn_on_provider_fallback(["CUDAExecutionProvider"], fake_session)
+
+    def test_make_session_surfaces_the_warning_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_path = Path(tmp) / "model.onnx"
+            _build_tiny_onnx_model(model_path)
+            with patch.object(providers, "resolve_providers",
+                               return_value=["CUDAExecutionProvider", CPU_PROVIDER]):
+                with patch.object(providers.LOG, "warning") as warn:
+                    make_session(model_path, providers=["CUDAExecutionProvider"])
+            self.assertTrue(warn.called)
+            warned = " ".join(str(c) for c in warn.call_args_list)
+            self.assertIn("CUDAExecutionProvider", warned)
+
+
+class TestTTSVoiceWarmup(unittest.TestCase):
+    def _make_voice(self):
+        from phoonnx.voice import TTSVoice
+
+        voice = TTSVoice.__new__(TTSVoice)
+        voice.session = MagicMock()
+        voice.config = MagicMock()
+        voice.phonetic_spellings = None
+        voice.phonemizer = MagicMock()
+        adapter = MagicMock()
+        adapter.default_params.return_value = {"noise_scale": 0.667}
+        adapter.synthesize.return_value = MagicMock(audio=np.zeros(4, dtype=np.float32))
+        voice.adapter = adapter
+        return voice
+
+    def test_warmup_runs_one_inference_with_a_valid_feed_dict(self):
+        voice = self._make_voice()
+        voice.warmup()
+
+        self.assertEqual(voice.adapter.synthesize.call_count, 1)
+        (request, session), _ = voice.adapter.synthesize.call_args
+        self.assertIs(session, voice.session)
+        self.assertEqual(request.phoneme_ids.shape, (1, 1))
+        self.assertEqual(int(request.phoneme_lengths[0]), 1)
+        self.assertEqual(request.params["noise_scale"], 0.667)
+
+    def test_warmup_no_ops_and_logs_debug_for_an_unsupported_adapter(self):
+        voice = self._make_voice()
+        voice.adapter.synthesize.side_effect = KeyError("unknown input name")
+
+        from phoonnx.voice import LOG as voice_log
+        with patch.object(voice_log, "debug") as debug:
+            voice.warmup()  # must not raise
+
+        self.assertTrue(debug.called)
+        logged = " ".join(str(c) for c in debug.call_args_list)
+        self.assertIn("warmup skipped", logged)
+
+    def test_load_with_warmup_true_triggers_one_inference(self):
+        from phoonnx.voice import TTSVoice
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_path = Path(tmp) / "model.onnx"
+            _build_tiny_onnx_model(model_path)
+
+            fake_adapter = MagicMock()
+            fake_adapter.default_params.return_value = {}
+            fake_adapter.synthesize.return_value = MagicMock(audio=np.zeros(4, dtype=np.float32))
+
+            with patch("phoonnx.voice.detect_engine", return_value=fake_adapter):
+                voice = TTSVoice.load(model_path=model_path, config_path=str(model_path) + ".missing",
+                                       providers=[CPU_PROVIDER], warmup=True)
+
+        self.assertEqual(fake_adapter.synthesize.call_count, 1)
+        self.assertEqual(voice.adapter, fake_adapter)
+
+    def test_load_with_warmup_false_does_not_run_inference(self):
+        from phoonnx.voice import TTSVoice
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_path = Path(tmp) / "model.onnx"
+            _build_tiny_onnx_model(model_path)
+
+            fake_adapter = MagicMock()
+            fake_adapter.default_params.return_value = {}
+
+            with patch("phoonnx.voice.detect_engine", return_value=fake_adapter):
+                TTSVoice.load(model_path=model_path, config_path=str(model_path) + ".missing",
+                               providers=[CPU_PROVIDER], warmup=False)
+
+        fake_adapter.synthesize.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- `make_session` (phoonnx/providers.py) supports caching the ONNX Runtime-optimized graph via `PHOONNX_ORT_CACHE_DIR` (or a `cache_dir` argument). The cache key is cheap to compute (model path + size + mtime + onnxruntime version + resolved provider list, no full-file hashing). First load writes the optimized model; later loads with the same key build the session directly from the cached file with `ORT_DISABLE_ALL`, skipping re-optimization. A stale/corrupt cache file is deleted with a warning and the loader falls back to a normal load. Unset by default — behavior is unchanged unless a caller opts in.
- `TTSVoice.warmup()` runs one throwaway inference through the adapter's own `build_feed_dict` → `session.run` → `parse_outputs` path with the smallest valid request (a single phoneme id), so it pays ONNX Runtime's first-call kernel-selection cost once, off the hot path. Adapters that can't make sense of the minimal input no-op and log at debug level rather than crashing. `TTSVoice.load(..., warmup=True)` calls it automatically.
- `make_session` now compares the resolved provider list against `session.get_providers()` and logs a `WARNING` naming the requested provider and the one actually active when the first requested provider silently failed to initialize (e.g. `CUDAExecutionProvider` advertised by the build but failing at runtime for a missing `libcublasLt`, falling back to CPU with no prior log line).

## Cold-start numbers

`piper/en_US-amy-low`, `PHOONNX_ONNX_PROVIDERS=CPUExecutionProvider`, median of 3 runs, cold `TTSVoice.load` + first `synthesize`:

| Scenario | load (s) | first synth (s) |
|---|---|---|
| (a) baseline `origin/dev` | 0.76–0.79 | 0.003–0.004 |
| (b) this branch, no cache env, `warmup=False` | 0.76–0.78 | 0.004–0.005 |
| (c) this branch, `PHOONNX_ORT_CACHE_DIR` set, cache warm, `warmup=True` | 0.62–0.64 | 0.007 |

Cache-cold (first write) load is slightly slower than baseline (~0.85–0.90s) since it pays the optimization + serialize cost once; every load after that is ~18% faster. `warmup=True` moves the (small, on CPU) first-inference cost into `load()` itself so it no longer lands on the first `synthesize` call.

## Test plan

- `tests/test_coldstart_warmup_cache.py` (16 new tests, real tiny ONNX models via the `onnx` package, no ORT mocking on the happy path):
  - cache: first load writes the optimized file; second load rebuilds the session from it with `ORT_DISABLE_ALL` and doesn't touch its mtime; env var vs explicit `cache_dir` precedence; corrupt cache file is removed with a warning and falls back; cache key changes with the provider list and with the model file.
  - provider fallback warning: warns when the first requested provider isn't active, doesn't warn when it is, doesn't crash if `get_providers()` raises, and fires end-to-end through `make_session`.
  - warmup: one adapter.synthesize() call with a valid feed dict; unsupported-adapter no-op path logs debug and doesn't raise; `load(warmup=True/False)` wiring.
- Full suite: `python3 -m unittest discover -s tests -p "test_*.py"` → 344 tests, 1 pre-existing skip, no failures (ran via the shared venv; `pytest` itself currently fails to collect in this venv due to an unrelated `ovoscope`/`ovos_workshop` import error at plugin-autoload time, unrelated to this change).

## PHOONNX_ORT_CACHE_DIR

Unset by default. Point it at a writable directory to cache the ORT-optimized graph across process restarts; documented in `docs/usage.md` and `docs/installation.md`.