### PR TITLE
feat: synthesize sentences lazily to cut time-to-first-audio

### DIFF
--- a/phoonnx/phonemizers/base.py
+++ b/phoonnx/phonemizers/base.py
@@ -2,7 +2,7 @@ import abc
 import re
 import string
 import unicodedata
-from typing import List, Tuple, Optional, Literal
+from typing import Iterator, List, Tuple, Optional, Literal
 
 from langcodes import tag_distance
 from quebra_frases import sentence_tokenize
@@ -71,18 +71,36 @@ class BasePhonemizer(metaclass=abc.ABCMeta):
         return text
 
     def phonemize(self, text: str, lang: str) -> PhonemizedChunks:
+        # PhonemizedChunks is list[list[str]]; empty text yields no
+        # sentences. (Returning the raw (str, str, bool) tuple form here
+        # corrupted the type and broke callers that mutate each sentence,
+        # e.g. inline ``[[phoneme]]`` blocks in TTSVoice.phonemize.)
+        return list(self.phonemize_lazy(text, lang))
+
+    def phonemize_lazy(self, text: str, lang: str) -> Iterator[List[str]]:
+        """Lazy, per-sentence variant of :meth:`phonemize`.
+
+        Yields one phoneme list per sentence-level chunk, invoking the
+        (potentially expensive) ``phonemize_string`` only as each sentence is
+        pulled from the generator. This lets a caller start synthesizing
+        sentence 1 before sentence 2 has been phonemized, cutting
+        time-to-first-audio.
+
+        Normalization and chunking still run over the *whole* text up front (both
+        are cheap and order-sensitive), so ``list(self.phonemize_lazy(text)) ==
+        self.phonemize(text)`` holds for any input.
+        """
         if not text:
-            # PhonemizedChunks is list[list[str]]; empty text yields no
-            # sentences. (Returning the raw (str, str, bool) tuple form here
-            # corrupted the type and broke callers that mutate each sentence,
-            # e.g. inline ``[[phoneme]]`` blocks in TTSVoice.phonemize.)
-            return []
-        results: RawPhonemizedChunks = []
+            return
         text = normalize(text, lang)
         for chunk, punct, eos in self.chunk_text(text):
             phoneme_str = self.phonemize_string(self.remove_punctuation(chunk), lang)
-            results += [(phoneme_str, punct, True)]
-        return self._process_phones(results)
+            # Filter out (lang) switch (flags) that surround words from languages
+            # other than the current voice — mirrors _process_phones().
+            phoneme_str = re.sub(r"\([^)]+\)", "", phoneme_str)
+            # phonemize() marks every chunk as end-of-sentence, so each chunk is
+            # its own sentence.
+            yield list(phoneme_str)
 
     @staticmethod
     def _process_phones(raw_phones: RawPhonemizedChunks) -> PhonemizedChunks:

--- a/phoonnx/phonemizers/shami.py
+++ b/phoonnx/phonemizers/shami.py
@@ -9,7 +9,7 @@ models can be driven directly from text.  The front-end emits:
 which the :class:`ShamiAdapter` feeds to the exported ONNX model.
 """
 
-from typing import List, Tuple
+from typing import Iterator, List, Tuple
 
 from quebra_frases import sentence_tokenize
 
@@ -54,17 +54,28 @@ class ShamiPhonemizer(BasePhonemizer):
         The returned language IDs are integers from :class:`phoonnx.thirdparty.shami.Lang`:
         ``PAD=0``, ``AR=1``, ``EN=2``, ``NEUTRAL=3``.
         """
-        if not text:
-            return [], []
-
         all_phonemes: PhonemizedChunks = []
         all_lang_ids: List[List[int]] = []
+        for phonemes, lang_ids in self.phonemize_with_language_ids_lazy(text, lang):
+            all_phonemes.append(phonemes)
+            all_lang_ids.append(lang_ids)
+        return all_phonemes, all_lang_ids
 
+    def phonemize_with_language_ids_lazy(
+        self, text: str, lang: str
+    ) -> Iterator[Tuple[List[str], List[int]]]:
+        """Lazy, per-sentence variant of :meth:`phonemize_with_language_ids`.
+
+        Yields ``(phonemes, language_ids)`` one sentence at a time, running the
+        text front-end only as each sentence is pulled. The phoneme stream and
+        the parallel language-ID stream are produced together per sentence, so
+        they can never fall out of alignment. ``list`` of the pairs reproduces
+        the two lists returned by :meth:`phonemize_with_language_ids` exactly.
+        """
+        if not text:
+            return
         for sentence in sentence_tokenize(text):
             if not sentence.strip():
                 continue
             utterance = self.frontend.process(sentence)
-            all_phonemes.append(utterance.symbols)
-            all_lang_ids.append(utterance.language_ids)
-
-        return all_phonemes, all_lang_ids
+            yield utterance.symbols, utterance.language_ids

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -17,6 +17,7 @@ from typing import Any, Iterable, Optional, Sequence, Union, Dict
 import numpy as np
 import onnxruntime
 from langcodes import closest_match
+from quebra_frases import sentence_tokenize
 
 from phoonnx.config import PhonemeType, VoiceConfig, SynthesisConfig, Alphabet, get_phonemizer
 from phoonnx.alphabet_convert import convert as alphabet_convert
@@ -404,6 +405,132 @@ class TTSVoice:
         token_ids =  self.tokenizer.tokenize(phonemes)
         return token_ids
 
+    def _diacritize(self, text: str, diacritizer_model: Optional[str]) -> str:
+        """Apply (Arabic/Hebrew) diacritics for the voice's language."""
+        return self.phonemizer.add_diacritics(
+            text, self.config.lang_code, model=diacritizer_model
+        )
+
+    def _text_parts(
+            self, text: str, do_diacritics: bool, diacritizer_model: Optional[str]
+    ) -> Iterable[str]:
+        """Yield the text unit(s) to phonemize.
+
+        Without diacritics the whole text is yielded once so the phonemizer's own
+        normalization + chunking runs over it exactly as before (guaranteeing the
+        lazy stream produces the same phonemes as a single whole-text call). With
+        diacritics enabled the text is split into sentences and each is
+        diacritized independently — Arabic/Hebrew diacritizer models are
+        sentence-level, and doing it per sentence keeps the first sentence off the
+        critical path of the rest.
+        """
+        if not do_diacritics:
+            yield text
+            return
+        for sentence in sentence_tokenize(text):
+            if not sentence.strip():
+                continue
+            yield self._diacritize(sentence, diacritizer_model)
+
+    def _iter_synthesis_ids(
+            self,
+            text: str,
+            syn_config: SynthesisConfig,
+            do_diacritics: bool,
+            diacritizer_model: Optional[str],
+            src_alphabet: Alphabet,
+            tgt_alphabet: Alphabet,
+    ) -> Iterable[tuple]:
+        """Lazily yield ``(phoneme_ids, language_ids)`` per sentence.
+
+        Preserves the exact dispatch semantics of :meth:`synthesize` while
+        deferring per-sentence phonemize/diacritize/tokenize work until each item
+        is pulled from the generator.
+        """
+        lang = self.config.lang_code
+
+        if src_alphabet == tgt_alphabet:
+            if src_alphabet == Alphabet.GRAPHEMES:
+                # Grapheme / text-token models: the adapter owns text -> token ids
+                # (some do their own whole-text normalization, e.g. subword BPE),
+                # so encode the whole text once; audio is still produced per
+                # sentence downstream.
+                if do_diacritics:
+                    text = self._diacritize(text, diacritizer_model)
+                for ids in self.adapter.encode_text(text, self, syn_config):
+                    yield ids, None
+            else:
+                # Already-phonemic input in the model's own alphabet: pass through.
+                if do_diacritics:
+                    text = self._diacritize(text, diacritizer_model)
+                for phonemes in _phonemic_chunks(text, tgt_alphabet):
+                    if phonemes:
+                        yield self.phonemes_to_ids(phonemes), None
+            return
+
+        if src_alphabet == Alphabet.GRAPHEMES:
+            # Normal phoneme model — the hot path. Language-aware phonemizers (e.g.
+            # Shami) provide per-phoneme language IDs; the two streams are produced
+            # together per sentence so they can never fall out of alignment.
+            lazy_lang_ids = getattr(
+                self.phonemizer, "phonemize_with_language_ids_lazy", None)
+            if lazy_lang_ids is not None:
+                for part in self._text_parts(text, do_diacritics, diacritizer_model):
+                    for phonemes, language_ids in lazy_lang_ids(part, lang):
+                        if phonemes:
+                            yield self.phonemes_to_ids(phonemes), language_ids
+            elif hasattr(self.phonemizer, "phonemize_with_language_ids"):
+                # Language-aware phonemizer without a lazy variant: eager fallback.
+                if do_diacritics:
+                    text = self._diacritize(text, diacritizer_model)
+                sentence_phonemes, sentence_language_ids = (
+                    self.phonemizer.phonemize_with_language_ids(text, lang))
+                for phonemes, language_ids in zip(sentence_phonemes, sentence_language_ids):
+                    if phonemes:
+                        yield self.phonemes_to_ids(phonemes), language_ids
+            elif _PHONEME_BLOCK_PATTERN.search(text):
+                # Inline [[phoneme]] blocks merge into adjacent sentences; keep the
+                # (eager) whole-text handling that owns that merge logic.
+                if do_diacritics:
+                    text = self._diacritize(text, diacritizer_model)
+                for phonemes in self.phonemize(text):
+                    if phonemes:
+                        yield self.phonemes_to_ids(phonemes), None
+            else:
+                # Lazy per-sentence phonemization; a phonemizer without a lazy
+                # variant falls back to its eager whole-text phonemize().
+                phonemize_lazy = getattr(self.phonemizer, "phonemize_lazy", None)
+                for part in self._text_parts(text, do_diacritics, diacritizer_model):
+                    sentences = (phonemize_lazy(part, lang) if phonemize_lazy is not None
+                                 else self.phonemizer.phonemize(part, lang))
+                    for phonemes in sentences:
+                        if phonemes:
+                            yield self.phonemes_to_ids(phonemes), None
+            return
+
+        # Already-phonemic input in a different alphabet: transcode to the model's
+        # alphabet through the conversion graph.
+        if do_diacritics:
+            text = self._diacritize(text, diacritizer_model)
+        converted = alphabet_convert(
+            text,
+            lang=lang,
+            src=src_alphabet,
+            tgt=tgt_alphabet,
+            phoneme_type=self.config.phoneme_type,
+        )
+        if isinstance(converted, list):
+            # PhonemizedChunks returned by a phonemization edge
+            sentence_phonemes = converted
+            if _PHONEME_BLOCK_PATTERN.search(text):
+                sentence_phonemes = self.phonemize(text)
+        else:
+            # Script-converted string — split into single-char token lists.
+            sentence_phonemes = _phonemic_chunks(converted, tgt_alphabet)
+        for phonemes in sentence_phonemes:
+            if phonemes:
+                yield self.phonemes_to_ids(phonemes), None
+
     def synthesize(
             self,
             text: str,
@@ -427,7 +554,8 @@ class TTSVoice:
         LOG.debug("text=%s", text)
 
         # Text preprocessing — engine-agnostic, operates on the text before encoding:
-        # user pronunciation overrides + (Arabic/Hebrew) diacritics.
+        # user pronunciation overrides (whole-text) + (Arabic/Hebrew) diacritics,
+        # which are applied per sentence inside the lazy stream below.
         if self.phonetic_spellings and syn_config.enable_phonetic_spellings:
             text = self.phonetic_spellings.apply(text)
 
@@ -436,14 +564,9 @@ class TTSVoice:
         do_diacritics = syn_config.add_diacritics
         if do_diacritics is None:
             do_diacritics = self.config.add_diacritics
-        if do_diacritics:
-            # same for the diacritizer model itself: an explicit per-call model wins,
-            # otherwise fall back to the voice config's own choice.
-            diacritizer_model = syn_config.diacritizer_model or self.config.diacritizer_model
-            text = self.phonemizer.add_diacritics(
-                text, self.config.lang_code,
-                model=diacritizer_model)
-            LOG.debug("text+diacritics=%s", text)
+        # An explicit per-call diacritizer model wins, otherwise fall back to the
+        # voice config's own choice.
+        diacritizer_model = syn_config.diacritizer_model or self.config.diacritizer_model
 
         # Alphabet dispatch (unified model + language-aware phonemizers):
         #   src == tgt          -> grapheme/text-token models use the adapter;
@@ -460,66 +583,15 @@ class TTSVoice:
                         else Alphabet.GRAPHEMES)
         tgt_alphabet = self.config.alphabet
 
-        if src_alphabet == tgt_alphabet:
-            if src_alphabet == Alphabet.GRAPHEMES:
-                # Grapheme / text-token models: the adapter owns text -> token ids.
-                all_ids_for_synthesis = [
-                    (ids, None) for ids in self.adapter.encode_text(text, self, syn_config)
-                ]
-            else:
-                # Already-phonemic input in the model's own alphabet: pass through.
-                sentence_phonemes = _phonemic_chunks(text, tgt_alphabet)
-                LOG.debug("phonemes=%s", sentence_phonemes)
-                all_ids_for_synthesis = [
-                    (self.phonemes_to_ids(phonemes), None)
-                    for phonemes in sentence_phonemes if phonemes
-                ]
-        elif src_alphabet == Alphabet.GRAPHEMES:
-            # Normal phoneme model. Language-aware phonemizers (e.g. Shami) provide
-            # per-phoneme language IDs; the two streams are built together here so
-            # they can never fall out of alignment.
-            if hasattr(self.phonemizer, "phonemize_with_language_ids"):
-                sentence_phonemes, sentence_language_ids = self.phonemizer.phonemize_with_language_ids(
-                    text, self.config.lang_code
-                )
-                LOG.debug("phonemes=%s", sentence_phonemes)
-                all_ids_for_synthesis = [
-                    (self.phonemes_to_ids(phonemes), language_ids)
-                    for phonemes, language_ids in zip(sentence_phonemes, sentence_language_ids)
-                    if phonemes
-                ]
-            else:
-                sentence_phonemes = self.phonemize(text)
-                LOG.debug("phonemes=%s", sentence_phonemes)
-                all_ids_for_synthesis = [
-                    (self.phonemes_to_ids(phonemes), None)
-                    for phonemes in sentence_phonemes if phonemes
-                ]
-        else:
-            # Already-phonemic input in a different alphabet: transcode to the model's
-            # alphabet through the conversion graph.
-            converted = alphabet_convert(
-                text,
-                lang=self.config.lang_code,
-                src=src_alphabet,
-                tgt=tgt_alphabet,
-                phoneme_type=self.config.phoneme_type,
-            )
-            if isinstance(converted, list):
-                # PhonemizedChunks returned by a phonemization edge
-                sentence_phonemes = converted
-                if _PHONEME_BLOCK_PATTERN.search(text):
-                    sentence_phonemes = self.phonemize(text)
-            else:
-                # Script-converted string — split into single-char token lists.
-                sentence_phonemes = _phonemic_chunks(converted, tgt_alphabet)
-            LOG.debug("phonemes=%s", sentence_phonemes)
-            all_ids_for_synthesis = [
-                (self.phonemes_to_ids(phonemes), None)
-                for phonemes in sentence_phonemes if phonemes
-            ]
+        # Per-sentence phonemize -> tokenize is done lazily so the first sentence
+        # reaches session.run before later sentences are phonemized/diacritized,
+        # cutting time-to-first-audio on multi-sentence input.
+        id_stream = self._iter_synthesis_ids(
+            text, syn_config, do_diacritics, diacritizer_model,
+            src_alphabet, tgt_alphabet,
+        )
 
-        for phoneme_ids, language_ids in all_ids_for_synthesis:
+        for phoneme_ids, language_ids in id_stream:
             if not phoneme_ids:
                 continue
 

--- a/tests/test_lazy_synthesis.py
+++ b/tests/test_lazy_synthesis.py
@@ -1,0 +1,175 @@
+"""Tests for lazy, per-sentence synthesis in phoonnx.voice.TTSVoice.
+
+Cover three properties of the lazy restructure:
+
+1. Equivalence — a whole-text ``phonemize`` produces exactly the concatenation
+   of the per-sentence ``phonemize_lazy`` stream (engine-independent: real
+   grapheme/unicode phonemizers + a mocked phonemizer).
+2. Ordering — sentence 2 is only phonemized *after* sentence 1 has reached
+   ``session.run`` (proved by recording call order through mocks).
+3. Language-ID alignment — the lazy Shami stream yields the same phoneme lists
+   and parallel language-ID lists as the eager whole-text call.
+"""
+import types
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from phoonnx.config import Alphabet, SynthesisConfig
+from phoonnx.phonemizers.base import (
+    BasePhonemizer,
+    GraphemePhonemizer,
+    UnicodeCodepointPhonemizer,
+)
+from phoonnx.voice import AudioChunk, TTSVoice
+
+
+MULTISENTENCE = (
+    "The quick brown fox jumps over the lazy dog. "
+    "A rainbow is a phenomenon caused by refraction of light. "
+    "Voice assistants rely on low latency to feel responsive."
+)
+
+
+class _RecordingPhonemizer(BasePhonemizer):
+    """Grapheme-style phonemizer that records every phonemize_string call.
+
+    Uses the base normalization-free char split so per-sentence and whole-text
+    calls are trivially comparable; ``events`` captures ordering.
+    """
+
+    def __init__(self, events=None):
+        super().__init__(Alphabet.IPA)
+        self.events = events if events is not None else []
+
+    def phonemize_string(self, text: str, lang: str) -> str:
+        self.events.append(("phonemize", text))
+        return text
+
+
+class TestPhonemizeLazyEquivalence(unittest.TestCase):
+    """list(phonemize_lazy(text)) == phonemize(text) for any input."""
+
+    def _assert_equivalent(self, phonemizer, text, lang="en"):
+        eager = phonemizer.phonemize(text, lang)
+        lazy = list(phonemizer.phonemize_lazy(text, lang))
+        self.assertEqual(lazy, eager)
+
+    def test_grapheme_phonemizer_multisentence(self):
+        self._assert_equivalent(GraphemePhonemizer(), MULTISENTENCE)
+
+    def test_unicode_phonemizer_multisentence(self):
+        self._assert_equivalent(UnicodeCodepointPhonemizer(), MULTISENTENCE)
+
+    def test_mocked_phonemizer_multisentence(self):
+        self._assert_equivalent(_RecordingPhonemizer(), MULTISENTENCE)
+
+    def test_empty_text(self):
+        for ph in (GraphemePhonemizer(), UnicodeCodepointPhonemizer(),
+                   _RecordingPhonemizer()):
+            self.assertEqual(list(ph.phonemize_lazy("", "en")), [])
+            self.assertEqual(ph.phonemize("", "en"), [])
+
+    def test_single_sentence(self):
+        self._assert_equivalent(GraphemePhonemizer(), "just one sentence here")
+
+    def test_delimiter_splitting_matches(self):
+        # ':' / ';' split intra-sentence chunks — both paths must chunk identically.
+        self._assert_equivalent(GraphemePhonemizer(),
+                                "first part: second part; third part. And a new one.")
+
+    def test_lazy_defers_phonemize_string_calls(self):
+        """phonemize_string must not run before the generator is pulled."""
+        events = []
+        ph = _RecordingPhonemizer(events)
+        gen = ph.phonemize_lazy(MULTISENTENCE, "en")
+        self.assertEqual(events, [])  # nothing phonemized yet
+        first = next(gen)
+        self.assertTrue(first)
+        self.assertEqual(len(events), 1)  # only the first sentence so far
+
+
+def _make_lazy_voice(events, alphabet=Alphabet.IPA):
+    """Build a TTSVoice wired to a recording phonemizer + recording synth step.
+
+    Grapheme input -> IPA model, so synthesis takes the lazy per-sentence phoneme
+    branch. ``events`` records both phonemize and session.run in call order.
+    """
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.phonetic_spellings = None
+    voice.phonemizer = _RecordingPhonemizer(events)
+
+    config = types.SimpleNamespace(
+        alphabet=alphabet,
+        lang_code="en",
+        add_diacritics=False,
+        diacritizer_model=None,
+        sample_rate=22050,
+    )
+    voice.config = config
+    voice.adapter = MagicMock()
+
+    voice.phonemes_to_ids = lambda phonemes: [1] * len(phonemes)
+
+    def _synth(phoneme_ids, syn_config=None, language_ids=None):
+        events.append(("run", tuple(phoneme_ids)))
+        return np.zeros(4, dtype=np.float32)
+
+    voice.phoneme_ids_to_audio = _synth
+    return voice
+
+
+class TestLazyOrdering(unittest.TestCase):
+    def test_sentence2_phonemized_after_sentence1_run(self):
+        events = []
+        voice = _make_lazy_voice(events)
+        gen = voice.synthesize(MULTISENTENCE, SynthesisConfig(normalize_audio=False))
+
+        first_chunk = next(gen)
+        self.assertIsInstance(first_chunk, AudioChunk)
+
+        # After the first yielded chunk: sentence 1 was phonemized AND run, but
+        # sentence 2 has NOT been phonemized yet.
+        kinds = [e[0] for e in events]
+        self.assertEqual(kinds, ["phonemize", "run"],
+                         f"expected only sentence 1 work before first chunk, got {events}")
+
+        # Drain the rest — now every sentence is phonemized and run, and each
+        # sentence's phonemize precedes its own run.
+        list(gen)
+        kinds = [e[0] for e in events]
+        # phonemize/run strictly interleaved: phon, run, phon, run, ...
+        self.assertEqual(kinds, ["phonemize", "run"] * 3)
+
+    def test_no_work_before_first_pull(self):
+        events = []
+        voice = _make_lazy_voice(events)
+        gen = voice.synthesize(MULTISENTENCE, SynthesisConfig(normalize_audio=False))
+        self.assertEqual(events, [])  # generator not yet consumed
+
+
+class TestLanguageIdAlignment(unittest.TestCase):
+    def test_shami_lazy_matches_eager(self):
+        try:
+            from phoonnx.phonemizers.shami import ShamiPhonemizer
+        except Exception as e:  # pragma: no cover - dependency-gated
+            self.skipTest(f"Shami unavailable: {e}")
+
+        ph = ShamiPhonemizer()
+        text = "مرحبا كيف حالك؟ Hello there. شكرا جزيلا."
+
+        eager_phonemes, eager_ids = ph.phonemize_with_language_ids(text, "ar")
+        lazy = list(ph.phonemize_with_language_ids_lazy(text, "ar"))
+        lazy_phonemes = [p for p, _ in lazy]
+        lazy_ids = [i for _, i in lazy]
+
+        self.assertEqual(lazy_phonemes, eager_phonemes)
+        self.assertEqual(lazy_ids, eager_ids)
+        # Alignment: each sentence's phoneme list and language-id list match length.
+        for phonemes, ids in lazy:
+            self.assertEqual(len(phonemes), len(ids))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`TTSVoice.synthesize()` used to phonemize (and diacritize) the entire input up front, building the token ids for every sentence before running the first `session.run`. On multi-sentence input that pushed all the per-sentence front-end cost onto the critical path to the first audio chunk.

Per-sentence phonemize / diacritize / tokenize now happens lazily inside a generator (`_iter_synthesis_ids`), so the first sentence reaches `session.run` before later sentences are phonemized. Whole-text normalization and chunking still run once up front (both cheap and order-sensitive), so the phoneme stream is unchanged:

- `list(BasePhonemizer.phonemize_lazy(t, lang)) == BasePhonemizer.phonemize(t, lang)` for any input.
- Added `ShamiPhonemizer.phonemize_with_language_ids_lazy` — yields `(phonemes, language_ids)` per sentence, keeping the two streams aligned; the eager method now delegates to it.
- Diacritics (Arabic/Hebrew) are applied per sentence (those diacritizer models are sentence-level), preserving the `syn_config.diacritizer_model or self.config.diacritizer_model` resolution.

All existing dispatch semantics are preserved: the `src == tgt` passthrough (grapheme adapter path and phonemic passthrough), the grapheme phoneme path including language-aware phonemizers, inline `[[phoneme]]` blocks (kept on the eager path that owns the merge logic), and the transcode-via-conversion-graph branch. A phonemizer without a lazy variant transparently falls back to its eager `phonemize()`.

`scripts/bench_latency.py` stage mirroring is unchanged: `phonemize()` and `phonemes_to_ids()` remain public with identical output, so the stage boundaries and JSON schema are stable.

## Benchmark (piper/en_US-amy-low, CPUExecutionProvider, 5 warm runs)

Time-to-first-audio (TTFA), median / p95:

| case | before TTFA | after TTFA |
|------|-------------|------------|
| 1 sentence | 169.8 / 215.9 ms | 142.5 / 154.2 ms |
| 5 sentence | 307.7 / 424.8 ms | 159.7 / 245.4 ms |

5-sentence TTFA drops ~48% (308 → 160 ms) — the front-end cost of sentences 2-5 no longer blocks the first chunk. 1-sentence TTFA does not regress. Total synthesis time is unchanged (same work, reordered).

## Test plan

- `tests/test_lazy_synthesis.py` (new):
  - whole-text vs per-sentence phonemize equivalence (grapheme, unicode, mocked phonemizer; multi-sentence, single, delimiter-split, empty)
  - laziness: no `phonemize_string` runs before the generator is pulled
  - ordering: with a recording phonemizer + synth step, sentence 2 is phonemized only after sentence 1's `session.run`
  - Shami language-id alignment: lazy stream equals the eager `(phonemes, language_ids)` output, lengths aligned per sentence
- `python -m pytest tests/ -q -p no:ovoscope`: no new failures. 16 pre-existing failures remain (styletts2 training extras, matcha golden tokenization) — unrelated to this change.
