### PR TITLE
test: cover alphabet conversion edges and en/mul/ar phonemizer dispatch

### DIFF
--- a/tests/test_alphabet_convert_edges.py
+++ b/tests/test_alphabet_convert_edges.py
@@ -1,0 +1,204 @@
+"""Adversarial edge-case coverage for phoonnx.alphabet_convert.
+
+Complements tests/test_alphabet_convert.py — deliberately avoids duplicating
+scenarios already covered there (identity, direct edge, multi-hop chaining,
+scriptconv notation edges, pykakasi hira happy/missing paths).
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import unicodedata
+
+from phoonnx.config import Alphabet, PhonemeType
+from phoonnx.alphabet_convert import (
+    ALPHABET_CONVERTERS,
+    convert,
+    register_converter,
+    _find_path,
+    _call_edge,
+)
+
+
+class TestFindPathNoPath(unittest.TestCase):
+    def test_returns_none_when_target_unreachable(self):
+        """SAMPA has no registered edges at all, so BFS must exhaust the
+        queue and return None rather than raising or looping forever."""
+        result = _find_path(Alphabet.SAMPA, Alphabet.ARPA)
+        self.assertIsNone(result)
+
+    def test_returns_empty_list_for_identical_nodes(self):
+        result = _find_path(Alphabet.IPA, Alphabet.IPA)
+        self.assertEqual(result, [])
+
+    def test_no_path_from_isolated_node_even_as_source(self):
+        """An alphabet that is never a source in the registry yields no path
+        even when other alphabets *do* have outgoing edges from it as a
+        target only."""
+        result = _find_path(Alphabet.SAMPA, Alphabet.HANGUL)
+        self.assertIsNone(result)
+
+
+class TestCallEdgeFallback(unittest.TestCase):
+    def test_typeerror_falls_back_to_two_arg_call(self):
+        """An edge function that only accepts (text, lang) must still be
+        callable: _call_edge first tries the 3-arg form, catches the
+        TypeError from the arity mismatch, and retries with 2 args."""
+        calls = []
+
+        def two_arg_edge(text, lang):
+            calls.append((text, lang))
+            return text.upper()
+
+        result = _call_edge(two_arg_edge, "hi", "en", PhonemeType.ESPEAK)
+        self.assertEqual(result, "HI")
+        self.assertEqual(calls, [("hi", "en")])
+
+    def test_three_arg_edge_receives_phoneme_type(self):
+        def three_arg_edge(text, lang, phoneme_type):
+            return f"{text}:{lang}:{phoneme_type}"
+
+        result = _call_edge(three_arg_edge, "hi", "en", PhonemeType.ESPEAK)
+        self.assertEqual(result, "hi:en:PhonemeType.ESPEAK")
+
+    def test_via_convert_end_to_end_with_two_arg_edge(self):
+        """Same fallback, exercised through the public convert() entry point
+        rather than calling _call_edge directly."""
+        key = (Alphabet.SAMPA, Alphabet.RFE)
+        old = ALPHABET_CONVERTERS.get(key)
+        try:
+            register_converter(Alphabet.SAMPA, Alphabet.RFE,
+                                lambda text, lang: text + "!")
+            result = convert("x", "en", Alphabet.SAMPA, Alphabet.RFE,
+                              phoneme_type=PhonemeType.ESPEAK)
+            self.assertEqual(result, "x!")
+        finally:
+            if old is None:
+                ALPHABET_CONVERTERS.pop(key, None)
+            else:
+                ALPHABET_CONVERTERS[key] = old
+
+
+class TestRegisterConverterOverwrite(unittest.TestCase):
+    def test_registering_same_edge_twice_overwrites(self):
+        key = (Alphabet.SAMPA, Alphabet.RFE)
+        old = ALPHABET_CONVERTERS.get(key)
+        try:
+            register_converter(Alphabet.SAMPA, Alphabet.RFE, lambda t, l, _=None: "first")
+            register_converter(Alphabet.SAMPA, Alphabet.RFE, lambda t, l, _=None: "second")
+            result = convert("x", "en", Alphabet.SAMPA, Alphabet.RFE)
+            self.assertEqual(result, "second")
+        finally:
+            if old is None:
+                ALPHABET_CONVERTERS.pop(key, None)
+            else:
+                ALPHABET_CONVERTERS[key] = old
+
+
+class TestConvertNoOpSameAlphabet(unittest.TestCase):
+    def test_convert_short_circuits_before_registry_lookup(self):
+        """src == tgt must never even consult ALPHABET_CONVERTERS."""
+        key = (Alphabet.BUCKWALTER, Alphabet.BUCKWALTER)
+        self.assertNotIn(key, ALPHABET_CONVERTERS)
+        result = convert("same", "ar", Alphabet.BUCKWALTER, Alphabet.BUCKWALTER)
+        self.assertEqual(result, "same")
+
+    def test_convert_no_op_on_empty_string(self):
+        result = convert("", "en", Alphabet.IPA, Alphabet.IPA)
+        self.assertEqual(result, "")
+
+
+class TestCangjiePassthrough(unittest.TestCase):
+    def test_pkuseg_import_error_falls_back_to_passthrough(self):
+        import sys as _sys
+        old = _sys.modules.pop("pkuseg", None)
+        try:
+            with patch.dict("sys.modules", {"pkuseg": None}):
+                result = convert("你好世界", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
+            self.assertEqual(result, "你好世界")
+        finally:
+            if old is not None:
+                _sys.modules["pkuseg"] = old
+
+    def test_pkuseg_generic_exception_falls_back_to_passthrough(self):
+        mock_pkuseg_module = MagicMock()
+        mock_pkuseg_module.pkuseg.side_effect = RuntimeError("model not downloaded")
+        with patch.dict("sys.modules", {"pkuseg": mock_pkuseg_module}):
+            result = convert("你好", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
+        self.assertEqual(result, "你好")
+
+    def test_pkuseg_success_path_segments_words(self):
+        mock_seg = MagicMock()
+        mock_seg.cut.return_value = ["你好", "世界"]
+        mock_pkuseg_module = MagicMock()
+        mock_pkuseg_module.pkuseg.return_value = mock_seg
+        with patch.dict("sys.modules", {"pkuseg": mock_pkuseg_module}):
+            result = convert("你好世界", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
+        self.assertEqual(result, "你好 世界")
+
+
+class TestKanaPassthrough(unittest.TestCase):
+    def test_pykakasi_import_error_falls_back_to_passthrough_for_kana(self):
+        import sys as _sys
+        old = _sys.modules.pop("pykakasi", None)
+        try:
+            with patch.dict("sys.modules", {"pykakasi": None}):
+                result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.KANA)
+            self.assertEqual(result, "東京")
+        finally:
+            if old is not None:
+                _sys.modules["pykakasi"] = old
+
+    def test_pykakasi_generic_exception_falls_back_to_passthrough(self):
+        mock_kakasi_module = MagicMock()
+        mock_kakasi_module.kakasi.side_effect = RuntimeError("dict load failed")
+        with patch.dict("sys.modules", {"pykakasi": mock_kakasi_module}):
+            result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.KANA)
+        self.assertEqual(result, "東京")
+
+    def test_pykakasi_success_path_for_kana(self):
+        mock_kks = MagicMock()
+        mock_kks.convert.return_value = [{"kana": "トウ"}, {"kana": "キョウ"}]
+        mock_kakasi_module = MagicMock()
+        mock_kakasi_module.kakasi.return_value = mock_kks
+        with patch.dict("sys.modules", {"pykakasi": mock_kakasi_module}):
+            result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.KANA)
+        self.assertEqual(result, "トウキョウ")
+
+
+class TestJamoDecomposeExceptionFallback(unittest.TestCase):
+    def test_normalize_failure_falls_back_to_passthrough(self):
+        text = "가"  # 가
+        with patch.object(unicodedata, "normalize", side_effect=RuntimeError("boom")):
+            result = convert(text, "ko", Alphabet.HANGUL, Alphabet.HIRA)
+        self.assertEqual(result, text)
+
+    def test_normalize_success_decomposes_hangul_syllable(self):
+        # 가 (U+AC00) decomposes to jamo ㄱ + ㅏ (NFD form).
+        result = convert("가", "ko", Alphabet.HANGUL, Alphabet.HIRA)
+        self.assertEqual(result, unicodedata.normalize("NFD", "가"))
+
+
+class TestHangulIdentityEdge(unittest.TestCase):
+    def test_graphemes_to_hangul_is_passthrough(self):
+        result = convert("한글", "ko", Alphabet.GRAPHEMES, Alphabet.HANGUL)
+        self.assertEqual(result, "한글")
+
+    def test_hangul_to_hangul_registered_identity(self):
+        result = convert("한글", "ko", Alphabet.HANGUL, Alphabet.HANGUL)
+        self.assertEqual(result, "한글")
+
+
+class TestMixedScriptScriptConversion(unittest.TestCase):
+    def test_mixed_script_input_through_pykakasi_mock(self):
+        """Latin+Kanji mixed input must not crash the hiragana edge."""
+        mock_kks = MagicMock()
+        mock_kks.convert.return_value = [{"hira": "abc"}, {"hira": "とうきょう"}]
+        mock_kakasi_module = MagicMock()
+        mock_kakasi_module.kakasi.return_value = mock_kks
+        with patch.dict("sys.modules", {"pykakasi": mock_kakasi_module}):
+            result = convert("abc東京", "ja", Alphabet.GRAPHEMES, Alphabet.HIRA)
+        self.assertEqual(result, "abcとうきょう")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ar.py
+++ b/tests/test_ar.py
@@ -1,6 +1,6 @@
 """Test suite for phoonnx Arabic phonemizer (MantoqPhonemizer)."""
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import sys
 import os
 
@@ -648,6 +648,177 @@ class TestMantoqPhonemizerIntegration(unittest.TestCase):
 
                 # Results should be different (BUCKWALTER vs IPA)
                 self.assertNotEqual(result_mantoq, result_ipa)
+
+
+class TestArbtokPhonemizer(unittest.TestCase):
+    """Adversarial coverage for ArbtokPhonemizer, the arbtok-backed Arabic
+    engine (lines 55-127 of phoonnx/phonemizers/ar.py). arbtok is imported
+    lazily, so it's mocked via sys.modules patching rather than requiring
+    the real package to be installed.
+    """
+
+    def setUp(self):
+        from phoonnx.phonemizers.ar import ArbtokPhonemizer
+        self.ArbtokPhonemizer = ArbtokPhonemizer
+
+    def test_rejects_non_ipa_alphabet(self):
+        with self.assertRaises(ValueError):
+            self.ArbtokPhonemizer(alphabet=Alphabet.BUCKWALTER)
+
+    def test_register_none_defers_to_engine_default(self):
+        inst = self.ArbtokPhonemizer()
+        self.assertIsNone(inst.register)
+
+    def test_register_irab_aliases_map_to_full(self):
+        for alias in ("irab", "i'rab", "iʿrab", "full", "IRAB", "Full"):
+            with self.subTest(alias=alias):
+                inst = self.ArbtokPhonemizer(register=alias)
+                self.assertEqual(inst.register, "full")
+
+    def test_register_pausal_passes_through_unchanged(self):
+        inst = self.ArbtokPhonemizer(register="pausal")
+        self.assertEqual(inst.register, "pausal")
+
+    def test_get_lang_raises_importerror_when_arbtok_missing(self):
+        import sys
+        old = sys.modules.pop("arbtok", None)
+        try:
+            with patch.dict(sys.modules, {"arbtok": None}):
+                with self.assertRaises(ImportError):
+                    self.ArbtokPhonemizer.get_lang("ar")
+        finally:
+            if old is not None:
+                sys.modules["arbtok"] = old
+
+    def test_get_lang_delegates_to_arbtok_spec_for_lang(self):
+        fake_arbtok = MagicMock()
+        fake_arbtok.spec_for_lang.return_value = "ar-EG"
+        with patch.dict(sys.modules, {"arbtok": fake_arbtok}):
+            result = self.ArbtokPhonemizer.get_lang("ar-EG")
+        self.assertEqual(result, "ar-EG")
+        fake_arbtok.spec_for_lang.assert_called_once_with("ar-EG")
+
+    def test_engine_raises_importerror_when_arbtok_plugin_missing(self):
+        inst = self.ArbtokPhonemizer()
+        import sys
+        old = sys.modules.pop("arbtok.plugin", None)
+        try:
+            with patch.dict(sys.modules, {"arbtok.plugin": None, "arbtok": None}):
+                with self.assertRaises(ImportError):
+                    inst._engine("ar")
+        finally:
+            if old is not None:
+                sys.modules["arbtok.plugin"] = old
+
+    def test_engine_is_cached_per_lang_and_register(self):
+        """The engine must be constructed once per (lang, register) pair and
+        reused on subsequent calls — never re-instantiated, never bypassed."""
+        fake_plugin_module = MagicMock()
+        fake_plugin_cls = MagicMock()
+        fake_plugin_module.ArbtokG2PPlugin = fake_plugin_cls
+        fake_instance = MagicMock()
+        fake_plugin_cls.return_value = fake_instance
+
+        inst = self.ArbtokPhonemizer()
+        with patch.dict(sys.modules, {"arbtok.plugin": fake_plugin_module}):
+            engine1 = inst._engine("ar-EG")
+            engine2 = inst._engine("ar-EG")
+
+        self.assertIs(engine1, engine2)
+        fake_plugin_cls.assert_called_once_with(lang="ar-EG", diacritize=True)
+
+    def test_engine_passes_register_kwarg_when_set(self):
+        fake_plugin_module = MagicMock()
+        fake_plugin_cls = MagicMock()
+        fake_plugin_module.ArbtokG2PPlugin = fake_plugin_cls
+
+        inst = self.ArbtokPhonemizer(register="full")
+        with patch.dict(sys.modules, {"arbtok.plugin": fake_plugin_module}):
+            inst._engine("ar")
+
+        fake_plugin_cls.assert_called_once_with(lang="ar", diacritize=True, register="full")
+
+    def test_phonemize_string_always_transcribes_via_arbtok_never_bypasses_it(self):
+        """ArbtokPhonemizer must always route through arbtok's engine.transcribe
+        for IPA output — it must never fall back to mantoq/espeak/o2i directly
+        for Arabic IPA (arbtok is the mandated engine)."""
+        inst = self.ArbtokPhonemizer()
+        fake_engine = MagicMock()
+        fake_engine.transcribe.return_value = "mar__aban"
+        with patch.object(inst, "_engine", return_value=fake_engine) as mock_engine, \
+             patch.object(self.ArbtokPhonemizer, "get_lang", return_value="ar"):
+            result = inst.phonemize_string("مرحبا", "ar")
+
+        mock_engine.assert_called_once_with("ar")
+        fake_engine.transcribe.assert_called_once_with("مرحبا")
+        self.assertEqual(result, "mar__aban")
+
+    def test_phonemize_string_bare_undiacritized_input(self):
+        inst = self.ArbtokPhonemizer()
+        fake_engine = MagicMock()
+        fake_engine.transcribe.return_value = "marħaban"
+        with patch.object(inst, "_engine", return_value=fake_engine), \
+             patch.object(self.ArbtokPhonemizer, "get_lang", return_value="ar"):
+            result = inst.phonemize_string("مرحبا بالعالم")
+        self.assertEqual(result, "marħaban")
+
+    def test_phonemize_string_fully_diacritized_input(self):
+        """Fully-vocalized (tashkeel-marked) input must still go through the
+        same transcribe() call — arbtok's diacritize=True restores what's
+        missing but must not choke on text that already has it."""
+        inst = self.ArbtokPhonemizer()
+        fake_engine = MagicMock()
+        fake_engine.transcribe.return_value = "marħaban"
+        diacritized = "مَرْحَبًا"
+        with patch.object(inst, "_engine", return_value=fake_engine) as mock_engine, \
+             patch.object(self.ArbtokPhonemizer, "get_lang", return_value="ar"):
+            result = inst.phonemize_string(diacritized)
+        fake_engine.transcribe.assert_called_once_with(diacritized)
+        self.assertEqual(result, "marħaban")
+
+    def test_phonemize_string_empty_input(self):
+        inst = self.ArbtokPhonemizer()
+        fake_engine = MagicMock()
+        fake_engine.transcribe.return_value = ""
+        with patch.object(inst, "_engine", return_value=fake_engine), \
+             patch.object(self.ArbtokPhonemizer, "get_lang", return_value="ar"):
+            result = inst.phonemize_string("")
+        self.assertEqual(result, "")
+
+    def test_phonemize_string_mixed_arabic_and_latin_input(self):
+        """Mixed-script input (Arabic + embedded Latin, e.g. a brand name)
+        must be passed through to arbtok untouched — no crash, no silent
+        truncation at the script boundary."""
+        inst = self.ArbtokPhonemizer()
+        fake_engine = MagicMock()
+        mixed = "مرحبا Wi-Fi يا صديقي"
+        fake_engine.transcribe.return_value = "marħaban wifi ja sˤadiːqiː"
+        with patch.object(inst, "_engine", return_value=fake_engine) as mock_engine, \
+             patch.object(self.ArbtokPhonemizer, "get_lang", return_value="ar"):
+            result = inst.phonemize_string(mixed)
+        fake_engine.transcribe.assert_called_once_with(mixed)
+        self.assertEqual(result, "marħaban wifi ja sˤadiːqiː")
+
+    def test_phonemize_string_engine_raises_propagates(self):
+        """If arbtok's engine raises (e.g. it returns/raises on malformed
+        input), the error must propagate — phonemize_string must not
+        silently swallow it and fall back to another phonemizer."""
+        inst = self.ArbtokPhonemizer()
+        fake_engine = MagicMock()
+        fake_engine.transcribe.side_effect = RuntimeError("arbtok choked")
+        with patch.object(inst, "_engine", return_value=fake_engine), \
+             patch.object(self.ArbtokPhonemizer, "get_lang", return_value="ar"):
+            with self.assertRaises(RuntimeError):
+                inst.phonemize_string("مرحبا")
+
+    def test_phonemize_string_unresolvable_lang_raises_not_bypasses(self):
+        """An unresolvable lang code must raise (via get_lang), not silently
+        fall back to a default variety or a non-arbtok phonemizer."""
+        inst = self.ArbtokPhonemizer()
+        with patch.object(self.ArbtokPhonemizer, "get_lang",
+                           side_effect=ValueError("no arbtok spec for lang")):
+            with self.assertRaises(ValueError):
+                inst.phonemize_string("مرحبا", "xx-nonexistent")
 
 
 if __name__ == '__main__':

--- a/tests/test_phonemizer_en.py
+++ b/tests/test_phonemizer_en.py
@@ -1,0 +1,257 @@
+"""Adversarial tests for phoonnx.phonemizers.en (DeepPhonemizer, OpenPhonemizer,
+G2PEnPhonemizer).
+
+Heavyweight backends (dp/torch, openphonemizer, nltk/g2p_en) are mocked via
+sys.modules patching so these tests run without the optional extras installed.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+from phoonnx.config import Alphabet
+
+
+def _fake_torch_and_dp_modules():
+    """Build minimal fake `dp` and `torch` modules sufficient for the
+    add_safe_globals dance every backend in en.py performs on import."""
+    fake_torch = MagicMock()
+    fake_torch.serialization.add_safe_globals = MagicMock()
+
+    fake_dp_preprocessing_text = MagicMock()
+    fake_dp_preprocessing_text.Preprocessor = MagicMock()
+    fake_dp_preprocessing_text.LanguageTokenizer = MagicMock()
+    fake_dp_preprocessing_text.SequenceTokenizer = MagicMock()
+
+    fake_dp_preprocessing = MagicMock()
+    fake_dp_preprocessing.text = fake_dp_preprocessing_text
+
+    fake_dp = MagicMock()
+    fake_dp.preprocessing = fake_dp_preprocessing
+
+    return fake_torch, fake_dp, fake_dp_preprocessing, fake_dp_preprocessing_text
+
+
+class TestDeepPhonemizerConstruction(unittest.TestCase):
+    def test_ipa_model_name_sets_ipa_alphabet(self):
+        from phoonnx.phonemizers.en import DeepPhonemizer
+
+        fake_torch, fake_dp, _, _ = _fake_torch_and_dp_modules()
+        fake_phonemizer_mod = MagicMock()
+        mock_backend = MagicMock()
+        fake_phonemizer_mod.Phonemizer.from_checkpoint.return_value = mock_backend
+
+        with patch.dict(sys.modules, {
+            "dp": fake_dp,
+            "dp.preprocessing": fake_dp.preprocessing,
+            "dp.preprocessing.text": fake_dp.preprocessing.text,
+            "dp.phonemizer": fake_phonemizer_mod,
+            "torch": fake_torch,
+        }), patch("os.path.isfile", return_value=True):
+            inst = DeepPhonemizer(model="latin_ipa_forward.pt")
+
+        self.assertEqual(inst.alphabet, Alphabet.IPA)
+        fake_phonemizer_mod.Phonemizer.from_checkpoint.assert_called_once_with("latin_ipa_forward.pt")
+
+    def test_non_ipa_model_name_sets_arpa_alphabet(self):
+        from phoonnx.phonemizers.en import DeepPhonemizer
+
+        fake_torch, fake_dp, _, _ = _fake_torch_and_dp_modules()
+        fake_phonemizer_mod = MagicMock()
+
+        with patch.dict(sys.modules, {
+            "dp": fake_dp,
+            "dp.preprocessing": fake_dp.preprocessing,
+            "dp.preprocessing.text": fake_dp.preprocessing.text,
+            "dp.phonemizer": fake_phonemizer_mod,
+            "torch": fake_torch,
+        }), patch("os.path.isfile", return_value=True):
+            inst = DeepPhonemizer(model="en_us_cmudict_forward.pt")
+
+        self.assertEqual(inst.alphabet, Alphabet.ARPA)
+
+    def test_unknown_local_model_path_raises_value_error(self):
+        """A model name that isn't a real file AND isn't in MODELS must raise,
+        never silently proceed to construct a Phonemizer from garbage."""
+        from phoonnx.phonemizers.en import DeepPhonemizer
+
+        fake_torch, fake_dp, _, _ = _fake_torch_and_dp_modules()
+        fake_phonemizer_mod = MagicMock()
+
+        with patch.dict(sys.modules, {
+            "dp": fake_dp,
+            "dp.preprocessing": fake_dp.preprocessing,
+            "dp.preprocessing.text": fake_dp.preprocessing.text,
+            "dp.phonemizer": fake_phonemizer_mod,
+            "torch": fake_torch,
+        }), patch("os.path.isfile", return_value=False):
+            with self.assertRaises(ValueError):
+                DeepPhonemizer(model="totally_unknown_model.pt")
+
+
+class TestDeepPhonemizerGetLang(unittest.TestCase):
+    def test_valid_lang_de_and_en_us(self):
+        from phoonnx.phonemizers.en import DeepPhonemizer
+        self.assertEqual(DeepPhonemizer.get_lang("de"), "de")
+        self.assertEqual(DeepPhonemizer.get_lang("en_us"), "en_us")
+
+    def test_unsupported_lang_raises(self):
+        from phoonnx.phonemizers.en import DeepPhonemizer
+        with self.assertRaises(ValueError):
+            DeepPhonemizer.get_lang("zz-totally-bogus")
+
+
+class TestDeepPhonemizerPhonemizeString(unittest.TestCase):
+    def _make_instance(self):
+        from phoonnx.phonemizers.en import DeepPhonemizer
+        inst = DeepPhonemizer.__new__(DeepPhonemizer)
+        inst.alphabet = Alphabet.IPA
+        inst.phonemizer = MagicMock(return_value="h eh l ow")
+        return inst
+
+    def test_phonemize_string_delegates_to_backend_with_resolved_lang(self):
+        inst = self._make_instance()
+        result = inst.phonemize_string("hello", "de")
+        inst.phonemizer.assert_called_once_with("hello", "de")
+        self.assertEqual(result, "h eh l ow")
+
+    def test_phonemize_string_empty_input(self):
+        inst = self._make_instance()
+        inst.phonemizer.return_value = ""
+        result = inst.phonemize_string("", "de")
+        self.assertEqual(result, "")
+
+    def test_phonemize_string_invalid_lang_raises(self):
+        inst = self._make_instance()
+        with self.assertRaises(ValueError):
+            inst.phonemize_string("hello", "xx-nope")
+
+
+class TestOpenPhonemizer(unittest.TestCase):
+    def test_get_lang_only_supports_en(self):
+        from phoonnx.phonemizers.en import OpenPhonemizer
+        self.assertEqual(OpenPhonemizer.get_lang("en"), "en")
+        self.assertEqual(OpenPhonemizer.get_lang("en-US"), "en")
+        with self.assertRaises(ValueError):
+            OpenPhonemizer.get_lang("de")
+
+    def test_construction_wires_backend_and_alphabet(self):
+        fake_openphonemizer_mod = MagicMock()
+        mock_backend_cls = MagicMock()
+        fake_openphonemizer_mod.OpenPhonemizer = mock_backend_cls
+        fake_torch, fake_dp, _, _ = _fake_torch_and_dp_modules()
+
+        with patch.dict(sys.modules, {
+            "openphonemizer": fake_openphonemizer_mod,
+            "torch": fake_torch,
+            "dp": fake_dp,
+            "dp.preprocessing": fake_dp.preprocessing,
+            "dp.preprocessing.text": fake_dp.preprocessing.text,
+        }):
+            from phoonnx.phonemizers.en import OpenPhonemizer
+            inst = OpenPhonemizer()
+
+        self.assertEqual(inst.alphabet, Alphabet.IPA)
+        mock_backend_cls.assert_called_once()
+
+    def test_phonemize_string_delegates_and_ignores_lang_arg_in_call(self):
+        from phoonnx.phonemizers.en import OpenPhonemizer
+        inst = OpenPhonemizer.__new__(OpenPhonemizer)
+        inst.alphabet = Alphabet.IPA
+        inst.phonemizer = MagicMock(return_value="h ə l oʊ")
+
+        result = inst.phonemize_string("hello", "en-GB")
+        inst.phonemizer.assert_called_once_with("hello")
+        self.assertEqual(result, "h ə l oʊ")
+
+    def test_phonemize_string_unsupported_lang_raises(self):
+        from phoonnx.phonemizers.en import OpenPhonemizer
+        inst = OpenPhonemizer.__new__(OpenPhonemizer)
+        inst.alphabet = Alphabet.IPA
+        inst.phonemizer = MagicMock()
+        with self.assertRaises(ValueError):
+            inst.phonemize_string("hello", "fr")
+
+
+class TestG2PEnPhonemizer(unittest.TestCase):
+    def test_rejects_unsupported_alphabet(self):
+        from phoonnx.phonemizers.en import G2PEnPhonemizer
+        with self.assertRaises(AssertionError):
+            with patch.dict(sys.modules, {
+                "nltk": MagicMock(),
+                "g2p_en": MagicMock(),
+            }):
+                G2PEnPhonemizer(alphabet=Alphabet.BUCKWALTER)
+
+    def test_construction_downloads_nltk_resources_and_builds_g2p(self):
+        fake_nltk = MagicMock()
+        fake_g2p_en_mod = MagicMock()
+        fake_g2p_cls = MagicMock()
+        fake_g2p_en_mod.G2p = fake_g2p_cls
+
+        with patch.dict(sys.modules, {"nltk": fake_nltk, "g2p_en": fake_g2p_en_mod}):
+            from phoonnx.phonemizers.en import G2PEnPhonemizer
+            inst = G2PEnPhonemizer()
+
+        fake_nltk.download.assert_any_call('averaged_perceptron_tagger_eng')
+        fake_nltk.download.assert_any_call('cmudict')
+        fake_g2p_cls.assert_called_once()
+        self.assertEqual(inst.alphabet, Alphabet.IPA)
+
+    def test_get_lang_only_supports_en(self):
+        from phoonnx.phonemizers.en import G2PEnPhonemizer
+        self.assertEqual(G2PEnPhonemizer.get_lang("en-US"), "en")
+        with self.assertRaises(ValueError):
+            G2PEnPhonemizer.get_lang("ja")
+
+    def test_phonemize_string_arpa_alphabet_returns_raw_arpa(self):
+        from phoonnx.phonemizers.en import G2PEnPhonemizer
+        inst = G2PEnPhonemizer.__new__(G2PEnPhonemizer)
+        inst.alphabet = Alphabet.ARPA
+        inst.g2p = MagicMock(return_value=["HH", "AH0", "L", "OW1"])
+
+        result = inst.phonemize_string("hello", "en")
+        self.assertEqual(result, ["HH", "AH0", "L", "OW1"])
+
+    def test_phonemize_string_ipa_alphabet_maps_arpa_to_ipa(self):
+        from phoonnx.phonemizers.en import G2PEnPhonemizer
+        inst = G2PEnPhonemizer.__new__(G2PEnPhonemizer)
+        inst.alphabet = Alphabet.IPA
+        inst.g2p = MagicMock(return_value=["HH", "AH0"])
+
+        with patch("phoonnx.phonemizers.en.arpa_to_ipa_lookup", {"HH": "h", "AH0": "ə"}):
+            result = inst.phonemize_string("hi", "en")
+        self.assertEqual(result, "hə")
+
+    def test_phonemize_string_oov_arpa_symbol_falls_back_to_symbol_itself(self):
+        """An ARPA symbol absent from the lookup table must be passed through
+        unchanged (via dict.get default), never raise a KeyError."""
+        from phoonnx.phonemizers.en import G2PEnPhonemizer
+        inst = G2PEnPhonemizer.__new__(G2PEnPhonemizer)
+        inst.alphabet = Alphabet.IPA
+        inst.g2p = MagicMock(return_value=["ZZZ_UNKNOWN"])
+
+        with patch("phoonnx.phonemizers.en.arpa_to_ipa_lookup", {}):
+            result = inst.phonemize_string("weirdword", "en")
+        self.assertEqual(result, "ZZZ_UNKNOWN")
+
+    def test_phonemize_string_empty_g2p_output(self):
+        from phoonnx.phonemizers.en import G2PEnPhonemizer
+        inst = G2PEnPhonemizer.__new__(G2PEnPhonemizer)
+        inst.alphabet = Alphabet.IPA
+        inst.g2p = MagicMock(return_value=[])
+
+        with patch("phoonnx.phonemizers.en.arpa_to_ipa_lookup", {}):
+            result = inst.phonemize_string("", "en")
+        self.assertEqual(result, "")
+
+    def test_phonemize_string_invalid_lang_raises(self):
+        from phoonnx.phonemizers.en import G2PEnPhonemizer
+        inst = G2PEnPhonemizer.__new__(G2PEnPhonemizer)
+        inst.alphabet = Alphabet.IPA
+        inst.g2p = MagicMock()
+        with self.assertRaises(ValueError):
+            inst.phonemize_string("x", "de")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_phonemizer_mul.py
+++ b/tests/test_phonemizer_mul.py
@@ -1,0 +1,429 @@
+"""Adversarial tests for phoonnx.phonemizers.mul — the multilingual phonemizer
+dispatch/fallback layer (EspeakPhonemizer, GruutPhonemizer, GoruutPhonemizer,
+EpitranPhonemizer, MisakiPhonemizer family, CharsiuPhonemizer).
+
+All heavy backends (espeak-ng binary/espyak, gruut, pygoruut, epitran, misaki,
+onnxruntime models) are mocked so these run without the optional extras.
+"""
+import subprocess
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from phoonnx.config import Alphabet
+from phoonnx.phonemizers.mul import (
+    EspeakPhonemizer,
+    EspeakError,
+    GruutPhonemizer,
+    GoruutPhonemizer,
+    EpitranPhonemizer,
+    MisakiPhonemizer,
+    CharsiuPhonemizer,
+    ByT5Phonemizer,
+)
+
+
+class TestEspeakGetLang(unittest.TestCase):
+    def test_en_gb_maps_to_rp_variant(self):
+        self.assertEqual(EspeakPhonemizer.get_lang("en-gb"), "en-gb-x-rp")
+        self.assertEqual(EspeakPhonemizer.get_lang("EN-GB"), "en-gb-x-rp")
+
+    def test_exact_match_passthrough(self):
+        self.assertEqual(EspeakPhonemizer.get_lang("pt-br"), "pt-br")
+
+    def test_unusual_but_valid_regional_code_falls_back_to_base_lang(self):
+        # pt-BR isn't itself in ESPEAK_LANGS with this casing, but its base
+        # "pt" is -- get_lang lowercases and strips the region.
+        self.assertEqual(EspeakPhonemizer.get_lang("pt-BR"), "pt")
+
+    def test_zh_tw_has_no_close_match_raises_valueerror_not_keyerror(self):
+        # zh-TW has no exact/base entry ("zh" isn't in ESPEAK_LANGS either,
+        # only "cmn"), and langcodes' tag_distance finds nothing close enough
+        # -- this must raise the controlled ValueError from match_lang,
+        # never a raw KeyError from a dict/table lookup.
+        with self.assertRaises(ValueError):
+            EspeakPhonemizer.get_lang("zh-TW")
+
+    def test_completely_unknown_lang_raises_valueerror_not_keyerror(self):
+        with self.assertRaises(ValueError):
+            EspeakPhonemizer.get_lang("xx-nonexistent-lang")
+
+
+class TestEspeakPhonemizeStringDispatch(unittest.TestCase):
+    def test_prefers_binary_when_available_and_not_forced_to_espyak(self):
+        inst = EspeakPhonemizer(prefer_espyak=False)
+        with patch.object(EspeakPhonemizer, "_has_binary", return_value=True), \
+             patch.object(EspeakPhonemizer, "_run_espeak_command", return_value="h ə l oʊ") as mock_run:
+            result = inst.phonemize_string("hello", "en-us")
+        mock_run.assert_called_once()
+        self.assertEqual(result, "h ə l oʊ")
+
+    def test_falls_back_to_espyak_when_binary_missing(self):
+        inst = EspeakPhonemizer(prefer_espyak=False)
+        fake_espyak_mod = MagicMock()
+        fake_g2p_instance = MagicMock()
+        fake_g2p_instance.phonemize.return_value = "h ə l oʊ"
+        fake_espyak_mod.G2P.return_value = fake_g2p_instance
+
+        with patch.object(EspeakPhonemizer, "_has_binary", return_value=False), \
+             patch.dict(sys.modules, {"espyak": fake_espyak_mod}):
+            result = inst.phonemize_string("hello", "en-us")
+
+        self.assertEqual(result, "h ə l oʊ")
+
+    def test_prefer_espyak_true_uses_espyak_even_when_binary_present(self):
+        inst = EspeakPhonemizer(prefer_espyak=True)
+        fake_espyak_mod = MagicMock()
+        fake_g2p_instance = MagicMock()
+        fake_g2p_instance.phonemize.return_value = "custom"
+        fake_espyak_mod.G2P.return_value = fake_g2p_instance
+
+        with patch.object(EspeakPhonemizer, "_has_binary", return_value=True) as mock_has_bin, \
+             patch.object(EspeakPhonemizer, "_run_espeak_command") as mock_run, \
+             patch.dict(sys.modules, {"espyak": fake_espyak_mod}):
+            result = inst.phonemize_string("hello", "en-us")
+
+        mock_run.assert_not_called()
+        self.assertEqual(result, "custom")
+
+    def test_espyak_missing_and_no_binary_raises_espeak_error_not_crash(self):
+        inst = EspeakPhonemizer(prefer_espyak=True)
+        with patch.object(EspeakPhonemizer, "_has_binary", return_value=False), \
+             patch.dict(sys.modules, {"espyak": None}):
+            with self.assertRaises(EspeakError):
+                inst.phonemize_string("hello", "en-us")
+
+    def test_espyak_g2p_instances_are_cached_per_lang(self):
+        inst = EspeakPhonemizer(prefer_espyak=True)
+        fake_espyak_mod = MagicMock()
+        fake_g2p_instance = MagicMock()
+        fake_g2p_instance.phonemize.return_value = "x"
+        fake_espyak_mod.G2P.return_value = fake_g2p_instance
+
+        with patch.dict(sys.modules, {"espyak": fake_espyak_mod}):
+            inst._espyak_phonemize("a", "en-us")
+            inst._espyak_phonemize("b", "en-us")
+
+        fake_espyak_mod.G2P.assert_called_once_with("en-us")
+
+    def test_empty_string_input_does_not_crash(self):
+        inst = EspeakPhonemizer(prefer_espyak=False)
+        with patch.object(EspeakPhonemizer, "_has_binary", return_value=True), \
+             patch.object(EspeakPhonemizer, "_run_espeak_command", return_value="") as mock_run:
+            result = inst.phonemize_string("", "en-us")
+        self.assertEqual(result, "")
+
+
+class TestEspeakRunCommandErrors(unittest.TestCase):
+    def test_binary_not_found_raises_espeak_error(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            with self.assertRaises(EspeakError):
+                EspeakPhonemizer._run_espeak_command(["-q"], input_text="hi")
+
+    def test_nonzero_exit_raises_espeak_error_with_details(self):
+        err = subprocess.CalledProcessError(1, ["espeak-ng"], output="", stderr="boom")
+        with patch("subprocess.run", side_effect=err):
+            with self.assertRaises(EspeakError) as ctx:
+                EspeakPhonemizer._run_espeak_command(["-q"], input_text="hi")
+        self.assertIn("boom", str(ctx.exception))
+
+    def test_unexpected_exception_is_wrapped_in_espeak_error(self):
+        with patch("subprocess.run", side_effect=RuntimeError("weird")):
+            with self.assertRaises(EspeakError):
+                EspeakPhonemizer._run_espeak_command(["-q"], input_text="hi")
+
+
+class TestGruutGetLangAndDispatch(unittest.TestCase):
+    def test_get_lang_exact_and_unsupported(self):
+        self.assertEqual(GruutPhonemizer.get_lang("en"), "en")
+        with self.assertRaises(ValueError):
+            GruutPhonemizer.get_lang("xx-bogus")
+
+    def _make_sentence(self, text, word_phonemes):
+        sentence = MagicMock()
+        sentence.text = text
+        sentence.__iter__.return_value = iter([
+            MagicMock(phonemes=ph) for ph in word_phonemes
+        ])
+        sentence.__bool__.return_value = True
+        return sentence
+
+    def test_question_mark_forces_final_token(self):
+        inst = GruutPhonemizer()
+        sentence = self._make_sentence("hi?", [["h", "i"]])
+        fake_gruut = MagicMock()
+        fake_gruut.sentences.return_value = [sentence]
+        with patch.dict(sys.modules, {"gruut": fake_gruut}):
+            result = inst.phonemize_string("hi?", "en")
+        self.assertTrue(result.endswith("?"))
+
+    def test_exclamation_forces_final_token(self):
+        inst = GruutPhonemizer()
+        sentence = self._make_sentence("wow!", [["w", "aʊ"]])
+        fake_gruut = MagicMock()
+        fake_gruut.sentences.return_value = [sentence]
+        with patch.dict(sys.modules, {"gruut": fake_gruut}):
+            result = inst.phonemize_string("wow!", "en")
+        self.assertTrue(result.endswith("!"))
+
+    def test_period_forces_final_token(self):
+        inst = GruutPhonemizer()
+        sentence = self._make_sentence("done.", [["d", "ʌ", "n"]])
+        fake_gruut = MagicMock()
+        fake_gruut.sentences.return_value = [sentence]
+        with patch.dict(sys.modules, {"gruut": fake_gruut}):
+            result = inst.phonemize_string("done.", "en")
+        self.assertTrue(result.endswith("."))
+
+    def test_empty_word_phonemes_raises_runtime_error_hinting_missing_lang_pack(self):
+        """Gruut sentence with no phonemized words signals a missing
+        language pack; this must raise a clear RuntimeError, not silently
+        drop the sentence or crash with an IndexError."""
+        inst = GruutPhonemizer()
+        sentence = MagicMock()
+        sentence.text = "hello"
+        sentence.__iter__.return_value = iter([MagicMock(phonemes=[])])
+        sentence.__bool__.return_value = True
+        fake_gruut = MagicMock()
+        fake_gruut.sentences.return_value = [sentence]
+        with patch.dict(sys.modules, {"gruut": fake_gruut}):
+            with self.assertRaises(RuntimeError):
+                inst.phonemize_string("hello", "en")
+
+    def test_empty_input_text_yields_empty_output(self):
+        inst = GruutPhonemizer()
+        fake_gruut = MagicMock()
+        fake_gruut.sentences.return_value = []
+        with patch.dict(sys.modules, {"gruut": fake_gruut}):
+            result = inst.phonemize_string("", "en")
+        self.assertEqual(result, "")
+
+
+class TestGoruutGetLang(unittest.TestCase):
+    def test_non_std_lang_passthrough(self):
+        self.assertEqual(GoruutPhonemizer.get_lang("EnglishAmerican"), "EnglishAmerican")
+
+    def test_en_us_special_case(self):
+        self.assertEqual(GoruutPhonemizer.get_lang("en-us"), "EnglishAmerican")
+
+    def test_en_gb_and_en_uk_special_case(self):
+        self.assertEqual(GoruutPhonemizer.get_lang("en-gb"), "EnglishBritish")
+        self.assertEqual(GoruutPhonemizer.get_lang("en-uk"), "EnglishBritish")
+
+    def test_iso639_lookup_resolves_two_letter_code(self):
+        self.assertEqual(GoruutPhonemizer.get_lang("fr"), "French")
+
+    def test_pt_br_resolves_via_iso639_base_match(self):
+        result = GoruutPhonemizer.get_lang("pt-BR")
+        self.assertEqual(result, "Portuguese")
+
+    def test_unsupported_code_raises_valueerror_not_keyerror(self):
+        with self.assertRaises(ValueError):
+            GoruutPhonemizer.get_lang("xx-totally-invalid")
+
+
+class TestGoruutPhonemizeString(unittest.TestCase):
+    def test_phonemize_string_delegates_with_resolved_lang(self):
+        inst = GoruutPhonemizer.__new__(GoruutPhonemizer)
+        inst.pygoruut = MagicMock()
+        inst.pygoruut.phonemize.return_value = "fake_result"
+        result = inst.phonemize_string("bonjour", "fr")
+        inst.pygoruut.phonemize.assert_called_once_with(language="French", sentence="bonjour")
+        self.assertEqual(result, "fake_result")
+
+
+class TestEpitranGetLangAndDispatch(unittest.TestCase):
+    def test_get_lang_exact_match(self):
+        self.assertEqual(EpitranPhonemizer.get_lang("eng-Latn"), "eng-Latn")
+
+    def test_get_lang_unsupported_raises(self):
+        with self.assertRaises(ValueError):
+            EpitranPhonemizer.get_lang("xx-nope")
+
+    def test_phonemize_string_lazily_builds_and_caches_epi_instance(self):
+        inst = EpitranPhonemizer.__new__(EpitranPhonemizer)
+        fake_epitran_module = MagicMock()
+        fake_epi_instance = MagicMock()
+        fake_epi_instance.transliterate.return_value = "phonemes"
+        fake_epitran_module.Epitran.return_value = fake_epi_instance
+        inst.epitran = fake_epitran_module
+        inst._epis = {}
+
+        result1 = inst.phonemize_string("hello", "eng-Latn")
+        result2 = inst.phonemize_string("world", "eng-Latn")
+
+        fake_epitran_module.Epitran.assert_called_once_with("eng-Latn")
+        self.assertEqual(result1, "phonemes")
+        self.assertEqual(result2, "phonemes")
+
+    def test_phonemize_string_empty_input(self):
+        inst = EpitranPhonemizer.__new__(EpitranPhonemizer)
+        fake_epitran_module = MagicMock()
+        fake_epi_instance = MagicMock()
+        fake_epi_instance.transliterate.return_value = ""
+        fake_epitran_module.Epitran.return_value = fake_epi_instance
+        inst.epitran = fake_epitran_module
+        inst._epis = {}
+
+        result = inst.phonemize_string("", "eng-Latn")
+        self.assertEqual(result, "")
+
+
+class TestMisakiDispatchTable(unittest.TestCase):
+    """MisakiPhonemizer._get_phonemizer dispatches by resolved lang code to
+    one of five per-language backends (zh/ko/vi/ja/en), lazily importing and
+    caching each. Every branch is exercised with a mocked backend module."""
+
+    def _make_instance(self, alphabet=Alphabet.IPA):
+        inst = MisakiPhonemizer.__new__(MisakiPhonemizer)
+        inst.alphabet = alphabet
+        inst.g2p_en = inst.g2p_zh = inst.g2p_ko = inst.g2p_vi = inst.g2p_ja = None
+        return inst
+
+    def test_zh_branch_uses_zh_version_from_alphabet(self):
+        inst = self._make_instance(alphabet=Alphabet.BOPOMOFO)
+        fake_zh_mod = MagicMock()
+        fake_zh_g2p = MagicMock()
+        fake_zh_mod.ZHG2P.return_value = fake_zh_g2p
+        with patch.dict(sys.modules, {"misaki.zh": fake_zh_mod}):
+            result = inst._get_phonemizer("zh")
+        fake_zh_mod.ZHG2P.assert_called_once_with(version="1.1")
+        self.assertIs(result, fake_zh_g2p)
+        self.assertIs(inst.g2p_zh, fake_zh_g2p)
+
+    def test_zh_branch_ipa_version_default(self):
+        inst = self._make_instance(alphabet=Alphabet.IPA)
+        fake_zh_mod = MagicMock()
+        with patch.dict(sys.modules, {"misaki.zh": fake_zh_mod}):
+            inst._get_phonemizer("zh")
+        fake_zh_mod.ZHG2P.assert_called_once_with(version="1.0")
+
+    def test_ko_branch(self):
+        inst = self._make_instance()
+        fake_ko_mod = MagicMock()
+        fake_ko_g2p = MagicMock()
+        fake_ko_mod.KOG2P.return_value = fake_ko_g2p
+        with patch.dict(sys.modules, {"misaki.ko": fake_ko_mod}):
+            result = inst._get_phonemizer("ko")
+        self.assertIs(result, fake_ko_g2p)
+
+    def test_vi_branch(self):
+        inst = self._make_instance()
+        fake_vi_mod = MagicMock()
+        fake_vi_g2p = MagicMock()
+        fake_vi_mod.VIG2P.return_value = fake_vi_g2p
+        with patch.dict(sys.modules, {"misaki.vi": fake_vi_mod}):
+            result = inst._get_phonemizer("vi")
+        self.assertIs(result, fake_vi_g2p)
+
+    def test_ja_branch(self):
+        inst = self._make_instance()
+        fake_ja_mod = MagicMock()
+        fake_ja_g2p = MagicMock()
+        fake_ja_mod.JAG2P.return_value = fake_ja_g2p
+        with patch.dict(sys.modules, {"misaki.ja": fake_ja_mod}):
+            result = inst._get_phonemizer("ja")
+        self.assertIs(result, fake_ja_g2p)
+
+    def test_en_us_branch_sets_british_false(self):
+        inst = self._make_instance()
+        fake_misaki_pkg = MagicMock()
+        fake_en_mod = MagicMock()
+        fake_en_g2p = MagicMock()
+        fake_en_mod.G2P.return_value = fake_en_g2p
+        with patch.dict(sys.modules, {"misaki": fake_misaki_pkg, "misaki.en": fake_en_mod}), \
+             patch("misaki.en", fake_en_mod, create=True):
+            result = inst._get_phonemizer("en-US")
+        self.assertFalse(fake_en_g2p.british)
+
+    def test_en_gb_branch_sets_british_true(self):
+        inst = self._make_instance()
+        fake_misaki_pkg = MagicMock()
+        fake_en_mod = MagicMock()
+        fake_en_g2p = MagicMock()
+        fake_en_mod.G2P.return_value = fake_en_g2p
+        with patch.dict(sys.modules, {"misaki": fake_misaki_pkg, "misaki.en": fake_en_mod}), \
+             patch("misaki.en", fake_en_mod, create=True):
+            result = inst._get_phonemizer("en-GB")
+        self.assertTrue(fake_en_g2p.british)
+
+    def test_en_backend_is_cached_across_calls(self):
+        inst = self._make_instance()
+        fake_misaki_pkg = MagicMock()
+        fake_en_mod = MagicMock()
+        fake_en_g2p = MagicMock()
+        fake_en_mod.G2P.return_value = fake_en_g2p
+        with patch.dict(sys.modules, {"misaki": fake_misaki_pkg, "misaki.en": fake_en_mod}), \
+             patch("misaki.en", fake_en_mod, create=True):
+            inst._get_phonemizer("en-US")
+            inst._get_phonemizer("en-GB")
+        fake_en_mod.G2P.assert_called_once()
+
+    def test_unsupported_lang_raises_valueerror_not_keyerror(self):
+        inst = self._make_instance()
+        with self.assertRaises(ValueError):
+            inst._get_phonemizer("xx-nonexistent")
+
+    def test_phonemize_string_returns_phonemes_discards_tokens(self):
+        inst = self._make_instance()
+        fake_backend = MagicMock(return_value=("f oʊ n iː m z", ["tok1", "tok2"]))
+        with patch.object(inst, "_get_phonemizer", return_value=fake_backend):
+            result = inst.phonemize_string("phonemes", "en-US")
+        self.assertEqual(result, "f oʊ n iː m z")
+
+
+class TestCharsiuWordByWordDispatch(unittest.TestCase):
+    def test_phonemize_string_splits_and_joins_per_word(self):
+        inst = CharsiuPhonemizer.__new__(CharsiuPhonemizer)
+        calls = []
+
+        def fake_infer(word, lang):
+            calls.append((word, lang))
+            return f"[{word}]"
+
+        inst._infer_onnx = fake_infer
+        result = inst.phonemize_string("hello world again", "eng-uk")
+
+        self.assertEqual(result, "[hello] [world] [again]")
+        self.assertEqual(calls, [("hello", "eng-uk"), ("world", "eng-uk"), ("again", "eng-uk")])
+
+    def test_phonemize_string_empty_input_yields_empty_output(self):
+        inst = CharsiuPhonemizer.__new__(CharsiuPhonemizer)
+        inst._infer_onnx = MagicMock(return_value="")
+        result = inst.phonemize_string("", "eng-uk")
+        self.assertEqual(result, "")
+        inst._infer_onnx.assert_not_called()
+
+    def test_get_lang_unusual_lang_code_not_keyerror(self):
+        with self.assertRaises(ValueError):
+            CharsiuPhonemizer.get_lang("zz-doesnotexist")
+
+    def test_get_lang_valid_code(self):
+        self.assertEqual(CharsiuPhonemizer.get_lang("eng-uk"), "eng-uk")
+
+
+class TestByT5DecodePhones(unittest.TestCase):
+    def test_decode_phones_skips_added_tokens(self):
+        inst = ByT5Phonemizer.__new__(ByT5Phonemizer)
+        inst.tokens = {"1": "special"}
+        # token 3 -> byte 0 -> b'\x00' decodes to a control char; verify the
+        # added-token id (1) is excluded but ordinary ones are decoded.
+        preds = [1, 104 + 3, 105 + 3]  # skip "1", decode "h", "i"
+        result = inst._decode_phones(preds)
+        self.assertEqual(result, "hi")
+
+    def test_decode_phones_empty_predictions(self):
+        inst = ByT5Phonemizer.__new__(ByT5Phonemizer)
+        inst.tokens = {}
+        self.assertEqual(inst._decode_phones([]), "")
+
+    def test_infer_onnx_empty_text_returns_empty_without_running_session(self):
+        inst = ByT5Phonemizer.__new__(ByT5Phonemizer)
+        inst.session = MagicMock()
+        result = inst._infer_onnx("   ", "en-US")
+        self.assertEqual(result, "")
+        inst.session.run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adversarial test coverage for the phonemizer/alphabet-conversion layer, targeting the four lowest-covered modules.

- `phoonnx/alphabet_convert.py`: new `tests/test_alphabet_convert_edges.py` — BFS no-path detection, `_call_edge`'s TypeError arity fallback, `register_converter` overwrite semantics, src==tgt no-op short-circuit, and the best-effort script converters' ImportError/generic-exception passthrough (pykakasi hira/kana, pkuseg cangjie, unicodedata jamo decompose), mocked via `sys.modules` patching.
- `phoonnx/phonemizers/en.py`: new `tests/test_phonemizer_en.py` — DeepPhonemizer/OpenPhonemizer/G2PEnPhonemizer construction, `get_lang` validation (valid + unsupported codes), and `phonemize_string` dispatch, including the ARPA→IPA lookup's OOV-symbol passthrough and empty-input handling. Heavy backends (dp/torch, openphonemizer, nltk/g2p_en) mocked.
- `phoonnx/phonemizers/mul.py`: new `tests/test_phonemizer_mul.py` — EspeakPhonemizer's binary-vs-espyak dispatch and error wrapping, `get_lang` for en-gb/regional/unusual codes (zh-TW, pt-BR) always raising `ValueError` rather than `KeyError`, GruutPhonemizer's punctuation-driven sentence termination and missing-language-pack `RuntimeError`, GoruutPhonemizer's ISO639/non-standard lookup, EpitranPhonemizer's lazy per-lang engine cache, MisakiPhonemizer's five-way (zh/ko/vi/ja/en) dispatch and caching, CharsiuPhonemizer's word-by-word inference, and ByT5Phonemizer's `_decode_phones`/`_infer_onnx` empty-input guard.
- `phoonnx/phonemizers/ar.py`: extended `tests/test_ar.py` with a new `TestArbtokPhonemizer` class (previously untested) — register-alias resolution (`irab`/`i'rab`/`iʿrab`/`full`), lazy per-(lang, register) engine caching, missing-`arbtok` `ImportError` surfacing, and `phonemize_string` always routing through arbtok's `transcribe()` for bare, fully-diacritized, mixed Arabic/Latin, and empty input. Confirmed no code path bypasses arbtok for Arabic IPA.

Coverage (isolated run of the four new/extended test files against their targets):

| module | before | after |
|---|---|---|
| `alphabet_convert.py` | 69.5% | 77% |
| `phonemizers/en.py` | 17.5% | 48% |
| `phonemizers/mul.py` | 27.6% | 59% |
| `phonemizers/ar.py` | 48.5% | 53%* |

\* `ar.py`'s remaining uncovered lines (130-207) are the `if __name__ == "__main__"` demo/comparison script at the bottom of the file, not reachable via unit import; the two testable classes (`MantoqPhonemizer`, `ArbtokPhonemizer`) are otherwise fully exercised.

No bugs found in the reviewed code paths; `ArbtokPhonemizer` was specifically checked for any bypass of arbtok for Arabic IPA and none was found.

## Test plan

- [x] `python -m pytest tests/test_alphabet_convert_edges.py tests/test_phonemizer_en.py tests/test_phonemizer_mul.py tests/test_ar.py -q -p no:ovoscope` — 147 passed, 1 skipped (pre-existing skip)
- [x] Full suite (`tests/`): 879 passed, 6 skipped, 16 failed — same 16 pre-existing failures as baseline (matcha golden + styletts2/plbert env cluster: missing optional deps / checkpoint format), no new failures introduced