### PR TITLE
test: cover config format detection and tokenizer vocabulary construction

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -793,7 +793,7 @@ def get_phonemizer(phoneme_type: PhonemeType,
 
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     config_files = [
         "/home/miro/PycharmProjects/phoonnx_tts/sabela_cotovia_vits.json",
         "/home/miro/PycharmProjects/phoonnx_tts/celtia_vits.json",

--- a/tests/test_config_detection.py
+++ b/tests/test_config_detection.py
@@ -1,0 +1,336 @@
+import os
+import tempfile
+import unittest
+
+from phoonnx.config import Alphabet, Engine, PhonemeType, VoiceConfig
+
+
+class TestIsMimic3(unittest.TestCase):
+    def test_missing_phonemizer_key_is_false(self):
+        self.assertFalse(VoiceConfig.is_mimic3({"phonemes": {}}))
+
+    def test_non_string_phonemizer_is_false(self):
+        self.assertFalse(VoiceConfig.is_mimic3({"phonemizer": 123, "phonemes": {}}))
+
+    def test_missing_phonemes_key_is_false(self):
+        self.assertFalse(VoiceConfig.is_mimic3({"phonemizer": "gruut"}))
+
+    def test_phonemes_not_a_dict_is_false(self):
+        self.assertFalse(VoiceConfig.is_mimic3({"phonemizer": "gruut", "phonemes": ["a", "b"]}))
+
+    def test_unknown_phonemizer_string_returns_false_not_raise(self):
+        # detection must degrade gracefully on an unrecognised value, never raise
+        self.assertFalse(VoiceConfig.is_mimic3({"phonemizer": "not_a_real_phonemizer", "phonemes": {}}))
+
+    def test_each_known_phonemizer_value_is_true(self):
+        for val in ("symbols", "gruut", "espeak", "epitran"):
+            with self.subTest(val=val):
+                self.assertTrue(VoiceConfig.is_mimic3({"phonemizer": val, "phonemes": {}}))
+
+
+class TestIsPiper(unittest.TestCase):
+    def test_piper_version_key_short_circuits_true(self):
+        self.assertTrue(VoiceConfig.is_piper({"piper_version": "1.0.0"}))
+
+    def test_declared_non_piper_engine_wins_over_shape_sniffing(self):
+        # a canonical coqui/phoonnx config with an espeak-shaped phoneme_id_map
+        # must not be misdetected as piper just because it phonemizes with espeak
+        cfg = {"engine": "coqui", "phoneme_type": "espeak",
+               "phoneme_id_map": {"a": [0], "b": [1]}}
+        self.assertFalse(VoiceConfig.is_piper(cfg))
+
+    def test_missing_phoneme_type_is_false(self):
+        self.assertFalse(VoiceConfig.is_piper({"phoneme_id_map": {"a": [0]}}))
+
+    def test_non_string_phoneme_type_is_false(self):
+        self.assertFalse(VoiceConfig.is_piper({"phoneme_type": 5, "phoneme_id_map": {"a": [0]}}))
+
+    def test_flat_phoneme_id_map_is_not_piper(self):
+        # piper's phoneme_id_map values are lists; a flat phoneme->int map is the
+        # canonical phoonnx/coqui shape, not piper
+        cfg = {"phoneme_type": "espeak", "phoneme_id_map": {"a": 0, "b": 1}}
+        self.assertFalse(VoiceConfig.is_piper(cfg))
+
+    def test_empty_phoneme_id_map_is_false(self):
+        cfg = {"phoneme_type": "espeak", "phoneme_id_map": {}}
+        self.assertFalse(VoiceConfig.is_piper(cfg))
+
+    def test_missing_phoneme_id_map_is_false(self):
+        self.assertFalse(VoiceConfig.is_piper({"phoneme_type": "espeak"}))
+
+    def test_unknown_phonemizer_type_is_false(self):
+        cfg = {"phoneme_type": "not_espeak_or_text", "phoneme_id_map": {"a": [0]}}
+        self.assertFalse(VoiceConfig.is_piper(cfg))
+
+    def test_valid_piper_shape_is_true(self):
+        cfg = {"phoneme_type": "espeak", "phoneme_id_map": {"a": [0], "b": [1]}}
+        self.assertTrue(VoiceConfig.is_piper(cfg))
+
+
+class TestIsCoquiVits(unittest.TestCase):
+    def test_missing_characters_key_is_false(self):
+        self.assertFalse(VoiceConfig.is_coqui_vits({}))
+
+    def test_characters_not_a_dict_is_false(self):
+        self.assertFalse(VoiceConfig.is_coqui_vits({"characters": "nope"}))
+
+    def test_unrecognised_characters_class_is_false(self):
+        cfg = {"characters": {"characters_class": "some.other.Class"}}
+        self.assertFalse(VoiceConfig.is_coqui_vits(cfg))
+
+    def test_recognised_vits_characters_class_is_true(self):
+        cfg = {"characters": {"characters_class": "TTS.tts.models.vits.VitsCharacters"}}
+        self.assertTrue(VoiceConfig.is_coqui_vits(cfg))
+
+    def test_recognised_graphemes_class_is_true(self):
+        cfg = {"characters": {"characters_class": "TTS.tts.utils.text.characters.Graphemes"}}
+        self.assertTrue(VoiceConfig.is_coqui_vits(cfg))
+
+
+class TestIsPhoonnx(unittest.TestCase):
+    def test_missing_version_key_is_false(self):
+        self.assertFalse(VoiceConfig.is_phoonnx({}))
+
+    def test_version_key_present_is_true(self):
+        self.assertTrue(VoiceConfig.is_phoonnx({"phoonnx_version": "1.0"}))
+
+
+class TestFromDictChatterbox(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from tokenizers import Tokenizer
+        from tokenizers.models import BPE
+        from tokenizers.trainers import BpeTrainer
+
+        raw = Tokenizer(BPE(unk_token="[UNK]"))
+        raw.train_from_iterator(["hello world", "foo bar baz"],
+                                 trainer=BpeTrainer(special_tokens=["[UNK]"]))
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.bpe_path = os.path.join(cls.tmpdir, "tokenizer.json")
+        raw.save(cls.bpe_path)
+
+    def test_missing_bpe_tokenizer_json_raises_value_error_with_clear_message(self):
+        with self.assertRaises(ValueError) as ctx:
+            VoiceConfig.from_dict({"engine": "chatterbox"})
+        self.assertIn("tokenizer.json", str(ctx.exception))
+        self.assertIn("bpe_tokenizer_json", str(ctx.exception))
+
+    def test_chatterbox_detected_via_engine_string_literal(self):
+        vc = VoiceConfig.from_dict({}, engine="chatterbox", bpe_tokenizer_json=self.bpe_path)
+        self.assertEqual(vc.engine, Engine.CHATTERBOX)
+
+    def test_chatterbox_detected_via_config_engine_key(self):
+        vc = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path)
+        self.assertEqual(vc.engine, Engine.CHATTERBOX)
+
+    def test_chatterbox_defaults_phoneme_type_and_alphabet_to_unicode(self):
+        vc = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path)
+        self.assertEqual(vc.phoneme_type, PhonemeType.UNICODE)
+        self.assertEqual(vc.alphabet, Alphabet.UNICODE)
+
+    def test_chatterbox_enables_diacritics_for_arabic_and_hebrew(self):
+        vc_ar = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path, lang_code="ar")
+        vc_he = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path, lang_code="he")
+        vc_en = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path, lang_code="en")
+        self.assertTrue(vc_ar.add_diacritics)
+        self.assertTrue(vc_he.add_diacritics)
+        self.assertFalse(vc_en.add_diacritics)
+
+    def test_chatterbox_defaults_sample_rate_to_24000(self):
+        vc = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path)
+        self.assertEqual(vc.sample_rate, 24000)
+
+    def test_chatterbox_num_symbols_derived_from_tokenizer_vocab_size(self):
+        vc = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path)
+        self.assertEqual(vc.num_symbols, vc.tokenizer._tok.get_vocab_size())
+
+
+class TestFromDictMimic3PhonemeTypeBranches(unittest.TestCase):
+    def _mimic3_cfg(self, phonemizer):
+        return {"phonemizer": phonemizer, "phonemes": {}, "text_language": "en"}
+
+    def test_symbols_phonemizer_yields_graphemes_and_unicode_alphabet(self):
+        vc = VoiceConfig.from_dict(self._mimic3_cfg("symbols"), tokens_txt="0 _\n1 a\n2 b\n")
+        self.assertEqual(vc.phoneme_type, PhonemeType.GRAPHEMES)
+        self.assertEqual(vc.alphabet, Alphabet.UNICODE)
+        self.assertEqual(vc.engine, Engine.MIMIC3)
+
+    def test_gruut_phonemizer_yields_ipa_alphabet(self):
+        vc = VoiceConfig.from_dict(self._mimic3_cfg("gruut"), tokens_txt="0 _\n1 a\n2 b\n")
+        self.assertEqual(vc.phoneme_type, PhonemeType.GRUUT)
+        self.assertEqual(vc.alphabet, Alphabet.IPA)
+
+    def test_missing_tokens_txt_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            VoiceConfig.from_dict(self._mimic3_cfg("gruut"))
+        self.assertIn("phonemes.txt", str(ctx.exception))
+
+
+class TestFromDictCoqui(unittest.TestCase):
+    def test_coqui_defaults_graphemes_and_unicode(self):
+        cfg = {"characters": {"characters_class": "TTS.tts.utils.text.characters.Graphemes",
+                              "characters": "ab", "punctuations": ""}}
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertEqual(vc.engine, Engine.COQUI)
+        self.assertEqual(vc.phoneme_type, PhonemeType.GRAPHEMES)
+        self.assertEqual(vc.alphabet, Alphabet.UNICODE)
+
+    def test_coqui_lang_code_pulled_from_datasets_when_absent(self):
+        cfg = {"characters": {"characters_class": "TTS.tts.utils.text.characters.Graphemes",
+                              "characters": "ab", "punctuations": ""},
+               "datasets": [{"language": "pt-pt"}]}
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertEqual(vc.lang_code, "pt-PT")
+
+    def test_coqui_explicit_lang_code_wins_over_datasets(self):
+        cfg = {"characters": {"characters_class": "TTS.tts.utils.text.characters.Graphemes",
+                              "characters": "ab", "punctuations": ""},
+               "datasets": [{"language": "pt-pt"}]}
+        vc = VoiceConfig.from_dict(cfg, lang_code="en")
+        self.assertEqual(vc.lang_code, "en")
+
+
+class TestFromDictPiperBranches(unittest.TestCase):
+    def _piper_cfg(self, phoneme_type="espeak", **extra):
+        cfg = {"piper_version": "1.0.0", "phoneme_type": phoneme_type,
+               "phoneme_id_map": {"a": [0], "b": [1]},
+               "espeak": {"voice": "en-us"}}
+        cfg.update(extra)
+        return cfg
+
+    def test_text_phoneme_type_maps_to_unicode_grapheme_model(self):
+        vc = VoiceConfig.from_dict(self._piper_cfg("text"))
+        self.assertEqual(vc.phoneme_type, PhonemeType.UNICODE)
+        self.assertEqual(vc.alphabet, Alphabet.UNICODE)
+
+    def test_pygoruut_phoneme_type_maps_to_goruut_ipa(self):
+        vc = VoiceConfig.from_dict(self._piper_cfg("pygoruut"))
+        self.assertEqual(vc.phoneme_type, PhonemeType.GORUUT)
+        self.assertEqual(vc.alphabet, Alphabet.IPA)
+
+    def test_espeak_phoneme_type_defaults_to_ipa_alphabet(self):
+        vc = VoiceConfig.from_dict(self._piper_cfg("espeak"))
+        self.assertEqual(vc.alphabet, Alphabet.IPA)
+
+    def test_lang_code_falls_back_to_espeak_voice(self):
+        vc = VoiceConfig.from_dict(self._piper_cfg())
+        self.assertEqual(vc.lang_code, "en-US")
+
+    def test_arabic_lang_code_enables_diacritics(self):
+        cfg = self._piper_cfg()
+        cfg["espeak"] = {"voice": "ar"}
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertTrue(vc.add_diacritics)
+
+
+class TestFromDictTransformersVocabBranch(unittest.TestCase):
+    def test_vocab_without_tokenizer_config_defaults_add_blank_true(self):
+        vocab = {"_": 0, "a": 1, "b": 2}
+        vc = VoiceConfig.from_dict({"blank": "_"}, vocab=vocab, phoneme_type="graphemes",
+                                    alphabet="unicode", lang_code="en")
+        self.assertTrue(vc.tokenizer.add_blank_char)
+        self.assertTrue(vc.tokenizer.blank_at_start)
+        self.assertTrue(vc.tokenizer.blank_at_end)
+        self.assertFalse(vc.tokenizer.use_eos_bos)
+
+    def test_vocab_with_tokenizer_config_overrides_lang_and_blank(self):
+        vocab = {"_": 0, "a": 1, "b": 2}
+        tok_cfg = {"add_blank": False, "language": "pt", "pad_token": "_"}
+        vc = VoiceConfig.from_dict({}, vocab=vocab, tokenizer_config=tok_cfg,
+                                    phoneme_type="graphemes", alphabet="unicode")
+        self.assertFalse(vc.tokenizer.add_blank_char)
+        self.assertEqual(vc.lang_code, "pt")
+
+
+class TestFromDictSherpaTokensTxtBranch(unittest.TestCase):
+    def test_txt_extension_builds_tokenizer_with_eos_bos(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+            f.write("_ 0\na 1\nb 2\n")
+            path = f.name
+        try:
+            vc = VoiceConfig.from_dict({}, tokens_txt=path, phoneme_type="graphemes",
+                                        alphabet="unicode", lang_code="en")
+            self.assertTrue(vc.tokenizer.use_eos_bos)
+            self.assertTrue(vc.tokenizer.add_blank_char)
+        finally:
+            os.unlink(path)
+
+
+class TestGetPhonemizerDispatch(unittest.TestCase):
+    def test_unsupported_phoneme_type_raises_value_error(self):
+        from phoonnx.config import get_phonemizer
+        with self.assertRaises(ValueError):
+            get_phonemizer("not-a-real-phoneme-type")
+
+    def test_espeak_phoneme_type_returns_espeak_phonemizer(self):
+        from phoonnx.config import get_phonemizer
+        from phoonnx.phonemizers import EspeakPhonemizer
+        phonemizer = get_phonemizer(PhonemeType.ESPEAK)
+        self.assertIsInstance(phonemizer, EspeakPhonemizer)
+
+    def test_graphemes_phoneme_type_returns_grapheme_phonemizer(self):
+        from phoonnx.config import get_phonemizer
+        from phoonnx.phonemizers import GraphemePhonemizer
+        phonemizer = get_phonemizer(PhonemeType.GRAPHEMES)
+        self.assertIsInstance(phonemizer, GraphemePhonemizer)
+
+
+class TestDiacritizerModelRoundTrip(unittest.TestCase):
+    def test_native_config_round_trips_custom_diacritizer_model(self):
+        cfg = {"phoonnx_version": "1.0", "phoneme_id_map": {"_": 0, "^": 1, "$": 2, "a": 3},
+               "inference": {"diacritizer_model": "custom-diacritizer"}}
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertEqual(vc.diacritizer_model, "custom-diacritizer")
+        native = vc.to_native_dict()
+        self.assertEqual(native["inference"]["diacritizer_model"], "custom-diacritizer")
+        vc2 = VoiceConfig.from_dict(native)
+        self.assertEqual(vc2.diacritizer_model, "custom-diacritizer")
+
+    def test_default_diacritizer_model_used_when_absent(self):
+        cfg = {"phoonnx_version": "1.0", "phoneme_id_map": {"_": 0, "^": 1, "$": 2, "a": 3}}
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertEqual(vc.diacritizer_model, "rawi-ensemble")
+
+    def test_non_phoonnx_config_also_carries_diacritizer_model_through_inference(self):
+        cfg = {"inference": {"diacritizer_model": "other-model"}}
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertEqual(vc.diacritizer_model, "other-model")
+
+
+class TestPostInit(unittest.TestCase):
+    def test_arabic_lang_code_defaults_add_diacritics_true(self):
+        vc = VoiceConfig(num_symbols=1, num_speakers=1, num_langs=1, sample_rate=16000,
+                          lang_code="ar", phoneme_type=PhonemeType.ESPEAK, alphabet=Alphabet.IPA,
+                          phonemizer_model=None)
+        self.assertTrue(vc.add_diacritics)
+
+    def test_non_arabic_lang_code_defaults_add_diacritics_false(self):
+        vc = VoiceConfig(num_symbols=1, num_speakers=1, num_langs=1, sample_rate=16000,
+                          lang_code="en", phoneme_type=PhonemeType.ESPEAK, alphabet=Alphabet.IPA,
+                          phonemizer_model=None)
+        self.assertFalse(vc.add_diacritics)
+
+    def test_explicit_add_diacritics_is_not_overridden(self):
+        vc = VoiceConfig(num_symbols=1, num_speakers=1, num_langs=1, sample_rate=16000,
+                          lang_code="ar", phoneme_type=PhonemeType.ESPEAK, alphabet=Alphabet.IPA,
+                          phonemizer_model=None, add_diacritics=False)
+        self.assertFalse(vc.add_diacritics)
+
+    def test_missing_lang_code_defaults_to_und(self):
+        vc = VoiceConfig(num_symbols=1, num_speakers=1, num_langs=1, sample_rate=16000,
+                          lang_code=None, phoneme_type=PhonemeType.ESPEAK, alphabet=Alphabet.IPA,
+                          phonemizer_model=None)
+        self.assertEqual(vc.lang_code, "und")
+
+    def test_string_engine_alphabet_phoneme_type_are_cast_to_enums(self):
+        vc = VoiceConfig(num_symbols=1, num_speakers=1, num_langs=1, sample_rate=16000,
+                          lang_code="en", phoneme_type="espeak", alphabet="ipa",
+                          phonemizer_model=None, engine="piper")
+        self.assertIsInstance(vc.engine, Engine)
+        self.assertIsInstance(vc.alphabet, Alphabet)
+        self.assertIsInstance(vc.phoneme_type, PhonemeType)
+        self.assertEqual(vc.engine, Engine.PIPER)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tokenizer_vocab.py
+++ b/tests/test_tokenizer_vocab.py
@@ -1,0 +1,443 @@
+import json
+import os
+import tempfile
+import unittest
+
+from phoonnx.tokenizer import (
+    BlankBetween,
+    BPETokenizer,
+    ChatterboxMTLTokenizer,
+    TTSTokenizer,
+    Vocabulary,
+    load_chatterbox_tokenizer,
+    phoneme_map_seed,
+    untrained_map_symbols,
+)
+
+
+def _tiny_tokenizer(add_blank_char, add_blank_word, use_eos_bos,
+                     blank_at_start=True, blank_at_end=True):
+    voc = Vocabulary(char2idx={"_": 0, "^": 1, "$": 2, " ": 3, "a": 4, "b": 5},
+                      pad="_", bos="^", eos="$", blank="_", blank_word=" ")
+    return TTSTokenizer(voc, add_blank_char=add_blank_char,
+                        add_blank_word=add_blank_word,
+                        use_eos_bos=use_eos_bos,
+                        blank_at_start=blank_at_start,
+                        blank_at_end=blank_at_end)
+
+
+class TestTinyVocabBooleanPermutations(unittest.TestCase):
+    """A wrong token ID here corrupts audio silently -- assert exact sequences."""
+
+    def test_add_blank_char_true_use_eos_bos_true(self):
+        tok = _tiny_tokenizer(add_blank_char=True, add_blank_word=False, use_eos_bos=True)
+        self.assertEqual(tok.tokenize("ab"), [1, 0, 4, 0, 5, 0, 2])
+
+    def test_add_blank_char_true_use_eos_bos_false(self):
+        tok = _tiny_tokenizer(add_blank_char=True, add_blank_word=False, use_eos_bos=False)
+        self.assertEqual(tok.tokenize("ab"), [0, 4, 0, 5, 0])
+
+    def test_add_blank_char_false_use_eos_bos_true(self):
+        tok = _tiny_tokenizer(add_blank_char=False, add_blank_word=False, use_eos_bos=True)
+        self.assertEqual(tok.tokenize("ab"), [1, 0, 4, 5, 2])
+
+    def test_add_blank_char_false_use_eos_bos_false(self):
+        tok = _tiny_tokenizer(add_blank_char=False, add_blank_word=False, use_eos_bos=False)
+        self.assertEqual(tok.tokenize("ab"), [0, 4, 5])
+
+    def test_word_blank_vs_char_blank(self):
+        # add_blank_word appends the word-separator id at encode-time (mimic3
+        # compatibility); add_blank_char is off so no interspersed blanks appear.
+        tok = _tiny_tokenizer(add_blank_char=False, add_blank_word=True, use_eos_bos=False,
+                              blank_at_start=False, blank_at_end=True)
+        self.assertEqual(tok.tokenize("a b"), [4, 3, 5, 3])
+
+    def test_blank_at_start_false_blank_at_end_true(self):
+        tok = _tiny_tokenizer(add_blank_char=True, add_blank_word=False, use_eos_bos=False,
+                              blank_at_start=False, blank_at_end=True)
+        self.assertEqual(tok.tokenize("ab"), [4, 0, 5, 0])
+
+    def test_blank_at_start_true_blank_at_end_false(self):
+        tok = _tiny_tokenizer(add_blank_char=True, add_blank_word=False, use_eos_bos=False,
+                              blank_at_start=True, blank_at_end=False)
+        self.assertEqual(tok.tokenize("ab"), [0, 4, 0, 5])
+
+    def test_blank_at_start_false_blank_at_end_false(self):
+        tok = _tiny_tokenizer(add_blank_char=True, add_blank_word=False, use_eos_bos=False,
+                              blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.tokenize("ab"), [4, 0, 5])
+
+
+class TestVocabularyFromPiperConfig(unittest.TestCase):
+    def test_missing_phoneme_id_map_yields_empty_vocab_with_defaults(self):
+        voc = Vocabulary.from_piper_config({})
+        self.assertEqual(voc.char2idx, {})
+        self.assertEqual(voc.pad, "_")
+        self.assertEqual(voc.bos, "^")
+        self.assertEqual(voc.eos, "$")
+        self.assertEqual(voc.blank, "_")
+
+    def test_extracts_first_element_of_id_lists(self):
+        cfg = {"phoneme_id_map": {"a": [4, 99], "b": [5]}}
+        voc = Vocabulary.from_piper_config(cfg)
+        self.assertEqual(voc.char2idx, {"a": 4, "b": 5})
+
+    def test_explicit_special_tokens_override_defaults(self):
+        cfg = {"phoneme_id_map": {}, "pad": "<P>", "bos": "<B>", "eos": "<E>", "blank": "<K>"}
+        voc = Vocabulary.from_piper_config(cfg)
+        self.assertEqual((voc.pad, voc.bos, voc.eos, voc.blank), ("<P>", "<B>", "<E>", "<K>"))
+
+
+class TestVocabularyFromMimic3Config(unittest.TestCase):
+    def test_duplicate_ids_across_distinct_tokens_do_not_raise(self):
+        # Two distinct phoneme strings sharing an id is a legal (if unusual)
+        # tokens.txt shape; char2idx is keyed by token, so both survive, but
+        # idx2char collapses to whichever entry iterates last.
+        tokens_txt = "0 a\n0 b\n1 c\n"
+        voc = Vocabulary.from_tokens_txt(tokens_txt, id_first=True)
+        self.assertEqual(voc.char2idx, {"a": 0, "b": 0, "c": 1})
+        self.assertIn(voc.idx2char[0], {"a", "b"})
+
+    def test_out_of_range_id_is_accepted_without_validation(self):
+        # from_tokens_txt performs no bounds checking on the parsed id.
+        tokens_txt = "0 a\n9999 b\n-5 c\n"
+        voc = Vocabulary.from_tokens_txt(tokens_txt, id_first=True)
+        self.assertEqual(voc.char2idx["b"], 9999)
+        self.assertEqual(voc.char2idx["c"], -5)
+
+    def test_malformed_lines_are_skipped_not_raised(self):
+        tokens_txt = "0 a\n\nnotanumber token\nsingletoken\n1 b\n"
+        voc = Vocabulary.from_tokens_txt(tokens_txt, id_first=True)
+        self.assertEqual(voc.char2idx, {"a": 0, "b": 1})
+
+    def test_special_tokens_pulled_from_phonemes_section(self):
+        tokens_txt = "0 _\n1 ^\n2 $\n3 a\n"
+        cfg = {"phonemes": {"pad": "_", "bos": "^", "eos": "$",
+                             "blank": "_", "blank_word": " "}}
+        voc = Vocabulary.from_mimic3_config(cfg, tokens_txt)
+        self.assertEqual(voc.pad, "_")
+        self.assertEqual(voc.bos, "^")
+        self.assertEqual(voc.eos, "$")
+        self.assertEqual(voc.blank, "_")
+        self.assertEqual(voc.blank_word, " ")
+
+    def test_phoneme_separator_and_word_separator_fallbacks(self):
+        # when "pad"/"blank_word" are absent, mimic3 configs use the older
+        # "phoneme_separator" / "word_separator" key names instead.
+        tokens_txt = "0 _\n1 a\n"
+        cfg = {"phonemes": {"phoneme_separator": "_", "word_separator": "#"}}
+        voc = Vocabulary.from_mimic3_config(cfg, tokens_txt)
+        self.assertEqual(voc.pad, "_")
+        self.assertEqual(voc.blank_word, "#")
+
+
+class TestVocabularyFromCoquiConfig(unittest.TestCase):
+    def test_unsupported_characters_class_raises(self):
+        cfg = {"characters": {"characters_class": "some.other.Class"}}
+        with self.assertRaises(ValueError):
+            Vocabulary.from_coqui_config(cfg)
+
+    def test_vits_characters_layout_exact_ids(self):
+        cfg = {"characters": {
+            "characters_class": "TTS.tts.models.vits.VitsCharacters",
+            "pad": "_", "punctuations": "!,",
+            "characters": "ab", "blank": "<BLNK>",
+        }}
+        voc = Vocabulary.from_coqui_config(cfg)
+        # vocab = punctuations + characters, pad inserted at 0, blank appended
+        self.assertEqual(voc.char2idx, {"_": 0, "!": 1, ",": 2, "a": 3, "b": 4, "<BLNK>": 5})
+
+    def test_vits_characters_add_blank_defaults_blank_token(self):
+        cfg = {"characters": {
+            "characters_class": "TTS.tts.models.vits.VitsCharacters",
+            "punctuations": "", "characters": "a",
+        }, "add_blank": True}
+        voc = Vocabulary.from_coqui_config(cfg)
+        self.assertEqual(voc.blank, "<BLNK>")
+        self.assertIn("<BLNK>", voc.char2idx)
+
+    def test_graphemes_layout_exact_ordering(self):
+        cfg = {"characters": {
+            "characters_class": "TTS.tts.utils.text.characters.Graphemes",
+            "pad": "_", "bos": "^", "eos": "$", "blank": "@",
+            "characters": "ba", "punctuations": "!",
+        }}
+        voc = Vocabulary.from_coqui_config(cfg)
+        # order: pad, eos, bos, blank, *characters(unsorted, as given), *punctuations
+        self.assertEqual(list(voc.char2idx.keys()), ["_", "$", "^", "@", "b", "a", "!"])
+
+    def test_graphemes_unique_and_sorted(self):
+        cfg = {"characters": {
+            "characters_class": "TTS.tts.utils.text.characters.Graphemes",
+            "characters": "baab", "punctuations": "",
+            "is_unique": True, "is_sorted": True,
+        }}
+        voc = Vocabulary.from_coqui_config(cfg)
+        self.assertEqual(list(voc.char2idx.keys()), ["a", "b"])
+
+
+class TestChatterboxTokenizerLoading(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from tokenizers import Tokenizer
+        from tokenizers.models import BPE
+        from tokenizers.trainers import BpeTrainer
+
+        cls.tmpdir = tempfile.mkdtemp()
+
+        base_tok = Tokenizer(BPE(unk_token="[UNK]"))
+        base_tok.train_from_iterator(["hello world", "foo bar baz"],
+                                      trainer=BpeTrainer(special_tokens=["[UNK]"]))
+        cls.base_path = os.path.join(cls.tmpdir, "base_tokenizer.json")
+        base_tok.save(cls.base_path)
+
+        mtl_tok = Tokenizer(BPE(unk_token="[UNK]"))
+        mtl_tok.train_from_iterator(["hello world", "foo bar baz"],
+                                     trainer=BpeTrainer(special_tokens=["[UNK]", "[SPACE]", "[pt]"]))
+        cls.mtl_path = os.path.join(cls.tmpdir, "mtl_tokenizer.json")
+        mtl_tok.save(cls.mtl_path)
+
+    def test_no_space_token_yields_plain_bpe_tokenizer(self):
+        tok = load_chatterbox_tokenizer(self.base_path)
+        self.assertIsInstance(tok, BPETokenizer)
+        self.assertNotIsInstance(tok, ChatterboxMTLTokenizer)
+
+    def test_space_token_present_yields_mtl_tokenizer(self):
+        tok = load_chatterbox_tokenizer(self.mtl_path)
+        self.assertIsInstance(tok, ChatterboxMTLTokenizer)
+
+    def test_bpe_tokenizer_encodes_to_int_ids(self):
+        tok = load_chatterbox_tokenizer(self.base_path)
+        ids = tok.tokenize("hello world")
+        self.assertTrue(len(ids) > 0)
+        self.assertTrue(all(isinstance(i, int) for i in ids))
+
+    def test_bpe_tokenizer_joins_list_input_before_encoding(self):
+        tok = load_chatterbox_tokenizer(self.base_path)
+        self.assertEqual(tok.tokenize(["h", "i"]), tok.tokenize("hi"))
+
+    def test_mtl_tokenizer_without_language_degrades_to_plain_bpe(self):
+        tok = load_chatterbox_tokenizer(self.mtl_path)
+        # no language given and lang_tokens absent -> same output as base encode
+        self.assertEqual(tok.tokenize("hello"), list(tok._tok.encode("hello").ids))
+
+    def test_mtl_tokenizer_unknown_language_without_vocab_token_degrades(self):
+        tok = load_chatterbox_tokenizer(self.mtl_path)
+        # "xx" has no [xx] token in this tiny vocab and no lang_tokens override
+        self.assertEqual(tok.tokenize("hello", language="xx"),
+                         list(tok._tok.encode("hello").ids))
+
+    def test_mtl_tokenizer_known_language_prefixes_lang_token(self):
+        tok = load_chatterbox_tokenizer(self.mtl_path)
+        out = tok.tokenize("hello", language="pt")
+        plain = list(tok._tok.encode("hello").ids)
+        self.assertNotEqual(out, plain)
+
+    def test_mtl_tokenizer_joins_list_input(self):
+        tok = load_chatterbox_tokenizer(self.mtl_path)
+        self.assertEqual(tok.tokenize(["he", "llo"], language="pt"),
+                         tok.tokenize("hello", language="pt"))
+
+    def test_mtl_tokenizer_explicit_lang_tokens_override_wins(self):
+        tok = load_chatterbox_tokenizer(self.mtl_path)
+        # literal lang_tokens entry is honoured even for a code with no vocab entry
+        out_literal = tok.tokenize("hello", language="eg-EG", lang_tokens={"eg-EG": "pt"})
+        out_derived = tok.tokenize("hello", language="pt")
+        self.assertEqual(out_literal, out_derived)
+
+
+class TestPhonemeMapSeedAndUntrainedSymbols(unittest.TestCase):
+    def test_seed_includes_default_ipa_table_when_requested(self):
+        syms = phoneme_map_seed({"x_custom"}, ipa=True)
+        self.assertIn("x_custom", syms)
+        self.assertIn("a", syms)  # from DEFAULT_IPA_PHONEME_ID_MAP
+
+    def test_seed_excludes_defaults_when_include_defaults_false(self):
+        syms = phoneme_map_seed({"x_custom"}, ipa=True, include_defaults=False)
+        self.assertEqual(syms, {"x_custom"})
+
+    def test_seed_excludes_defaults_when_not_ipa(self):
+        syms = phoneme_map_seed({"x_custom"}, ipa=False)
+        self.assertEqual(syms, {"x_custom"})
+
+    def test_untrained_symbols_excludes_special_tokens(self):
+        phoneme_id_map = {"_": 0, "^": 1, "$": 2, " ": 3, "a": 4, "z": 5}
+        untrained = untrained_map_symbols(phoneme_id_map, corpus_phonemes={"a"})
+        # special tokens (_, ^, $, blank-word " ") are excluded even though
+        # they're absent from the corpus; only "z" is a genuinely unseen symbol.
+        self.assertEqual(untrained, ["z"])
+
+    def test_untrained_symbols_empty_when_all_covered(self):
+        phoneme_id_map = {"a": 0, "b": 1}
+        self.assertEqual(untrained_map_symbols(phoneme_id_map, corpus_phonemes={"a", "b"}), [])
+
+
+class TestTTSTokenizerFactoriesFromConfig(unittest.TestCase):
+    def test_from_piper_config_defaults(self):
+        cfg = {"phoneme_id_map": {"a": [4], "b": [5]}, "pad": "_", "bos": "^", "eos": "$", "blank": "_"}
+        tok = TTSTokenizer.from_piper_config(cfg)
+        self.assertTrue(tok.add_blank_char)
+        self.assertFalse(tok.add_blank_word)
+        self.assertTrue(tok.use_eos_bos)
+        self.assertTrue(tok.blank_at_start)
+        self.assertTrue(tok.blank_at_end)
+
+    def test_from_mimic3_config_tokens_blank(self):
+        cfg = {"phonemes": {"blank_between": "tokens", "blank_at_end": False,
+                             "blank_at_start": False, "auto_bos_eos": False}}
+        tok = TTSTokenizer.from_mimic3_config(cfg, "0 _\n1 a\n")
+        self.assertTrue(tok.add_blank_char)  # blank_between != WORDS
+        self.assertFalse(tok.add_blank_word)  # blank_between == TOKENS
+        self.assertFalse(tok.blank_at_end)
+        self.assertFalse(tok.blank_at_start)
+        self.assertFalse(tok.use_eos_bos)
+
+    def test_from_mimic3_config_words_blank(self):
+        cfg = {"phonemes": {"blank_between": "words"}}
+        tok = TTSTokenizer.from_mimic3_config(cfg, "0 _\n1 a\n")
+        self.assertFalse(tok.add_blank_char)  # blank_between == WORDS
+        self.assertTrue(tok.add_blank_word)
+
+    def test_from_tokens_txt_factory_defaults(self):
+        tok = TTSTokenizer.from_tokens_txt("0 _\n1 a\n2 b\n")
+        self.assertTrue(tok.add_blank_char)
+        self.assertFalse(tok.add_blank_word)
+        self.assertTrue(tok.blank_at_start)
+        self.assertTrue(tok.blank_at_end)
+        self.assertFalse(tok.use_eos_bos)
+
+    def test_from_coqui_config_add_blank_true(self):
+        cfg = {"characters": {"characters_class": "TTS.tts.utils.text.characters.Graphemes",
+                              "characters": "ab", "punctuations": ""},
+               "add_blank": True, "enable_eos_bos_chars": True}
+        tok = TTSTokenizer.from_coqui_config(cfg)
+        self.assertTrue(tok.add_blank_char)
+        self.assertTrue(tok.blank_at_start)
+        self.assertTrue(tok.blank_at_end)
+        self.assertTrue(tok.use_eos_bos)
+        self.assertFalse(tok.add_blank_word)
+
+    def test_from_coqui_config_add_blank_false_defaults(self):
+        cfg = {"characters": {"characters_class": "TTS.tts.utils.text.characters.Graphemes",
+                              "characters": "ab", "punctuations": ""}}
+        tok = TTSTokenizer.from_coqui_config(cfg)
+        self.assertFalse(tok.add_blank_char)
+        self.assertFalse(tok.blank_at_start)
+        self.assertFalse(tok.blank_at_end)
+        self.assertFalse(tok.use_eos_bos)
+
+
+class TestCompoundPhonemeEncoding(unittest.TestCase):
+    """Mimic3-style tokens.txt can define multi-character (diphthong) tokens
+    that must be matched greedily before falling back to single characters."""
+
+    def test_compound_token_preferred_over_single_chars(self):
+        voc = Vocabulary(char2idx={"a": 0, "i": 1, "ai": 2}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("ai"), [2])
+
+    def test_unmatched_compound_falls_back_to_single_chars(self):
+        voc = Vocabulary(char2idx={"a": 0, "b": 1, "ai": 2}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("ab"), [0, 1])
+
+    def test_out_of_vocabulary_characters_are_dropped(self):
+        voc = Vocabulary(char2idx={"a": 0}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("azb"), [0])
+
+
+class TestBosEosSafetyPath(unittest.TestCase):
+    def test_pad_with_bos_eos_without_bos_returns_input_unchanged(self):
+        voc = Vocabulary(char2idx={"a": 0}, bos=None, eos="$")
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.pad_with_bos_eos([0]), [0])
+
+    def test_intersperse_without_blank_token_returns_input_unchanged(self):
+        voc = Vocabulary(char2idx={"a": 0}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=True, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=True, blank_at_end=True)
+        self.assertEqual(tok.intersperse_blank_char([0]), [0])
+
+
+class TestVocabularyAndTokenizerFromPhoonnxConfig(unittest.TestCase):
+    def test_vocabulary_from_phoonnx_config_defaults(self):
+        voc = Vocabulary.from_phoonnx_config({"phoneme_id_map": {"a": 0}})
+        self.assertEqual(voc.char2idx, {"a": 0})
+        self.assertEqual((voc.pad, voc.bos, voc.eos, voc.blank), ("_", "^", "$", "_"))
+
+    def test_vocabulary_from_phoonnx_config_explicit_tokens(self):
+        cfg = {"phoneme_id_map": {"a": 0}, "pad": "P", "bos": "B", "eos": "E", "blank": "K"}
+        voc = Vocabulary.from_phoonnx_config(cfg)
+        self.assertEqual((voc.pad, voc.bos, voc.eos, voc.blank), ("P", "B", "E", "K"))
+
+    def test_tokenizer_from_phoonnx_config_defaults(self):
+        cfg = {"phoneme_id_map": {"a": 0, "_": 1, "^": 2, "$": 3}}
+        tok = TTSTokenizer.from_phoonnx_config(cfg)
+        self.assertTrue(tok.add_blank_char)
+        self.assertTrue(tok.blank_at_start)
+        self.assertTrue(tok.blank_at_end)
+        self.assertTrue(tok.use_eos_bos)
+        self.assertFalse(tok.add_blank_word)
+
+    def test_tokenizer_from_phoonnx_config_explicit_flags_respected(self):
+        cfg = {"phoneme_id_map": {"a": 0}, "add_blank_char": False, "blank_at_end": False,
+               "blank_at_start": False, "use_eos_bos": False, "add_blank_word": True}
+        tok = TTSTokenizer.from_phoonnx_config(cfg)
+        self.assertFalse(tok.add_blank_char)
+        self.assertFalse(tok.blank_at_end)
+        self.assertFalse(tok.blank_at_start)
+        self.assertFalse(tok.use_eos_bos)
+        self.assertTrue(tok.add_blank_word)
+
+
+class TestVocabularyProperties(unittest.TestCase):
+    def test_num_chars_and_ids(self):
+        voc = Vocabulary(char2idx={"_": 0, "^": 1, "$": 2, " ": 3, "a": 4},
+                          pad="_", bos="^", eos="$", blank="_", blank_word=" ")
+        self.assertEqual(voc.num_chars, 5)
+        self.assertEqual(voc.pad_id, 0)
+        self.assertEqual(voc.bos_id, 1)
+        self.assertEqual(voc.eos_id, 2)
+        self.assertEqual(voc.blank_id, 0)
+        self.assertEqual(voc.blank_word_id, 3)
+
+    def test_tokenizer_blank_word_id_property(self):
+        voc = Vocabulary(char2idx={" ": 3}, blank_word=" ")
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=True,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.blank_word_id, 3)
+
+    def test_ids_are_none_when_special_token_absent_from_vocab(self):
+        voc = Vocabulary(char2idx={"a": 0}, pad="_", bos=None, eos=None, blank=None, blank_word=None)
+        self.assertIsNone(voc.pad_id)  # "_" not in char2idx
+        self.assertIsNone(voc.bos_id)
+        self.assertIsNone(voc.eos_id)
+        self.assertIsNone(voc.blank_id)
+        self.assertIsNone(voc.blank_word_id)
+
+
+class TestBPETokenizerDelegates(unittest.TestCase):
+    def test_encode_delegates_to_tokenize(self):
+        from tokenizers import Tokenizer
+        from tokenizers.models import BPE
+        from tokenizers.trainers import BpeTrainer
+
+        raw = Tokenizer(BPE(unk_token="[UNK]"))
+        raw.train_from_iterator(["hello world"], trainer=BpeTrainer(special_tokens=["[UNK]"]))
+        path = os.path.join(tempfile.mkdtemp(), "t.json")
+        raw.save(path)
+
+        tok = BPETokenizer(path)
+        self.assertEqual(tok.encode("hello"), tok.tokenize("hello"))
+        self.assertIsNone(tok.pad_id)
+        self.assertIsNone(tok.blank_id)
+        self.assertIsNone(tok.blank_word_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `tests/test_config_detection.py` covering `phoonnx/config.py` format-detection branches: `is_mimic3`/`is_piper`/`is_coqui_vits`/`is_phoonnx`, and the Chatterbox/piper/mimic3/coqui/transformers-vocab/sherpa-tokens_txt arms of `VoiceConfig.from_dict`, plus the `diacritizer_model` round-trip through `to_native_dict`.
- Adds `tests/test_tokenizer_vocab.py` covering `phoonnx/tokenizer.py` vocabulary/tokenizer construction: `Vocabulary.from_{piper,mimic3,coqui,phoonnx}_config`, `TTSTokenizer.from_{piper,mimic3,coqui,phoonnx}_config`/`from_tokens_txt`, compound-phoneme encoding, the BOS/EOS and blank-insertion safety paths, and Chatterbox BPE tokenizer loading (plain vs. multilingual `[SPACE]`-token detection).
- Exact-list assertions for the 4 `add_blank_char` x `use_eos_bos` permutations (plus `blank_at_start`/`blank_at_end` and word-blank-vs-char-blank variants) on a tiny fixed vocabulary, since an off-by-one in token-id construction corrupts audio silently rather than raising.
- One non-test edit: added `# pragma: no cover` to the `if __name__ == "__main__":` debug block in `phoonnx/config.py` (it references author-machine absolute paths and was never meant to run under test).

## Coverage
| Module | Before | After (new files only) |
| --- | --- | --- |
| `phoonnx/config.py` | 76.5% | 89% |
| `phoonnx/tokenizer.py` | 58.1% | 80% |

Combined (`config.py` + `tokenizer.py`, new test files only): 85%.

## Test plan
- [x] `python -m pytest tests/test_config_detection.py tests/test_tokenizer_vocab.py -q -p no:ovoscope --cov=phoonnx.config --cov=phoonnx.tokenizer --cov-report=term` — 108 passed, 89%/80% coverage.
- [x] Full suite (`python -m pytest tests/ -q -p no:ovoscope`) before and after: 883 passed / 16 failed / 6 skipped in both cases, no new failures. The 16 pre-existing failures are the known matcha-golden (`espeak not installed`) and styletts2/plbert environment-dependent cluster (missing optional deps / import errors), unrelated to this change.

## Bugs found
None — all adversarial cases (unknown/malformed `phonemizer`/`phoneme_type` values, duplicate or out-of-range ids in a mimic3-style tokens.txt, missing `bpe_tokenizer_json` for Chatterbox, missing vocab keys) degrade or raise as documented; no fix commit required.