### PR TITLE
feat: OptiSpeech training engine

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,5 +11,5 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.11", "3.12", "3.13", "3.14"]'
-      install_extras: 'test,train,train-styletts2,train-eval,train-data'
+      install_extras: 'test,train,train-styletts2,train-eval,train-data,train-optispeech'
       test_path: 'tests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'phoonnx'
       test_path: 'tests/'
-      install_extras: '-e .[test,train,train-styletts2,train-eval,train-data]'
+      install_extras: '-e .[test,train,train-styletts2,train-eval,train-data,train-optispeech]'
       min_coverage: 0

--- a/docs/training/engines/optispeech.md
+++ b/docs/training/engines/optispeech.md
@@ -128,6 +128,73 @@ voice.synthesize("Hello.", SynthesisConfig(extra_params={"d_factor": 1.0,
                                                           "e_factor": 1.0}))
 ```
 
+## Training
+
+OptiSpeech trains on the standard phoonnx preprocessed dataset. The vendored
+model code lives under `phoonnx_train/optispeech/` and is constructed entirely
+in plain Python — a quality preset fully determines the model, no external
+config file is involved. Install the engine extra:
+
+```bash
+pip install phoonnx[train,train-optispeech]
+```
+
+```bash
+python -m phoonnx_train.train \
+    --engine optispeech \
+    --dataset-dir ./dataset \
+    --default-root-dir ./checkpoints \
+    --quality medium
+```
+
+Quality presets change the constructed model (hidden width, encoder/decoder
+depth and the WaveNeXt vocoder size):
+
+| Preset | Acoustic `dim` | Encoder / decoder layers | Vocoder `dim` / layers |
+|--------|----------------|--------------------------|------------------------|
+| `x-low` | 128 | 2 / 2 | 256 / 4 |
+| `medium` | 256 | 4 / 4 | 384 / 8 |
+| `high` | 384 | 6 / 6 | 512 / 8 |
+
+Use `--quality <preset>` or set `quality` in the `extra` config; any preset
+field can be overridden individually through `extra` (e.g. `{"dim": 320}`).
+
+Architecture: a ConvNeXt text encoder with scaled sinusoidal positional
+embeddings, FastSpeech2-style duration / pitch / energy variance predictors, a
+learned monotonic alignment (ForwardSum + Viterbi) with Gaussian upsampling, a
+ConvNeXt decoder, and a **WaveNeXt** neural vocoder trained adversarially against
+multi-period and multi-resolution discriminators. Losses combine alignment,
+duration, pitch and energy terms with the GAN mel / multi-resolution-STFT /
+feature-matching terms.
+
+Training uses manual optimization (two optimizers — generator and
+discriminator — each with a cosine-with-warmup schedule). Checkpoints carry the
+optimizer state, scheduler state and epoch, so a run is fully resumable:
+
+```bash
+python -m phoonnx_train.train --engine optispeech --dataset-dir ./dataset \
+    --default-root-dir ./checkpoints \
+    --resume-from-checkpoint ./checkpoints/last.ckpt
+```
+
+To fine-tune from an existing checkpoint whose vocabulary, speaker count or
+vocoder size differs, the engine warm-starts by mapping matching tensors by
+name and shape and logs exactly which keys were loaded and which were skipped.
+
+Export a trained checkpoint to the single-file ONNX described above:
+
+```bash
+python -m phoonnx_train.export_onnx \
+    --engine optispeech \
+    --checkpoint ./checkpoints/last.ckpt \
+    --output-dir ./onnx
+```
+
+The exported `model.onnx` is self-contained: the waveform comes straight out
+(no separate vocoder ONNX) and the full runtime config — sample rate, inference
+defaults, symbol table and text-processor flags — is embedded under the
+`inference` metadata key, which the adapter reads back automatically.
+
 ## Gotchas / aliases
 
 - **Text processing depends on the tokenizer name.** The tokenizer flags come

--- a/phoonnx_train/engines/__init__.py
+++ b/phoonnx_train/engines/__init__.py
@@ -92,6 +92,7 @@ def _register_builtins() -> None:
     # their heavy torch imports until a model is actually built, so the
     # registry stays importable in torch-free environments.
     from phoonnx_train.engines.matcha import MatchaTrainingEngine
+    from phoonnx_train.engines.optispeech import OptiSpeechTrainingEngine
     from phoonnx_train.engines.vits import VitsTrainingEngine
     from phoonnx_train.engines.fastpitch import (
         ForwardTTSTrainingEngine,
@@ -109,6 +110,7 @@ def _register_builtins() -> None:
     register_engine("vits", VitsTrainingEngine)
     register_engine("glowtts", GlowTTSTrainingEngine)
     register_engine("matcha", MatchaTrainingEngine)
+    register_engine("optispeech", OptiSpeechTrainingEngine)
     register_engine("fastpitch", ForwardTTSTrainingEngine)
     register_engine("speedyspeech", SpeedySpeechTrainingEngine)
     register_engine("zipvoice", ZipVoiceTrainingEngine)

--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -1,0 +1,758 @@
+"""
+OptiSpeech training engine.
+
+OptiSpeech is a non-autoregressive, FastSpeech2-style acoustic model with a
+GAN-trained neural vocoder (WaveNeXt).  The model code is vendored under
+``phoonnx_train.optispeech`` so training runs on the same pytorch_lightning
+stack, dataset format and CLI as every other phoonnx engine.
+
+The upstream project wired its model together with Hydra: an external YAML
+tree described every sub-module and Hydra ``instantiate``-d it at runtime.
+None of that is used here.  Every sub-module is constructed with plain
+Python — ``functools.partial`` factories carry the preset-derived
+hyper-parameters, and the nested config namespaces become explicit
+dataclasses with sane defaults.  A quality preset therefore fully
+determines the constructed model without any config file.
+
+Checkpointing:
+    The LightningModule uses manual optimization (GAN).  ``configure_optimizers``
+    builds two optimizers (generator + discriminator) and two step-wise cosine
+    schedulers.  Lightning persists optimizer state, scheduler state, epoch and
+    global step in every checkpoint, so training is resumable via
+    ``Trainer(...).fit(model, ckpt_path=...)``.  ``load_checkpoint`` additionally
+    supports warm-starting from a *partial* checkpoint: it maps matching keys by
+    name+shape and logs exactly which keys were loaded and which were skipped.
+"""
+import contextlib
+import functools
+import json
+import logging
+import math
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:  # heavy imports — only needed for type annotations
+    import pytorch_lightning as pl
+
+from phoonnx_train.engines.base import BaseTrainingEngine, TrainingEngineConfig
+
+_LOG = logging.getLogger(__name__)
+
+# ONNX opset used for export.
+OPSET_VERSION = 15
+
+
+# ------------------------------------------------------------------
+# Quality presets — each tier fully changes the constructed model.
+# Fields map directly onto ``OptiSpeechEngineConfig``.
+# ------------------------------------------------------------------
+_QUALITY_PRESETS: Dict[str, Dict[str, Any]] = {
+    "x-low": {
+        "dim": 128,
+        "encoder_num_layers": 2,
+        "encoder_intermediate_dim": 512,
+        "decoder_num_layers": 2,
+        "decoder_intermediate_dim": 512,
+        "vocoder_dim": 256,
+        "vocoder_intermediate_dim": 768,
+        "vocoder_num_layers": 4,
+    },
+    "medium": {
+        "dim": 256,
+        "encoder_num_layers": 4,
+        "encoder_intermediate_dim": 1024,
+        "decoder_num_layers": 4,
+        "decoder_intermediate_dim": 1024,
+        "vocoder_dim": 384,
+        "vocoder_intermediate_dim": 1152,
+        "vocoder_num_layers": 8,
+    },
+    "high": {
+        "dim": 384,
+        "encoder_num_layers": 6,
+        "encoder_intermediate_dim": 1536,
+        "decoder_num_layers": 6,
+        "decoder_intermediate_dim": 1536,
+        "vocoder_dim": 512,
+        "vocoder_intermediate_dim": 1536,
+        "vocoder_num_layers": 8,
+    },
+}
+
+
+# ------------------------------------------------------------------
+# Explicit dataclasses replacing the Hydra DictConfig namespaces.
+# These are module-level (picklable) so they survive save_hyperparameters
+# and checkpoint round-trips.
+# ------------------------------------------------------------------
+@dataclass
+class GeneratorLossCoeffs:
+    """Weights for the acoustic-model loss terms (was ``loss_coeffs``)."""
+
+    lambda_align: float = 5.0
+    lambda_duration: float = 1.0
+    lambda_pitch: float = 1.0
+    lambda_energy: float = 1.0
+
+
+@dataclass
+class DiscriminatorLossCoeffs:
+    """Weights for the vocoder-discriminator loss terms."""
+
+    lambda_mel: float = 45.0
+    lambda_mr_stft: float = 1.0
+    lambda_mrd: float = 0.1
+
+
+@dataclass
+class OptiSpeechTrainArgs:
+    """Training-loop knobs (was ``train_args``)."""
+
+    cache_generator_outputs: bool = False
+    gradient_clip_val: float = 10.0
+    gradient_accumulate_batches: Optional[int] = None
+    pretraining_steps: int = 0
+    # Perceptual validation metrics pull in optional heavy deps
+    # (UTMOS / PESQ / periodicity); off by default.
+    evaluate_periodicity: bool = False
+    evaluate_utmos: bool = False
+    evaluate_pesq: bool = False
+
+
+@dataclass
+class OptiSpeechInferenceArgs:
+    """Default synthesis scaling factors (was ``inference_args``)."""
+
+    d_factor: float = 1.0
+    p_factor: float = 1.0
+    e_factor: float = 1.0
+
+
+@dataclass
+class OptiSpeechDataArgs:
+    """Data-side namespace passed to the LightningModule (was ``data_args``)."""
+
+    num_speakers: int
+    batch_size: int
+    num_workers: int
+    pin_memory: bool
+    text_processor: Any
+    feature_extractor: Any
+    data_statistics: Any = None
+
+
+# ------------------------------------------------------------------
+# Dependency-free cosine-with-warmup schedule (replaces the
+# transformers.get_cosine_schedule_with_warmup import).
+# ------------------------------------------------------------------
+def get_cosine_schedule_with_warmup(
+    optimizer,
+    num_warmup_steps: int,
+    num_training_steps: int,
+    num_cycles: float = 0.5,
+    last_epoch: int = -1,
+):
+    """LambdaLR cosine schedule with linear warmup.
+
+    Kept API-compatible with the upstream helper so
+    ``BaseLightningModule.configure_optimizers`` can rewrite
+    ``num_training_steps`` via the partial's ``keywords``.
+    """
+    from torch.optim.lr_scheduler import LambdaLR
+
+    def lr_lambda(current_step: int) -> float:
+        if current_step < num_warmup_steps:
+            return float(current_step) / float(max(1, num_warmup_steps))
+        progress = float(current_step - num_warmup_steps) / float(
+            max(1, num_training_steps - num_warmup_steps)
+        )
+        return max(
+            0.0, 0.5 * (1.0 + math.cos(math.pi * float(num_cycles) * 2.0 * progress))
+        )
+
+    return LambdaLR(optimizer, lr_lambda, last_epoch)
+
+
+@dataclass
+class OptiSpeechEngineConfig:
+    """Explicit, flat config for OptiSpeech training.
+
+    ``from_training_config`` maps the shared :class:`TrainingEngineConfig`
+    plus a quality preset onto these fields; :func:`_build_model_kwargs`
+    turns them into the ``functools.partial`` factories the vendored model
+    expects.
+    """
+
+    # Shared
+    num_symbols: int = 178
+    num_speakers: int = 1
+    sample_rate: int = 22050
+
+    # Acoustic-model hidden width (shared by text-embedding / encoder /
+    # variance predictors / decoder).
+    dim: int = 256
+
+    # Feature extractor / mel
+    n_feats: int = 80
+    n_fft: int = 1024
+    hop_length: int = 256
+    win_length: int = 1024
+    f_min: int = 0
+    f_max: int = 8000
+
+    # Text processing
+    tokenizer: str = "ipa"
+    add_blank: bool = False
+    add_bos_eos: bool = False
+    normalize_text: bool = True
+    languages: List[str] = field(default_factory=lambda: ["en-us"])
+    max_source_positions: int = 2000
+
+    # Encoder (ConvNeXt backbone)
+    encoder_num_layers: int = 4
+    encoder_intermediate_dim: int = 1024
+    encoder_drop_path: float = 0.0
+
+    # Decoder (ConvNeXt backbone)
+    decoder_num_layers: int = 4
+    decoder_intermediate_dim: int = 1024
+    decoder_drop_path: float = 0.0
+
+    # Duration predictor
+    duration_num_layers: int = 2
+    duration_intermediate_dim: int = 384
+    duration_kernel_size: int = 3
+    duration_dropout: float = 0.1
+
+    # Pitch predictor
+    pitch_num_layers: int = 5
+    pitch_intermediate_dim: int = 256
+    pitch_kernel_size: int = 5
+    pitch_dropout: float = 0.5
+    pitch_embed_kernel_size: int = 9
+    pitch_embed_dropout: float = 0.2
+
+    # Energy predictor
+    energy_num_layers: int = 2
+    energy_intermediate_dim: int = 384
+    energy_kernel_size: int = 3
+    energy_dropout: float = 0.5
+    energy_embed_kernel_size: int = 9
+    energy_embed_dropout: float = 0.5
+
+    # Vocoder (WaveNeXt)
+    vocoder_dim: int = 384
+    vocoder_intermediate_dim: int = 1152
+    vocoder_num_layers: int = 8
+    vocoder_drop_path: float = 0.0
+
+    # Alignment / segmenting
+    segment_size: int = 64
+    text_dropout: float = 0.1
+
+    # Loss coefficients
+    lambda_align: float = 5.0
+    lambda_duration: float = 1.0
+    lambda_pitch: float = 1.0
+    lambda_energy: float = 1.0
+    lambda_mel: float = 45.0
+    lambda_mr_stft: float = 1.0
+    lambda_mrd: float = 0.1
+
+    # Inference defaults
+    d_factor: float = 1.0
+    p_factor: float = 1.0
+    e_factor: float = 1.0
+
+    # Training loop
+    batch_size: int = 16
+    num_workers: int = 1
+    learning_rate: float = 2e-4
+    weight_decay: float = 1e-2
+    adam_b1: float = 0.8
+    adam_b2: float = 0.99
+    warmup_steps: int = 1000
+    pretraining_steps: int = 0
+    gradient_clip_val: float = 10.0
+    cache_generator_outputs: bool = False
+
+    @classmethod
+    def from_training_config(cls, cfg: TrainingEngineConfig) -> "OptiSpeechEngineConfig":
+        """Build from the shared config + quality preset + engine overrides."""
+        extra = dict(cfg.extra)
+        preset_name = extra.pop("quality", "medium")
+        if preset_name not in _QUALITY_PRESETS:
+            _LOG.warning(
+                "unknown quality preset %r; falling back to 'medium'", preset_name
+            )
+            preset_name = "medium"
+        params = dict(_QUALITY_PRESETS[preset_name])
+        params.update(extra)
+
+        known = {f.name for f in fields(cls)}
+        ignored = set(params) - known
+        if ignored:
+            _LOG.debug("ignoring non-optispeech config keys: %s", sorted(ignored))
+
+        return cls(
+            num_symbols=cfg.num_symbols,
+            num_speakers=cfg.num_speakers,
+            sample_rate=cfg.sample_rate,
+            **{k: v for k, v in params.items() if k in known},
+        )
+
+
+def _build_feature_extractor(ocfg: "OptiSpeechEngineConfig"):
+    from phoonnx_train.optispeech.dataset.feature_extractors import CommonFeatureExtractor
+    from phoonnx_train.optispeech.dataset.feature_extractors.pitch_extractors import (
+        DIOPitchExtractor,
+    )
+
+    return CommonFeatureExtractor(
+        sample_rate=ocfg.sample_rate,
+        n_feats=ocfg.n_feats,
+        n_fft=ocfg.n_fft,
+        hop_length=ocfg.hop_length,
+        win_length=ocfg.win_length,
+        f_min=ocfg.f_min,
+        f_max=ocfg.f_max,
+        center=True,
+        pitch_extractor=functools.partial(DIOPitchExtractor, interpolate=True),
+    )
+
+
+def _build_text_processor(ocfg: "OptiSpeechEngineConfig"):
+    from phoonnx_train.optispeech.text import TextProcessor
+
+    # The tokenizer treats add_blank / add_bos_eos truthiness as the flag.
+    return TextProcessor(
+        tokenizer=ocfg.tokenizer,
+        add_blank=bool(ocfg.add_blank),
+        add_bos_eos=bool(ocfg.add_bos_eos),
+        normalize_text=ocfg.normalize_text,
+        languages=list(ocfg.languages),
+    )
+
+
+def _build_model_kwargs(
+    ocfg: "OptiSpeechEngineConfig",
+    feature_extractor,
+    text_processor,
+) -> Dict[str, Any]:
+    """Assemble the explicit partial factories the vendored model expects."""
+    import torch
+
+    from phoonnx_train.optispeech.model.generator import OptiSpeechGenerator
+    from phoonnx_train.optispeech.model.generator.modules import (
+        ConvNeXtBackbone,
+        DurationPredictor,
+        EnergyPredictor,
+        PitchPredictor,
+        TextEmbedding,
+    )
+    from phoonnx_train.optispeech.model.vocoder.wavenext import WaveNeXt
+    from phoonnx_train.optispeech.model.vocoder.wavenext.disc import VocosDiscriminator
+
+    text_embedding = functools.partial(
+        TextEmbedding,
+        n_vocab=ocfg.num_symbols,
+        dropout=ocfg.text_dropout,
+        padding_idx=0,
+        max_source_positions=ocfg.max_source_positions,
+    )
+    encoder = functools.partial(
+        ConvNeXtBackbone,
+        intermediate_dim=ocfg.encoder_intermediate_dim,
+        num_layers=ocfg.encoder_num_layers,
+        drop_path=ocfg.encoder_drop_path,
+    )
+    decoder = functools.partial(
+        ConvNeXtBackbone,
+        intermediate_dim=ocfg.decoder_intermediate_dim,
+        num_layers=ocfg.decoder_num_layers,
+        drop_path=ocfg.decoder_drop_path,
+    )
+    duration_predictor = functools.partial(
+        DurationPredictor,
+        num_layers=ocfg.duration_num_layers,
+        intermediate_dim=ocfg.duration_intermediate_dim,
+        kernel_size=ocfg.duration_kernel_size,
+        dropout=ocfg.duration_dropout,
+        conv_layer_class=torch.nn.Conv1d,
+    )
+    pitch_predictor = functools.partial(
+        PitchPredictor,
+        num_layers=ocfg.pitch_num_layers,
+        intermediate_dim=ocfg.pitch_intermediate_dim,
+        kernel_size=ocfg.pitch_kernel_size,
+        dropout=ocfg.pitch_dropout,
+        conv_layer_class=torch.nn.Conv1d,
+        embed_kernel_size=ocfg.pitch_embed_kernel_size,
+        embed_dropout=ocfg.pitch_embed_dropout,
+    )
+    energy_predictor = functools.partial(
+        EnergyPredictor,
+        num_layers=ocfg.energy_num_layers,
+        intermediate_dim=ocfg.energy_intermediate_dim,
+        kernel_size=ocfg.energy_kernel_size,
+        dropout=ocfg.energy_dropout,
+        conv_layer_class=torch.nn.Conv1d,
+        embed_kernel_size=ocfg.energy_embed_kernel_size,
+        embed_dropout=ocfg.energy_embed_dropout,
+    )
+
+    generator = functools.partial(
+        OptiSpeechGenerator,
+        segment_size=ocfg.segment_size,
+        text_embedding=text_embedding,
+        encoder=encoder,
+        duration_predictor=duration_predictor,
+        pitch_predictor=pitch_predictor,
+        energy_predictor=energy_predictor,
+        decoder=decoder,
+        loss_coeffs=GeneratorLossCoeffs(
+            lambda_align=ocfg.lambda_align,
+            lambda_duration=ocfg.lambda_duration,
+            lambda_pitch=ocfg.lambda_pitch,
+            lambda_energy=ocfg.lambda_energy,
+        ),
+    )
+    vocoder = functools.partial(
+        WaveNeXt,
+        dim=ocfg.vocoder_dim,
+        intermediate_dim=ocfg.vocoder_intermediate_dim,
+        num_layers=ocfg.vocoder_num_layers,
+        drop_path=ocfg.vocoder_drop_path,
+    )
+    discriminator = functools.partial(
+        VocosDiscriminator,
+        loss_coeffs=DiscriminatorLossCoeffs(
+            lambda_mel=ocfg.lambda_mel,
+            lambda_mr_stft=ocfg.lambda_mr_stft,
+            lambda_mrd=ocfg.lambda_mrd,
+        ),
+    )
+
+    optimizer = functools.partial(
+        torch.optim.AdamW,
+        lr=ocfg.learning_rate,
+        betas=(ocfg.adam_b1, ocfg.adam_b2),
+        weight_decay=ocfg.weight_decay,
+    )
+    scheduler = functools.partial(
+        get_cosine_schedule_with_warmup,
+        num_warmup_steps=ocfg.warmup_steps,
+        num_training_steps=1,  # rewritten in configure_optimizers
+    )
+
+    return {
+        "dim": ocfg.dim,
+        "generator": generator,
+        "vocoder": vocoder,
+        "discriminator": discriminator,
+        "train_args": OptiSpeechTrainArgs(
+            cache_generator_outputs=ocfg.cache_generator_outputs,
+            gradient_clip_val=ocfg.gradient_clip_val,
+            gradient_accumulate_batches=None,
+            pretraining_steps=ocfg.pretraining_steps,
+        ),
+        "data_args": OptiSpeechDataArgs(
+            num_speakers=ocfg.num_speakers,
+            batch_size=ocfg.batch_size,
+            num_workers=ocfg.num_workers,
+            pin_memory=False,
+            text_processor=text_processor,
+            feature_extractor=feature_extractor,
+            data_statistics=None,
+        ),
+        "inference_args": OptiSpeechInferenceArgs(
+            d_factor=ocfg.d_factor,
+            p_factor=ocfg.p_factor,
+            e_factor=ocfg.e_factor,
+        ),
+        "optimizer": optimizer,
+        "scheduler": scheduler,
+    }
+
+
+def build_optispeech(ocfg: "OptiSpeechEngineConfig") -> "pl.LightningModule":
+    """Construct an :class:`OptiSpeech` LightningModule from an explicit config."""
+    from phoonnx_train.optispeech.model.optispeech import OptiSpeech
+
+    feature_extractor = _build_feature_extractor(ocfg)
+    text_processor = _build_text_processor(ocfg)
+    kwargs = _build_model_kwargs(ocfg, feature_extractor, text_processor)
+    model = OptiSpeech(**kwargs)
+    # Keep the flat config around for export/metadata.
+    model._engine_config = ocfg
+    return model
+
+
+class OptiSpeechTrainingEngine(BaseTrainingEngine):
+
+    def trainer_kwargs(self) -> Dict[str, Any]:
+        # OptiSpeech uses manual optimization; a global gradient_clip_val is
+        # rejected by Lightning in that mode. Clipping is applied inside the
+        # LightningModule via train_args.gradient_clip_val.
+        return {}
+
+    # ------------------------------------------------------------------
+    # Required
+    # ------------------------------------------------------------------
+
+    def create_model(
+        self,
+        config: TrainingEngineConfig,
+        dataset_paths: List[Path],
+        **kwargs: Any,
+    ) -> "pl.LightningModule":
+        ocfg = OptiSpeechEngineConfig.from_training_config(config)
+        return build_optispeech(ocfg)
+
+    def extra_preprocess(
+        self,
+        utterance_audio_path: Path,
+        cache_dir: Path,
+        sample_rate: int,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        # Pitch/energy features are extracted by the vendored feature
+        # extractor inside the datamodule; nothing extra is cached per
+        # utterance at this stage.
+        return {}
+
+    def export_onnx(
+        self,
+        checkpoint_path: Path,
+        config_path: Path,
+        output_dir: Path,
+        **kwargs: Any,
+    ) -> Path:
+        """Export a trained OptiSpeech checkpoint to ONNX.
+
+        Produces the input/output contract the phoonnx ``OptiSpeechAdapter``
+        expects:
+
+          inputs:  ``x``, ``x_lengths``, ``scales`` (=[d, p, e]),
+                   optional ``sids`` / ``lids``
+          outputs: ``wav``, ``wav_lengths``, ``durations``
+
+        All runtime config is embedded under the ``inference`` metadata key
+        as a JSON blob (sample_rate, inference_args, input_symbols,
+        special_symbols, text_processor, speakers, languages).
+        """
+        import torch
+
+        model = self.load_lightning_module(checkpoint_path)
+        model.eval()
+
+        gen = model.generator
+        is_multi_speaker = model.num_speakers > 1
+        is_multi_language = getattr(model.text_processor, "is_multi_language", False)
+
+        d0 = model.inference_args.d_factor
+        p0 = model.inference_args.p_factor
+        e0 = model.inference_args.e_factor
+
+        dummy_len = 20
+        # phoneme ids within a safe low range of the vocab
+        x = torch.randint(1, 10, (1, dummy_len), dtype=torch.long)
+        x_lengths = torch.LongTensor([dummy_len])
+        scales = torch.tensor([d0, p0, e0], dtype=torch.float32)
+
+        model_inputs: List[Any] = [x, x_lengths, scales]
+        input_names = ["x", "x_lengths", "scales"]
+        dynamic_axes: Dict[str, Dict[int, str]] = {
+            "x": {0: "batch_size", 1: "time"},
+            "x_lengths": {0: "batch_size"},
+            "wav": {0: "batch_size", 1: "time"},
+            "wav_lengths": {0: "batch_size"},
+            "durations": {0: "batch_size", 1: "time"},
+        }
+        if is_multi_speaker:
+            model_inputs.append(torch.LongTensor([0]))
+            input_names.append("sids")
+            dynamic_axes["sids"] = {0: "batch_size"}
+        if is_multi_language:
+            model_inputs.append(torch.LongTensor([0]))
+            input_names.append("lids")
+            dynamic_axes["lids"] = {0: "batch_size"}
+
+        def onnx_forward(x, x_lengths, scales, sids=None, lids=None):
+            out = gen.synthesise(
+                x=x,
+                x_lengths=x_lengths,
+                sids=sids,
+                lids=lids,
+                d_factor=scales[0],
+                p_factor=scales[1],
+                e_factor=scales[2],
+            )
+            return out["wav"], out["wav_lengths"], out["durations"]
+
+        model.forward = onnx_forward
+
+        output_path = output_dir / "model.onnx"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        from phoonnx_train.torch_compat import onnx_export_kwargs
+
+        torch.onnx.export(
+            model,
+            tuple(model_inputs),
+            str(output_path),
+            input_names=input_names,
+            output_names=["wav", "wav_lengths", "durations"],
+            dynamic_axes=dynamic_axes,
+            opset_version=OPSET_VERSION,
+            export_params=True,
+            do_constant_folding=True,
+            **onnx_export_kwargs(),
+        )
+
+        self._embed_metadata(output_path, model)
+        _LOG.info("ONNX model exported to %s", output_path)
+        return output_path
+
+    def quality_presets(self) -> Dict[str, Dict[str, Any]]:
+        return _QUALITY_PRESETS
+
+    # ------------------------------------------------------------------
+    # Checkpoint handling
+    # ------------------------------------------------------------------
+
+    def load_lightning_module(self, checkpoint_path: Path) -> "pl.LightningModule":
+        """Reconstruct a full :class:`OptiSpeech` module from a checkpoint.
+
+        The hyper-parameters saved by ``save_hyperparameters`` include the
+        explicit dataclasses and ``functools.partial`` factories built by this
+        engine, so the whole module (optimizer/scheduler config included) is
+        rebuilt on load.
+        """
+        import torch
+
+        from phoonnx_train.optispeech.model.optispeech import OptiSpeech
+
+        with self._allow_checkpoint_globals():
+            return OptiSpeech.load_from_checkpoint(
+                str(checkpoint_path), map_location="cpu"
+            )
+
+    def load_checkpoint(
+        self,
+        model: "pl.LightningModule",
+        checkpoint_path: Path,
+        **kwargs: Any,
+    ) -> "pl.LightningModule":
+        """Warm-start *model* from a (possibly partial) checkpoint.
+
+        Matches keys by name and shape, loads them, and logs precisely which
+        keys were loaded and which were skipped — so a mismatched or partial
+        checkpoint (e.g. different vocab / speaker count / vocoder) still
+        transfers what it can.
+        """
+        import torch
+
+        with self._allow_checkpoint_globals():
+            ckpt = torch.load(
+                str(checkpoint_path), map_location="cpu", weights_only=False
+            )
+        state_dict = ckpt.get("state_dict", ckpt)
+        model_state = model.state_dict()
+
+        matched = {
+            k: v
+            for k, v in state_dict.items()
+            if k in model_state and v.shape == model_state[k].shape
+        }
+        skipped_ckpt = sorted(set(state_dict) - set(matched))
+        missing_model = sorted(set(model_state) - set(matched))
+
+        model.load_state_dict(matched, strict=False)
+
+        _LOG.info(
+            "warm-start: loaded %d/%d checkpoint tensors into model (%d model "
+            "tensors left at init)",
+            len(matched),
+            len(state_dict),
+            len(missing_model),
+        )
+        if skipped_ckpt:
+            _LOG.info("warm-start: skipped %d checkpoint keys", len(skipped_ckpt))
+            _LOG.debug("warm-start skipped keys: %s", skipped_ckpt)
+        if missing_model:
+            _LOG.debug("warm-start missing (kept at init) keys: %s", missing_model)
+        return model
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _checkpoint_safe_globals() -> List[Any]:
+        return [
+            functools.partial,
+            GeneratorLossCoeffs,
+            DiscriminatorLossCoeffs,
+            OptiSpeechTrainArgs,
+            OptiSpeechInferenceArgs,
+            OptiSpeechDataArgs,
+            OptiSpeechEngineConfig,
+            get_cosine_schedule_with_warmup,
+        ]
+
+    @classmethod
+    def _allow_checkpoint_globals(cls):
+        """Allow-list our config/partial objects for ``weights_only`` unpickling.
+
+        On torch<2.4 ``safe_globals`` does not exist and ``weights_only``
+        defaults to ``False``, so a no-op context is sufficient.
+        """
+        import torch
+
+        safe_globals = getattr(torch.serialization, "safe_globals", None)
+        if safe_globals is None:
+            return contextlib.nullcontext()
+        return safe_globals(cls._checkpoint_safe_globals())
+
+    @staticmethod
+    def _embed_metadata(onnx_path: Path, model: "pl.LightningModule") -> None:
+        import onnx
+
+        tp = model.text_processor
+        tokenizer = getattr(tp, "tokenizer", None)
+        input_symbols = dict(getattr(tokenizer, "input_symbols", {}) or {})
+        special_symbols = dict(getattr(tokenizer, "special_symbols", {}) or {})
+
+        inference_meta = {
+            "name": "optispeech",
+            "sample_rate": int(model.sample_rate),
+            "inference_args": {
+                "d_factor": model.inference_args.d_factor,
+                "p_factor": model.inference_args.p_factor,
+                "e_factor": model.inference_args.e_factor,
+            },
+            "input_symbols": input_symbols,
+            "special_symbols": special_symbols,
+            "speakers": list(getattr(model, "speakers", []) or []),
+            "languages": list(getattr(tp, "languages", []) or []),
+            "text_processor": {
+                "tokenizer": getattr(tokenizer, "name", tp.tokenizer_ref)
+                if not isinstance(tp.tokenizer_ref, str)
+                else tp.tokenizer_ref,
+                "add_blank": bool(tp.add_blank),
+                "add_bos_eos": bool(tp.add_bos_eos),
+                "normalize_text": bool(tp.normalize_text),
+                "languages": list(tp.languages),
+            },
+        }
+
+        onnx_model = onnx.load(str(onnx_path))
+        entry = onnx_model.metadata_props.add()
+        entry.key = "inference"
+        entry.value = json.dumps(inference_meta)
+        type_entry = onnx_model.metadata_props.add()
+        type_entry.key = "model_type"
+        type_entry.value = "optispeech"
+        onnx.save(onnx_model, str(onnx_path))

--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -23,7 +23,6 @@ Checkpointing:
     supports warm-starting from a *partial* checkpoint: it maps matching keys by
     name+shape and logs exactly which keys were loaded and which were skipped.
 """
-import contextlib
 import functools
 import json
 import logging
@@ -630,11 +629,13 @@ class OptiSpeechTrainingEngine(BaseTrainingEngine):
         engine, so the whole module (optimizer/scheduler config included) is
         rebuilt on load.
         """
-        import torch
-
         from phoonnx_train.optispeech.model.optispeech import OptiSpeech
+        from phoonnx_train.torch_compat import trusting_torch_load
 
-        with self._allow_checkpoint_globals():
+        # Our checkpoints embed the engine's dataclasses and partial factories;
+        # torch>=2.6 defaults torch.load(weights_only=True) and rejects them.
+        # Loading our own checkpoint is trusted.
+        with trusting_torch_load():
             return OptiSpeech.load_from_checkpoint(
                 str(checkpoint_path), map_location="cpu"
             )
@@ -654,10 +655,10 @@ class OptiSpeechTrainingEngine(BaseTrainingEngine):
         """
         import torch
 
-        with self._allow_checkpoint_globals():
-            ckpt = torch.load(
-                str(checkpoint_path), map_location="cpu", weights_only=False
-            )
+        from phoonnx_train.torch_compat import trusting_torch_load
+
+        with trusting_torch_load():
+            ckpt = torch.load(str(checkpoint_path), map_location="cpu")
         state_dict = ckpt.get("state_dict", ckpt)
         model_state = model.state_dict()
 
@@ -688,33 +689,6 @@ class OptiSpeechTrainingEngine(BaseTrainingEngine):
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _checkpoint_safe_globals() -> List[Any]:
-        return [
-            functools.partial,
-            GeneratorLossCoeffs,
-            DiscriminatorLossCoeffs,
-            OptiSpeechTrainArgs,
-            OptiSpeechInferenceArgs,
-            OptiSpeechDataArgs,
-            OptiSpeechEngineConfig,
-            get_cosine_schedule_with_warmup,
-        ]
-
-    @classmethod
-    def _allow_checkpoint_globals(cls):
-        """Allow-list our config/partial objects for ``weights_only`` unpickling.
-
-        On torch<2.4 ``safe_globals`` does not exist and ``weights_only``
-        defaults to ``False``, so a no-op context is sufficient.
-        """
-        import torch
-
-        safe_globals = getattr(torch.serialization, "safe_globals", None)
-        if safe_globals is None:
-            return contextlib.nullcontext()
-        return safe_globals(cls._checkpoint_safe_globals())
 
     @staticmethod
     def _embed_metadata(onnx_path: Path, model: "pl.LightningModule") -> None:

--- a/phoonnx_train/optispeech/__init__.py
+++ b/phoonnx_train/optispeech/__init__.py
@@ -1,0 +1,1 @@
+from phoonnx_train.optispeech.model.optispeech import OptiSpeech

--- a/phoonnx_train/optispeech/dataset/__init__.py
+++ b/phoonnx_train/optispeech/dataset/__init__.py
@@ -1,0 +1,1 @@
+from .text_wav_datamodule import TextWavDataModule, TextWavDataset, do_preprocess_utterance

--- a/phoonnx_train/optispeech/dataset/feature_extractors/__init__.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/__init__.py
@@ -1,0 +1,205 @@
+from typing import Callable, Optional
+
+import librosa
+import numpy as np
+import torch
+from librosa.filters import mel as librosa_mel_fn
+from torchaudio.functional import highpass_biquad, lowpass_biquad
+
+from phoonnx_train.optispeech.utils import pylogger, trim_or_pad_to_target_length
+from phoonnx_train.optispeech.utils.audio import normalize_loudness, spectral_normalize_torch
+from .norm_audio import make_silence_detector, trim_audio
+
+
+log = pylogger.get_pylogger(__name__)
+
+
+class FeatureExtractor:
+    hann_window = {}
+
+    def __init__(
+        self,
+        sample_rate: int,
+        n_feats: int,
+        n_fft: int,
+        hop_length: int,
+        win_length: int,
+        f_min: int,
+        f_max: int,
+        center: bool,
+        pitch_extractor: Callable,
+        batch_size: int = 32,
+        preemphasis_filter_coef: Optional[float] = None,
+        lowpass_freq: Optional[int] = None,
+        highpass_freq: Optional[int] = None,
+        loudness_norm_target_db: Optional[int] = None,
+        trim_silence: bool = False,
+        trim_silence_args: Optional[dict] = None,
+    ):
+        self.sample_rate = sample_rate
+        self.n_feats = n_feats
+        self.n_fft = n_fft
+        self.hop_length = hop_length
+        self.win_length = win_length
+        self.f_min = f_min
+        self.f_max = f_max
+        self.center = center
+        self.preemphasis_filter_coef = preemphasis_filter_coef
+        self.lowpass_freq = lowpass_freq
+        self.highpass_freq = highpass_freq
+        self.loudness_norm_target_db = loudness_norm_target_db
+        self.trim_silence = trim_silence
+        self.trim_silence_args = trim_silence_args
+        self.pitch_extractor_initializer = pitch_extractor
+        self.batch_size = batch_size
+        # These may load additional models we don't need during training
+        self.pitch_extractor = None
+        self._silence_detector = None
+
+    def initialize_components(self):
+        if self.pitch_extractor is not None:
+            return
+        self.pitch_extractor = self.pitch_extractor_initializer(
+            sample_rate=self.sample_rate,
+            n_feats=self.n_feats,
+            hop_length=self.hop_length,
+            n_fft=self.n_fft,
+            win_length=self.win_length,
+            f_min=self.f_min,
+            f_max=self.f_max,
+            batch_size=self.batch_size,
+        )
+        self._silence_detector = make_silence_detector()
+    
+    def __call__(self, audio_path):
+        if self.pitch_extractor is None:
+            raise RuntimeError("Feature extractor not fully initialized. call `feature_extractor.initialize_components()` first.")
+        if not self.trim_silence:
+            wav, __sr = librosa.load(audio_path, sr=self.sample_rate, mono=True)
+        else:
+            wav, __sr = trim_audio(
+                audio_path=audio_path,
+                detector=self._silence_detector,
+                sample_rate=self.sample_rate,
+                **self.trim_silence_args,
+            )
+        assert __sr == self.sample_rate
+        # Enhance higher frequencies (useful with some datasets)
+        if self.preemphasis_filter_coef is not None:
+            wav = librosa.effects.preemphasis(wav, coef=self.preemphasis_filter_coef)
+        # Cutt-off higher freqs
+        if self.lowpass_freq is not None:
+            wav = lowpass_biquad(
+                torch.from_numpy(wav.copy()), sample_rate=self.sample_rate, cutoff_freq=self.lowpass_freq
+            ).numpy()
+        if self.highpass_freq is not None:
+            wav = highpass_biquad(
+                torch.from_numpy(wav.copy()), sample_rate=self.sample_rate, cutoff_freq=self.highpass_freq
+            ).numpy()
+        if self.loudness_norm_target_db is not None:
+            # Normalize loudness
+            wav = normalize_loudness(
+                audio=wav,
+                sample_rate=self.sample_rate,
+                target_db=self.loudness_norm_target_db
+            )
+        # Peak normalization
+        wav = librosa.util.normalize(wav)
+        mel = self.get_mel(wav)
+        mel_length = mel.shape[-1]
+        energy = self.get_energy(wav, mel_length)
+        pitch = self.get_pitch(wav, mel_length)
+        return (wav.squeeze(), mel.squeeze(), energy.squeeze(), pitch.squeeze())
+
+    def get_mel(self, wav: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def get_energy(self, wav, mel_length):
+        y = torch.from_numpy(wav).unsqueeze(0)
+
+        hann_win_key = str(y.device)
+        if hann_win_key not in self.hann_window:
+            self.hann_window[hann_win_key] = torch.hann_window(self.win_length).to(y.device)
+
+        y = torch.nn.functional.pad(
+            y.unsqueeze(1),
+            (int((self.n_fft - self.hop_length) / 2), int((self.n_fft - self.hop_length) / 2)),
+            mode="reflect",
+        )
+        y = y.squeeze(1)
+
+        spec = torch.view_as_real(
+            torch.stft(
+                y,
+                self.n_fft,
+                hop_length=self.hop_length,
+                win_length=self.win_length,
+                window=self.hann_window[hann_win_key],
+                center=self.center,
+                pad_mode="reflect",
+                normalized=False,
+                onesided=True,
+                return_complex=True,
+            )
+        )
+
+        magnitudes = torch.sqrt(spec.pow(2).sum(-1) + (1e-9))
+        energy = torch.norm(magnitudes, dim=1)
+        energy = trim_or_pad_to_target_length(
+            energy.squeeze().cpu().numpy(), mel_length
+        )
+
+        return energy
+
+    def get_pitch(self, wav, mel_length) -> np.ndarray:
+        return self.pitch_extractor(wav, mel_length)
+
+class CommonFeatureExtractor(FeatureExtractor):
+    """Compatible with most popular neural vocoders."""
+
+    mel_basis = {}
+
+    def get_mel(self, wav):
+        y = torch.from_numpy(wav).unsqueeze(0)
+
+        if torch.min(y) < -1.0:
+            log.warning(f"min value is {torch.min(y)}")
+        if torch.max(y) > 1.0:
+            log.warning(f"max value is {torch.max(y)}")
+
+        mel_basis_key = str(self.f_max) + "_" + str(y.device)
+        hann_win_key = str(y.device)
+
+        if mel_basis_key not in self.mel_basis:
+            mel = librosa_mel_fn(
+                sr=self.sample_rate, n_fft=self.n_fft, n_mels=self.n_feats, fmin=self.f_min, fmax=self.f_max
+            )
+            self.mel_basis[mel_basis_key] = torch.from_numpy(mel).float().to(y.device)
+            self.hann_window[hann_win_key] = torch.hann_window(self.win_length).to(y.device)
+
+        y = torch.nn.functional.pad(
+            y.unsqueeze(1),
+            (int((self.n_fft - self.hop_length) / 2), int((self.n_fft - self.hop_length) / 2)),
+            mode="reflect",
+        )
+        y = y.squeeze(1)
+
+        spec = torch.view_as_real(
+            torch.stft(
+                y,
+                self.n_fft,
+                hop_length=self.hop_length,
+                win_length=self.win_length,
+                window=self.hann_window[hann_win_key],
+                center=self.center,
+                pad_mode="reflect",
+                normalized=False,
+                onesided=True,
+                return_complex=True,
+            )
+        )
+
+        magnitudes = torch.sqrt(spec.pow(2).sum(-1) + (1e-9))
+        spec = torch.matmul(self.mel_basis[mel_basis_key], magnitudes)
+        spec = spectral_normalize_torch(spec)
+        return spec.squeeze().cpu().numpy()

--- a/phoonnx_train/optispeech/dataset/feature_extractors/norm_audio/__init__.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/norm_audio/__init__.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+import librosa
+import numpy as np
+import torch
+
+from .trim import trim_silence
+from .vad import SileroVoiceActivityDetector
+
+_DIR = Path(__file__).parent
+
+
+def make_silence_detector() -> SileroVoiceActivityDetector:
+    silence_model = _DIR / "models" / "silero_vad.onnx"
+    if not silence_model.is_file():
+        raise FileNotFoundError(
+            f"Silero VAD model not found at {silence_model}. Silence trimming "
+            "(trim_silence=True) needs a silero_vad.onnx there; download one "
+            "from https://github.com/snakers4/silero-vad or disable trim_silence."
+        )
+    return SileroVoiceActivityDetector(silence_model)
+
+
+def trim_audio(
+    audio_path: Path,
+    detector: SileroVoiceActivityDetector,
+    sample_rate: int,
+    silence_threshold: float = 0.2,
+    silence_samples_per_chunk: int = 480,
+    silence_keep_chunks_before: int = 2,
+    silence_keep_chunks_after: int = 2,
+) -> Tuple[np.array, int]:
+    # The VAD model works on 16khz, so we determine the portion of audio
+    # to keep and then just load that with librosa.
+    vad_sample_rate = 16000
+    audio_16khz, _sr = librosa.load(path=audio_path, sr=vad_sample_rate)
+
+    offset_sec, duration_sec = trim_silence(
+        audio_16khz,
+        detector,
+        threshold=silence_threshold,
+        samples_per_chunk=silence_samples_per_chunk,
+        sample_rate=vad_sample_rate,
+        keep_chunks_before=silence_keep_chunks_before,
+        keep_chunks_after=silence_keep_chunks_after,
+    )
+
+    # NOTE: audio is already in [-1, 1] coming from librosa
+    audio_norm_array, _sr = librosa.load(
+        path=audio_path,
+        sr=sample_rate,
+        offset=offset_sec,
+        duration=duration_sec,
+    )
+
+    return audio_norm_array, _sr

--- a/phoonnx_train/optispeech/dataset/feature_extractors/norm_audio/trim.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/norm_audio/trim.py
@@ -1,0 +1,50 @@
+from typing import Optional, Tuple
+
+import numpy as np
+
+from .vad import SileroVoiceActivityDetector
+
+
+def trim_silence(
+    audio_array: np.ndarray,
+    detector: SileroVoiceActivityDetector,
+    threshold: float = 0.2,
+    samples_per_chunk=480,
+    sample_rate=16000,
+    keep_chunks_before: int = 2,
+    keep_chunks_after: int = 2,
+) -> Tuple[float, Optional[float]]:
+    """Returns the offset/duration of trimmed audio in seconds"""
+    offset_sec: float = 0.0
+    duration_sec: Optional[float] = None
+    first_chunk: Optional[int] = None
+    last_chunk: Optional[int] = None
+    seconds_per_chunk: float = samples_per_chunk / sample_rate
+
+    chunk_idx: int = 0
+
+    # Determine main block of speech
+    while len(audio_array) > 0:
+        chunk = audio_array[:samples_per_chunk]
+        audio_array = audio_array[samples_per_chunk:]
+        prob = detector(chunk, sample_rate=sample_rate)
+        is_speech = prob >= threshold
+
+        if is_speech:
+            if first_chunk is None:
+                first_chunk = chunk_idx
+            else:
+                last_chunk = chunk_idx
+
+        chunk_idx += 1
+
+    if (first_chunk is not None) and (last_chunk is not None):
+        first_chunk = max(0, first_chunk - keep_chunks_before)
+        last_chunk = min(chunk_idx, last_chunk + keep_chunks_after)
+
+        # Compute offset/duration
+        offset_sec = first_chunk * seconds_per_chunk
+        last_sec = (last_chunk + 1) * seconds_per_chunk
+        duration_sec = last_sec - offset_sec
+
+    return offset_sec, duration_sec

--- a/phoonnx_train/optispeech/dataset/feature_extractors/norm_audio/vad.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/norm_audio/vad.py
@@ -1,0 +1,52 @@
+import typing
+from pathlib import Path
+
+import numpy as np
+import onnxruntime
+
+
+class SileroVoiceActivityDetector:
+    """Detects speech/silence using Silero VAD.
+
+    https://github.com/snakers4/silero-vad
+    """
+
+    def __init__(self, onnx_path: typing.Union[str, Path]):
+        onnx_path = str(onnx_path)
+
+        self.session = onnxruntime.InferenceSession(onnx_path)
+        self.session.intra_op_num_threads = 1
+        self.session.inter_op_num_threads = 1
+
+        self._h = np.zeros((2, 1, 64)).astype("float32")
+        self._c = np.zeros((2, 1, 64)).astype("float32")
+
+    def __call__(self, audio_array: np.ndarray, sample_rate: int = 16000):
+        """Return probability of speech in audio [0-1].
+
+        Audio must be 16Khz 16-bit mono PCM.
+        """
+        if len(audio_array.shape) == 1:
+            # Add batch dimension
+            audio_array = np.expand_dims(audio_array, 0)
+
+        if len(audio_array.shape) > 2:
+            raise ValueError(f"Too many dimensions for input audio chunk {audio_array.shape}")
+
+        if audio_array.shape[0] > 1:
+            raise ValueError("Onnx model does not support batching")
+
+        if sample_rate != 16000:
+            raise ValueError("Only 16Khz audio is supported")
+
+        ort_inputs = {
+            "input": audio_array.astype(np.float32),
+            "h0": self._h,
+            "c0": self._c,
+        }
+        ort_outs = self.session.run(None, ort_inputs)
+        out, self._h, self._c = ort_outs
+
+        out = out.squeeze(2)[:, 1]  # make output type match JIT analog
+
+        return out

--- a/phoonnx_train/optispeech/dataset/feature_extractors/pitch_extractors.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/pitch_extractors.py
@@ -1,0 +1,286 @@
+import dataclasses
+import typing
+import warnings
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import librosa
+import numpy as np
+import torch
+import torchaudio
+from scipy.interpolate import interp1d
+
+from phoonnx_train.optispeech.utils import pylogger, trim_or_pad_to_target_length
+
+log = pylogger.get_pylogger(__name__)
+
+# Optional pitch extraction backends — each extractor imports its own
+# library lazily so missing deps don't break the whole module.
+_torchcrepe = _penn = _pyworld = _jdc = None
+
+
+def _get_pyworld():
+    global _pyworld
+    if _pyworld is None:
+        import pyworld as _pyworld_mod
+        _pyworld = _pyworld_mod
+    return _pyworld
+
+
+def _get_torchcrepe():
+    global _torchcrepe
+    if _torchcrepe is None:
+        import torchcrepe as _torchcrepe_mod
+        _torchcrepe = _torchcrepe_mod
+    return _torchcrepe
+
+
+def _get_penn():
+    global _penn
+    if _penn is None:
+        import penn as _penn_mod
+        _penn = _penn_mod
+    return _penn
+
+
+def _get_jdc():
+    global _jdc
+    if _jdc is None:
+        from phoonnx_train.optispeech.vendor.jdc import load_F0_model as _jdc_mod
+        _jdc = _jdc_mod
+    return _jdc
+
+
+log = pylogger.get_pylogger(__name__)
+
+
+@dataclass
+class BasePitchExtractor(ABC):
+    sample_rate: int
+    n_feats: int
+    hop_length: int
+    n_fft: int
+    win_length: int
+    f_min: int
+    f_max: int
+    batch_size: int
+    interpolate: bool = True
+
+    def __post_init__(self):
+        pass
+
+    @abstractmethod
+    def __call__(self, wav: np.ndarray, mel_length: int) -> np.ndarray:
+        """Extract pitch."""
+
+    def __getstate__(self):
+        return dataclasses.asdict(self)
+
+    def __setstate__(self, state):
+        for (attr, value) in state.items():
+            setattr(self, attr, value)
+        self.__post_init__()
+
+    @staticmethod
+    def perform_interpolation(pitch):
+        # interpolate to cover the unvoiced segments as well
+        nonzero_ids = np.where(pitch != 0)[0]
+        interp_fn = interp1d(
+            nonzero_ids,
+            pitch[nonzero_ids],
+            fill_value=(pitch[nonzero_ids[0]], pitch[nonzero_ids[-1]]),
+            bounds_error=False,
+        )
+        pitch = interp_fn(np.arange(0, len(pitch)))
+        return pitch
+
+
+@dataclass
+class DIOPitchExtractor(BasePitchExtractor):
+    _METHOD: typing.ClassVar[str] = "dio"
+
+    def __post_init__(self):
+        self.extraction_func = getattr(_get_pyworld(), self._METHOD)
+
+    def __call__(self, wav, mel_length):
+        wav = wav.astype(np.double)
+        pitch, t = self.extraction_func(
+            wav, self.sample_rate, frame_period=self.hop_length / self.sample_rate * 1000
+        )
+        pitch = _get_pyworld().stonemask(wav, pitch, t, self.sample_rate)
+        pitch = trim_or_pad_to_target_length(pitch, mel_length)
+        if self.interpolate:
+            pitch = self.perform_interpolation(pitch)
+        return pitch
+
+
+class HarvestPitchExtractor(DIOPitchExtractor):
+    _METHOD: str = "harvest"
+
+
+@dataclass
+class PENNPitchExtractor(BasePitchExtractor):
+    """PENN (Pitch Estimating Neural Networks)."""
+
+    # Dataset dependent value
+    # override it in config
+    # Periodicity threshold for pitch interpolation 
+    interp_unvoiced_at: float = 0.04
+
+    def __call__(self, wav, mel_length):
+        pitch, periodicity = _get_penn().from_audio(
+            torch.from_numpy(wav).unsqueeze(0),
+            sample_rate=self.sample_rate,
+            hopsize=(self.hop_length / self.sample_rate),
+            fmin=self.f_min,
+            fmax=self.f_max,
+            batch_size=self.batch_size,
+            interp_unvoiced_at=self.interp_unvoiced_at,
+            gpu=0
+        )
+        pitch = pitch.detach().cpu().numpy().squeeze()
+        pitch = trim_or_pad_to_target_length(pitch, mel_length)
+        return pitch
+
+
+@dataclass
+class JDCPitchExtractor(BasePitchExtractor):
+    """https://github.com/yl4579/StyleTTS2/tree/main/Utils/JDC"""
+
+    def __post_init__(self):
+        self.jdc_model = _get_jdc()()
+        self.device = "cpu"
+        if torch.cuda.is_available():
+            self.jdc_model.to('cuda')
+            self.device = "cuda"
+        self.mel_feat = torchaudio.transforms.MelSpectrogram(
+            n_mels=80,
+            n_fft=2048,
+            win_length=1200,
+            hop_length=300,
+        )
+        self.mean, self.std = -4, 4
+
+    def extract_mel(self, wave):
+        wave_tensor = torch.from_numpy(wave).float()
+        mel_tensor = self.mel_feat(wave_tensor)
+        mel_tensor = (torch.log(1e-5 + mel_tensor.unsqueeze(0)) - self.mean) / self.std
+        return mel_tensor
+
+    def __call__(self, wav, mel_length):
+        mel = self.extract_mel(wav).to(self.device)
+        F0_real, _, _ = self.jdc_model(mel.unsqueeze(1))
+        F0_real[F0_real < 21] = 0.0
+        pitch = F0_real.detach().cpu().numpy()
+        pitch = trim_or_pad_to_target_length(pitch, mel_length)
+        return pitch
+
+
+@dataclass
+class CrepePitchExtractor(BasePitchExtractor):
+    """https://github.com/maxrmorrison/torchcrepe"""
+    
+    def __post_init__(self):
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.pe_fmin = self.f_min
+        # Upper limit for Crepe
+        self.pe_fmax = min(self.f_max, 1536)
+        self.crepe_model_type = "full"
+
+    def __call__(self, wav, mel_length):
+        hop_length_new = int((self.hop_length / self.sample_rate) * 16000.0)
+        f0 = self.get_f0_features_using_crepe(
+            audio=wav,
+            mel_len=mel_length,
+            fs=self.sample_rate,
+            hop_length=self.hop_length,
+            hop_length_new=hop_length_new,
+            f0_min=self.pe_fmin,
+            f0_max=self.pe_fmax,
+        )
+        f0 = f0.detach().cpu().numpy().squeeze()
+        pitch = trim_or_pad_to_target_length(f0, mel_length)
+        return pitch
+
+    @staticmethod
+    def get_f0_features_using_crepe(
+        audio, mel_len, fs, hop_length, hop_length_new, f0_min, f0_max, threshold=0.3
+    ):
+        """Using torchcrepe to extract the f0 feature.
+        Args:
+            audio
+            mel_len
+            fs
+            hop_length
+            hop_length_new
+            f0_min
+            f0_max
+            threshold(default=0.3)
+        Returns:
+            f0: numpy array of shape (frame_len,)
+        """
+        # Currently, crepe only supports 16khz audio
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        audio_16k = librosa.resample(audio, orig_sr=fs, target_sr=16000)
+        audio_16k_torch = torch.FloatTensor(audio_16k).unsqueeze(0).to(device)
+
+        # Get the raw pitch
+        f0, pd = _get_torchcrepe().predict(
+            audio_16k_torch,
+            16000,
+            hop_length_new,
+            f0_min,
+            f0_max,
+            pad=True,
+            model="full",
+            batch_size=1024,
+            device=device,
+            return_periodicity=True,
+        )
+
+        # Filter, de-silence, set up threshold for unvoiced part
+        pd = _get_torchcrepe().filter.median(pd, 3)
+        pd = _get_torchcrepe().threshold.Silence(-60.0)(pd, audio_16k_torch, 16000, hop_length_new)
+        f0 = _get_torchcrepe().threshold.At(threshold)(f0, pd)
+        f0 = _get_torchcrepe().filter.mean(f0, 3)
+        
+        # Convert unvoiced part to 0hz
+        f0 = torch.where(torch.isnan(f0), torch.full_like(f0, 0), f0)
+        return f0
+
+
+@dataclass
+class EnsemblePitchExtractor(BasePitchExtractor):
+    # cls -> voiced-reliability score
+    extractor_classes = {
+        DIOPitchExtractor: 0.75,
+        PENNPitchExtractor: 0.08,
+        JDCPitchExtractor: 0.15,
+        CrepePitchExtractor: 0.02,
+    }
+
+    def __post_init__(self):
+        extractor_kw = dataclasses.asdict(self)
+        self._extractors = [
+            (ex_cls(**extractor_kw), score)
+            for (ex_cls, score) in self.extractor_classes.items()
+        ]
+        self.uv_threshold = self.f_min // 3.5
+
+    def __call__(self, wav, mel_length):
+        preds = []
+        weights = []
+        for (extractor, score) in self._extractors:
+            weights.append(score)
+            ptch = extractor(wav, mel_length)
+            preds.append(ptch)
+        pitch = np.stack(preds, 0)
+        uv_detector = pitch[2] # JDC
+        uv_mask = uv_detector <= self.uv_threshold
+        pitch = np.average(pitch, axis=0, weights=weights)
+        pitch[uv_mask] = 0.0
+        if self.interpolate:
+            pitch = self.perform_interpolation(pitch)
+        return pitch
+
+

--- a/phoonnx_train/optispeech/dataset/text_wav_datamodule.py
+++ b/phoonnx_train/optispeech/dataset/text_wav_datamodule.py
@@ -1,0 +1,265 @@
+import json
+import random
+from hashlib import md5
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import librosa
+import numpy as np
+import torch
+import torchaudio as ta
+from pytorch_lightning import LightningDataModule
+from scipy.interpolate import interp1d
+from torch.utils.data.dataloader import DataLoader
+
+from phoonnx_train.optispeech.dataset.feature_extractors import FeatureExtractor
+from phoonnx_train.optispeech.text import TextProcessor
+from phoonnx_train.optispeech.utils import normalize, pylogger
+
+log = pylogger.get_pylogger(__name__)
+
+
+
+def do_preprocess_utterance(
+    feature_extractor: FeatureExtractor,
+    text_processor: TextProcessor,
+    audio_filepath: str,
+    text: str,
+    lang: str|None
+):
+    if text_processor.is_multi_language:
+        assert lang is not None, "Language not provided for multi-language model"
+    lang = lang if text_processor.is_multi_language else None
+    phoneme_ids, text = text_processor(text, lang=lang)
+    wav, mel, energy, pitch = feature_extractor(audio_filepath)
+    return dict(
+        phoneme_ids=phoneme_ids,
+        text=text,
+        wav=wav,
+        mel=mel,
+        energy=energy,
+        pitch=pitch,
+    )
+
+
+def parse_filelist(filelist_path):
+    filepaths = Path(filelist_path).read_text(encoding="utf-8").splitlines()
+    filepaths = [f for f in filepaths if f.strip()]
+    return filepaths
+
+
+class TextWavDataModule(LightningDataModule):
+    def __init__(  # pylint: disable=unused-argument
+        self,
+        name,
+        num_speakers,
+        train_filelist_path,
+        valid_filelist_path,
+        batch_size,
+        num_workers,
+        pin_memory,
+        text_processor,
+        feature_extractor,
+        data_statistics,
+        seed,
+    ):
+        super().__init__()
+
+        # this line allows to access init params with 'self.hparams' attribute
+        # also ensures init params will be stored in ckpt
+        self.save_hyperparameters(logger=False)
+        self.feature_extractor = feature_extractor
+        self.text_processor = text_processor
+        self.num_speakers = num_speakers
+        self.n_feats = feature_extractor.n_feats
+
+    def setup(self, stage: Optional[str] = None):  # pylint: disable=unused-argument
+        """Load data. Set variables: `self.data_train`, `self.data_val`, `self.data_test`.
+
+        This method is called by lightning with both `trainer.fit()` and `trainer.test()`, so be
+        careful not to execute things like random split twice!
+        """
+        # load and split datasets only if not loaded already
+
+        self.trainset = TextWavDataset(  # pylint: disable=attribute-defined-outside-init
+            num_speakers=self.hparams.num_speakers,
+            filelist_path=self.hparams.train_filelist_path,
+            text_processor=self.hparams.text_processor,
+            feature_extractor=self.feature_extractor,
+            seed=self.hparams.seed,
+        )
+        self.validset = TextWavDataset(  # pylint: disable=attribute-defined-outside-init
+            num_speakers=self.hparams.num_speakers,
+            filelist_path=self.hparams.valid_filelist_path,
+            text_processor=self.hparams.text_processor,
+            feature_extractor=self.feature_extractor,
+            seed=self.hparams.seed,
+        )
+
+    def train_dataloader(self, do_normalize=True):
+        return DataLoader(
+            dataset=self.trainset,
+            batch_size=self.hparams.batch_size,
+            num_workers=self.hparams.num_workers,
+            pin_memory=self.hparams.pin_memory,
+            shuffle=True,
+            collate_fn=TextWavBatchCollate(self.n_feats, self.hparams.data_statistics, do_normalize=do_normalize),
+        )
+
+    def val_dataloader(self):
+        return DataLoader(
+            dataset=self.validset,
+            batch_size=self.hparams.batch_size,
+            num_workers=self.hparams.num_workers,
+            pin_memory=self.hparams.pin_memory,
+            shuffle=False,
+            collate_fn=TextWavBatchCollate(self.n_feats, self.hparams.data_statistics),
+        )
+
+    def teardown(self, stage: Optional[str] = None):
+        """Clean up after fit or test."""
+        pass  # pylint: disable=unnecessary-pass
+
+    def state_dict(self):
+        """Extra things to save to checkpoint."""
+        return {}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]):
+        """Things to do when loading checkpoint."""
+        pass  # pylint: disable=unnecessary-pass
+
+
+class TextWavDataset(torch.utils.data.Dataset):
+    def __init__(
+        self,
+        num_speakers,
+        filelist_path,
+        text_processor,
+        feature_extractor,
+        seed=None,
+    ):
+        self.num_speakers = num_speakers
+        self.text_processor = text_processor
+        self.feature_extractor = feature_extractor
+        self.file_paths = parse_filelist(filelist_path)
+        self.data_dir = Path(filelist_path).parent.joinpath("data")
+        self.uv_threshold = self.feature_extractor.f_min // 3.5
+        random.seed(seed)
+        random.shuffle(self.file_paths)
+
+    def get_datapoint(self, filepath):
+        input_file = Path(filepath)
+        json_filepath = input_file.with_suffix(".json")
+        arrays_filepath = input_file.with_suffix(".npz")
+        with open(json_filepath, encoding="utf-8") as file:
+            data = json.load(file)
+            phoneme_ids = data["phoneme_ids"]
+            text = data["text"]
+            sid = data.get("sid")
+            lid = data.get("lid")
+            phoneme_ids = torch.LongTensor(phoneme_ids)
+        data = np.load(arrays_filepath, allow_pickle=False)
+        # TODO: Maybe revisit this later
+        pitch = torch.from_numpy(data["pitch"])
+        pitch[pitch <= self.uv_threshold] = 0.0
+        return dict(
+            x=phoneme_ids,
+            wav=torch.from_numpy(data["wav"]),
+            mel=torch.from_numpy(data["mel"]),
+            energy=torch.from_numpy(data["energy"]),
+            pitch=pitch,
+            sid=sid,
+            lid=lid,
+            text=text,
+            filepath=filepath,
+        )
+
+    def preprocess_utterance(self, audio_filepath: str, text: str, lang: str):
+        return do_preprocess_utterance(
+            feature_extractor=self.feature_extractor,
+            text_processor=self.text_processor,
+            audio_filepath=audio_filepath,
+            text=text,
+            lang=lang
+        )
+
+    def __getitem__(self, index):
+        filepath = self.file_paths[index]
+        datapoint = self.get_datapoint(filepath)
+        return datapoint
+
+    def __len__(self):
+        return len(self.file_paths)
+
+
+class TextWavBatchCollate:
+    def __init__(self, n_feats: float, data_statistics: Dict[str, float], do_normalize: bool = True):
+        self.n_feats = n_feats
+        self.data_statistics = data_statistics
+        self.do_normalize = do_normalize
+
+    def __call__(self, batch):
+        B = len(batch)
+
+        x_max_length = max([item["x"].shape[-1] for item in batch])
+        mel_max_length = max([item["mel"].shape[-1] for item in batch])
+        wav_max_length = max([item["wav"].shape[-1] for item in batch])
+
+        x = torch.zeros((B, x_max_length), dtype=torch.long)
+        wav = np.zeros((B, wav_max_length), dtype=np.float32)
+        mel = torch.zeros((B, self.n_feats, mel_max_length), dtype=torch.float32)
+
+        pitches = torch.zeros((B, mel_max_length), dtype=torch.float)
+        energies = torch.zeros((B, mel_max_length), dtype=torch.float)
+
+        x_lengths, wav_lengths, mel_lengths = [], [], []
+        sids, lids = [], []
+        x_texts, filepaths = [], []
+        for i, item in enumerate(batch):
+            x_, wav_, mel_ = item["x"], item["wav"], item["mel"]
+            x_lengths.append(x_.shape[-1])
+            wav_lengths.append(wav_.shape[-1])
+            mel_lengths.append(mel_.shape[-1])
+            x[i, : x_.shape[-1]] = x_
+            wav[i, : wav_.shape[-1]] = wav_
+            mel[i, :, : item["mel"].shape[-1]] = mel_
+            energies[i, : item["energy"].shape[-1]] = item["energy"].float()
+            pitches[i, : item["pitch"].shape[-1]] = item["pitch"].float()
+            if item["sid"] is not None:
+                sids.append(item["sid"])
+            if item["lid"] is not None:
+                lids.append(item["lid"])
+            x_texts.append(item["text"])
+            filepaths.append(item["filepath"])
+
+        x_lengths = torch.tensor(x_lengths, dtype=torch.long)
+        wav_lengths = torch.tensor(wav_lengths, dtype=torch.long)
+        mel_lengths = torch.tensor(mel_lengths, dtype=torch.long)
+        sids = torch.LongTensor(sids) if sids else None
+        lids = torch.LongTensor(lids) if lids else None
+
+        if sids is not None:
+            assert sids.shape[0] == B, "Not all speaker IDs are provided"
+        if lids is not None:
+            assert lids.shape[0] == B, "Not all language IDs are provided"
+
+        if self.do_normalize:
+            wav = wav.clip(-1, 1)
+            mel = normalize(mel, self.data_statistics["mel_mean"], self.data_statistics["mel_std"])
+            energies = normalize(energies, self.data_statistics["energy_mean"], self.data_statistics["energy_std"])
+            pitches = normalize(pitches, self.data_statistics["pitch_mean"], self.data_statistics["pitch_std"])
+
+        return dict(
+            x=x,
+            wav=wav,
+            mel=mel,
+            x_lengths=x_lengths,
+            wav_lengths=wav_lengths,
+            mel_lengths=mel_lengths,
+            energies=energies,
+            pitches=pitches,
+            sids=sids,
+            lids=lids,
+            x_texts=x_texts,
+            filepaths=filepaths,
+        )

--- a/phoonnx_train/optispeech/model/base_lightning_module.py
+++ b/phoonnx_train/optispeech/model/base_lightning_module.py
@@ -1,0 +1,309 @@
+"""
+This is a base lightning module that can be used to train a model.
+The benefit of this abstraction is that all the logic outside of model definition can be reused for different models.
+"""
+
+import math
+from abc import ABC
+from typing import Any, Dict
+
+import numpy as np
+import torch
+import torchaudio
+from pytorch_lightning import LightningModule
+from pytorch_lightning.utilities import grad_norm
+
+from phoonnx_train.optispeech.utils import get_pylogger, plot_tensor
+from phoonnx_train.optispeech.utils.segments import get_segments_numpy
+
+log = get_pylogger(__name__)
+
+
+class BaseLightningModule(LightningModule, ABC):
+    def _process_batch(self, batch):
+        sids = batch["sids"]
+        lids = batch["lids"]
+        gen_outputs = self.generator(
+            x=batch["x"].to(self.device),
+            x_lengths=batch["x_lengths"].to(self.device),
+            mel=batch["mel"].to(self.device),
+            mel_lengths=batch["mel_lengths"].to(self.device),
+            pitches=batch["pitches"].to(self.device),
+            energies=batch["energies"].to(self.device),
+            sids=sids.to(self.device) if sids is not None else None,
+            lids=lids.to(self.device) if lids is not None else None,
+        )
+        segment_size = gen_outputs["segment_size"]
+        seg_gt_wav = get_segments_numpy(
+            x=np.expand_dims(batch["wav"], 1),
+            start_idxs=gen_outputs["start_idx"] * self.hop_length,
+            segment_size=segment_size * self.hop_length,
+        )
+        seg_gt_wav = torch.from_numpy(seg_gt_wav.squeeze(1)).type_as(gen_outputs["wav_hat"])
+        gen_outputs["wav"] = seg_gt_wav
+        return gen_outputs
+
+    def configure_optimizers(self):
+        gen_params = [
+            {"params": self.generator.parameters()},
+        ]
+        disc_params = [
+            {"params": self.discriminator.parameters()},
+        ]
+        opt_gen = self.hparams.optimizer(gen_params)
+        opt_disc = self.hparams.optimizer(disc_params)
+
+        # Max steps per optimizer
+        max_steps = self.trainer.max_steps // 2
+        # Adjust by gradient accumulation batches
+        if self.train_args.gradient_accumulate_batches is not None:
+            max_epochs = self.trainer.max_epochs if self.trainer.max_epochs is not None else -1
+            max_steps = math.ceil(max_steps / self.train_args.gradient_accumulate_batches) * max(max_epochs, 1)
+
+        if "num_training_steps" in self.hparams.scheduler.keywords:
+            self.hparams.scheduler.keywords["num_training_steps"] = max_steps
+        # Schedulers are constructed fresh (last_epoch=-1); on resume Lightning
+        # restores their state via ``load_state_dict`` from the checkpoint's
+        # ``lr_schedulers`` entry, so the schedule continues from the right step
+        # without requiring ``initial_lr`` to be pre-seeded in the param groups.
+        scheduler_gen = self.hparams.scheduler(opt_gen)
+        scheduler_disc = self.hparams.scheduler(opt_disc)
+        return (
+            [opt_gen, opt_disc],
+            [{"scheduler": scheduler_gen, "interval": "step"}, {"scheduler": scheduler_disc, "interval": "step"}],
+        )
+
+    def on_train_epoch_start(self) -> None:
+        if self.current_epoch == self.trainer.max_epochs - 1:
+            # Workaround to always save the last epoch until the bug is fixed in lightning (https://github.com/Lightning-AI/lightning/issues/4539)
+            self.trainer.check_val_every_n_epoch = 1
+
+    def training_step(self, batch, batch_idx, **kwargs):
+        # manual gradient accumulation
+        gradient_accumulate_batches = self.train_args.gradient_accumulate_batches
+        if gradient_accumulate_batches is not None:
+            loss_scaling_factor = float(gradient_accumulate_batches)
+            should_apply_gradients = (batch_idx + 1) % gradient_accumulate_batches == 0
+        else:
+            loss_scaling_factor = 1.0
+            should_apply_gradients = True
+        # Generator pretraining
+        train_discriminator = self.global_step >= self.train_args.pretraining_steps
+        # Extract generator/discriminator optimizer/scheduler
+        opt_g, opt_d = self.optimizers()
+        sched_g, sched_d = self.lr_schedulers()
+        # train generator
+        self.toggle_optimizer(opt_g)
+        loss_g, wav_outputs = self.training_step_g(batch, train_discriminator=train_discriminator)
+        # Scale (grad accumulate)
+        loss_g /= loss_scaling_factor
+        if should_apply_gradients:
+            opt_g.zero_grad()
+        self.manual_backward(loss_g)
+        self.clip_gradients(
+            opt_g, gradient_clip_val=self.train_args.gradient_clip_val, gradient_clip_algorithm="norm"
+        )
+        if should_apply_gradients:
+            opt_g.step()
+            sched_g.step()
+        self.untoggle_optimizer(opt_g)
+        # train discriminator
+        if not train_discriminator:
+            # we're still in generator pretraining
+            return
+        self.toggle_optimizer(opt_d)
+        if not self.train_args.cache_generator_outputs:
+            wav_outputs = None
+        loss_d = self.training_step_d(batch, wav_outputs=wav_outputs)
+        # Scale (grad accumulate)
+        loss_d /= loss_scaling_factor
+        if should_apply_gradients:
+            opt_d.zero_grad()
+        self.manual_backward(loss_d, retain_graph=True)
+        self.clip_gradients(
+            opt_d, gradient_clip_val=self.train_args.gradient_clip_val, gradient_clip_algorithm="norm"
+        )
+        if should_apply_gradients:
+            opt_d.step()
+            sched_d.step()
+        self.untoggle_optimizer(opt_d)
+
+    def training_step_g(self, batch, train_discriminator):
+        log_outputs = {}
+        gen_outputs = self._process_batch(batch)
+        gen_am_loss = gen_outputs["loss"]
+        log_outputs.update(
+            {
+                "total_loss/train_am_loss": gen_am_loss.item(),
+                "gen_subloss/train_alighn_loss": gen_outputs["align_loss"].item(),
+                "gen_subloss/train_duration_loss": gen_outputs["duration_loss"].item(),
+                "gen_subloss/train_pitch_loss": gen_outputs["pitch_loss"].item(),
+                "gen_subloss/train_energy_loss": gen_outputs["energy_loss"].item(),
+            }
+        )
+        wav, wav_hat = gen_outputs["wav"], gen_outputs["wav_hat"]
+        if train_discriminator:
+            gen_adv_loss, log_dict = self.discriminator.forward_gen(wav, wav_hat)
+            log_outputs["total_loss/train_gen_adv_loss"] = gen_adv_loss.item()
+            log_outputs.update({
+                f"gen_adv_loss/train_{key}": value.item() if isinstance(value, torch.Tensor) else value
+                for (key, value) in log_dict.items()
+            })
+        else:
+            gen_adv_loss = 0.0
+        loss = gen_am_loss + gen_adv_loss
+        log_outputs["total_loss/generator"] = loss.item()
+        self.log_dict(
+            log_outputs,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=self.data_args.batch_size,
+        )
+        return loss, (wav.detach(), wav_hat)
+
+    def training_step_d(self, batch, wav_outputs=None):
+        log_outputs = {}
+        if wav_outputs is None:
+            # Don't train generator in discriminator's turn
+            with torch.no_grad():
+                gen_outputs = self._process_batch(batch)
+            wav, wav_hat = gen_outputs["wav"], gen_outputs["wav_hat"]
+        else:
+            wav, wav_hat = wav_outputs
+        loss, log_dict = self.discriminator.forward_disc(wav, wav_hat)
+        log_outputs["total_loss/discriminator"] = loss.item()
+        log_outputs.update({
+            f"discriminator/{key}": value.item() if isinstance(value, torch.Tensor) else value
+            for key, value in log_dict.items()
+        })
+        self.log_dict(
+            log_outputs,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=self.data_args.batch_size,
+        )
+        return loss
+
+    def on_validation_epoch_start(self):
+        if self.train_args.evaluate_utmos:
+            from phoonnx_train.optispeech.vendor.metrics.UTMOS import UTMOSScore
+
+            if not hasattr(self, "utmos_model"):
+                self.utmos_model = UTMOSScore(device=self.device)
+
+    def validation_step(self, batch, batch_idx, **kwargs):
+        log_outputs = {}
+        gen_outputs = self._process_batch(batch)
+        gen_am_loss = gen_outputs["loss"]
+        log_outputs.update(
+            {
+                "total_loss/val_am_loss": gen_outputs["loss"].item(),
+                "gen_subloss/val_alighn_loss": gen_outputs["align_loss"].item(),
+                "gen_subloss/val_duration_loss": gen_outputs["duration_loss"].item(),
+                "gen_subloss/val_pitch_loss": gen_outputs["pitch_loss"].item(),
+                "gen_subloss/val_energy_loss": gen_outputs["energy_loss"].item()
+            }
+        )
+        wav, wav_hat = gen_outputs["wav"], gen_outputs["wav_hat"]
+        gen_adv_loss, log_dict = self.discriminator.forward_val(wav, wav_hat)
+        log_outputs["total_loss/val_gen_adv_loss"] = gen_adv_loss.item()
+        log_outputs.update({
+            f"gen_adv_loss/val_{key}": value.item() if isinstance(value, torch.Tensor) else value
+            for key, value in log_dict.items()
+        })
+        # perceptual eval
+        audio_16_khz = torchaudio.functional.resample(wav, orig_freq=self.sample_rate, new_freq=16000)
+        audio_hat_16khz = torchaudio.functional.resample(wav_hat, orig_freq=self.sample_rate, new_freq=16000)
+        if self.train_args.evaluate_periodicity:
+            from phoonnx_train.optispeech.vendor.metrics.periodicity import calculate_periodicity_metrics
+
+            periodicity_loss, perio_pitch_loss, f1_score = calculate_periodicity_metrics(audio_16_khz, audio_hat_16khz)
+            log_outputs.update(
+                {
+                    "val/periodicity_loss": periodicity_loss.item(),
+                    "val/perio_pitch_loss": perio_pitch_loss.item(),
+                    "val/f1_score": f1_score.item(),
+                }
+            )
+        if self.train_args.evaluate_utmos:
+            utmos_score = self.utmos_model.score(audio_hat_16khz.unsqueeze(1)).mean()
+            utmos_loss = 5 - utmos_score
+        else:
+            utmos_loss = torch.zeros(1, device=self.device)
+        if self.train_args.evaluate_pesq:
+            from pesq import pesq
+
+            pesq_score = 0
+            for ref, deg in zip(audio_16_khz.cpu().numpy(), audio_hat_16khz.cpu().numpy()):
+                pesq_score += pesq(16000, ref, deg, "wb", on_error=1)
+            pesq_score /= len(audio_16_khz)
+            pesq_score = torch.tensor(pesq_score)
+            pesq_loss = 5 - pesq_score
+        else:
+            pesq_loss = torch.zeros(1, device=self.device)
+        total_loss = gen_am_loss + gen_adv_loss + utmos_loss + pesq_loss
+        log_outputs["total_loss/val_total"] = total_loss.item()
+        self.log_dict(
+            log_outputs,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=self.data_args.batch_size,
+        )
+
+    def on_validation_end(self) -> None:
+        if self.trainer.is_global_zero:
+            one_batch = next(iter(self.trainer.val_dataloaders))
+            if self.current_epoch == 0:
+                log.debug("Plotting original samples")
+                for i in range(2):
+                    gt_wav = one_batch["wav"][i].squeeze()
+                    self.logger.experiment.add_audio(
+                        f"wav/original_{i}", gt_wav, self.global_step, self.sample_rate
+                    )
+                    mel = one_batch["mel"][i].unsqueeze(0).to(self.device)
+                    self.logger.experiment.add_image(
+                        f"mel/original_{i}",
+                        plot_tensor(mel.detach().squeeze().float().cpu()),
+                        self.current_epoch,
+                        dataformats="HWC",
+                    )
+            log.debug("Synthesising...")
+            for i in range(2):
+                x = one_batch["x"][i].unsqueeze(0).to(self.device)
+                x_lengths = one_batch["x_lengths"][i].unsqueeze(0).to(self.device)
+                synth_out = self.generator.synthesise(x=x[:, :x_lengths], x_lengths=x_lengths)
+                wav_hat = synth_out["wav"].squeeze().float().detach().cpu().numpy()
+                mel_hat = self.data_args.feature_extractor.get_mel(wav_hat)
+                self.logger.experiment.add_image(
+                    f"mel/generated_{i}",
+                    plot_tensor(mel_hat.squeeze()),
+                    self.current_epoch,
+                    dataformats="HWC",
+                )
+                self.logger.experiment.add_audio(f"wav/generated_{i}", wav_hat, self.global_step, self.sample_rate)
+
+    def test_step(self, batch, batch_idx):
+        pass
+
+    def on_before_optimizer_step(self, optimizer):
+        self.log_dict({f"grad_norm/{k}": v for k, v in grad_norm(self, norm_type=2).items()})
+
+    @property
+    def global_step(self):
+        """
+        Override global_step so that it returns the total number of batches processed with respect to `gradient_accumulate_batches`
+        """
+        if self.train_args.gradient_accumulate_batches is not None:
+            global_step = self.trainer.fit_loop.total_batch_idx // self.train_args.gradient_accumulate_batches
+        else:
+            global_step = self.trainer.fit_loop.total_batch_idx
+        return int(global_step)
+
+    def on_load_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
+        self.ckpt_loaded_epoch = checkpoint["epoch"]  # pylint: disable=attribute-defined-outside-init

--- a/phoonnx_train/optispeech/model/discriminator/__init__.py
+++ b/phoonnx_train/optispeech/model/discriminator/__init__.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+from typing import TypeAlias
+
+from torch import FloatTensor
+from torch import nn
+
+LossOutput: TypeAlias = tuple[FloatTensor, dict[str, FloatTensor | int]]
+
+
+class BaseVocoderDiscriminator(nn.Module, ABC):
+
+    @abstractmethod
+    def forward_disc(self, wav, wav_hat) -> LossOutput:
+        """Calculate discriminator's loss for training batch"""
+
+    @abstractmethod
+    def forward_gen(self, wav, wav_hat) -> LossOutput:
+        """Calculate adversarial loss for training batch"""
+
+    @abstractmethod
+    def forward_val(self, wav, wav_hat) -> LossOutput:
+        """Calculate loss for validation batch."""

--- a/phoonnx_train/optispeech/model/generator/__init__.py
+++ b/phoonnx_train/optispeech/model/generator/__init__.py
@@ -1,0 +1,299 @@
+from time import perf_counter
+
+import torch
+from torch import nn
+
+from phoonnx_train.optispeech.utils import sequence_mask
+from phoonnx_train.optispeech.utils.segments import get_segments, get_random_segments
+from .alignments import (
+    AlignmentModule,
+    GaussianUpsampling,
+    average_by_duration,
+    expand_by_duration,
+    viterbi_decode,
+)
+from .loss import FastSpeech2Loss, ForwardSumLoss
+
+
+class OptiSpeechGenerator(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            segment_size,
+            text_embedding,
+            encoder,
+            duration_predictor,
+            pitch_predictor,
+            energy_predictor,
+            decoder,
+            vocoder,
+            loss_coeffs,
+            feature_extractor,
+            num_speakers,
+            num_languages,
+            data_statistics,
+            **kwargs
+    ):
+        super().__init__()
+
+        self.segment_size = segment_size
+        self.loss_coeffs = loss_coeffs
+        self.n_feats = feature_extractor.n_feats
+        self.n_fft = feature_extractor.n_fft
+        self.hop_length = feature_extractor.hop_length
+        self.sample_rate = feature_extractor.sample_rate
+        self.data_statistics = data_statistics
+        self.num_speakers = num_speakers
+        self.num_languages = num_languages
+
+        self.text_embedding = text_embedding(dim=dim)
+        self.encoder = encoder(dim=dim)
+        self.duration_predictor = duration_predictor(dim=dim)
+        self.alignment_module = AlignmentModule(adim=dim, odim=self.n_feats)
+        self.pitch_predictor = pitch_predictor(dim=dim)
+        self.energy_predictor = energy_predictor(dim=dim)
+        self.feature_upsampler = GaussianUpsampling()
+        self.decoder = decoder(dim=dim)
+        self.vocoder = vocoder(
+            input_channels=dim,
+            sample_rate=self.sample_rate,
+            n_fft=self.n_fft,
+            hop_length=self.hop_length
+        )
+        if self.num_speakers > 1:
+            self.sid_embed = torch.nn.Embedding(self.num_speakers, dim)
+        if self.num_languages > 1:
+            self.lid_embed = torch.nn.Embedding(self.num_languages, dim)
+        self.loss_criterion = FastSpeech2Loss()
+        self.forwardsum_loss = ForwardSumLoss()
+
+    def forward(self, x, x_lengths, mel, mel_lengths, pitches, energies, sids, lids):
+        """
+        Args:
+            x (torch.Tensor): batch of texts, converted to a tensor with phoneme embedding ids.
+                shape: (batch_size, max_text_length)
+            x_lengths (torch.Tensor): lengths of texts in batch.
+                shape: (batch_size,)
+            pitches (torch.Tensor): phoneme-level pitch values.
+                shape: (batch_size, max_text_length)
+            energies (torch.Tensor): phoneme-level energy values.
+                shape: (batch_size, max_text_length)
+            sids (torch.LongTensor): list of speaker IDs for each input sentence.
+                shape: (batch_size,)
+            lids (torch.LongTensor): list of language IDs for each input sentence.
+                shape: (batch_size,)
+
+        Returns:
+            loss: (torch.Tensor): scaler representing total loss
+            alignment_loss: (torch.Tensor): scaler representing alignment loss
+            duration_loss: (torch.Tensor): scaler representing durations loss
+            pitch_loss: (torch.Tensor): scaler representing pitch loss
+            energy_loss: (torch.Tensor): scaler representing energy loss
+        """
+        f0_real = pitches
+        x_max_length = x_lengths.max()
+        x_mask = torch.unsqueeze(sequence_mask(x_lengths, x_max_length), 1).type_as(x)
+
+        mel_max_length = mel_lengths.max()
+        mel_mask = torch.unsqueeze(sequence_mask(mel_lengths, mel_max_length), 1).type_as(x)
+
+        input_padding_mask = ~x_mask.squeeze(1).bool().to(x.device)
+        target_padding_mask = ~mel_mask.squeeze(1).bool().to(x.device)
+
+        # text embedding
+        x, __ = self.text_embedding(x)
+
+        # Encoder
+        x = self.encoder(x, input_padding_mask)
+
+        # Speaker and language embedding
+        if sids is not None:
+            sid_emb = self.sid_embed(sids.view(-1))
+            x = x + sid_emb.unsqueeze(1)
+        if lids is not None:
+            lid_embs = self.lid_embed(lids.view(-1))
+            x = x + lid_embs.unsqueeze(1)
+
+        # alignment
+        log_p_attn = self.alignment_module(
+            text=x,
+            feats=mel.transpose(1, 2),
+            text_lengths=x_lengths,
+            feats_lengths=mel_lengths,
+            x_masks=input_padding_mask,
+        )
+        durations, bin_loss = viterbi_decode(log_p_attn, x_lengths, mel_lengths)
+        duration_hat = self.duration_predictor(x.detach(), input_padding_mask)
+
+        # Average pitch and energy values based on durations
+        pitches = average_by_duration(durations, pitches.unsqueeze(-1), x_lengths, mel_lengths)
+        energies = average_by_duration(durations, energies.unsqueeze(-1), x_lengths, mel_lengths)
+
+        # variance predictors
+        x, pitch_hat = self.pitch_predictor(x, input_padding_mask, pitches)
+        x, energy_hat = self.energy_predictor(x, input_padding_mask, energies)
+
+        # upsample to mel lengths
+        y = self.feature_upsampler(
+            hs=x, ds=durations, h_masks=mel_mask.squeeze(1).bool(), d_masks=x_mask.squeeze(1).bool()
+        )
+
+        # Decoder
+        y = self.decoder(y, target_padding_mask)
+
+        # get random segments
+        segment_size = min(self.segment_size, y.shape[-2])
+        num_frames = mel_lengths - 4  # mel-centered
+        segment, start_idx = get_random_segments(
+            y.transpose(1, 2),
+            num_frames.type_as(y),
+            segment_size,
+        )
+        f0_cond = get_segments(
+            f0_real.unsqueeze(1),
+            start_idxs=start_idx,
+            segment_size=segment_size
+        )
+
+        # Generate wav
+        wav_hat = self.vocoder(segment.detach(), f0=f0_cond.detach())
+
+        # Losses
+        loss_coeffs = self.loss_coeffs
+        duration_loss, pitch_loss, energy_loss = self.loss_criterion(
+            d_outs=duration_hat.unsqueeze(-1),
+            p_outs=pitch_hat.unsqueeze(-1),
+            e_outs=energy_hat.unsqueeze(-1),
+            ds=durations.unsqueeze(-1),
+            ps=pitches.unsqueeze(-1),
+            es=energies.unsqueeze(-1),
+            ilens=x_lengths,
+        )
+        forwardsum_loss = self.forwardsum_loss(log_p_attn, x_lengths, mel_lengths)
+        align_loss = forwardsum_loss + bin_loss
+        loss = (
+                (align_loss * loss_coeffs.lambda_align)
+                + (duration_loss * loss_coeffs.lambda_duration)
+                + (pitch_loss * loss_coeffs.lambda_pitch)
+                + (energy_loss * loss_coeffs.lambda_energy)
+        )
+
+        return {
+            "wav_hat": wav_hat,
+            "start_idx": start_idx,
+            "segment_size": segment_size,
+            "loss": loss,
+            "align_loss": align_loss.detach().cpu(),
+            "duration_loss": duration_loss.detach().cpu(),
+            "pitch_loss": pitch_loss.detach().cpu(),
+            "energy_loss": energy_loss.detach().cpu(),
+        }
+
+    @torch.inference_mode()
+    def synthesise(self, x, x_lengths, sids=None, lids=None, d_factor=1.0, p_factor=1.0, e_factor=1.0):
+        """
+        Args:
+            x (torch.Tensor): batch of texts, converted to a tensor with phoneme embedding ids.
+                shape: (batch_size, max_text_length)
+            x_lengths (torch.Tensor): lengths of texts in batch.
+                shape: (batch_size,)
+            sids (Optional[torch.LongTensor]): list of speaker IDs for each input sentence.
+                shape: (batch_size,)
+            lids (Optional[torch.LongTensor]): list of language IDs for each input sentence.
+                shape: (batch_size,)
+            d_factor (Optional[float]): scaler to control phoneme durations.
+            p_factor (Optional[float]): scaler to control pitch.
+            e_factor (Optional[float]): scaler to control energy.
+
+        Returns:
+            wav (torch.Tensor): generated waveform
+                shape: (batch_size, T)
+            durations: (torch.Tensor): predicted phoneme durations
+                shape: (batch_size, max_text_length)
+            pitch: (torch.Tensor): predicted pitch
+                shape: (batch_size, max_text_length)
+            energy: (torch.Tensor): predicted energy
+                shape: (batch_size, max_text_length)
+            rtf: (float): total Realtime Factor (inference_t/audio_t)
+        """
+        am_t0 = perf_counter()
+
+        x_max_length = x_lengths.max()
+        x_mask = torch.unsqueeze(sequence_mask(x_lengths, x_max_length), 1).to(x.dtype)
+        x_mask = x_mask.to(x.device)
+        input_padding_mask = ~x_mask.squeeze(1).bool().to(x.device)
+
+        # text embedding
+        x, __ = self.text_embedding(x)
+
+        # Encoder
+        x = self.encoder(x, input_padding_mask)
+
+        # Set default speaker/language during inference when not specified
+        if (self.num_speakers > 1) and sids is None:
+            sids = torch.zeros(x.shape[0]).long().to(x.device)
+        if (self.num_languages > 1) and lids is None:
+            lids = torch.zeros(x.shape[0]).long().to(x.device)
+
+        # Speaker and language embedding
+        if sids is not None:
+            sid_emb = self.sid_embed(sids.view(-1))
+            x = x + sid_emb.unsqueeze(1)
+        if lids is not None:
+            lid_embs = self.lid_embed(lids.view(-1))
+            x = x + lid_embs.unsqueeze(1)
+
+        # duration predictor
+        durations = self.duration_predictor.infer(x, input_padding_mask, factor=d_factor)
+
+        # variance predictors
+        x, pitch = self.pitch_predictor.infer(x, input_padding_mask, p_factor)
+        if self.energy_predictor is not None:
+            x, energy = self.energy_predictor.infer(x, input_padding_mask, e_factor)
+        else:
+            energy = None
+
+        y_lengths = durations.sum(dim=1)
+        y_max_length = y_lengths.max()
+        y_mask = torch.unsqueeze(sequence_mask(y_lengths, y_max_length), 1).type_as(x)
+        target_padding_mask = ~y_mask.squeeze(1).bool()
+
+        y = self.feature_upsampler(
+            hs=x, ds=durations, h_masks=y_mask.squeeze(1).bool(), d_masks=x_mask.squeeze(1).bool()
+        )
+
+        # Decoder
+        y = self.decoder(y, target_padding_mask)
+        am_infer = (perf_counter() - am_t0) * 1000
+
+        v_t0 = perf_counter()
+        # Generate wav
+        f0_cond, _ = expand_by_duration(
+            pitch.unsqueeze(-1),
+            durations
+        )
+        wav = self.vocoder(
+            y.transpose(1, 2),
+            f0=f0_cond.transpose(1, -1),
+            padding_mask=target_padding_mask
+        )
+        wav_lengths = y_lengths * self.hop_length
+        v_infer = (perf_counter() - v_t0) * 1000
+
+        wav_t = wav.shape[-1] / (self.sample_rate * 1e-3)
+        am_rtf = am_infer / wav_t
+        v_rtf = v_infer / wav_t
+        rtf = am_rtf + v_rtf
+        latency = am_infer + v_infer
+
+        return {
+            "wav": wav.detach().cpu(),
+            "wav_lengths": wav_lengths.detach().cpu(),
+            "durations": durations.detach().cpu(),
+            "pitch": pitch.detach().cpu(),
+            "energy": energy.detach().cpu(),
+            "am_rtf": am_rtf,
+            "v_rtf": v_rtf,
+            "rtf": rtf,
+            "latency": latency,
+        }

--- a/phoonnx_train/optispeech/model/generator/alignments.py
+++ b/phoonnx_train/optispeech/model/generator/alignments.py
@@ -1,0 +1,297 @@
+# Copyright 2022 Dan Lim
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+import logging
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from numba import jit
+from scipy.stats import betabinom
+
+
+class AlignmentModule(nn.Module):
+    """Alignment Learning Framework proposed for parallel TTS models in:
+
+    https://arxiv.org/abs/2108.10447
+
+    """
+
+    def __init__(self, adim, odim, cache_prior=True):
+        """Initialize AlignmentModule.
+
+        Args:
+            adim (int): Dimension of attention.
+            odim (int): Dimension of feats.
+            cache_prior (bool): Whether to cache beta-binomial prior.
+
+        """
+        super().__init__()
+        self.cache_prior = cache_prior
+        self._cache = {}
+
+        self.t_conv1 = nn.Conv1d(adim, adim, kernel_size=3, padding=1)
+        self.t_conv2 = nn.Conv1d(adim, adim, kernel_size=1, padding=0)
+
+        self.f_conv1 = nn.Conv1d(odim, adim, kernel_size=3, padding=1)
+        self.f_conv2 = nn.Conv1d(adim, adim, kernel_size=3, padding=1)
+        self.f_conv3 = nn.Conv1d(adim, adim, kernel_size=1, padding=0)
+
+    def forward(self, text, feats, text_lengths, feats_lengths, x_masks=None):
+        """Calculate alignment loss.
+
+        Args:
+            text (Tensor): Batched text embedding (B, T_text, adim).
+            feats (Tensor): Batched acoustic feature (B, T_feats, odim).
+            text_lengths (Tensor): Text length tensor (B,).
+            feats_lengths (Tensor): Feature length tensor (B,).
+            x_masks (Tensor): Mask tensor (B, T_text).
+
+        Returns:
+            Tensor: Log probability of attention matrix (B, T_feats, T_text).
+
+        """
+        text = text.transpose(1, 2)
+        text = F.relu(self.t_conv1(text))
+        text = self.t_conv2(text)
+        text = text.transpose(1, 2)
+
+        feats = feats.transpose(1, 2)
+        feats = F.relu(self.f_conv1(feats))
+        feats = F.relu(self.f_conv2(feats))
+        feats = self.f_conv3(feats)
+        feats = feats.transpose(1, 2)
+
+        dist = feats.unsqueeze(2) - text.unsqueeze(1)
+        dist = torch.norm(dist, p=2, dim=3)
+        score = -dist
+
+        if x_masks is not None:
+            x_masks = x_masks.unsqueeze(-2)
+            score = score.masked_fill(x_masks, -np.inf)
+
+        log_p_attn = F.log_softmax(score, dim=-1)
+
+        # add beta-binomial prior
+        bb_prior = self._generate_prior(
+            text_lengths,
+            feats_lengths,
+        ).to(dtype=log_p_attn.dtype, device=log_p_attn.device)
+        log_p_attn = log_p_attn + bb_prior
+
+        return log_p_attn
+
+    def _generate_prior(self, text_lengths, feats_lengths, w=1) -> torch.Tensor:
+        """Generate alignment prior formulated as beta-binomial distribution
+
+        Args:
+            text_lengths (Tensor): Batch of the lengths of each input (B,).
+            feats_lengths (Tensor): Batch of the lengths of each target (B,).
+            w (float): Scaling factor; lower -> wider the width.
+
+        Returns:
+            Tensor: Batched 2d static prior matrix (B, T_feats, T_text).
+
+        """
+        B = len(text_lengths)
+        T_text = text_lengths.max()
+        T_feats = feats_lengths.max()
+
+        bb_prior = torch.full((B, T_feats, T_text), fill_value=-np.inf)
+        for bidx in range(B):
+            T = feats_lengths[bidx].item()
+            N = text_lengths[bidx].item()
+
+            key = str(T) + "," + str(N)
+            if self.cache_prior and key in self._cache:
+                prob = self._cache[key]
+            else:
+                alpha = w * np.arange(1, T + 1, dtype=float)  # (T,)
+                beta = w * np.array([T - t + 1 for t in alpha])
+                k = np.arange(N)
+                batched_k = k[..., None]  # (N,1)
+                prob = betabinom.logpmf(batched_k, N, alpha, beta)  # (N,T)
+
+            # store cache
+            if self.cache_prior and key not in self._cache:
+                self._cache[key] = prob
+
+            prob = torch.from_numpy(prob).transpose(0, 1)  # -> (T,N)
+            bb_prior[bidx, :T, :N] = prob
+
+        return bb_prior
+
+
+class GaussianUpsampling(torch.nn.Module):
+    """
+    Gaussian upsampling with fixed temperature as in:
+    https://arxiv.org/abs/2010.04301
+    """
+
+    def __init__(self, delta=0.1):
+        super().__init__()
+        self.delta = delta
+
+    def forward(self, hs, ds, h_masks=None, d_masks=None):
+        """Upsample hidden states according to durations.
+
+        Args:
+            hs (Tensor): Batched hidden state to be expanded (B, T_text, adim).
+            ds (Tensor): Batched token duration (B, T_text).
+            h_masks (Tensor): Mask tensor (B, T_feats).
+            d_masks (Tensor): Mask tensor (B, T_text).
+
+        Returns:
+            Tensor: Expanded hidden state (B, T_feat, adim).
+
+        """
+        B = ds.size(0)
+        device = ds.device
+
+        if ds.sum() == 0:
+            logging.warning("predicted durations includes all 0 sequences. " "fill the first element with 1.")
+            # NOTE(kan-bayashi): This case must not be happened in teacher forcing.
+            #   It will be happened in inference with a bad duration predictor.
+            #   So we do not need to care the padded sequence case here.
+            ds[ds.sum(dim=1).eq(0)] = 1
+
+        if h_masks is None:
+            T_feats = ds.sum().int()
+        else:
+            T_feats = h_masks.size(-1)
+        t = torch.arange(0, T_feats).unsqueeze(0).repeat(B, 1).to(device).float()
+        if h_masks is not None:
+            t = t * h_masks.float()
+
+        c = ds.cumsum(dim=-1) - ds / 2
+        energy = -1 * self.delta * (t.unsqueeze(-1) - c.unsqueeze(1)) ** 2
+        if d_masks is not None:
+            energy = energy.masked_fill(~(d_masks.unsqueeze(1).repeat(1, T_feats, 1)), -float("inf"))
+
+        p_attn = torch.softmax(energy, dim=2)  # (B, T_feats, T_text)
+        hs = torch.matmul(p_attn, hs)
+        return hs
+
+
+@jit(nopython=True)
+def _monotonic_alignment_search(log_p_attn):
+    # https://arxiv.org/abs/2005.11129
+    T_mel = log_p_attn.shape[0]
+    T_inp = log_p_attn.shape[1]
+    Q = np.full((T_inp, T_mel), fill_value=-np.inf)
+
+    log_prob = log_p_attn.transpose(1, 0)  # -> (T_inp,T_mel)
+    # 1.  Q <- init first row for all j
+    for j in range(T_mel):
+        Q[0, j] = log_prob[0, : j + 1].sum()
+
+    # 2.
+    for j in range(1, T_mel):
+        for i in range(1, min(j + 1, T_inp)):
+            Q[i, j] = max(Q[i - 1, j - 1], Q[i, j - 1]) + log_prob[i, j]
+
+    # 3.
+    A = np.full((T_mel,), fill_value=T_inp - 1)
+    for j in range(T_mel - 2, -1, -1):  # T_mel-2, ..., 0
+        # 'i' in {A[j+1]-1, A[j+1]}
+        i_a = A[j + 1] - 1
+        i_b = A[j + 1]
+        if i_b == 0:
+            argmax_i = 0
+        elif Q[i_a, j] >= Q[i_b, j]:
+            argmax_i = i_a
+        else:
+            argmax_i = i_b
+        A[j] = argmax_i
+    return A
+
+
+def viterbi_decode(log_p_attn, text_lengths, feats_lengths):
+    """Extract duration from an attention probability matrix
+
+    Args:
+        log_p_attn (Tensor): Batched log probability of attention
+            matrix (B, T_feats, T_text).
+        text_lengths (Tensor): Text length tensor (B,).
+        feats_legnths (Tensor): Feature length tensor (B,).
+
+    Returns:
+        Tensor: Batched token duration extracted from `log_p_attn` (B, T_text).
+        Tensor: Binarization loss tensor ().
+
+    """
+    B = log_p_attn.size(0)
+    T_text = log_p_attn.size(2)
+    device = log_p_attn.device
+
+    bin_loss = 0
+    ds = torch.zeros((B, T_text), device=device)
+    for b in range(B):
+        cur_log_p_attn = log_p_attn[b, : feats_lengths[b], : text_lengths[b]]
+        viterbi = _monotonic_alignment_search(cur_log_p_attn.detach().float().cpu().numpy())
+        _ds = np.bincount(viterbi)
+        ds[b, : len(_ds)] = torch.from_numpy(_ds).to(device)
+
+        t_idx = torch.arange(feats_lengths[b])
+        bin_loss = bin_loss - cur_log_p_attn[t_idx, viterbi].mean()
+    bin_loss = bin_loss / B
+    return ds, bin_loss
+
+
+@jit(nopython=True)
+def _average_by_duration(ds, xs, text_lengths, feats_lengths):
+    B = ds.shape[0]
+    xs_avg = np.zeros_like(ds)
+    ds = ds.astype(np.int32)
+    for b in range(B):
+        t_text = text_lengths[b]
+        t_feats = feats_lengths[b]
+        d = ds[b, :t_text]
+        d_cumsum = d.cumsum()
+        d_cumsum = [0] + list(d_cumsum)
+        x = xs[b, :t_feats]
+        for n, (start, end) in enumerate(zip(d_cumsum[:-1], d_cumsum[1:])):
+            if len(x[start:end]) != 0:
+                xs_avg[b, n] = x[start:end].mean()
+            else:
+                xs_avg[b, n] = 0
+    return xs_avg
+
+
+def average_by_duration(ds, xs, text_lengths, feats_lengths):
+    """Average frame-level features into token-level according to durations
+
+    Args:
+        ds (Tensor): Batched token duration (B, T_text).
+        xs (Tensor): Batched feature sequences to be averaged (B, T_feats).
+        text_lengths (Tensor): Text length tensor (B,).
+        feats_lengths (Tensor): Feature length tensor (B,).
+
+    Returns:
+        Tensor: Batched feature averaged according to the token duration (B, T_text).
+
+    """
+    device = ds.device
+    args = [ds, xs, text_lengths, feats_lengths]
+    args = [arg.detach().float().cpu().numpy() for arg in args]
+    xs_avg = _average_by_duration(*args)
+    xs_avg = torch.from_numpy(xs_avg).to(device)
+    return xs_avg
+
+
+def expand_by_duration(x, durations):
+    dtype = x.dtype
+    lengths = durations.sum(dim=1)
+    max_len = lengths.max()
+    dur_cumsum = torch.cumsum(F.pad(durations, (1, 0, 0, 0), value=0.0), dim=1)
+    dur_cumsum = dur_cumsum[:, None, :]
+    dur_cumsum = dur_cumsum.to(dtype)
+    range_ = torch.arange(max_len, device=x.device)[None, :, None]
+    mult = (
+            (dur_cumsum[:, :, :-1] <= range_)
+            & (dur_cumsum[:, :, 1:] > range_)
+    )
+    mult = mult.to(dtype)
+    expanded = torch.matmul(mult, x)
+    return expanded, lengths

--- a/phoonnx_train/optispeech/model/generator/loss.py
+++ b/phoonnx_train/optispeech/model/generator/loss.py
@@ -1,0 +1,192 @@
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.nn import functional as F
+
+from phoonnx_train.optispeech.utils.model import make_non_pad_mask
+
+
+class DurationPredictorLoss(torch.nn.Module):
+    """Loss function module for duration predictor.
+    The loss value is Calculated in log domain to make it Gaussian.
+    """
+
+    def __init__(self, clip_val=1e-8, reduction="mean"):
+        """
+        Args:
+            clip_val (float, optional): Offset value to avoid nan in log domain.
+            reduction (str): Reduction type in loss calculation.
+
+        """
+        super().__init__()
+        self.criterion = torch.nn.MSELoss(reduction=reduction)
+        self.clip_val = clip_val
+
+    def forward(self, outputs, targets):
+        """Calculate forward propagation.
+
+        Args:
+            outputs (Tensor): Batch of prediction durations in log domain (B, T)
+            targets (LongTensor): Batch of groundtruth durations in linear domain (B, T)
+
+        Returns:
+            Tensor: Mean squared error loss value.
+
+        Note:
+            `outputs` is in log domain but `targets` is in linear domain.
+
+        """
+        # NOTE: outputs is in log domain while targets in linear
+        targets = torch.log(targets.float() + self.clip_val)
+        loss = self.criterion(outputs, targets)
+
+        return loss
+
+
+class FastSpeech2Loss(torch.nn.Module):
+    """
+    Loss function module for FastSpeech2.
+    Taken from ESPnet2
+    """
+
+    def __init__(self, regression_loss_type: str = "l1", use_masking: bool = True, use_weighted_masking: bool = False):
+        """
+        Initialize feed-forward Transformer loss module.
+
+        Args:
+            regression_loss_type: one of {"mse", "l1"}
+            use_masking (bool): Whether to apply masking for padded part in loss
+                calculation.
+            use_weighted_masking (bool): Whether to weighted masking in loss
+                calculation.
+
+        """
+        super().__init__()
+
+        assert (use_masking != use_weighted_masking) or not use_masking
+        self.use_masking = use_masking
+        self.use_weighted_masking = use_weighted_masking
+
+        # define criterions
+        reduction = "none" if self.use_weighted_masking else "mean"
+        if regression_loss_type == "mse":
+            self.regression_criterion = torch.nn.MSELoss(reduction=reduction)
+        elif regression_loss_type == "l1":
+            self.regression_criterion = torch.nn.SmoothL1Loss(reduction=reduction)
+        else:
+            raise ValueError(f"Unknown regression loss type: {regression_loss_type}")
+        self.duration_criterion = DurationPredictorLoss(reduction=reduction)
+
+    def forward(
+            self,
+            d_outs: torch.Tensor,
+            p_outs: torch.Tensor,
+            e_outs: torch.Tensor,
+            ds: torch.Tensor,
+            ps: torch.Tensor,
+            es: torch.Tensor,
+            ilens: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Calculate forward propagation.
+
+        Args:
+            d_outs (LongTensor): Batch of outputs of duration predictor (B, T_text).
+            p_outs (Tensor): Batch of outputs of pitch predictor (B, T_text, 1).
+            e_outs (Tensor): Batch of outputs of energy predictor (B, T_text, 1).
+            ds (LongTensor): Batch of durations (B, T_text).
+            ps (Tensor): Batch of target token-averaged pitch (B, T_text, 1).
+            es (Tensor): Batch of target token-averaged energy (B, T_text, 1).
+            ilens (LongTensor): Batch of the lengths of each input (B,).
+
+        Returns:
+            Tensor: Duration predictor loss value.
+            Tensor: Pitch predictor loss value.
+            Tensor: Energy predictor loss value.
+
+        """
+        # apply mask to remove padded part
+        if self.use_masking:
+            with torch.no_grad():
+                duration_masks = make_non_pad_mask(ilens).to(ds.device)
+                pitch_masks = make_non_pad_mask(ilens).unsqueeze(-1).to(ds.device)
+            d_outs = d_outs.masked_select(duration_masks)
+            ds = ds.masked_select(duration_masks)
+            p_outs = p_outs.masked_select(pitch_masks)
+            ps = ps.masked_select(pitch_masks)
+            e_outs = e_outs.masked_select(pitch_masks)
+            es = es.masked_select(pitch_masks)
+
+        # calculate loss
+        duration_loss = self.duration_criterion(d_outs, ds)
+        pitch_loss = self.regression_criterion(p_outs, ps)
+        energy_loss = self.regression_criterion(e_outs, es)
+
+        # make weighted mask and apply it
+        if self.use_weighted_masking:
+            with torch.no_grad():
+                duration_masks = make_non_pad_mask(ilens).to(ds.device)
+                duration_weights = duration_masks.float() / duration_masks.sum(dim=1, keepdim=True).float()
+                duration_weights /= ds.size(0)
+                pitch_masks = duration_masks.unsqueeze(-1)
+                pitch_weights = duration_weights.unsqueeze(-1)
+            # apply weight
+            duration_loss = duration_loss.mul(duration_weights).masked_select(duration_masks).sum()
+            pitch_loss = pitch_loss.mul(pitch_weights).masked_select(pitch_masks).sum()
+            energy_loss = energy_loss.mul(pitch_weights).masked_select(pitch_masks).sum()
+
+        return duration_loss, pitch_loss, energy_loss
+
+
+class ForwardSumLoss(torch.nn.Module):
+    """Forwardsum loss described at https://openreview.net/forum?id=0NQwnnwAORi"""
+
+    def __init__(self):
+        """Initialize forwardsum loss module."""
+        super().__init__()
+
+    def forward(
+            self,
+            log_p_attn: torch.Tensor,
+            ilens: torch.Tensor,
+            olens: torch.Tensor,
+            blank_prob: float = np.e ** -1,
+    ) -> torch.Tensor:
+        """Calculate forward propagation.
+
+        Args:
+            log_p_attn (Tensor): Batch of log probability of attention matrix
+                (B, T_feats, T_text).
+            ilens (Tensor): Batch of the lengths of each input (B,).
+            olens (Tensor): Batch of the lengths of each target (B,).
+            blank_prob (float): Blank symbol probability.
+
+        Returns:
+            Tensor: forwardsum loss value.
+
+        """
+        B = log_p_attn.size(0)
+
+        # a row must be added to the attention matrix to account for
+        #    blank token of CTC loss
+        # (B,T_feats,T_text+1)
+        log_p_attn_pd = F.pad(log_p_attn, (1, 0, 0, 0, 0, 0), value=np.log(blank_prob))
+
+        loss = 0
+        for bidx in range(B):
+            # construct target sequnece.
+            # Every text token is mapped to a unique sequnece number.
+            target_seq = torch.arange(1, ilens[bidx] + 1).unsqueeze(0)
+            cur_log_p_attn_pd = log_p_attn_pd[bidx, : olens[bidx], : ilens[bidx] + 1].unsqueeze(
+                1
+            )  # (T_feats,1,T_text+1)
+            cur_log_p_attn_pd = F.log_softmax(cur_log_p_attn_pd, dim=-1)
+            loss += F.ctc_loss(
+                log_probs=cur_log_p_attn_pd,
+                targets=target_seq,
+                input_lengths=olens[bidx: bidx + 1],
+                target_lengths=ilens[bidx: bidx + 1],
+                zero_infinity=True,
+            )
+        loss = loss / B
+        return loss

--- a/phoonnx_train/optispeech/model/generator/modules/__init__.py
+++ b/phoonnx_train/optispeech/model/generator/modules/__init__.py
@@ -1,0 +1,11 @@
+"""Reusable standalone modules."""
+
+from .conformer import Conformer
+from .convnext import ConvNeXtBackbone, ConvNeXtBlock, DropPath
+from .core import DurationPredictor, EnergyPredictor, PitchPredictor, TextEmbedding
+from .layers import ConvSeparable, EncSepConvLayer, ScaledSinusoidalEmbedding
+from .lightspeech_transformer import (
+    LightSpeechTransformerDecoder,
+    LightSpeechTransformerEncoder,
+)
+from .transformer import Transformer

--- a/phoonnx_train/optispeech/model/generator/modules/_conformer/contextual_block_encoder_layer.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_conformer/contextual_block_encoder_layer.py
@@ -1,0 +1,303 @@
+"""
+Created on Sat Aug 21 16:57:31 2021.
+
+@author: Keqi Deng (UCAS)
+"""
+
+import torch
+from torch import nn
+
+from .._transformer.layer_norm import LayerNorm
+
+
+class ContextualBlockEncoderLayer(nn.Module):
+    """Contexutal Block Encoder layer module.
+
+    Args:
+        size (int): Input dimension.
+        self_attn (torch.nn.Module): Self-attention module instance.
+            `MultiHeadedAttention` or `RelPositionMultiHeadedAttention` instance
+            can be used as the argument.
+        feed_forward (torch.nn.Module): Feed-forward module instance.
+            `PositionwiseFeedForward`, `MultiLayeredConv1d`, or `Conv1dLinear` instance
+            can be used as the argument.
+        feed_forward_macaron (torch.nn.Module): Additional feed-forward module instance.
+            `PositionwiseFeedForward`, `MultiLayeredConv1d`, or `Conv1dLinear` instance
+            can be used as the argument.
+        conv_module (torch.nn.Module): Convolution module instance.
+            `ConvlutionModule` instance can be used as the argument.
+        dropout_rate (float): Dropout rate.
+        total_layer_num (int): Total number of layers
+        normalize_before (bool): Whether to use layer_norm before the first block.
+        concat_after (bool): Whether to concat attention layer's input and output.
+            if True, additional linear will be applied.
+            i.e. x -> x + linear(concat(x, att(x)))
+            if False, no additional linear will be applied. i.e. x -> x + att(x)
+
+    """
+
+    def __init__(
+            self,
+            size,
+            self_attn,
+            feed_forward,
+            feed_forward_macaron,
+            conv_module,
+            dropout_rate,
+            total_layer_num,
+            normalize_before=True,
+            concat_after=False,
+    ):
+        """Construct an EncoderLayer object."""
+        super().__init__()
+        self.self_attn = self_attn
+        self.feed_forward = feed_forward
+        self.feed_forward_macaron = feed_forward_macaron
+        self.conv_module = conv_module
+        self.norm1 = LayerNorm(size)
+        self.norm2 = LayerNorm(size)
+        if feed_forward_macaron is not None:
+            self.norm_ff_macaron = LayerNorm(size)
+            self.ff_scale = 0.5
+        else:
+            self.ff_scale = 1.0
+        if self.conv_module is not None:
+            self.norm_conv = LayerNorm(size)  # for the CNN module
+            self.norm_final = LayerNorm(size)  # for the final output of the block
+        self.dropout = nn.Dropout(dropout_rate)
+        self.size = size
+        self.normalize_before = normalize_before
+        self.concat_after = concat_after
+        self.total_layer_num = total_layer_num
+        if self.concat_after:
+            self.concat_linear = nn.Linear(size + size, size)
+
+    def forward(
+            self,
+            x,
+            mask,
+            infer_mode=False,
+            past_ctx=None,
+            next_ctx=None,
+            is_short_segment=False,
+            layer_idx=0,
+            cache=None,
+    ):
+        """Calculate forward propagation."""
+        if self.training or not infer_mode:
+            return self.forward_train(x, mask, past_ctx, next_ctx, layer_idx, cache)
+        else:
+            return self.forward_infer(x, mask, past_ctx, next_ctx, is_short_segment, layer_idx, cache)
+
+    def forward_train(self, x, mask, past_ctx=None, next_ctx=None, layer_idx=0, cache=None):
+        """Compute encoded features.
+
+        Args:
+            x_input (torch.Tensor): Input tensor (#batch, time, size).
+            mask (torch.Tensor): Mask tensor for the input (#batch, time).
+            past_ctx (torch.Tensor): Previous contexutal vector
+            next_ctx (torch.Tensor): Next contexutal vector
+            cache (torch.Tensor): Cache tensor of the input (#batch, time - 1, size).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, size).
+            torch.Tensor: Mask tensor (#batch, time).
+            cur_ctx (torch.Tensor): Current contexutal vector
+            next_ctx (torch.Tensor): Next contexutal vector
+            layer_idx (int): layer index number
+
+        """
+        nbatch = x.size(0)
+        nblock = x.size(1)
+
+        if past_ctx is not None:
+            if next_ctx is None:
+                # store all context vectors in one tensor
+                next_ctx = past_ctx.new_zeros(nbatch, nblock, self.total_layer_num, x.size(-1))
+            else:
+                x[:, :, 0] = past_ctx[:, :, layer_idx]
+
+        # reshape ( nbatch, nblock, block_size + 2, dim )
+        #     -> ( nbatch * nblock, block_size + 2, dim )
+        x = x.view(-1, x.size(-2), x.size(-1))
+        if mask is not None:
+            mask = mask.view(-1, mask.size(-2), mask.size(-1))
+
+        # whether to use macaron style
+        if self.feed_forward_macaron is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_ff_macaron(x)
+            x = residual + self.ff_scale * self.dropout(self.feed_forward_macaron(x))
+            if not self.normalize_before:
+                x = self.norm_ff_macaron(x)
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm1(x)
+
+        if cache is None:
+            x_q = x
+        else:
+            assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
+            x_q = x[:, -1:, :]
+            residual = residual[:, -1:, :]
+            mask = None if mask is None else mask[:, -1:, :]
+
+        if self.concat_after:
+            x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
+            x = residual + self.concat_linear(x_concat)
+        else:
+            x = residual + self.dropout(self.self_attn(x_q, x, x, mask))
+        if not self.normalize_before:
+            x = self.norm1(x)
+
+        # convolution module
+        if self.conv_module is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_conv(x)
+            x = residual + self.dropout(self.conv_module(x))
+            if not self.normalize_before:
+                x = self.norm_conv(x)
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm2(x)
+        x = residual + self.ff_scale * self.dropout(self.feed_forward(x))
+        if not self.normalize_before:
+            x = self.norm2(x)
+
+        if self.conv_module is not None:
+            x = self.norm_final(x)
+
+        if cache is not None:
+            x = torch.cat([cache, x], dim=1)
+
+        layer_idx += 1
+        # reshape ( nbatch * nblock, block_size + 2, dim )
+        #       -> ( nbatch, nblock, block_size + 2, dim )
+        x = x.view(nbatch, -1, x.size(-2), x.size(-1)).squeeze(1)
+        if mask is not None:
+            mask = mask.view(nbatch, -1, mask.size(-2), mask.size(-1)).squeeze(1)
+
+        if next_ctx is not None and layer_idx < self.total_layer_num:
+            next_ctx[:, 0, layer_idx, :] = x[:, 0, -1, :]
+            next_ctx[:, 1:, layer_idx, :] = x[:, 0:-1, -1, :]
+
+        return x, mask, False, next_ctx, next_ctx, False, layer_idx
+
+    def forward_infer(
+            self,
+            x,
+            mask,
+            past_ctx=None,
+            next_ctx=None,
+            is_short_segment=False,
+            layer_idx=0,
+            cache=None,
+    ):
+        """Compute encoded features.
+
+        Args:
+            x_input (torch.Tensor): Input tensor (#batch, time, size).
+            mask (torch.Tensor): Mask tensor for the input (#batch, 1, time).
+            past_ctx (torch.Tensor): Previous contexutal vector
+            next_ctx (torch.Tensor): Next contexutal vector
+            cache (torch.Tensor): Cache tensor of the input (#batch, time - 1, size).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, size).
+            torch.Tensor: Mask tensor (#batch, 1, time).
+            cur_ctx (torch.Tensor): Current contexutal vector
+            next_ctx (torch.Tensor): Next contexutal vector
+            layer_idx (int): layer index number
+
+        """
+        nbatch = x.size(0)
+        nblock = x.size(1)
+        # if layer_idx == 0, next_ctx has to be None
+        if layer_idx == 0:
+            assert next_ctx is None
+            next_ctx = x.new_zeros(nbatch, self.total_layer_num, x.size(-1))
+
+        # reshape ( nbatch, nblock, block_size + 2, dim )
+        #     -> ( nbatch * nblock, block_size + 2, dim )
+        x = x.view(-1, x.size(-2), x.size(-1))
+        if mask is not None:
+            mask = mask.view(-1, mask.size(-2), mask.size(-1))
+
+        # whether to use macaron style
+        if self.feed_forward_macaron is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_ff_macaron(x)
+            x = residual + self.ff_scale * self.dropout(self.feed_forward_macaron(x))
+            if not self.normalize_before:
+                x = self.norm_ff_macaron(x)
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm1(x)
+
+        if cache is None:
+            x_q = x
+        else:
+            assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
+            x_q = x[:, -1:, :]
+            residual = residual[:, -1:, :]
+            mask = None if mask is None else mask[:, -1:, :]
+
+        if self.concat_after:
+            x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
+            x = residual + self.concat_linear(x_concat)
+        else:
+            x = residual + self.dropout(self.self_attn(x_q, x, x, mask))
+        if not self.normalize_before:
+            x = self.norm1(x)
+
+        # convolution module
+        if self.conv_module is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_conv(x)
+            x = residual + self.dropout(self.conv_module(x))
+            if not self.normalize_before:
+                x = self.norm_conv(x)
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm2(x)
+        x = residual + self.ff_scale * self.dropout(self.feed_forward(x))
+        if not self.normalize_before:
+            x = self.norm2(x)
+
+        if self.conv_module is not None:
+            x = self.norm_final(x)
+
+        if cache is not None:
+            x = torch.cat([cache, x], dim=1)
+
+        # reshape ( nbatch * nblock, block_size + 2, dim )
+        #       -> ( nbatch, nblock, block_size + 2, dim )
+        x = x.view(nbatch, nblock, x.size(-2), x.size(-1))
+        if mask is not None:
+            mask = mask.view(nbatch, nblock, mask.size(-2), mask.size(-1))
+
+        # Propagete context information (the last frame of each block)
+        # to the first frame
+        # of the next block
+
+        if not is_short_segment:
+            if past_ctx is None:
+                # First block of an utterance
+                x[:, 0, 0, :] = x[:, 0, -1, :]
+            else:
+                x[:, 0, 0, :] = past_ctx[:, layer_idx, :]
+            if nblock > 1:
+                x[:, 1:, 0, :] = x[:, 0:-1, -1, :]
+            next_ctx[:, layer_idx, :] = x[:, -1, -1, :]
+        else:
+            next_ctx = None
+
+        return x, mask, True, past_ctx, next_ctx, is_short_segment, layer_idx + 1

--- a/phoonnx_train/optispeech/model/generator/modules/_conformer/convolution.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_conformer/convolution.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""ConvolutionModule definition."""
+
+from torch import nn
+
+
+class ConvolutionModule(nn.Module):
+    """ConvolutionModule in Conformer model.
+
+    Args:
+        channels (int): The number of channels of conv layers.
+        kernel_size (int): Kernerl size of conv layers.
+
+    """
+
+    def __init__(self, channels, kernel_size, activation=nn.ReLU(), bias=True):
+        """Construct an ConvolutionModule object."""
+        super().__init__()
+        # kernerl_size should be a odd number for 'SAME' padding
+        assert (kernel_size - 1) % 2 == 0
+
+        self.pointwise_conv1 = nn.Conv1d(
+            channels,
+            2 * channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=bias,
+        )
+        self.depthwise_conv = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+            groups=channels,
+            bias=bias,
+        )
+        self.norm = nn.BatchNorm1d(channels)
+        self.pointwise_conv2 = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=bias,
+        )
+        self.activation = activation
+
+    def forward(self, x):
+        """Compute convolution module.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, channels).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, channels).
+
+        """
+        # exchange the temporal dimension and the feature dimension
+        x = x.transpose(1, 2)
+
+        # GLU mechanism
+        x = self.pointwise_conv1(x)  # (batch, 2*channel, dim)
+        x = nn.functional.glu(x, dim=1)  # (batch, channel, dim)
+
+        # 1D Depthwise Conv
+        x = self.depthwise_conv(x)
+        x = self.activation(self.norm(x))
+
+        x = self.pointwise_conv2(x)
+
+        return x.transpose(1, 2)

--- a/phoonnx_train/optispeech/model/generator/modules/_conformer/encoder.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_conformer/encoder.py
@@ -1,0 +1,283 @@
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Encoder definition."""
+
+import logging
+
+import torch
+
+from .convolution import ConvolutionModule
+from .encoder_layer import EncoderLayer
+from .nets_utils import get_activation
+from .._transformer.attention import (
+    LegacyRelPositionMultiHeadedAttention,
+    MultiHeadedAttention,
+    RelPositionMultiHeadedAttention,
+)
+from .._transformer.embedding import (
+    LegacyRelPositionalEncoding,
+    PositionalEncoding,
+    RelPositionalEncoding,
+    ScaledPositionalEncoding,
+)
+from .._transformer.layer_norm import LayerNorm
+from .._transformer.multi_layer_conv import Conv1dLinear, MultiLayeredConv1d
+from .._transformer.positionwise_feed_forward import PositionwiseFeedForward
+from .._transformer.repeat import repeat
+from .._transformer.subsampling import Conv2dSubsampling
+
+
+class Encoder(torch.nn.Module):
+    """Conformer encoder module.
+
+    Args:
+        idim (int): Input dimension.
+        attention_dim (int): Dimension of attention.
+        attention_heads (int): The number of heads of multi head attention.
+        linear_units (int): The number of units of position-wise feed forward.
+        num_blocks (int): The number of decoder blocks.
+        dropout_rate (float): Dropout rate.
+        positional_dropout_rate (float): Dropout rate after adding positional encoding.
+        attention_dropout_rate (float): Dropout rate in attention.
+        input_layer (Union[str, torch.nn.Module]): Input layer type.
+        normalize_before (bool): Whether to use layer_norm before the first block.
+        concat_after (bool): Whether to concat attention layer's input and output.
+            if True, additional linear will be applied.
+            i.e. x -> x + linear(concat(x, att(x)))
+            if False, no additional linear will be applied. i.e. x -> x + att(x)
+        positionwise_layer_type (str): "linear", "conv1d", or "conv1d-linear".
+        positionwise_conv_kernel_size (int): Kernel size of positionwise conv1d layer.
+        macaron_style (bool): Whether to use macaron style for positionwise layer.
+        pos_enc_layer_type (str): Encoder positional encoding layer type.
+        selfattention_layer_type (str): Encoder attention layer type.
+        activation_type (str): Encoder activation function type.
+        use_cnn_module (bool): Whether to use convolution module.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
+        cnn_module_kernel (int): Kernerl size of convolution module.
+        padding_idx (int): Padding idx for input_layer=embed.
+        stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
+        intermediate_layers (Union[List[int], None]): indices of intermediate CTC layer.
+            indices start from 1.
+            if not None, intermediate outputs are returned (which changes return type
+            signature.)
+
+    """
+
+    def __init__(
+            self,
+            idim,
+            attention_dim=256,
+            attention_heads=4,
+            linear_units=2048,
+            num_blocks=6,
+            dropout_rate=0.1,
+            positional_dropout_rate=0.1,
+            attention_dropout_rate=0.0,
+            input_layer="conv2d",
+            normalize_before=True,
+            concat_after=False,
+            positionwise_layer_type="linear",
+            positionwise_conv_kernel_size=1,
+            macaron_style=False,
+            pos_enc_layer_type="abs_pos",
+            selfattention_layer_type="selfattn",
+            activation_type="swish",
+            use_cnn_module=False,
+            zero_triu=False,
+            cnn_module_kernel=31,
+            padding_idx=-1,
+            stochastic_depth_rate=0.0,
+            intermediate_layers=None,
+            ctc_softmax=None,
+            conditioning_layer_dim=None,
+    ):
+        """Construct an Encoder object."""
+        super().__init__()
+
+        activation = get_activation(activation_type)
+        if pos_enc_layer_type == "abs_pos":
+            pos_enc_class = PositionalEncoding
+        elif pos_enc_layer_type == "scaled_abs_pos":
+            pos_enc_class = ScaledPositionalEncoding
+        elif pos_enc_layer_type == "rel_pos":
+            assert selfattention_layer_type == "rel_selfattn"
+            pos_enc_class = RelPositionalEncoding
+        elif pos_enc_layer_type == "legacy_rel_pos":
+            pos_enc_class = LegacyRelPositionalEncoding
+            assert selfattention_layer_type == "legacy_rel_selfattn"
+        else:
+            raise ValueError("unknown pos_enc_layer: " + pos_enc_layer_type)
+
+        self.conv_subsampling_factor = 1
+        if input_layer == "linear":
+            self.embed = torch.nn.Sequential(
+                torch.nn.Linear(idim, attention_dim),
+                torch.nn.LayerNorm(attention_dim),
+                torch.nn.Dropout(dropout_rate),
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif input_layer == "conv2d":
+            self.embed = Conv2dSubsampling(
+                idim,
+                attention_dim,
+                dropout_rate,
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+            self.conv_subsampling_factor = 4
+        elif input_layer == "embed":
+            self.embed = torch.nn.Sequential(
+                torch.nn.Embedding(idim, attention_dim, padding_idx=padding_idx),
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif isinstance(input_layer, torch.nn.Module):
+            self.embed = torch.nn.Sequential(
+                input_layer,
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif input_layer is None:
+            self.embed = torch.nn.Sequential(pos_enc_class(attention_dim, positional_dropout_rate))
+        else:
+            raise ValueError("unknown input_layer: " + input_layer)
+        self.normalize_before = normalize_before
+
+        # self-attention module definition
+        if selfattention_layer_type == "selfattn":
+            logging.info("encoder self-attention layer type = self-attention")
+            encoder_selfattn_layer = MultiHeadedAttention
+            encoder_selfattn_layer_args = (
+                attention_heads,
+                attention_dim,
+                attention_dropout_rate,
+            )
+        elif selfattention_layer_type == "legacy_rel_selfattn":
+            assert pos_enc_layer_type == "legacy_rel_pos"
+            encoder_selfattn_layer = LegacyRelPositionMultiHeadedAttention
+            encoder_selfattn_layer_args = (
+                attention_heads,
+                attention_dim,
+                attention_dropout_rate,
+            )
+        elif selfattention_layer_type == "rel_selfattn":
+            logging.info("encoder self-attention layer type = relative self-attention")
+            assert pos_enc_layer_type == "rel_pos"
+            encoder_selfattn_layer = RelPositionMultiHeadedAttention
+            encoder_selfattn_layer_args = (
+                attention_heads,
+                attention_dim,
+                attention_dropout_rate,
+                zero_triu,
+            )
+        else:
+            raise ValueError("unknown encoder_attn_layer: " + selfattention_layer_type)
+
+        # feed-forward module definition
+        if positionwise_layer_type == "linear":
+            positionwise_layer = PositionwiseFeedForward
+            positionwise_layer_args = (
+                attention_dim,
+                linear_units,
+                dropout_rate,
+                activation,
+            )
+        elif positionwise_layer_type == "conv1d":
+            positionwise_layer = MultiLayeredConv1d
+            positionwise_layer_args = (
+                attention_dim,
+                linear_units,
+                positionwise_conv_kernel_size,
+                dropout_rate,
+            )
+        elif positionwise_layer_type == "conv1d-linear":
+            positionwise_layer = Conv1dLinear
+            positionwise_layer_args = (
+                attention_dim,
+                linear_units,
+                positionwise_conv_kernel_size,
+                dropout_rate,
+            )
+        else:
+            raise NotImplementedError("Support only linear or conv1d.")
+
+        # convolution module definition
+        convolution_layer = ConvolutionModule
+        convolution_layer_args = (attention_dim, cnn_module_kernel, activation)
+
+        self.encoders = repeat(
+            num_blocks,
+            lambda lnum: EncoderLayer(
+                attention_dim,
+                encoder_selfattn_layer(*encoder_selfattn_layer_args),
+                positionwise_layer(*positionwise_layer_args),
+                positionwise_layer(*positionwise_layer_args) if macaron_style else None,
+                convolution_layer(*convolution_layer_args) if use_cnn_module else None,
+                dropout_rate,
+                normalize_before,
+                concat_after,
+                stochastic_depth_rate * float(1 + lnum) / num_blocks,
+            ),
+        )
+        if self.normalize_before:
+            self.after_norm = LayerNorm(attention_dim)
+
+        self.intermediate_layers = intermediate_layers
+        self.use_conditioning = True if ctc_softmax is not None else False
+        if self.use_conditioning:
+            self.ctc_softmax = ctc_softmax
+            self.conditioning_layer = torch.nn.Linear(conditioning_layer_dim, attention_dim)
+
+    def forward(self, xs, masks):
+        """Encode input sequence.
+
+        Args:
+            xs (torch.Tensor): Input tensor (#batch, time, idim).
+            masks (torch.Tensor): Mask tensor (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, attention_dim).
+            torch.Tensor: Mask tensor (#batch, 1, time).
+
+        """
+        if isinstance(self.embed, (Conv2dSubsampling,)):
+            xs, masks = self.embed(xs, masks)
+        else:
+            xs = self.embed(xs)
+
+        if self.intermediate_layers is None:
+            xs, masks = self.encoders(xs, masks)
+        else:
+            intermediate_outputs = []
+            for layer_idx, encoder_layer in enumerate(self.encoders):
+                xs, masks = encoder_layer(xs, masks)
+
+                if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                    # intermediate branches also require normalization.
+                    encoder_output = xs
+                    if isinstance(encoder_output, tuple):
+                        encoder_output = encoder_output[0]
+
+                    if self.normalize_before:
+                        encoder_output = self.after_norm(encoder_output)
+
+                    intermediate_outputs.append(encoder_output)
+
+                    if self.use_conditioning:
+                        intermediate_result = self.ctc_softmax(encoder_output)
+
+                        if isinstance(xs, tuple):
+                            x, pos_emb = xs[0], xs[1]
+                            x = x + self.conditioning_layer(intermediate_result)
+                            xs = (x, pos_emb)
+                        else:
+                            xs = xs + self.conditioning_layer(intermediate_result)
+
+        if isinstance(xs, tuple):
+            xs = xs[0]
+
+        if self.normalize_before:
+            xs = self.after_norm(xs)
+
+        if self.intermediate_layers is not None:
+            return xs, masks, intermediate_outputs
+        return xs, masks

--- a/phoonnx_train/optispeech/model/generator/modules/_conformer/encoder_layer.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_conformer/encoder_layer.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Encoder self-attention layer definition."""
+
+import torch
+from torch import nn
+
+from .._transformer.layer_norm import LayerNorm
+
+
+class EncoderLayer(nn.Module):
+    """Encoder layer module.
+
+    Args:
+        size (int): Input dimension.
+        self_attn (torch.nn.Module): Self-attention module instance.
+            `MultiHeadedAttention` or `RelPositionMultiHeadedAttention` instance
+            can be used as the argument.
+        feed_forward (torch.nn.Module): Feed-forward module instance.
+            `PositionwiseFeedForward`, `MultiLayeredConv1d`, or `Conv1dLinear` instance
+            can be used as the argument.
+        feed_forward_macaron (torch.nn.Module): Additional feed-forward module instance.
+            `PositionwiseFeedForward`, `MultiLayeredConv1d`, or `Conv1dLinear` instance
+            can be used as the argument.
+        conv_module (torch.nn.Module): Convolution module instance.
+            `ConvlutionModule` instance can be used as the argument.
+        dropout_rate (float): Dropout rate.
+        normalize_before (bool): Whether to use layer_norm before the first block.
+        concat_after (bool): Whether to concat attention layer's input and output.
+            if True, additional linear will be applied.
+            i.e. x -> x + linear(concat(x, att(x)))
+            if False, no additional linear will be applied. i.e. x -> x + att(x)
+        stochastic_depth_rate (float): Proability to skip this layer.
+            During training, the layer may skip residual computation and return input
+            as-is with given probability.
+    """
+
+    def __init__(
+            self,
+            size,
+            self_attn,
+            feed_forward,
+            feed_forward_macaron,
+            conv_module,
+            dropout_rate,
+            normalize_before=True,
+            concat_after=False,
+            stochastic_depth_rate=0.0,
+    ):
+        """Construct an EncoderLayer object."""
+        super().__init__()
+        self.self_attn = self_attn
+        self.feed_forward = feed_forward
+        self.feed_forward_macaron = feed_forward_macaron
+        self.conv_module = conv_module
+        self.norm_ff = LayerNorm(size)  # for the FNN module
+        self.norm_mha = LayerNorm(size)  # for the MHA module
+        if feed_forward_macaron is not None:
+            self.norm_ff_macaron = LayerNorm(size)
+            self.ff_scale = 0.5
+        else:
+            self.ff_scale = 1.0
+        if self.conv_module is not None:
+            self.norm_conv = LayerNorm(size)  # for the CNN module
+            self.norm_final = LayerNorm(size)  # for the final output of the block
+        self.dropout = nn.Dropout(dropout_rate)
+        self.size = size
+        self.normalize_before = normalize_before
+        self.concat_after = concat_after
+        if self.concat_after:
+            self.concat_linear = nn.Linear(size + size, size)
+        self.stochastic_depth_rate = stochastic_depth_rate
+
+    def forward(self, x_input, mask, cache=None):
+        """Compute encoded features.
+
+        Args:
+            x_input (Union[Tuple, torch.Tensor]): Input tensor w/ or w/o pos emb.
+                - w/ pos emb: Tuple of tensors [(#batch, time, size), (1, time, size)].
+                - w/o pos emb: Tensor (#batch, time, size).
+            mask (torch.Tensor): Mask tensor for the input (#batch, 1, time).
+            cache (torch.Tensor): Cache tensor of the input (#batch, time - 1, size).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, size).
+            torch.Tensor: Mask tensor (#batch, 1, time).
+
+        """
+        if isinstance(x_input, tuple):
+            x, pos_emb = x_input[0], x_input[1]
+        else:
+            x, pos_emb = x_input, None
+
+        skip_layer = False
+        # with stochastic depth, residual connection `x + f(x)` becomes
+        # `x <- x + 1 / (1 - p) * f(x)` at training time.
+        stoch_layer_coeff = 1.0
+        if self.training and self.stochastic_depth_rate > 0:
+            skip_layer = torch.rand(1).item() < self.stochastic_depth_rate
+            stoch_layer_coeff = 1.0 / (1 - self.stochastic_depth_rate)
+
+        if skip_layer:
+            if cache is not None:
+                x = torch.cat([cache, x], dim=1)
+            if pos_emb is not None:
+                return (x, pos_emb), mask
+            return x, mask
+
+        # whether to use macaron style
+        if self.feed_forward_macaron is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_ff_macaron(x)
+            x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(self.feed_forward_macaron(x))
+            if not self.normalize_before:
+                x = self.norm_ff_macaron(x)
+
+        # multi-headed self-attention module
+        residual = x
+        if self.normalize_before:
+            x = self.norm_mha(x)
+
+        if cache is None:
+            x_q = x
+        else:
+            assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
+            x_q = x[:, -1:, :]
+            residual = residual[:, -1:, :]
+            mask = None if mask is None else mask[:, -1:, :]
+
+        if pos_emb is not None:
+            x_att = self.self_attn(x_q, x, x, pos_emb, mask)
+        else:
+            x_att = self.self_attn(x_q, x, x, mask)
+
+        if self.concat_after:
+            x_concat = torch.cat((x, x_att), dim=-1)
+            x = residual + stoch_layer_coeff * self.concat_linear(x_concat)
+        else:
+            x = residual + stoch_layer_coeff * self.dropout(x_att)
+        if not self.normalize_before:
+            x = self.norm_mha(x)
+
+        # convolution module
+        if self.conv_module is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_conv(x)
+            x = residual + stoch_layer_coeff * self.dropout(self.conv_module(x))
+            if not self.normalize_before:
+                x = self.norm_conv(x)
+
+        # feed forward module
+        residual = x
+        if self.normalize_before:
+            x = self.norm_ff(x)
+        x = residual + stoch_layer_coeff * self.ff_scale * self.dropout(self.feed_forward(x))
+        if not self.normalize_before:
+            x = self.norm_ff(x)
+
+        if self.conv_module is not None:
+            x = self.norm_final(x)
+
+        if cache is not None:
+            x = torch.cat([cache, x], dim=1)
+
+        if pos_emb is not None:
+            return (x, pos_emb), mask
+
+        return x, mask

--- a/phoonnx_train/optispeech/model/generator/modules/_conformer/nets_utils.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_conformer/nets_utils.py
@@ -1,0 +1,604 @@
+"""Network related utility tools."""
+
+import logging
+from typing import Dict
+
+import numpy as np
+import torch
+
+
+def to_device(m, x):
+    """Send tensor into the device of the module.
+
+    Args:
+        m (torch.nn.Module): Torch module.
+        x (Tensor): Torch tensor.
+
+    Returns:
+        Tensor: Torch tensor located in the same place as torch module.
+
+    """
+    if isinstance(m, torch.nn.Module):
+        device = next(m.parameters()).device
+    elif isinstance(m, torch.Tensor):
+        device = m.device
+    else:
+        raise TypeError("Expected torch.nn.Module or torch.tensor, " f"bot got: {type(m)}")
+    return x.to(device)
+
+
+def pad_list(xs, pad_value):
+    """Perform padding for the list of tensors.
+
+    Args:
+        xs (List): List of Tensors [(T_1, `*`), (T_2, `*`), ..., (T_B, `*`)].
+        pad_value (float): Value for padding.
+
+    Returns:
+        Tensor: Padded tensor (B, Tmax, `*`).
+
+    Examples:
+        >>> x = [torch.ones(4), torch.ones(2), torch.ones(1)]
+        >>> x
+        [tensor([1., 1., 1., 1.]), tensor([1., 1.]), tensor([1.])]
+        >>> pad_list(x, 0)
+        tensor([[1., 1., 1., 1.],
+                [1., 1., 0., 0.],
+                [1., 0., 0., 0.]])
+
+    """
+    n_batch = len(xs)
+    max_len = max(x.size(0) for x in xs)
+    pad = xs[0].new(n_batch, max_len, *xs[0].size()[1:]).fill_(pad_value)
+
+    for i in range(n_batch):
+        pad[i, : xs[i].size(0)] = xs[i]
+
+    return pad
+
+
+def make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
+    """Make mask tensor containing indices of padded part.
+
+    Args:
+        lengths (LongTensor or List): Batch of lengths (B,).
+        xs (Tensor, optional): The reference tensor.
+            If set, masks will be the same shape as this tensor.
+        length_dim (int, optional): Dimension indicator of the above tensor.
+            See the example.
+
+    Returns:
+        Tensor: Mask tensor containing indices of padded part.
+                dtype=torch.uint8 in PyTorch 1.2-
+                dtype=torch.bool in PyTorch 1.2+ (including 1.2)
+
+    Examples:
+        With only lengths.
+
+        >>> lengths = [5, 3, 2]
+        >>> make_pad_mask(lengths)
+        masks = [[0, 0, 0, 0 ,0],
+                 [0, 0, 0, 1, 1],
+                 [0, 0, 1, 1, 1]]
+
+        With the reference tensor.
+
+        >>> xs = torch.zeros((3, 2, 4))
+        >>> make_pad_mask(lengths, xs)
+        tensor([[[0, 0, 0, 0],
+                 [0, 0, 0, 0]],
+                [[0, 0, 0, 1],
+                 [0, 0, 0, 1]],
+                [[0, 0, 1, 1],
+                 [0, 0, 1, 1]]], dtype=torch.uint8)
+        >>> xs = torch.zeros((3, 2, 6))
+        >>> make_pad_mask(lengths, xs)
+        tensor([[[0, 0, 0, 0, 0, 1],
+                 [0, 0, 0, 0, 0, 1]],
+                [[0, 0, 0, 1, 1, 1],
+                 [0, 0, 0, 1, 1, 1]],
+                [[0, 0, 1, 1, 1, 1],
+                 [0, 0, 1, 1, 1, 1]]], dtype=torch.uint8)
+
+        With the reference tensor and dimension indicator.
+
+        >>> xs = torch.zeros((3, 6, 6))
+        >>> make_pad_mask(lengths, xs, 1)
+        tensor([[[0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [1, 1, 1, 1, 1, 1]],
+                [[0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1]],
+                [[0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1]]], dtype=torch.uint8)
+        >>> make_pad_mask(lengths, xs, 2)
+        tensor([[[0, 0, 0, 0, 0, 1],
+                 [0, 0, 0, 0, 0, 1],
+                 [0, 0, 0, 0, 0, 1],
+                 [0, 0, 0, 0, 0, 1],
+                 [0, 0, 0, 0, 0, 1],
+                 [0, 0, 0, 0, 0, 1]],
+                [[0, 0, 0, 1, 1, 1],
+                 [0, 0, 0, 1, 1, 1],
+                 [0, 0, 0, 1, 1, 1],
+                 [0, 0, 0, 1, 1, 1],
+                 [0, 0, 0, 1, 1, 1],
+                 [0, 0, 0, 1, 1, 1]],
+                [[0, 0, 1, 1, 1, 1],
+                 [0, 0, 1, 1, 1, 1],
+                 [0, 0, 1, 1, 1, 1],
+                 [0, 0, 1, 1, 1, 1],
+                 [0, 0, 1, 1, 1, 1],
+                 [0, 0, 1, 1, 1, 1]]], dtype=torch.uint8)
+
+    """
+    if length_dim == 0:
+        raise ValueError(f"length_dim cannot be 0: {length_dim}")
+
+    # If the input dimension is 2 or 3,
+    # then we use ESPnet-ONNX based implementation for tracable modeling.
+    # otherwise we use the traditional implementation for research use.
+    if isinstance(lengths, list):
+        logging.warning(
+            "Using make_pad_mask with a list of lengths is not tracable. "
+            + "If you try to trace this function with type(lengths) == list, "
+            + "please change the type of lengths to torch.LongTensor."
+        )
+
+    if (
+            (xs is None or xs.dim() in (2, 3))
+            and length_dim <= 2
+            and (not isinstance(lengths, list) and lengths.dim() == 1)
+    ):
+        return _make_pad_mask_traceable(lengths, xs, length_dim, maxlen)
+    else:
+        return _make_pad_mask(lengths, xs, length_dim, maxlen)
+
+
+def _make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
+    if not isinstance(lengths, list):
+        lengths = lengths.long().tolist()
+
+    bs = int(len(lengths))
+    if maxlen is None:
+        if xs is None:
+            maxlen = int(max(lengths))
+        else:
+            maxlen = xs.size(length_dim)
+    else:
+        assert xs is None, "When maxlen is specified, xs must not be specified."
+        assert maxlen >= int(max(lengths)), f"maxlen {maxlen} must be >= max(lengths) {max(lengths)}"
+
+    seq_range = torch.arange(0, maxlen, dtype=torch.int64)
+    seq_range_expand = seq_range.unsqueeze(0).expand(bs, maxlen)
+    seq_length_expand = seq_range_expand.new(lengths).unsqueeze(-1)
+    mask = seq_range_expand >= seq_length_expand
+
+    if xs is not None:
+        assert xs.size(0) == bs, f"The size of x.size(0) {xs.size(0)} must match the batch size {bs}"
+
+        if length_dim < 0:
+            length_dim = xs.dim() + length_dim
+        # ind = (:, None, ..., None, :, , None, ..., None)
+        ind = tuple(slice(None) if i in (0, length_dim) else None for i in range(xs.dim()))
+        mask = mask[ind].expand_as(xs).to(xs.device)
+    return mask
+
+
+def _make_pad_mask_traceable(lengths, xs, length_dim, maxlen=None):
+    """
+    Make mask tensor containing indices of padded part.
+    This is a simplified implementation of make_pad_mask without the xs input
+    that supports JIT tracing for applications like exporting models to ONNX.
+    Dimension length of xs should be 2 or 3
+    This function will create torch.ones(maxlen, maxlen).triu(diagonal=1) and
+    select rows to create mask tensor.
+    """
+
+    if xs is None:
+        device = lengths.device
+    else:
+        device = xs.device
+
+    if xs is not None and len(xs.shape) == 3:
+        if length_dim == 1:
+            lengths = lengths.unsqueeze(1).expand(*xs.transpose(1, 2).shape[:2])
+        else:
+            # Then length_dim is 2 or -1.
+            if length_dim not in (-1, 2):
+                logging.warn(f"Invalid length_dim {length_dim}." + "We set it to -1, which is the default value.")
+                length_dim = -1
+            lengths = lengths.unsqueeze(1).expand(*xs.shape[:2])
+
+    if maxlen is not None:
+        assert xs is None
+        assert maxlen >= lengths.max()
+    elif xs is not None:
+        maxlen = xs.shape[length_dim]
+    else:
+        maxlen = lengths.max()
+
+    # clip max(length) to maxlen
+    lengths = torch.clamp(lengths, max=maxlen).type(torch.long)
+
+    mask = torch.ones(maxlen + 1, maxlen + 1, dtype=torch.bool, device=device)
+    mask = triu_onnx(mask)[1:, :-1]  # onnx cannot handle diagonal argument.
+    mask = mask[lengths - 1][..., :maxlen]
+
+    if xs is not None and len(xs.shape) == 3 and length_dim == 1:
+        return mask.transpose(1, 2)
+    else:
+        return mask
+
+
+def triu_onnx(x):
+    arange = torch.arange(x.size(0), device=x.device)
+    mask = arange.unsqueeze(-1).expand(-1, x.size(0)) <= arange
+    return x * mask
+
+
+def make_non_pad_mask(lengths, xs=None, length_dim=-1):
+    """Make mask tensor containing indices of non-padded part.
+
+    Args:
+        lengths (LongTensor or List): Batch of lengths (B,).
+        xs (Tensor, optional): The reference tensor.
+            If set, masks will be the same shape as this tensor.
+        length_dim (int, optional): Dimension indicator of the above tensor.
+            See the example.
+
+    Returns:
+        ByteTensor: mask tensor containing indices of padded part.
+                    dtype=torch.uint8 in PyTorch 1.2-
+                    dtype=torch.bool in PyTorch 1.2+ (including 1.2)
+
+    Examples:
+        With only lengths.
+
+        >>> lengths = [5, 3, 2]
+        >>> make_non_pad_mask(lengths)
+        masks = [[1, 1, 1, 1 ,1],
+                 [1, 1, 1, 0, 0],
+                 [1, 1, 0, 0, 0]]
+
+        With the reference tensor.
+
+        >>> xs = torch.zeros((3, 2, 4))
+        >>> make_non_pad_mask(lengths, xs)
+        tensor([[[1, 1, 1, 1],
+                 [1, 1, 1, 1]],
+                [[1, 1, 1, 0],
+                 [1, 1, 1, 0]],
+                [[1, 1, 0, 0],
+                 [1, 1, 0, 0]]], dtype=torch.uint8)
+        >>> xs = torch.zeros((3, 2, 6))
+        >>> make_non_pad_mask(lengths, xs)
+        tensor([[[1, 1, 1, 1, 1, 0],
+                 [1, 1, 1, 1, 1, 0]],
+                [[1, 1, 1, 0, 0, 0],
+                 [1, 1, 1, 0, 0, 0]],
+                [[1, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 0, 0, 0]]], dtype=torch.uint8)
+
+        With the reference tensor and dimension indicator.
+
+        >>> xs = torch.zeros((3, 6, 6))
+        >>> make_non_pad_mask(lengths, xs, 1)
+        tensor([[[1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [0, 0, 0, 0, 0, 0]],
+                [[1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0]],
+                [[1, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 1, 1, 1],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0]]], dtype=torch.uint8)
+        >>> make_non_pad_mask(lengths, xs, 2)
+        tensor([[[1, 1, 1, 1, 1, 0],
+                 [1, 1, 1, 1, 1, 0],
+                 [1, 1, 1, 1, 1, 0],
+                 [1, 1, 1, 1, 1, 0],
+                 [1, 1, 1, 1, 1, 0],
+                 [1, 1, 1, 1, 1, 0]],
+                [[1, 1, 1, 0, 0, 0],
+                 [1, 1, 1, 0, 0, 0],
+                 [1, 1, 1, 0, 0, 0],
+                 [1, 1, 1, 0, 0, 0],
+                 [1, 1, 1, 0, 0, 0],
+                 [1, 1, 1, 0, 0, 0]],
+                [[1, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 0, 0, 0]]], dtype=torch.uint8)
+
+    """
+    return ~make_pad_mask(lengths, xs, length_dim)
+
+
+def mask_by_length(xs, lengths, fill=0):
+    """Mask tensor according to length.
+
+    Args:
+        xs (Tensor): Batch of input tensor (B, `*`).
+        lengths (LongTensor or List): Batch of lengths (B,).
+        fill (int or float): Value to fill masked part.
+
+    Returns:
+        Tensor: Batch of masked input tensor (B, `*`).
+
+    Examples:
+        >>> x = torch.arange(5).repeat(3, 1) + 1
+        >>> x
+        tensor([[1, 2, 3, 4, 5],
+                [1, 2, 3, 4, 5],
+                [1, 2, 3, 4, 5]])
+        >>> lengths = [5, 3, 2]
+        >>> mask_by_length(x, lengths)
+        tensor([[1, 2, 3, 4, 5],
+                [1, 2, 3, 0, 0],
+                [1, 2, 0, 0, 0]])
+
+    """
+    assert xs.size(0) == len(lengths)
+    ret = xs.data.new(*xs.size()).fill_(fill)
+    for i, l in enumerate(lengths):
+        ret[i, :l] = xs[i, :l]
+    return ret
+
+
+def th_accuracy(pad_outputs, pad_targets, ignore_label):
+    """Calculate accuracy.
+
+    Args:
+        pad_outputs (Tensor): Prediction tensors (B * Lmax, D).
+        pad_targets (LongTensor): Target label tensors (B, Lmax, D).
+        ignore_label (int): Ignore label id.
+
+    Returns:
+        float: Accuracy value (0.0 - 1.0).
+
+    """
+    pad_pred = pad_outputs.view(pad_targets.size(0), pad_targets.size(1), pad_outputs.size(1)).argmax(2)
+    mask = pad_targets != ignore_label
+    numerator = torch.sum(pad_pred.masked_select(mask) == pad_targets.masked_select(mask))
+    denominator = torch.sum(mask)
+    return float(numerator) / float(denominator)
+
+
+def to_torch_tensor(x):
+    """Change to torch.Tensor or ComplexTensor from numpy.ndarray.
+
+    Args:
+        x: Inputs. It should be one of numpy.ndarray, Tensor, ComplexTensor, and dict.
+
+    Returns:
+        Tensor or ComplexTensor: Type converted inputs.
+
+    Examples:
+        >>> xs = np.ones(3, dtype=np.float32)
+        >>> xs = to_torch_tensor(xs)
+        tensor([1., 1., 1.])
+        >>> xs = torch.ones(3, 4, 5)
+        >>> assert to_torch_tensor(xs) is xs
+        >>> xs = {'real': xs, 'imag': xs}
+        >>> to_torch_tensor(xs)
+        ComplexTensor(
+        Real:
+        tensor([1., 1., 1.])
+        Imag;
+        tensor([1., 1., 1.])
+        )
+
+    """
+    # If numpy, change to torch tensor
+    if isinstance(x, np.ndarray):
+        if x.dtype.kind == "c":
+            # Dynamically importing because torch_complex requires python3
+            from torch_complex.tensor import ComplexTensor
+
+            return ComplexTensor(x)
+        else:
+            return torch.from_numpy(x)
+
+    # If {'real': ..., 'imag': ...}, convert to ComplexTensor
+    elif isinstance(x, dict):
+        # Dynamically importing because torch_complex requires python3
+        from torch_complex.tensor import ComplexTensor
+
+        if "real" not in x or "imag" not in x:
+            raise ValueError(f"has 'real' and 'imag' keys: {list(x)}")
+        # Relative importing because of using python3 syntax
+        return ComplexTensor(x["real"], x["imag"])
+
+    # If torch.Tensor, as it is
+    elif isinstance(x, torch.Tensor):
+        return x
+
+    else:
+        error = (
+            "x must be numpy.ndarray, torch.Tensor or a dict like "
+            "{{'real': torch.Tensor, 'imag': torch.Tensor}}, "
+            "but got {}".format(type(x))
+        )
+        try:
+            from torch_complex.tensor import ComplexTensor
+        except Exception:
+            # If PY2
+            raise ValueError(error)
+        else:
+            # If PY3
+            if isinstance(x, ComplexTensor):
+                return x
+            else:
+                raise ValueError(error)
+
+
+def get_subsample(train_args, mode, arch):
+    """Parse the subsampling factors from the args for the specified `mode` and `arch`.
+
+    Args:
+        train_args: argument Namespace containing options.
+        mode: one of ('asr', 'mt', 'st')
+        arch: one of ('rnn', 'rnn-t', 'rnn_mix', 'rnn_mulenc', 'transformer')
+
+    Returns:
+        np.ndarray / List[np.ndarray]: subsampling factors.
+    """
+    if arch == "transformer":
+        return np.array([1])
+
+    elif mode == "mt" and arch == "rnn":
+        # +1 means input (+1) and layers outputs (train_args.elayer)
+        subsample = np.ones(train_args.elayers + 1, dtype=np.int64)
+        logging.warning("Subsampling is not performed for machine translation.")
+        logging.info("subsample: " + " ".join([str(x) for x in subsample]))
+        return subsample
+
+    elif (
+            (mode == "asr" and arch in ("rnn", "rnn-t"))
+            or (mode == "mt" and arch == "rnn")
+            or (mode == "st" and arch == "rnn")
+    ):
+        subsample = np.ones(train_args.elayers + 1, dtype=np.int64)
+        if train_args.etype.endswith("p") and not train_args.etype.startswith("vgg"):
+            ss = train_args.subsample.split("_")
+            for j in range(min(train_args.elayers + 1, len(ss))):
+                subsample[j] = int(ss[j])
+        else:
+            logging.warning("Subsampling is not performed for vgg*. " "It is performed in max pooling layers at CNN.")
+        logging.info("subsample: " + " ".join([str(x) for x in subsample]))
+        return subsample
+
+    elif mode == "asr" and arch == "rnn_mix":
+        subsample = np.ones(train_args.elayers_sd + train_args.elayers + 1, dtype=np.int64)
+        if train_args.etype.endswith("p") and not train_args.etype.startswith("vgg"):
+            ss = train_args.subsample.split("_")
+            for j in range(min(train_args.elayers_sd + train_args.elayers + 1, len(ss))):
+                subsample[j] = int(ss[j])
+        else:
+            logging.warning("Subsampling is not performed for vgg*. " "It is performed in max pooling layers at CNN.")
+        logging.info("subsample: " + " ".join([str(x) for x in subsample]))
+        return subsample
+
+    elif mode == "asr" and arch == "rnn_mulenc":
+        subsample_list = []
+        for idx in range(train_args.num_encs):
+            subsample = np.ones(train_args.elayers[idx] + 1, dtype=np.int64)
+            if train_args.etype[idx].endswith("p") and not train_args.etype[idx].startswith("vgg"):
+                ss = train_args.subsample[idx].split("_")
+                for j in range(min(train_args.elayers[idx] + 1, len(ss))):
+                    subsample[j] = int(ss[j])
+            else:
+                logging.warning(
+                    "Encoder %d: Subsampling is not performed for vgg*. "
+                    "It is performed in max pooling layers at CNN.",
+                    idx + 1,
+                )
+            logging.info("subsample: " + " ".join([str(x) for x in subsample]))
+            subsample_list.append(subsample)
+        return subsample_list
+
+    else:
+        raise ValueError(f"Invalid options: mode={mode}, arch={arch}")
+
+
+def rename_state_dict(old_prefix: str, new_prefix: str, state_dict: Dict[str, torch.Tensor]):
+    """Replace keys of old prefix with new prefix in state dict."""
+    # need this list not to break the dict iterator
+    old_keys = [k for k in state_dict if k.startswith(old_prefix)]
+    if len(old_keys) > 0:
+        logging.warning(f"Rename: {old_prefix} -> {new_prefix}")
+    for k in old_keys:
+        v = state_dict.pop(k)
+        new_k = k.replace(old_prefix, new_prefix)
+        state_dict[new_k] = v
+
+
+def get_activation(act):
+    """Return activation function."""
+    # Lazy load to avoid unused import
+    from .swish import Swish
+
+    activation_funcs = {
+        "hardtanh": torch.nn.Hardtanh,
+        "tanh": torch.nn.Tanh,
+        "relu": torch.nn.ReLU,
+        "selu": torch.nn.SELU,
+        "swish": Swish,
+    }
+
+    return activation_funcs[act]()
+
+
+def trim_by_ctc_posterior(
+        h: torch.Tensor,
+        ctc_probs: torch.Tensor,
+        masks: torch.Tensor,
+        pos_emb: torch.Tensor = None,
+):
+    """
+    Trim the encoder hidden output using CTC posterior.
+    The continuous frames in the tail that confidently represent
+    blank symbols are trimmed.
+    """
+
+    # Empirical settings
+    frame_tolerance = 5
+    conf_tolerance = 0.95
+    blank_id = 0
+
+    assert masks.size(1) == 1
+    masks = masks.squeeze(1)
+    hlens = masks.sum(dim=1)
+    assert h.size()[:2] == ctc_probs.size()[:2]
+    assert h.size(0) == hlens.size(0)
+
+    # blank frames
+    max_values, max_indices = ctc_probs.max(dim=2)
+    blank_masks = torch.logical_and(max_values > conf_tolerance, max_indices == blank_id)
+
+    # plus ignored frames
+    joint_masks = torch.logical_or(blank_masks, ~masks)
+
+    # lengths after the trimming
+    B, T, _ = h.size()
+    frame_idx = torch.where(joint_masks, -1, torch.arange(T).unsqueeze(0).repeat(B, 1).to(h.device))
+    after_lens = torch.where(
+        frame_idx.max(dim=-1)[0] + frame_tolerance + 1 < hlens,
+        frame_idx.max(dim=-1)[0] + frame_tolerance + 1,
+        hlens,
+    )
+
+    h = h[:, : max(after_lens)]
+    masks = ~make_pad_mask(after_lens).to(h.device).unsqueeze(1)
+
+    if pos_emb is None:
+        pos_emb = None
+    elif (hlens.max() * 2 - 1).item() == pos_emb.size(1):  # RelPositionalEncoding
+        pos_emb = pos_emb[:, pos_emb.size(1) // 2 - h.size(1) + 1: pos_emb.size(1) // 2 + h.size(1)]
+    else:
+        pos_emb = pos_emb[:, : h.size(1)]
+
+    return h, masks, pos_emb

--- a/phoonnx_train/optispeech/model/generator/modules/_conformer/swish.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_conformer/swish.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Johns Hopkins University (Shinji Watanabe)
+#                Northwestern Polytechnical University (Pengcheng Guo)
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Swish() activation function for Conformer."""
+
+import torch
+
+
+class Swish(torch.nn.Module):
+    """Construct an Swish object."""
+
+    def forward(self, x):
+        """Return Swich activation function."""
+        return x * torch.sigmoid(x)

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/__init__.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/__init__.py
@@ -1,0 +1,1 @@
+"""Adapted from espnet."""

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/attention.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/attention.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Multi-Head Attention layer definition."""
+
+import math
+
+import torch
+from torch import nn
+
+
+class MultiHeadedAttention(nn.Module):
+    """Multi-Head Attention layer.
+
+    Args:
+        n_head (int): The number of heads.
+        n_feat (int): The number of features.
+        dropout_rate (float): Dropout rate.
+
+    """
+
+    def __init__(self, n_head, n_feat, dropout_rate):
+        """Construct an MultiHeadedAttention object."""
+        super().__init__()
+        assert n_feat % n_head == 0
+        # We assume d_v always equals d_k
+        self.d_k = n_feat // n_head
+        self.h = n_head
+        self.linear_q = nn.Linear(n_feat, n_feat)
+        self.linear_k = nn.Linear(n_feat, n_feat)
+        self.linear_v = nn.Linear(n_feat, n_feat)
+        self.linear_out = nn.Linear(n_feat, n_feat)
+        self.attn = None
+        self.dropout = nn.Dropout(p=dropout_rate)
+
+    def forward_qkv(self, query, key, value, expand_kv=False):
+        """Transform query, key and value.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            expand_kv (bool): Used only for partially autoregressive (PAR) decoding.
+
+        Returns:
+            torch.Tensor: Transformed query tensor (#batch, n_head, time1, d_k).
+            torch.Tensor: Transformed key tensor (#batch, n_head, time2, d_k).
+            torch.Tensor: Transformed value tensor (#batch, n_head, time2, d_k).
+
+        """
+        n_batch = query.size(0)
+        q = self.linear_q(query).view(n_batch, -1, self.h, self.d_k)
+
+        if expand_kv:
+            k_shape = key.shape
+            k = self.linear_k(key[:1, :, :]).expand(n_batch, k_shape[1], k_shape[2]).view(n_batch, -1, self.h, self.d_k)
+            v_shape = value.shape
+            v = (
+                self.linear_v(value[:1, :, :])
+                .expand(n_batch, v_shape[1], v_shape[2])
+                .view(n_batch, -1, self.h, self.d_k)
+            )
+        else:
+            k = self.linear_k(key).view(n_batch, -1, self.h, self.d_k)
+            v = self.linear_v(value).view(n_batch, -1, self.h, self.d_k)
+
+        q = q.transpose(1, 2)  # (batch, head, time1, d_k)
+        k = k.transpose(1, 2)  # (batch, head, time2, d_k)
+        v = v.transpose(1, 2)  # (batch, head, time2, d_k)
+
+        return q, k, v
+
+    def forward_attention(self, value, scores, mask):
+        """Compute attention context vector.
+
+        Args:
+            value (torch.Tensor): Transformed value (#batch, n_head, time2, d_k).
+            scores (torch.Tensor): Attention score (#batch, n_head, time1, time2).
+            mask (torch.Tensor): Mask (#batch, 1, time2) or (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Transformed value (#batch, time1, d_model)
+                weighted by the attention score (#batch, time1, time2).
+
+        """
+        n_batch = value.size(0)
+        if mask is not None:
+            mask = mask.unsqueeze(1).eq(0)  # (batch, 1, *, time2)
+            min_value = torch.finfo(scores.dtype).min
+            scores = scores.masked_fill(mask, min_value)
+            self.attn = torch.softmax(scores, dim=-1).masked_fill(mask, 0.0)  # (batch, head, time1, time2)
+        else:
+            self.attn = torch.softmax(scores, dim=-1)  # (batch, head, time1, time2)
+
+        p_attn = self.dropout(self.attn)
+        x = torch.matmul(p_attn, value)  # (batch, head, time1, d_k)
+        x = x.transpose(1, 2).contiguous().view(n_batch, -1, self.h * self.d_k)  # (batch, time1, d_model)
+
+        return self.linear_out(x)  # (batch, time1, d_model)
+
+    def forward(self, query, key, value, mask, expand_kv=False):
+        """Compute scaled dot product attention.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
+                (#batch, time1, time2).
+            expand_kv (bool): Used only for partially autoregressive (PAR) decoding.
+        When set to `True`, `Linear` layers are computed only for the first batch.
+        This is useful to reduce the memory usage during decoding when the batch size is
+        #beam_size x #mask_count, which can be very large. Typically, in single waveform
+        inference of PAR, `Linear` layers should not be computed for all batches
+        for source-attention.
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        q, k, v = self.forward_qkv(query, key, value, expand_kv)
+        scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.d_k)
+        return self.forward_attention(v, scores, mask)
+
+
+class LegacyRelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """Multi-Head Attention layer with relative position encoding (old version).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    Paper: https://arxiv.org/abs/1901.02860
+
+    Args:
+        n_head (int): The number of heads.
+        n_feat (int): The number of features.
+        dropout_rate (float): Dropout rate.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
+
+    """
+
+    def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
+        """Construct an RelPositionMultiHeadedAttention object."""
+        super().__init__(n_head, n_feat, dropout_rate)
+        self.zero_triu = zero_triu
+        # linear transformation for positional encoding
+        self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
+        # these two learnable bias are used in matrix c and matrix d
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        self.pos_bias_u = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        self.pos_bias_v = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        torch.nn.init.xavier_uniform_(self.pos_bias_u)
+        torch.nn.init.xavier_uniform_(self.pos_bias_v)
+
+    def rel_shift(self, x):
+        """Compute relative positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, head, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor.
+
+        """
+        zero_pad = torch.zeros((*x.size()[:3], 1), device=x.device, dtype=x.dtype)
+        x_padded = torch.cat([zero_pad, x], dim=-1)
+
+        x_padded = x_padded.view(*x.size()[:2], x.size(3) + 1, x.size(2))
+        x = x_padded[:, :, 1:].view_as(x)
+
+        if self.zero_triu:
+            ones = torch.ones((x.size(2), x.size(3)))
+            x = x * torch.tril(ones, x.size(3) - x.size(2))[None, None, :, :]
+
+        return x
+
+    def forward(self, query, key, value, pos_emb, mask):
+        """Compute 'Scaled Dot Product Attention' with rel. positional encoding.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            pos_emb (torch.Tensor): Positional embedding tensor (#batch, time1, size).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
+                (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+        q = q.transpose(1, 2)  # (batch, time1, head, d_k)
+
+        n_batch_pos = pos_emb.size(0)
+        p = self.linear_pos(pos_emb).view(n_batch_pos, -1, self.h, self.d_k)
+        p = p.transpose(1, 2)  # (batch, head, time1, d_k)
+
+        # (batch, head, time1, d_k)
+        q_with_bias_u = (q + self.pos_bias_u).transpose(1, 2)
+        # (batch, head, time1, d_k)
+        q_with_bias_v = (q + self.pos_bias_v).transpose(1, 2)
+
+        # compute attention score
+        # first compute matrix a and matrix c
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        # (batch, head, time1, time2)
+        matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+
+        # compute matrix b and matrix d
+        # (batch, head, time1, time1)
+        matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)
+
+        scores = (matrix_ac + matrix_bd) / math.sqrt(self.d_k)  # (batch, head, time1, time2)
+
+        return self.forward_attention(v, scores, mask)
+
+
+class RelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """Multi-Head Attention layer with relative position encoding (new implementation).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    Paper: https://arxiv.org/abs/1901.02860
+
+    Args:
+        n_head (int): The number of heads.
+        n_feat (int): The number of features.
+        dropout_rate (float): Dropout rate.
+        zero_triu (bool): Whether to zero the upper triangular part of attention matrix.
+
+    """
+
+    def __init__(self, n_head, n_feat, dropout_rate, zero_triu=False):
+        """Construct an RelPositionMultiHeadedAttention object."""
+        super().__init__(n_head, n_feat, dropout_rate)
+        self.zero_triu = zero_triu
+        # linear transformation for positional encoding
+        self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
+        # these two learnable bias are used in matrix c and matrix d
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        self.pos_bias_u = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        self.pos_bias_v = nn.Parameter(torch.Tensor(self.h, self.d_k))
+        torch.nn.init.xavier_uniform_(self.pos_bias_u)
+        torch.nn.init.xavier_uniform_(self.pos_bias_v)
+
+    def rel_shift(self, x):
+        """Compute relative positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, head, time1, 2*time1-1).
+            time1 means the length of query vector.
+
+        Returns:
+            torch.Tensor: Output tensor.
+
+        """
+        zero_pad = torch.zeros((*x.size()[:3], 1), device=x.device, dtype=x.dtype)
+        x_padded = torch.cat([zero_pad, x], dim=-1)
+
+        x_padded = x_padded.view(*x.size()[:2], x.size(3) + 1, x.size(2))
+        x = x_padded[:, :, 1:].view_as(x)[:, :, :, : x.size(-1) // 2 + 1]  # only keep the positions from 0 to time2
+
+        if self.zero_triu:
+            ones = torch.ones((x.size(2), x.size(3)), device=x.device)
+            x = x * torch.tril(ones, x.size(3) - x.size(2))[None, None, :, :]
+
+        return x
+
+    def forward(self, query, key, value, pos_emb, mask):
+        """Compute 'Scaled Dot Product Attention' with rel. positional encoding.
+
+        Args:
+            query (torch.Tensor): Query tensor (#batch, time1, size).
+            key (torch.Tensor): Key tensor (#batch, time2, size).
+            value (torch.Tensor): Value tensor (#batch, time2, size).
+            pos_emb (torch.Tensor): Positional embedding tensor
+                (#batch, 2*time1-1, size).
+            mask (torch.Tensor): Mask tensor (#batch, 1, time2) or
+                (#batch, time1, time2).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time1, d_model).
+
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+        q = q.transpose(1, 2)  # (batch, time1, head, d_k)
+
+        n_batch_pos = pos_emb.size(0)
+        p = self.linear_pos(pos_emb).view(n_batch_pos, -1, self.h, self.d_k)
+        p = p.transpose(1, 2)  # (batch, head, 2*time1-1, d_k)
+
+        # (batch, head, time1, d_k)
+        q_with_bias_u = (q + self.pos_bias_u).transpose(1, 2)
+        # (batch, head, time1, d_k)
+        q_with_bias_v = (q + self.pos_bias_v).transpose(1, 2)
+
+        # compute attention score
+        # first compute matrix a and matrix c
+        # as described in https://arxiv.org/abs/1901.02860 Section 3.3
+        # (batch, head, time1, time2)
+        matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+
+        # compute matrix b and matrix d
+        # (batch, head, time1, 2*time1-1)
+        matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)
+
+        scores = (matrix_ac + matrix_bd) / math.sqrt(self.d_k)  # (batch, head, time1, time2)
+
+        return self.forward_attention(v, scores, mask)

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/dynamic_conv.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/dynamic_conv.py
@@ -1,0 +1,122 @@
+"""Dynamic Convolution module."""
+
+import numpy
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+MIN_VALUE = float(numpy.finfo(numpy.float32).min)
+
+
+class DynamicConvolution(nn.Module):
+    """Dynamic Convolution layer.
+
+    This implementation is based on
+    https://github.com/pytorch/fairseq/tree/master/fairseq
+
+    Args:
+        wshare (int): the number of kernel of convolution
+        n_feat (int): the number of features
+        dropout_rate (float): dropout_rate
+        kernel_size (int): kernel size (length)
+        use_kernel_mask (bool): Use causal mask or not for convolution kernel
+        use_bias (bool): Use bias term or not.
+
+    """
+
+    def __init__(
+            self,
+            wshare,
+            n_feat,
+            dropout_rate,
+            kernel_size,
+            use_kernel_mask=False,
+            use_bias=False,
+    ):
+        """Construct Dynamic Convolution layer."""
+        super().__init__()
+
+        assert n_feat % wshare == 0
+        self.wshare = wshare
+        self.use_kernel_mask = use_kernel_mask
+        self.dropout_rate = dropout_rate
+        self.kernel_size = kernel_size
+        self.attn = None
+
+        # linear -> GLU -- -> lightconv -> linear
+        #               \        /
+        #                 Linear
+        self.linear1 = nn.Linear(n_feat, n_feat * 2)
+        self.linear2 = nn.Linear(n_feat, n_feat)
+        self.linear_weight = nn.Linear(n_feat, self.wshare * 1 * kernel_size)
+        nn.init.xavier_uniform_(self.linear_weight.weight)
+        self.act = nn.GLU()
+
+        # dynamic conv related
+        self.use_bias = use_bias
+        if self.use_bias:
+            self.bias = nn.Parameter(torch.Tensor(n_feat))
+
+    def forward(self, query, key, value, mask):
+        """Forward of 'Dynamic Convolution'.
+
+        This function takes query, key and value but uses only quert.
+        This is just for compatibility with self-attention layer (attention.py)
+
+        Args:
+            query (torch.Tensor): (batch, time1, d_model) input tensor
+            key (torch.Tensor): (batch, time2, d_model) NOT USED
+            value (torch.Tensor): (batch, time2, d_model) NOT USED
+            mask (torch.Tensor): (batch, time1, time2) mask
+
+        Return:
+            x (torch.Tensor): (batch, time1, d_model) output
+
+        """
+        # linear -> GLU -- -> lightconv -> linear
+        #               \        /
+        #                 Linear
+        x = query
+        B, T, C = x.size()
+        H = self.wshare
+        k = self.kernel_size
+
+        # first liner layer
+        x = self.linear1(x)
+
+        # GLU activation
+        x = self.act(x)
+
+        # get kernel of convolution
+        weight = self.linear_weight(x)  # B x T x kH
+        weight = F.dropout(weight, self.dropout_rate, training=self.training)
+        weight = weight.view(B, T, H, k).transpose(1, 2).contiguous()  # B x H x T x k
+        weight_new = torch.zeros(B * H * T * (T + k - 1), dtype=weight.dtype)
+        weight_new = weight_new.view(B, H, T, T + k - 1).fill_(float("-inf"))
+        weight_new = weight_new.to(x.device)  # B x H x T x T+k-1
+        weight_new.as_strided((B, H, T, k), ((T + k - 1) * T * H, (T + k - 1) * T, T + k, 1)).copy_(weight)
+        weight_new = weight_new.narrow(-1, int((k - 1) / 2), T)  # B x H x T x T(k)
+        if self.use_kernel_mask:
+            kernel_mask = torch.tril(torch.ones(T, T, device=x.device)).unsqueeze(0)
+            weight_new = weight_new.masked_fill(kernel_mask == 0.0, float("-inf"))
+        weight_new = F.softmax(weight_new, dim=-1)
+        self.attn = weight_new
+        weight_new = weight_new.view(B * H, T, T)
+
+        # convolution
+        x = x.transpose(1, 2).contiguous()  # B x C x T
+        x = x.view(B * H, int(C / H), T).transpose(1, 2)
+        x = torch.bmm(weight_new, x)  # BH x T x C/H
+        x = x.transpose(1, 2).contiguous().view(B, C, T)
+
+        if self.use_bias:
+            x = x + self.bias.view(1, -1, 1)
+        x = x.transpose(1, 2)  # B x T x C
+
+        if mask is not None and not self.use_kernel_mask:
+            mask = mask.transpose(-1, -2)
+            x = x.masked_fill(mask == 0, 0.0)
+
+        # second linear layer
+        x = self.linear2(x)
+        return x

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/dynamic_conv2d.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/dynamic_conv2d.py
@@ -1,0 +1,133 @@
+"""Dynamic 2-Dimensional Convolution module."""
+
+import numpy
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+MIN_VALUE = float(numpy.finfo(numpy.float32).min)
+
+
+class DynamicConvolution2D(nn.Module):
+    """Dynamic 2-Dimensional Convolution layer.
+
+    This implementation is based on
+    https://github.com/pytorch/fairseq/tree/master/fairseq
+
+    Args:
+        wshare (int): the number of kernel of convolution
+        n_feat (int): the number of features
+        dropout_rate (float): dropout_rate
+        kernel_size (int): kernel size (length)
+        use_kernel_mask (bool): Use causal mask or not for convolution kernel
+        use_bias (bool): Use bias term or not.
+
+    """
+
+    def __init__(
+            self,
+            wshare,
+            n_feat,
+            dropout_rate,
+            kernel_size,
+            use_kernel_mask=False,
+            use_bias=False,
+    ):
+        """Construct Dynamic 2-Dimensional Convolution layer."""
+        super().__init__()
+
+        assert n_feat % wshare == 0
+        self.wshare = wshare
+        self.use_kernel_mask = use_kernel_mask
+        self.dropout_rate = dropout_rate
+        self.kernel_size = kernel_size
+        self.padding_size = int(kernel_size / 2)
+        self.attn_t = None
+        self.attn_f = None
+
+        # linear -> GLU -- -> lightconv -> linear
+        #               \        /
+        #                 Linear
+        self.linear1 = nn.Linear(n_feat, n_feat * 2)
+        self.linear2 = nn.Linear(n_feat * 2, n_feat)
+        self.linear_weight = nn.Linear(n_feat, self.wshare * 1 * kernel_size)
+        nn.init.xavier_uniform_(self.linear_weight.weight)
+        self.linear_weight_f = nn.Linear(n_feat, kernel_size)
+        nn.init.xavier_uniform_(self.linear_weight_f.weight)
+        self.act = nn.GLU()
+
+        # dynamic conv related
+        self.use_bias = use_bias
+        if self.use_bias:
+            self.bias = nn.Parameter(torch.Tensor(n_feat))
+
+    def forward(self, query, key, value, mask):
+        """Forward of 'Dynamic 2-Dimensional Convolution'.
+
+        This function takes query, key and value but uses only query.
+        This is just for compatibility with self-attention layer (attention.py)
+
+        Args:
+            query (torch.Tensor): (batch, time1, d_model) input tensor
+            key (torch.Tensor): (batch, time2, d_model) NOT USED
+            value (torch.Tensor): (batch, time2, d_model) NOT USED
+            mask (torch.Tensor): (batch, time1, time2) mask
+
+        Return:
+            x (torch.Tensor): (batch, time1, d_model) output
+
+        """
+        # linear -> GLU -- -> lightconv -> linear
+        #               \        /
+        #                 Linear
+        x = query
+        B, T, C = x.size()
+        H = self.wshare
+        k = self.kernel_size
+
+        # first liner layer
+        x = self.linear1(x)
+
+        # GLU activation
+        x = self.act(x)
+
+        # convolution of frequency axis
+        weight_f = self.linear_weight_f(x).view(B * T, 1, k)  # B x T x k
+        self.attn_f = weight_f.view(B, T, k).unsqueeze(1)
+        xf = F.conv1d(x.view(1, B * T, C), weight_f, padding=self.padding_size, groups=B * T)
+        xf = xf.view(B, T, C)
+
+        # get kernel of convolution
+        weight = self.linear_weight(x)  # B x T x kH
+        weight = F.dropout(weight, self.dropout_rate, training=self.training)
+        weight = weight.view(B, T, H, k).transpose(1, 2).contiguous()  # B x H x T x k
+        weight_new = torch.zeros(B * H * T * (T + k - 1), dtype=weight.dtype)
+        weight_new = weight_new.view(B, H, T, T + k - 1).fill_(float("-inf"))
+        weight_new = weight_new.to(x.device)  # B x H x T x T+k-1
+        weight_new.as_strided((B, H, T, k), ((T + k - 1) * T * H, (T + k - 1) * T, T + k, 1)).copy_(weight)
+        weight_new = weight_new.narrow(-1, int((k - 1) / 2), T)  # B x H x T x T(k)
+        if self.use_kernel_mask:
+            kernel_mask = torch.tril(torch.ones(T, T, device=x.device)).unsqueeze(0)
+            weight_new = weight_new.masked_fill(kernel_mask == 0.0, float("-inf"))
+        weight_new = F.softmax(weight_new, dim=-1)
+        self.attn_t = weight_new
+        weight_new = weight_new.view(B * H, T, T)
+
+        # convolution
+        x = x.transpose(1, 2).contiguous()  # B x C x T
+        x = x.view(B * H, int(C / H), T).transpose(1, 2)
+        x = torch.bmm(weight_new, x)
+        x = x.transpose(1, 2).contiguous().view(B, C, T)
+
+        if self.use_bias:
+            x = x + self.bias.view(1, -1, 1)
+        x = x.transpose(1, 2)  # B x T x C
+        x = torch.cat((x, xf), -1)  # B x T x Cx2
+
+        if mask is not None and not self.use_kernel_mask:
+            mask = mask.transpose(-1, -2)
+            x = x.masked_fill(mask == 0, 0.0)
+
+        # second linear layer
+        x = self.linear2(x)
+        return x

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/embedding.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/embedding.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Positional Encoding Module."""
+
+import math
+
+import torch
+
+
+def _pre_hook(
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+):
+    """Perform pre-hook in load_state_dict for backward compatibility.
+
+    Note:
+        We saved self.pe until v.0.5.2 but we have omitted it later.
+        Therefore, we remove the item "pe" from `state_dict` for backward compatibility.
+
+    """
+    k = prefix + "pe"
+    if k in state_dict:
+        state_dict.pop(k)
+
+
+class PositionalEncoding(torch.nn.Module):
+    """Positional encoding.
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+        reverse (bool): Whether to reverse the input position. Only for
+        the class LegacyRelPositionalEncoding. We remove it in the current
+        class RelPositionalEncoding.
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000, reverse=False):
+        """Construct an PositionalEncoding object."""
+        super().__init__()
+        self.d_model = d_model
+        self.reverse = reverse
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.pe = None
+        self.extend_pe(torch.tensor(0.0).expand(1, max_len))
+        self._register_load_state_dict_pre_hook(_pre_hook)
+
+    def extend_pe(self, x):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            if self.pe.size(1) >= x.size(1):
+                if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
+                return
+        pe = torch.zeros(x.size(1), self.d_model)
+        if self.reverse:
+            position = torch.arange(x.size(1) - 1, -1, -1.0, dtype=torch.float32).unsqueeze(1)
+        else:
+            position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32) * -(math.log(10000.0) / self.d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+        """
+        self.extend_pe(x)
+        x = x * self.xscale + self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class ScaledPositionalEncoding(PositionalEncoding):
+    """Scaled positional encoding module.
+
+    See Sec. 3.2  https://arxiv.org/abs/1809.08895
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Initialize class."""
+        super().__init__(d_model=d_model, dropout_rate=dropout_rate, max_len=max_len)
+        self.alpha = torch.nn.Parameter(torch.tensor(1.0))
+
+    def reset_parameters(self):
+        """Reset parameters."""
+        self.alpha.data = torch.tensor(1.0)
+
+    def forward(self, x):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        self.extend_pe(x)
+        x = x + self.alpha * self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class LearnableFourierPosEnc(torch.nn.Module):
+    """Learnable Fourier Features for Positional Encoding.
+
+    See https://arxiv.org/pdf/2106.02795.pdf
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+        gamma (float): init parameter for the positional kernel variance
+            see https://arxiv.org/pdf/2106.02795.pdf.
+        apply_scaling (bool): Whether to scale the input before adding the pos encoding.
+        hidden_dim (int): if not None, we modulate the pos encodings with
+            an MLP whose hidden layer has hidden_dim neurons.
+    """
+
+    def __init__(
+            self,
+            d_model,
+            dropout_rate=0.0,
+            max_len=5000,
+            gamma=1.0,
+            apply_scaling=False,
+            hidden_dim=None,
+    ):
+        """Initialize class."""
+        super().__init__()
+
+        self.d_model = d_model
+
+        if apply_scaling:
+            self.xscale = math.sqrt(self.d_model)
+        else:
+            self.xscale = 1.0
+
+        self.dropout = torch.nn.Dropout(dropout_rate)
+        self.max_len = max_len
+
+        self.gamma = gamma
+        if self.gamma is None:
+            self.gamma = self.d_model // 2
+
+        assert d_model % 2 == 0, "d_model should be divisible by two in order to use this layer."
+        self.w_r = torch.nn.Parameter(torch.empty(1, d_model // 2))
+        self._reset()  # init the weights
+
+        self.hidden_dim = hidden_dim
+        if self.hidden_dim is not None:
+            self.mlp = torch.nn.Sequential(
+                torch.nn.Linear(d_model, hidden_dim),
+                torch.nn.GELU(),
+                torch.nn.Linear(hidden_dim, d_model),
+            )
+
+    def _reset(self):
+        self.w_r.data = torch.normal(0, (1 / math.sqrt(self.gamma)), (1, self.d_model // 2))
+
+    def extend_pe(self, x):
+        """Reset the positional encodings."""
+        position_v = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1).to(x)
+
+        cosine = torch.cos(torch.matmul(position_v, self.w_r))
+        sine = torch.sin(torch.matmul(position_v, self.w_r))
+        pos_enc = torch.cat((cosine, sine), -1)
+        pos_enc /= math.sqrt(self.d_model)
+
+        if self.hidden_dim is None:
+            return pos_enc.unsqueeze(0)
+        else:
+            return self.mlp(pos_enc.unsqueeze(0))
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+        """
+        pe = self.extend_pe(x)
+        x = x * self.xscale + pe
+        return self.dropout(x)
+
+
+class LegacyRelPositionalEncoding(PositionalEncoding):
+    """Relative positional encoding module (old version).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    See : Appendix B in https://arxiv.org/abs/1901.02860
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Initialize class."""
+        super().__init__(
+            d_model=d_model,
+            dropout_rate=dropout_rate,
+            max_len=max_len,
+            reverse=True,
+        )
+
+    def forward(self, x):
+        """Compute positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+            torch.Tensor: Positional embedding tensor (1, time, `*`).
+
+        """
+        self.extend_pe(x)
+        x = x * self.xscale
+        pos_emb = self.pe[:, : x.size(1)]
+        return self.dropout(x), self.dropout(pos_emb)
+
+
+class RelPositionalEncoding(torch.nn.Module):
+    """Relative positional encoding module (new implementation).
+
+    Details can be found in https://github.com/espnet/espnet/pull/2816.
+
+    See : Appendix B in https://arxiv.org/abs/1901.02860
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Construct an PositionalEncoding object."""
+        super().__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.pe = None
+        self.extend_pe(torch.tensor(0.0).expand(1, max_len))
+
+    def extend_pe(self, x):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            # self.pe contains both positive and negative parts
+            # the length of self.pe is 2 * input_len - 1
+            if self.pe.size(1) >= x.size(1) * 2 - 1:
+                if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
+                return
+        # Suppose `i` means to the position of query vecotr and `j` means the
+        # position of key vector. We use position relative positions when keys
+        # are to the left (i>j) and negative relative positions otherwise (i<j).
+        pe_positive = torch.zeros(x.size(1), self.d_model)
+        pe_negative = torch.zeros(x.size(1), self.d_model)
+        position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32) * -(math.log(10000.0) / self.d_model)
+        )
+        pe_positive[:, 0::2] = torch.sin(position * div_term)
+        pe_positive[:, 1::2] = torch.cos(position * div_term)
+        pe_negative[:, 0::2] = torch.sin(-1 * position * div_term)
+        pe_negative[:, 1::2] = torch.cos(-1 * position * div_term)
+
+        # Reserve the order of positive indices and concat both positive and
+        # negative indices. This is used to support the shifting trick
+        # as in https://arxiv.org/abs/1901.02860
+        pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
+        pe_negative = pe_negative[1:].unsqueeze(0)
+        pe = torch.cat([pe_positive, pe_negative], dim=1)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        self.extend_pe(x)
+        x = x * self.xscale
+        pos_emb = self.pe[
+            :,
+            self.pe.size(1) // 2 - x.size(1) + 1: self.pe.size(1) // 2 + x.size(1),
+        ]
+        return self.dropout(x), self.dropout(pos_emb)
+
+
+class StreamPositionalEncoding(torch.nn.Module):
+    """Streaming Positional encoding.
+
+    Args:
+        d_model (int): Embedding dimension.
+        dropout_rate (float): Dropout rate.
+        max_len (int): Maximum input length.
+
+    """
+
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Construct an PositionalEncoding object."""
+        super().__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+        self.pe = None
+        self.tmp = torch.tensor(0.0).expand(1, max_len)
+        self.extend_pe(self.tmp.size(1), self.tmp.device, self.tmp.dtype)
+        self._register_load_state_dict_pre_hook(_pre_hook)
+
+    def extend_pe(self, length, device, dtype):
+        """Reset the positional encodings."""
+        if self.pe is not None:
+            if self.pe.size(1) >= length:
+                if self.pe.dtype != dtype or self.pe.device != device:
+                    self.pe = self.pe.to(dtype=dtype, device=device)
+                return
+        pe = torch.zeros(length, self.d_model)
+        position = torch.arange(0, length, dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32) * -(math.log(10000.0) / self.d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.pe = pe.to(device=device, dtype=dtype)
+
+    def forward(self, x: torch.Tensor, start_idx: int = 0):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        self.extend_pe(x.size(1) + start_idx, x.device, x.dtype)
+        x = x * self.xscale + self.pe[:, start_idx: start_idx + x.size(1)]
+        return self.dropout(x)

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/encoder.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/encoder.py
@@ -1,0 +1,341 @@
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Encoder definition."""
+
+import logging
+
+import torch
+
+from .attention import MultiHeadedAttention
+from .dynamic_conv import DynamicConvolution
+from .dynamic_conv2d import DynamicConvolution2D
+from .embedding import PositionalEncoding
+from .encoder_layer import EncoderLayer
+from .layer_norm import LayerNorm
+from .lightconv import LightweightConvolution
+from .lightconv2d import LightweightConvolution2D
+from .multi_layer_conv import Conv1dLinear, MultiLayeredConv1d
+from .positionwise_feed_forward import PositionwiseFeedForward
+from .repeat import repeat
+from .subsampling import Conv2dSubsampling, Conv2dSubsampling6, Conv2dSubsampling8
+
+
+class Encoder(torch.nn.Module):
+    """Transformer encoder module.
+
+    Args:
+        idim (int): Input dimension.
+        attention_dim (int): Dimension of attention.
+        attention_heads (int): The number of heads of multi head attention.
+        conv_wshare (int): The number of kernel of convolution. Only used in
+            selfattention_layer_type == "lightconv*" or "dynamiconv*".
+        conv_kernel_length (Union[int, str]): Kernel size str of convolution
+            (e.g. 71_71_71_71_71_71). Only used in selfattention_layer_type
+            == "lightconv*" or "dynamiconv*".
+        conv_usebias (bool): Whether to use bias in convolution. Only used in
+            selfattention_layer_type == "lightconv*" or "dynamiconv*".
+        linear_units (int): The number of units of position-wise feed forward.
+        num_blocks (int): The number of decoder blocks.
+        dropout_rate (float): Dropout rate.
+        positional_dropout_rate (float): Dropout rate after adding positional encoding.
+        attention_dropout_rate (float): Dropout rate in attention.
+        input_layer (Union[str, torch.nn.Module]): Input layer type.
+        pos_enc_class (torch.nn.Module): Positional encoding module class.
+            `PositionalEncoding `or `ScaledPositionalEncoding`
+        normalize_before (bool): Whether to use layer_norm before the first block.
+        concat_after (bool): Whether to concat attention layer's input and output.
+            if True, additional linear will be applied.
+            i.e. x -> x + linear(concat(x, att(x)))
+            if False, no additional linear will be applied. i.e. x -> x + att(x)
+        positionwise_layer_type (str): "linear", "conv1d", or "conv1d-linear".
+        positionwise_conv_kernel_size (int): Kernel size of positionwise conv1d layer.
+        selfattention_layer_type (str): Encoder attention layer type.
+        padding_idx (int): Padding idx for input_layer=embed.
+        stochastic_depth_rate (float): Maximum probability to skip the encoder layer.
+        intermediate_layers (Union[List[int], None]): indices of intermediate CTC layer.
+            indices start from 1.
+            if not None, intermediate outputs are returned (which changes return type
+            signature.)
+
+    """
+
+    def __init__(
+            self,
+            idim,
+            attention_dim=256,
+            attention_heads=4,
+            conv_wshare=4,
+            conv_kernel_length="11",
+            conv_usebias=False,
+            linear_units=2048,
+            num_blocks=6,
+            dropout_rate=0.1,
+            positional_dropout_rate=0.1,
+            attention_dropout_rate=0.0,
+            input_layer="conv2d",
+            pos_enc_class=PositionalEncoding,
+            normalize_before=True,
+            concat_after=False,
+            positionwise_layer_type="linear",
+            positionwise_conv_kernel_size=1,
+            selfattention_layer_type="selfattn",
+            padding_idx=-1,
+            stochastic_depth_rate=0.0,
+            intermediate_layers=None,
+            ctc_softmax=None,
+            conditioning_layer_dim=None,
+    ):
+        """Construct an Encoder object."""
+        super().__init__()
+
+        self.conv_subsampling_factor = 1
+        if input_layer == "linear":
+            self.embed = torch.nn.Sequential(
+                torch.nn.Linear(idim, attention_dim),
+                torch.nn.LayerNorm(attention_dim),
+                torch.nn.Dropout(dropout_rate),
+                torch.nn.ReLU(),
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif input_layer == "conv2d":
+            self.embed = Conv2dSubsampling(idim, attention_dim, dropout_rate)
+            self.conv_subsampling_factor = 4
+        elif input_layer == "conv2d-scaled-pos-enc":
+            self.embed = Conv2dSubsampling(
+                idim,
+                attention_dim,
+                dropout_rate,
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+            self.conv_subsampling_factor = 4
+        elif input_layer == "conv2d6":
+            self.embed = Conv2dSubsampling6(idim, attention_dim, dropout_rate)
+            self.conv_subsampling_factor = 6
+        elif input_layer == "conv2d8":
+            self.embed = Conv2dSubsampling8(idim, attention_dim, dropout_rate)
+            self.conv_subsampling_factor = 8
+        elif input_layer == "embed":
+            self.embed = torch.nn.Sequential(
+                torch.nn.Embedding(idim, attention_dim, padding_idx=padding_idx),
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif isinstance(input_layer, torch.nn.Module):
+            self.embed = torch.nn.Sequential(
+                input_layer,
+                pos_enc_class(attention_dim, positional_dropout_rate),
+            )
+        elif input_layer is None:
+            self.embed = torch.nn.Sequential(pos_enc_class(attention_dim, positional_dropout_rate))
+        else:
+            raise ValueError("unknown input_layer: " + input_layer)
+        self.normalize_before = normalize_before
+        positionwise_layer, positionwise_layer_args = self.get_positionwise_layer(
+            positionwise_layer_type,
+            attention_dim,
+            linear_units,
+            dropout_rate,
+            positionwise_conv_kernel_size,
+        )
+        if selfattention_layer_type in [
+            "selfattn",
+            "rel_selfattn",
+            "legacy_rel_selfattn",
+        ]:
+            logging.info("encoder self-attention layer type = self-attention")
+            encoder_selfattn_layer = MultiHeadedAttention
+            encoder_selfattn_layer_args = [
+                                              (
+                                                  attention_heads,
+                                                  attention_dim,
+                                                  attention_dropout_rate,
+                                              )
+                                          ] * num_blocks
+        elif selfattention_layer_type == "lightconv":
+            logging.info("encoder self-attention layer type = lightweight convolution")
+            encoder_selfattn_layer = LightweightConvolution
+            encoder_selfattn_layer_args = [
+                (
+                    conv_wshare,
+                    attention_dim,
+                    attention_dropout_rate,
+                    int(conv_kernel_length.split("_")[lnum]),
+                    False,
+                    conv_usebias,
+                )
+                for lnum in range(num_blocks)
+            ]
+        elif selfattention_layer_type == "lightconv2d":
+            logging.info("encoder self-attention layer " "type = lightweight convolution 2-dimensional")
+            encoder_selfattn_layer = LightweightConvolution2D
+            encoder_selfattn_layer_args = [
+                (
+                    conv_wshare,
+                    attention_dim,
+                    attention_dropout_rate,
+                    int(conv_kernel_length.split("_")[lnum]),
+                    False,
+                    conv_usebias,
+                )
+                for lnum in range(num_blocks)
+            ]
+        elif selfattention_layer_type == "dynamicconv":
+            logging.info("encoder self-attention layer type = dynamic convolution")
+            encoder_selfattn_layer = DynamicConvolution
+            encoder_selfattn_layer_args = [
+                (
+                    conv_wshare,
+                    attention_dim,
+                    attention_dropout_rate,
+                    int(conv_kernel_length.split("_")[lnum]),
+                    False,
+                    conv_usebias,
+                )
+                for lnum in range(num_blocks)
+            ]
+        elif selfattention_layer_type == "dynamicconv2d":
+            logging.info("encoder self-attention layer type = dynamic convolution 2-dimensional")
+            encoder_selfattn_layer = DynamicConvolution2D
+            encoder_selfattn_layer_args = [
+                (
+                    conv_wshare,
+                    attention_dim,
+                    attention_dropout_rate,
+                    int(conv_kernel_length.split("_")[lnum]),
+                    False,
+                    conv_usebias,
+                )
+                for lnum in range(num_blocks)
+            ]
+        else:
+            raise NotImplementedError(selfattention_layer_type)
+
+        self.encoders = repeat(
+            num_blocks,
+            lambda lnum: EncoderLayer(
+                attention_dim,
+                encoder_selfattn_layer(*encoder_selfattn_layer_args[lnum]),
+                positionwise_layer(*positionwise_layer_args),
+                dropout_rate,
+                normalize_before,
+                concat_after,
+                stochastic_depth_rate * float(1 + lnum) / num_blocks,
+            ),
+        )
+        if self.normalize_before:
+            self.after_norm = LayerNorm(attention_dim)
+
+        self.intermediate_layers = intermediate_layers
+        self.use_conditioning = True if ctc_softmax is not None else False
+        if self.use_conditioning:
+            self.ctc_softmax = ctc_softmax
+            self.conditioning_layer = torch.nn.Linear(conditioning_layer_dim, attention_dim)
+
+    def get_positionwise_layer(
+            self,
+            positionwise_layer_type="linear",
+            attention_dim=256,
+            linear_units=2048,
+            dropout_rate=0.1,
+            positionwise_conv_kernel_size=1,
+    ):
+        """Define positionwise layer."""
+        if positionwise_layer_type == "linear":
+            positionwise_layer = PositionwiseFeedForward
+            positionwise_layer_args = (attention_dim, linear_units, dropout_rate)
+        elif positionwise_layer_type == "conv1d":
+            positionwise_layer = MultiLayeredConv1d
+            positionwise_layer_args = (
+                attention_dim,
+                linear_units,
+                positionwise_conv_kernel_size,
+                dropout_rate,
+            )
+        elif positionwise_layer_type == "conv1d-linear":
+            positionwise_layer = Conv1dLinear
+            positionwise_layer_args = (
+                attention_dim,
+                linear_units,
+                positionwise_conv_kernel_size,
+                dropout_rate,
+            )
+        else:
+            raise NotImplementedError("Support only linear or conv1d.")
+        return positionwise_layer, positionwise_layer_args
+
+    def forward(self, xs, masks):
+        """Encode input sequence.
+
+        Args:
+            xs (torch.Tensor): Input tensor (#batch, time, idim).
+            masks (torch.Tensor): Mask tensor (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, attention_dim).
+            torch.Tensor: Mask tensor (#batch, 1, time).
+
+        """
+        if isinstance(
+                self.embed,
+                (
+                        Conv2dSubsampling,
+                        Conv2dSubsampling6,
+                        Conv2dSubsampling8,
+                ),
+        ):
+            xs, masks = self.embed(xs, masks)
+        else:
+            xs = self.embed(xs)
+
+        if self.intermediate_layers is None:
+            xs, masks = self.encoders(xs, masks)
+        else:
+            intermediate_outputs = []
+            for layer_idx, encoder_layer in enumerate(self.encoders):
+                xs, masks = encoder_layer(xs, masks)
+
+                if self.intermediate_layers is not None and layer_idx + 1 in self.intermediate_layers:
+                    encoder_output = xs
+                    # intermediate branches also require normalization.
+                    if self.normalize_before:
+                        encoder_output = self.after_norm(encoder_output)
+                    intermediate_outputs.append(encoder_output)
+
+                    if self.use_conditioning:
+                        intermediate_result = self.ctc_softmax(encoder_output)
+                        xs = xs + self.conditioning_layer(intermediate_result)
+
+        if self.normalize_before:
+            xs = self.after_norm(xs)
+
+        if self.intermediate_layers is not None:
+            return xs, masks, intermediate_outputs
+        return xs, masks
+
+    def forward_one_step(self, xs, masks, *, cache=None):
+        """Encode input frame.
+
+        Args:
+            xs (torch.Tensor): Input tensor.
+            masks (torch.Tensor): Mask tensor.
+            cache (List[torch.Tensor]): List of cache tensors.
+
+        Returns:
+            torch.Tensor: Output tensor.
+            torch.Tensor: Mask tensor.
+            List[torch.Tensor]: List of new cache tensors.
+
+        """
+        if isinstance(self.embed, Conv2dSubsampling):
+            xs, masks = self.embed(xs, masks)
+        else:
+            xs = self.embed(xs)
+        if cache is None:
+            cache = [None for _ in range(len(self.encoders))]
+        new_cache = []
+        for c, e in zip(cache, self.encoders):
+            xs, masks = e(xs, masks, cache=c)
+            new_cache.append(xs)
+        if self.normalize_before:
+            xs = self.after_norm(xs)
+        return xs, masks, new_cache

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/encoder_layer.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/encoder_layer.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Encoder self-attention layer definition."""
+
+import torch
+from torch import nn
+
+from .layer_norm import LayerNorm
+
+
+class EncoderLayer(nn.Module):
+    """Encoder layer module.
+
+    Args:
+        size (int): Input dimension.
+        self_attn (torch.nn.Module): Self-attention module instance.
+            `MultiHeadedAttention` or `RelPositionMultiHeadedAttention` instance
+            can be used as the argument.
+        feed_forward (torch.nn.Module): Feed-forward module instance.
+            `PositionwiseFeedForward`, `MultiLayeredConv1d`, or `Conv1dLinear` instance
+            can be used as the argument.
+        dropout_rate (float): Dropout rate.
+        normalize_before (bool): Whether to use layer_norm before the first block.
+        concat_after (bool): Whether to concat attention layer's input and output.
+            if True, additional linear will be applied.
+            i.e. x -> x + linear(concat(x, att(x)))
+            if False, no additional linear will be applied. i.e. x -> x + att(x)
+        stochastic_depth_rate (float): Proability to skip this layer.
+            During training, the layer may skip residual computation and return input
+            as-is with given probability.
+    """
+
+    def __init__(
+            self,
+            size,
+            self_attn,
+            feed_forward,
+            dropout_rate,
+            normalize_before=True,
+            concat_after=False,
+            stochastic_depth_rate=0.0,
+    ):
+        """Construct an EncoderLayer object."""
+        super().__init__()
+        self.self_attn = self_attn
+        self.feed_forward = feed_forward
+        self.norm1 = LayerNorm(size)
+        self.norm2 = LayerNorm(size)
+        self.dropout = nn.Dropout(dropout_rate)
+        self.size = size
+        self.normalize_before = normalize_before
+        self.concat_after = concat_after
+        if self.concat_after:
+            self.concat_linear = nn.Linear(size + size, size)
+        self.stochastic_depth_rate = stochastic_depth_rate
+
+    def forward(self, x, mask, cache=None):
+        """Compute encoded features.
+
+        Args:
+            x_input (torch.Tensor): Input tensor (#batch, time, size).
+            mask (torch.Tensor): Mask tensor for the input (#batch, 1, time).
+            cache (torch.Tensor): Cache tensor of the input (#batch, time - 1, size).
+
+        Returns:
+            torch.Tensor: Output tensor (#batch, time, size).
+            torch.Tensor: Mask tensor (#batch, 1, time).
+
+        """
+        skip_layer = False
+        # with stochastic depth, residual connection `x + f(x)` becomes
+        # `x <- x + 1 / (1 - p) * f(x)` at training time.
+        stoch_layer_coeff = 1.0
+        if self.training and self.stochastic_depth_rate > 0:
+            skip_layer = torch.rand(1).item() < self.stochastic_depth_rate
+            stoch_layer_coeff = 1.0 / (1 - self.stochastic_depth_rate)
+
+        if skip_layer:
+            if cache is not None:
+                x = torch.cat([cache, x], dim=1)
+            return x, mask
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm1(x)
+
+        if cache is None:
+            x_q = x
+        else:
+            assert cache.shape == (x.shape[0], x.shape[1] - 1, self.size)
+            x_q = x[:, -1:, :]
+            residual = residual[:, -1:, :]
+            mask = None if mask is None else mask[:, -1:, :]
+
+        if self.concat_after:
+            x_concat = torch.cat((x, self.self_attn(x_q, x, x, mask)), dim=-1)
+            x = residual + stoch_layer_coeff * self.concat_linear(x_concat)
+        else:
+            x = residual + stoch_layer_coeff * self.dropout(self.self_attn(x_q, x, x, mask))
+        if not self.normalize_before:
+            x = self.norm1(x)
+
+        residual = x
+        if self.normalize_before:
+            x = self.norm2(x)
+        x = residual + stoch_layer_coeff * self.dropout(self.feed_forward(x))
+        if not self.normalize_before:
+            x = self.norm2(x)
+
+        if cache is not None:
+            x = torch.cat([cache, x], dim=1)
+
+        return x, mask

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/initialize.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/initialize.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+"""Initialize modules for espnet2 neural networks."""
+
+import logging
+import math
+
+import torch
+
+
+def initialize(model: torch.nn.Module, init: str):
+    """Initialize weights of a neural network module.
+
+    Parameters are initialized using the given method or distribution.
+
+    Custom initialization routines can be implemented into submodules
+    as function `espnet_initialization_fn` within the custom module.
+
+    Args:
+        model: Target.
+        init: Method of initialization.
+    """
+
+    if init == "chainer":
+        # 1. lecun_normal_init_parameters
+        for name, p in model.named_parameters():
+            data = p.data
+            if ".bias" in name and data.dim() == 1:
+                # bias
+                data.zero_()
+                logging.info(f"Initialize {name} to zeros")
+            elif data.dim() == 1:
+                # linear weight
+                n = data.size(0)
+                stdv = 1.0 / math.sqrt(n)
+                data.normal_(0, stdv)
+            elif data.dim() == 2:
+                # linear weight
+                n = data.size(1)
+                stdv = 1.0 / math.sqrt(n)
+                data.normal_(0, stdv)
+            elif data.dim() in (3, 4):
+                # conv weight
+                n = data.size(1)
+                for k in data.size()[2:]:
+                    n *= k
+                stdv = 1.0 / math.sqrt(n)
+                data.normal_(0, stdv)
+            else:
+                raise NotImplementedError
+
+        for mod in model.modules():
+            # 2. embed weight ~ Normal(0, 1)
+            if isinstance(mod, torch.nn.Embedding):
+                mod.weight.data.normal_(0, 1)
+            # 3. forget-bias = 1.0
+            elif isinstance(mod, torch.nn.RNNCellBase):
+                n = mod.bias_ih.size(0)
+                mod.bias_ih.data[n // 4: n // 2].fill_(1.0)
+            elif isinstance(mod, torch.nn.RNNBase):
+                for name, param in mod.named_parameters():
+                    if "bias" in name:
+                        n = param.size(0)
+                        param.data[n // 4: n // 2].fill_(1.0)
+            if hasattr(mod, "espnet_initialization_fn"):
+                mod.espnet_initialization_fn()
+
+    else:
+        # weight init
+        for p in model.parameters():
+            if p.dim() > 1:
+                if init == "xavier_uniform":
+                    torch.nn.init.xavier_uniform_(p.data)
+                elif init == "xavier_normal":
+                    torch.nn.init.xavier_normal_(p.data)
+                elif init == "kaiming_uniform":
+                    torch.nn.init.kaiming_uniform_(p.data, nonlinearity="relu")
+                elif init == "kaiming_normal":
+                    torch.nn.init.kaiming_normal_(p.data, nonlinearity="relu")
+                else:
+                    raise ValueError("Unknown initialization: " + init)
+        # bias init
+        for name, p in model.named_parameters():
+            if ".bias" in name and p.dim() == 1:
+                p.data.zero_()
+                logging.info(f"Initialize {name} to zeros")
+
+        # reset some modules with default init
+        for m in model.modules():
+            if isinstance(m, (torch.nn.Embedding, torch.nn.LayerNorm, torch.nn.GroupNorm)):
+                m.reset_parameters()
+            if hasattr(m, "espnet_initialization_fn"):
+                m.espnet_initialization_fn()
+
+        # TODO(xkc): Hacking s3prl_frontend and wav2vec2encoder initialization
+        if getattr(model, "encoder", None) and getattr(model.encoder, "reload_pretrained_parameters", None):
+            model.encoder.reload_pretrained_parameters()
+        if getattr(model, "frontend", None):
+            if getattr(model.frontend, "reload_pretrained_parameters", None):
+                model.frontend.reload_pretrained_parameters()
+            elif isinstance(
+                    getattr(model.frontend, "frontends", None),
+                    torch.nn.ModuleList,
+            ):
+                for i, _ in enumerate(getattr(model.frontend, "frontends")):
+                    if getattr(
+                            model.frontend.frontends[i],
+                            "reload_pretrained_parameters",
+                            None,
+                    ):
+                        model.frontend.frontends[i].reload_pretrained_parameters()
+        if getattr(model, "postencoder", None) and getattr(model.postencoder, "reload_pretrained_parameters", None):
+            model.postencoder.reload_pretrained_parameters()
+        if getattr(model, "decoder", None) and getattr(model.decoder, "reload_pretrained_parameters", None):
+            model.decoder.reload_pretrained_parameters()

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/layer_norm.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/layer_norm.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Layer normalization module."""
+
+import torch
+
+
+class LayerNorm(torch.nn.LayerNorm):
+    """Layer normalization module.
+
+    Args:
+        nout (int): Output dim size.
+        dim (int): Dimension to be normalized.
+
+    """
+
+    def __init__(self, nout, dim=-1):
+        """Construct an LayerNorm object."""
+        super().__init__(nout, eps=1e-12)
+        self.dim = dim
+
+    def forward(self, x):
+        """Apply layer normalization.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Normalized tensor.
+
+        """
+        if self.dim == -1:
+            return super().forward(x)
+        return super().forward(x.transpose(self.dim, -1)).transpose(self.dim, -1)

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/lightconv.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/lightconv.py
@@ -1,0 +1,107 @@
+"""Lightweight Convolution Module."""
+
+import numpy
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+MIN_VALUE = float(numpy.finfo(numpy.float32).min)
+
+
+class LightweightConvolution(nn.Module):
+    """Lightweight Convolution layer.
+
+    This implementation is based on
+    https://github.com/pytorch/fairseq/tree/master/fairseq
+
+    Args:
+        wshare (int): the number of kernel of convolution
+        n_feat (int): the number of features
+        dropout_rate (float): dropout_rate
+        kernel_size (int): kernel size (length)
+        use_kernel_mask (bool): Use causal mask or not for convolution kernel
+        use_bias (bool): Use bias term or not.
+
+    """
+
+    def __init__(
+            self,
+            wshare,
+            n_feat,
+            dropout_rate,
+            kernel_size,
+            use_kernel_mask=False,
+            use_bias=False,
+    ):
+        """Construct Lightweight Convolution layer."""
+        super().__init__()
+
+        assert n_feat % wshare == 0
+        self.wshare = wshare
+        self.use_kernel_mask = use_kernel_mask
+        self.dropout_rate = dropout_rate
+        self.kernel_size = kernel_size
+        self.padding_size = int(kernel_size / 2)
+
+        # linear -> GLU -> lightconv -> linear
+        self.linear1 = nn.Linear(n_feat, n_feat * 2)
+        self.linear2 = nn.Linear(n_feat, n_feat)
+        self.act = nn.GLU()
+
+        # lightconv related
+        self.weight = nn.Parameter(torch.Tensor(self.wshare, 1, kernel_size).uniform_(0, 1))
+        self.use_bias = use_bias
+        if self.use_bias:
+            self.bias = nn.Parameter(torch.Tensor(n_feat))
+
+        # mask of kernel
+        kernel_mask0 = torch.zeros(self.wshare, int(kernel_size / 2))
+        kernel_mask1 = torch.ones(self.wshare, int(kernel_size / 2 + 1))
+        self.kernel_mask = torch.cat((kernel_mask1, kernel_mask0), dim=-1).unsqueeze(1)
+
+    def forward(self, query, key, value, mask):
+        """Forward of 'Lightweight Convolution'.
+
+        This function takes query, key and value but uses only query.
+        This is just for compatibility with self-attention layer (attention.py)
+
+        Args:
+            query (torch.Tensor): (batch, time1, d_model) input tensor
+            key (torch.Tensor): (batch, time2, d_model) NOT USED
+            value (torch.Tensor): (batch, time2, d_model) NOT USED
+            mask (torch.Tensor): (batch, time1, time2) mask
+
+        Return:
+            x (torch.Tensor): (batch, time1, d_model) output
+
+        """
+        # linear -> GLU -> lightconv -> linear
+        x = query
+        B, T, C = x.size()
+        H = self.wshare
+
+        # first liner layer
+        x = self.linear1(x)
+
+        # GLU activation
+        x = self.act(x)
+
+        # lightconv
+        x = x.transpose(1, 2).contiguous().view(-1, H, T)  # B x C x T
+        weight = F.dropout(self.weight, self.dropout_rate, training=self.training)
+        if self.use_kernel_mask:
+            self.kernel_mask = self.kernel_mask.to(x.device)
+            weight = weight.masked_fill(self.kernel_mask == 0.0, float("-inf"))
+        weight = F.softmax(weight, dim=-1)
+        x = F.conv1d(x, weight, padding=self.padding_size, groups=self.wshare).view(B, C, T)
+        if self.use_bias:
+            x = x + self.bias.view(1, -1, 1)
+        x = x.transpose(1, 2)  # B x T x C
+
+        if mask is not None and not self.use_kernel_mask:
+            mask = mask.transpose(-1, -2)
+            x = x.masked_fill(mask == 0, 0.0)
+
+        # second linear layer
+        x = self.linear2(x)
+        return x

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/lightconv2d.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/lightconv2d.py
@@ -1,0 +1,115 @@
+"""Lightweight 2-Dimensional Convolution module."""
+
+import numpy
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+MIN_VALUE = float(numpy.finfo(numpy.float32).min)
+
+
+class LightweightConvolution2D(nn.Module):
+    """Lightweight 2-Dimensional Convolution layer.
+
+    This implementation is based on
+    https://github.com/pytorch/fairseq/tree/master/fairseq
+
+    Args:
+        wshare (int): the number of kernel of convolution
+        n_feat (int): the number of features
+        dropout_rate (float): dropout_rate
+        kernel_size (int): kernel size (length)
+        use_kernel_mask (bool): Use causal mask or not for convolution kernel
+        use_bias (bool): Use bias term or not.
+
+    """
+
+    def __init__(
+            self,
+            wshare,
+            n_feat,
+            dropout_rate,
+            kernel_size,
+            use_kernel_mask=False,
+            use_bias=False,
+    ):
+        """Construct Lightweight 2-Dimensional Convolution layer."""
+        super().__init__()
+
+        assert n_feat % wshare == 0
+        self.wshare = wshare
+        self.use_kernel_mask = use_kernel_mask
+        self.dropout_rate = dropout_rate
+        self.kernel_size = kernel_size
+        self.padding_size = int(kernel_size / 2)
+
+        # linear -> GLU -> lightconv -> linear
+        self.linear1 = nn.Linear(n_feat, n_feat * 2)
+        self.linear2 = nn.Linear(n_feat * 2, n_feat)
+        self.act = nn.GLU()
+
+        # lightconv related
+        self.weight = nn.Parameter(torch.Tensor(self.wshare, 1, kernel_size).uniform_(0, 1))
+        self.weight_f = nn.Parameter(torch.Tensor(1, 1, kernel_size).uniform_(0, 1))
+        self.use_bias = use_bias
+        if self.use_bias:
+            self.bias = nn.Parameter(torch.Tensor(n_feat))
+
+        # mask of kernel
+        kernel_mask0 = torch.zeros(self.wshare, int(kernel_size / 2))
+        kernel_mask1 = torch.ones(self.wshare, int(kernel_size / 2 + 1))
+        self.kernel_mask = torch.cat((kernel_mask1, kernel_mask0), dim=-1).unsqueeze(1)
+
+    def forward(self, query, key, value, mask):
+        """Forward of 'Lightweight 2-Dimensional Convolution'.
+
+        This function takes query, key and value but uses only query.
+        This is just for compatibility with self-attention layer (attention.py)
+
+        Args:
+            query (torch.Tensor): (batch, time1, d_model) input tensor
+            key (torch.Tensor): (batch, time2, d_model) NOT USED
+            value (torch.Tensor): (batch, time2, d_model) NOT USED
+            mask (torch.Tensor): (batch, time1, time2) mask
+
+        Return:
+            x (torch.Tensor): (batch, time1, d_model) output
+
+        """
+        # linear -> GLU -> lightconv -> linear
+        x = query
+        B, T, C = x.size()
+        H = self.wshare
+
+        # first liner layer
+        x = self.linear1(x)
+
+        # GLU activation
+        x = self.act(x)
+
+        # convolution along frequency axis
+        weight_f = F.softmax(self.weight_f, dim=-1)
+        weight_f = F.dropout(weight_f, self.dropout_rate, training=self.training)
+        weight_new = torch.zeros(B * T, 1, self.kernel_size, device=x.device, dtype=x.dtype).copy_(weight_f)
+        xf = F.conv1d(x.view(1, B * T, C), weight_new, padding=self.padding_size, groups=B * T).view(B, T, C)
+
+        # lightconv
+        x = x.transpose(1, 2).contiguous().view(-1, H, T)  # B x C x T
+        weight = F.dropout(self.weight, self.dropout_rate, training=self.training)
+        if self.use_kernel_mask:
+            self.kernel_mask = self.kernel_mask.to(x.device)
+            weight = weight.masked_fill(self.kernel_mask == 0.0, float("-inf"))
+        weight = F.softmax(weight, dim=-1)
+        x = F.conv1d(x, weight, padding=self.padding_size, groups=self.wshare).view(B, C, T)
+        if self.use_bias:
+            x = x + self.bias.view(1, -1, 1)
+        x = x.transpose(1, 2)  # B x T x C
+        x = torch.cat((x, xf), -1)  # B x T x Cx2
+
+        if mask is not None and not self.use_kernel_mask:
+            mask = mask.transpose(-1, -2)
+            x = x.masked_fill(mask == 0, 0.0)
+
+        # second linear layer
+        x = self.linear2(x)
+        return x

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/multi_layer_conv.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/multi_layer_conv.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Tomoki Hayashi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Layer modules for FFT block in FastSpeech (Feed-forward Transformer)."""
+
+import torch
+
+
+class MultiLayeredConv1d(torch.nn.Module):
+    """Multi-layered conv1d for Transformer block.
+
+    This is a module of multi-leyered conv1d designed
+    to replace positionwise feed-forward network
+    in Transforner block, which is introduced in
+    `FastSpeech: Fast, Robust and Controllable Text to Speech`_.
+
+    .. _`FastSpeech: Fast, Robust and Controllable Text to Speech`:
+        https://arxiv.org/pdf/1905.09263.pdf
+
+    """
+
+    def __init__(self, in_chans, hidden_chans, kernel_size, dropout_rate):
+        """Initialize MultiLayeredConv1d module.
+
+        Args:
+            in_chans (int): Number of input channels.
+            hidden_chans (int): Number of hidden channels.
+            kernel_size (int): Kernel size of conv1d.
+            dropout_rate (float): Dropout rate.
+
+        """
+        super().__init__()
+        self.w_1 = torch.nn.Conv1d(
+            in_chans,
+            hidden_chans,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+        )
+        self.w_2 = torch.nn.Conv1d(
+            hidden_chans,
+            in_chans,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+        )
+        self.dropout = torch.nn.Dropout(dropout_rate)
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (torch.Tensor): Batch of input tensors (B, T, in_chans).
+
+        Returns:
+            torch.Tensor: Batch of output tensors (B, T, hidden_chans).
+
+        """
+        x = torch.relu(self.w_1(x.transpose(-1, 1))).transpose(-1, 1)
+        return self.w_2(self.dropout(x).transpose(-1, 1)).transpose(-1, 1)
+
+
+class Conv1dLinear(torch.nn.Module):
+    """Conv1D + Linear for Transformer block.
+
+    A variant of MultiLayeredConv1d, which replaces second conv-layer to linear.
+
+    """
+
+    def __init__(self, in_chans, hidden_chans, kernel_size, dropout_rate):
+        """Initialize Conv1dLinear module.
+
+        Args:
+            in_chans (int): Number of input channels.
+            hidden_chans (int): Number of hidden channels.
+            kernel_size (int): Kernel size of conv1d.
+            dropout_rate (float): Dropout rate.
+
+        """
+        super().__init__()
+        self.w_1 = torch.nn.Conv1d(
+            in_chans,
+            hidden_chans,
+            kernel_size,
+            stride=1,
+            padding=(kernel_size - 1) // 2,
+        )
+        self.w_2 = torch.nn.Linear(hidden_chans, in_chans)
+        self.dropout = torch.nn.Dropout(dropout_rate)
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (torch.Tensor): Batch of input tensors (B, T, in_chans).
+
+        Returns:
+            torch.Tensor: Batch of output tensors (B, T, hidden_chans).
+
+        """
+        x = torch.relu(self.w_1(x.transpose(-1, 1))).transpose(-1, 1)
+        return self.w_2(self.dropout(x))

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/positionwise_feed_forward.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/positionwise_feed_forward.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Positionwise feed forward layer definition."""
+
+import torch
+
+
+class PositionwiseFeedForward(torch.nn.Module):
+    """Positionwise feed forward layer.
+
+    Args:
+        idim (int): Input dimenstion.
+        hidden_units (int): The number of hidden units.
+        dropout_rate (float): Dropout rate.
+
+    """
+
+    def __init__(self, idim, hidden_units, dropout_rate, activation=torch.nn.ReLU()):
+        """Construct an PositionwiseFeedForward object."""
+        super().__init__()
+        self.w_1 = torch.nn.Linear(idim, hidden_units)
+        self.w_2 = torch.nn.Linear(hidden_units, idim)
+        self.dropout = torch.nn.Dropout(dropout_rate)
+        self.activation = activation
+
+    def forward(self, x):
+        """Forward function."""
+        return self.w_2(self.dropout(self.activation(self.w_1(x))))

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/repeat.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/repeat.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Repeat the same layer definition."""
+
+import torch
+
+
+class MultiSequential(torch.nn.Sequential):
+    """Multi-input multi-output torch.nn.Sequential."""
+
+    def __init__(self, *args, layer_drop_rate=0.0):
+        """Initialize MultiSequential with layer_drop.
+
+        Args:
+            layer_drop_rate (float): Probability of dropping out each fn (layer).
+
+        """
+        super().__init__(*args)
+        self.layer_drop_rate = layer_drop_rate
+
+    def forward(self, *args):
+        """Repeat."""
+        _probs = torch.empty(len(self)).uniform_()
+        for idx, m in enumerate(self):
+            if not self.training or (_probs[idx] >= self.layer_drop_rate):
+                args = m(*args)
+        return args
+
+
+def repeat(N, fn, layer_drop_rate=0.0):
+    """Repeat module N times.
+
+    Args:
+        N (int): Number of repeat time.
+        fn (Callable): Function to generate module.
+        layer_drop_rate (float): Probability of dropping out each fn (layer).
+
+    Returns:
+        MultiSequential: Repeated model instance.
+
+    """
+    return MultiSequential(*[fn(n) for n in range(N)], layer_drop_rate=layer_drop_rate)

--- a/phoonnx_train/optispeech/model/generator/modules/_transformer/subsampling.py
+++ b/phoonnx_train/optispeech/model/generator/modules/_transformer/subsampling.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Shigeki Karita
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Subsampling layer definition."""
+
+import torch
+
+from .embedding import PositionalEncoding
+
+
+class TooShortUttError(Exception):
+    """Raised when the utt is too short for subsampling.
+
+    Args:
+        message (str): Message for error catch
+        actual_size (int): the short size that cannot pass the subsampling
+        limit (int): the limit size for subsampling
+
+    """
+
+    def __init__(self, message, actual_size, limit):
+        """Construct a TooShortUttError for error handler."""
+        super().__init__(message)
+        self.actual_size = actual_size
+        self.limit = limit
+
+
+def check_short_utt(ins, size):
+    """Check if the utterance is too short for subsampling."""
+    if isinstance(ins, Conv1dSubsampling1) and size < 5:
+        return True, 5
+    if isinstance(ins, Conv1dSubsampling2) and size < 5:
+        return True, 5
+    if isinstance(ins, Conv1dSubsampling3) and size < 7:
+        return True, 7
+    if isinstance(ins, Conv2dSubsampling1) and size < 5:
+        return True, 5
+    if isinstance(ins, Conv2dSubsampling2) and size < 7:
+        return True, 7
+    if isinstance(ins, Conv2dSubsampling) and size < 7:
+        return True, 7
+    if isinstance(ins, Conv2dSubsampling6) and size < 11:
+        return True, 11
+    if isinstance(ins, Conv2dSubsampling8) and size < 15:
+        return True, 15
+    return False, -1
+
+
+class Conv1dSubsampling1(torch.nn.Module):
+    """Convolutional 1D subsampling.
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv1dSubsampling1 object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv1d(idim, odim, 3, 1),
+            torch.nn.ReLU(),
+            torch.nn.Conv1d(odim, odim, 3, 1),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim, odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 2.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 2.
+
+        """
+        x = x.transpose(2, 1)  # (#batch, idim, time)
+        x = self.conv(x)
+        b, c, t = x.size()
+        x = self.out(x.transpose(1, 2).contiguous())
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:1][:, :, :-2:1]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+
+class Conv1dSubsampling2(torch.nn.Module):
+    """Convolutional 1D subsampling (to 1/2 length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv1dSubsampling2 object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv1d(idim, odim, 3, 1),
+            torch.nn.ReLU(),
+            torch.nn.Conv1d(odim, odim, 3, 2),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim, odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 2.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 2.
+
+        """
+        x = x.transpose(2, 1)  # (#batch, idim, time)
+        x = self.conv(x)
+        b, c, t = x.size()
+        x = self.out(x.transpose(1, 2).contiguous())
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:1][:, :, :-2:2]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+
+class Conv1dSubsampling3(torch.nn.Module):
+    """Convolutional 1D subsampling (to 1/3 length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv1dSubsampling3 object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv1d(idim, odim, 3, 1),
+            torch.nn.ReLU(),
+            torch.nn.Conv1d(odim, odim, 5, 3),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim, odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 2.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 2.
+
+        """
+        x = x.transpose(2, 1)  # (#batch, idim, time)
+        x = self.conv(x)
+        b, c, t = x.size()
+        x = self.out(x.transpose(1, 2).contiguous())
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:1][:, :, :-4:3]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+
+class Conv2dSubsampling(torch.nn.Module):
+    """Convolutional 2D subsampling (to 1/4 length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv2dSubsampling object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv2d(1, odim, 3, 2),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(odim, odim, 3, 2),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim * (((idim - 1) // 2 - 1) // 2), odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 4.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 4.
+
+        """
+        x = x.unsqueeze(1)  # (b, c, t, f)
+        x = self.conv(x)
+        b, c, t, f = x.size()
+        x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:2][:, :, :-2:2]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+
+class Conv2dSubsampling1(torch.nn.Module):
+    """Similar to Conv2dSubsampling module, but without any subsampling performed.
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv2dSubsampling1 object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv2d(1, odim, 3, 1),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(odim, odim, 3, 1),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim * (idim - 4), odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Pass x through 2 Conv2d layers without subsampling.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim).
+                where time' = time - 4.
+            torch.Tensor: Subsampled mask (#batch, 1, time').
+                where time' = time - 4.
+
+        """
+        x = x.unsqueeze(1)  # (b, c, t, f)
+        x = self.conv(x)
+        b, c, t, f = x.size()
+        x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-4]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+
+class Conv2dSubsampling2(torch.nn.Module):
+    """Convolutional 2D subsampling (to 1/2 length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv2dSubsampling2 object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv2d(1, odim, 3, 2),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(odim, odim, 3, 1),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim * ((idim - 1) // 2 - 2), odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 2.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 2.
+
+        """
+        x = x.unsqueeze(1)  # (b, c, t, f)
+        x = self.conv(x)
+        b, c, t, f = x.size()
+        x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:2][:, :, :-2:1]
+
+    def __getitem__(self, key):
+        """Get item.
+
+        When reset_parameters() is called, if use_scaled_pos_enc is used,
+            return the positioning encoding.
+
+        """
+        if key != -1:
+            raise NotImplementedError("Support only `-1` (for `reset_parameters`).")
+        return self.out[key]
+
+
+class Conv2dSubsampling6(torch.nn.Module):
+    """Convolutional 2D subsampling (to 1/6 length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv2dSubsampling6 object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv2d(1, odim, 3, 2),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(odim, odim, 5, 3),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim * (((idim - 1) // 2 - 2) // 3), odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 6.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 6.
+
+        """
+        x = x.unsqueeze(1)  # (b, c, t, f)
+        x = self.conv(x)
+        b, c, t, f = x.size()
+        x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:2][:, :, :-4:3]
+
+
+class Conv2dSubsampling8(torch.nn.Module):
+    """Convolutional 2D subsampling (to 1/8 length).
+
+    Args:
+        idim (int): Input dimension.
+        odim (int): Output dimension.
+        dropout_rate (float): Dropout rate.
+        pos_enc (torch.nn.Module): Custom position encoding layer.
+
+    """
+
+    def __init__(self, idim, odim, dropout_rate, pos_enc=None):
+        """Construct an Conv2dSubsampling8 object."""
+        super().__init__()
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv2d(1, odim, 3, 2),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(odim, odim, 3, 2),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(odim, odim, 3, 2),
+            torch.nn.ReLU(),
+        )
+        self.out = torch.nn.Sequential(
+            torch.nn.Linear(odim * ((((idim - 1) // 2 - 1) // 2 - 1) // 2), odim),
+            pos_enc if pos_enc is not None else PositionalEncoding(odim, dropout_rate),
+        )
+
+    def forward(self, x, x_mask):
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time // 8.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time // 8.
+
+        """
+        x = x.unsqueeze(1)  # (b, c, t, f)
+        x = self.conv(x)
+        b, c, t, f = x.size()
+        x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
+        if x_mask is None:
+            return x, None
+        return x, x_mask[:, :, :-2:2][:, :, :-2:2][:, :, :-2:2]

--- a/phoonnx_train/optispeech/model/generator/modules/attentions/__init__.py
+++ b/phoonnx_train/optispeech/model/generator/modules/attentions/__init__.py
@@ -1,0 +1,2 @@
+from .amlp import AMLPCov
+from .s4d import S4D

--- a/phoonnx_train/optispeech/model/generator/modules/attentions/amlp.py
+++ b/phoonnx_train/optispeech/model/generator/modules/attentions/amlp.py
@@ -1,0 +1,932 @@
+"""
+Attentive Multi-Layer Perceptron for Non-autoregressive Generation
+https://arxiv.org/abs/2310.09512
+"""
+
+import functools
+import math
+import warnings
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+
+class AbstractAttention(nn.Module):
+
+    def __init__(self, cross=False, causal=False, **kwargs) -> None:
+        super(AbstractAttention, self).__init__()
+        self.name = f"{self.__class__.__name__}.{hash(self)}"
+        self.causal = causal
+        self.cross = cross
+
+    def _reset_parameters(self):
+        raise NotImplementedError
+
+    def forward(
+            self,
+            query: Tensor,
+            key: Tensor,
+            value: Tensor,
+            query_padding_mask: Optional[Tensor] = None,
+            key_padding_mask: Optional[Tensor] = None,
+            need_weights: bool = True,
+            need_head_weights: bool = False,
+            attn_mask: Optional[Tensor] = None,
+            static_kv: bool = False,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+            **kwargs,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        raise NotImplementedError
+
+    def _get_input_buffer(
+            self, incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]]
+    ) -> Dict[str, Optional[Tensor]]:
+        return incremental_state[self.name] if incremental_state and self.name in incremental_state is not None else {}
+
+    def _set_input_buffer(
+            self,
+            incremental_state: Dict[str, Dict[str, Optional[Tensor]]],
+            buffer: Dict[str, Optional[Tensor]],
+    ):
+        incremental_state[self.name] = buffer
+        return incremental_state
+
+    def _apply_attention(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def _get_saved_states(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def _update_saved_states(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class MultiheadAttention(AbstractAttention):
+    r"""
+    Args:
+        embed_dim: Total dimension of the model.
+        num_heads: Number of parallel attention heads. Note that ``embed_dim`` will be split
+            across ``num_heads`` (i.e. each head will have dimension ``embed_dim // num_heads``).
+        dropout: Dropout probability on ``attn_output_weights``. Default: ``0.0`` (no dropout).
+        bias: If specified, adds bias to input / output projection layers. Default: ``True``.
+        add_bias_kv: If specified, adds bias to the key and value sequences at dim=0. Default: ``False``.
+        add_zero_attn: If specified, adds a new batch of zeros to the key and value sequences at dim=1.
+            Default: ``False``.
+        kdim: Total number of features for keys. Default: ``None`` (uses ``kdim=embed_dim``).
+        vdim: Total number of features for values. Default: ``None`` (uses ``vdim=embed_dim``).
+
+    Usage:
+
+        from efficient_attention import MultiheadAttention
+        attn = MultiheadAttention(embed_dim=embed_dim, num_heads=num_heads, dropout=dropout)
+
+        result, _ = attn(query, key, value, key_padding_mask=key_padding_mask, batch_first=batch_first, query_padding_mask=query_padding_mask, incremental_state=incremental_state)
+
+    """
+
+    def __init__(
+            self,
+            embed_dim,
+            num_heads,
+            dropout=0.0,
+            bias=True,
+            add_bias_kv=False,
+            add_zero_attn=False,
+            kdim=None,
+            vdim=None,
+            **kwargs,
+    ) -> None:
+        super(MultiheadAttention, self).__init__(**kwargs)
+        self.embed_dim = embed_dim
+        self.kdim = kdim if kdim is not None else embed_dim
+        self.vdim = vdim if vdim is not None else embed_dim
+        self.qkv_same_dim = self.kdim == embed_dim and self.vdim == embed_dim
+
+        self.num_heads = num_heads
+        self.dropout = dropout
+        self.head_dim = embed_dim // num_heads
+        assert self.head_dim * num_heads == self.embed_dim, "embed_dim must be divisible by num_heads"
+
+        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.k_proj = nn.Linear(self.kdim, embed_dim, bias=bias)
+        self.v_proj = nn.Linear(self.vdim, embed_dim, bias=bias)
+
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+
+        if add_bias_kv:
+            self.bias_k = nn.Parameter(torch.empty((1, 1, embed_dim)))
+            self.bias_v = nn.Parameter(torch.empty((1, 1, embed_dim)))
+        else:
+            self.bias_k = self.bias_v = None
+
+        self.add_zero_attn = add_zero_attn
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for proj in [self.k_proj, self.v_proj, self.q_proj, self.out_proj]:
+            kwargs = {"gain": 1 / math.sqrt(2)} if self.qkv_same_dim and proj is not self.out_proj else {}
+            nn.init.xavier_uniform_(proj.weight, **kwargs)
+            if proj.bias is not None:
+                nn.init.constant_(proj.bias, 0.0)
+
+        if self.bias_k is not None:
+            nn.init.xavier_normal_(self.bias_k)
+        if self.bias_v is not None:
+            nn.init.xavier_normal_(self.bias_v)
+
+    def forward(
+            self,
+            query: Tensor,
+            key: Optional[Tensor] = None,
+            value: Optional[Tensor] = None,
+            query_padding_mask: Optional[Tensor] = None,
+            key_padding_mask: Optional[Tensor] = None,
+            need_weights: bool = True,
+            need_head_weights: bool = False,
+            attn_mask: Optional[Tensor] = None,
+            static_kv: bool = False,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+            batch_first: bool = False,
+            **kwargs,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Forward attention layer.
+
+        Args:
+            query (Tensor): Query embeddings of shape :math:`(Nt, B, E_q)` when ``batch_first=False`` or :math:`(B, Nt, E_q)`
+                when ``batch_first=True``, where :math:`Nt` is the sequence length of query, :math:`B` is the batch size,
+                and :math:`E_q` is the query embedding dimension ``embed_dim``. Queries are compared against
+                key-value pairs to produce the output. See "Attention Is All You Need" for more details.
+            key (Optional[Tensor], optional): Key embeddings of shape :math:`(Ns, B, E_k)` when ``batch_first=False`` or :math:`(B, Ns, E_k)` when
+                ``batch_first=True``, where :math:`Ns` is the sequence length of key, :math:`B` is the batch size, and
+                :math:`E_k` is the key embedding dimension ``kdim``. See "Attention Is All You Need" for more details. Defaults to None.
+            value (Optional[Tensor], optional): Value embeddings of shape :math:`(Ns, B, E_v)` when ``batch_first=False`` or :math:`(B, Ns, E_v)` when
+                ``batch_first=True``, where :math:`Ns` is the sequence length of value, :math:`B` is the batch size, and
+                :math:`E_v` is the value embedding dimension ``vdim``. See "Attention Is All You Need" for more details. Defaults to None.
+            query_padding_mask (Optional[Tensor], optional): If specified, a mask of shape :math:`(B, Nt)` indicating which elements within ``query``
+                to ignore for the purpose of attention (i.e. treat as "padding"). Binary and byte masks are supported.
+                For a binary mask, a ``True`` value indicates that the corresponding ``query`` value will be ignored for
+                the purpose of attention. For a byte mask, a non-zero value indicates that the corresponding ``query``
+                value will be ignored. Defaults to None.
+            key_padding_mask (Optional[Tensor], optional): If specified, a mask of shape :math:`(B, Ns)` indicating which elements within ``key``
+                to ignore for the purpose of attention (i.e. treat as "padding"). Binary and byte masks are supported.
+                For a binary mask, a ``True`` value indicates that the corresponding ``key`` value will be ignored for
+                the purpose of attention. For a byte mask, a non-zero value indicates that the corresponding ``key``
+                value will be ignored. Defaults to None.
+            need_weights (bool, optional): If specified, returns ``attn_output_weights`` in addition to ``attn_outputs``. Defaults to True.
+            need_head_weights (bool, optional): return the attention
+                weights for each head. Implies *need_weights*. If specified, it defaults to
+                return the average attention weights over all heads. Defaults to False.
+            attn_mask (Optional[Tensor], optional): If specified, a 2D or 3D mask preventing attention to certain positions. Must be of shape
+                :math:`(Nt, Ns)` or :math:`(B\cdot\text{num\_heads}, Nt, Ns)`, where :math:`B` is the batch size,
+                :math:`Nt` is the target sequence length, and :math:`Ns` is the source sequence length. A 2D mask will be
+                broadcasted across the batch while a 3D mask allows for a different mask for each entry in the batch.
+                Binary, byte, and float masks are supported. For a binary mask, a ``True`` value indicates that the
+                corresponding position is not allowed to attend. For a byte mask, a non-zero value indicates that the
+                corresponding position is not allowed to attend. For a float mask, the mask values will be added to
+                the attention weight. Defaults to None.
+            static_kv (bool, optional): If specified, key and value are computed only once and cached for future computation. Defaults to False.
+            incremental_state (Optional[Dict[str, Dict[str, Optional[Tensor]]]], optional): If specified, it caches historical internal states
+                and is further updated after current computation process. Defaults to None.
+            batch_first (bool, optional): Whether to transform shape so that each tensor's shape is (B, ...). Defaults to False.
+
+        Returns:
+            Tuple[Tensor, Optional[Tensor]]:
+                - **attn_output** - Attention outputs of shape :math:`(Nt, B, E)` when ``batch_first=False`` or
+                    :math:`(B, Nt, E)` when ``batch_first=True``, where :math:`Nt` is the target sequence length, :math:`B` is
+                    the batch size, and :math:`E` is the embedding dimension ``embed_dim``.
+                - **attn_output_weights** - Attention output weights of shape :math:`(B, Nt, Ns)`, where :math:`B` is the batch
+                    size, :math:`Nt` is the target sequence length, and :math:`Ns` is the source sequence length. Only returned
+                    when ``need_weights=True``.
+        """
+
+        if need_head_weights:
+            need_weights = True
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+
+        # set up shape vars
+        if batch_first:
+            bsz, tgt_len, embed_dim = query.shape
+        else:
+            tgt_len, bsz, embed_dim = query.shape
+
+        if incremental_state is not None:
+            saved_state: Optional[Dict[str, Optional[Tensor]]] = {}
+            key, value = self._get_saved_states(incremental_state, saved_state, static_kv, key, value)
+        else:
+            saved_state: Optional[Dict[str, Optional[Tensor]]] = None
+
+        # check shape of input tensor
+        self._input_shape_check(key, value, key_padding_mask, batch_first)
+
+        q, k, v = self._in_proj(query, key, value)
+
+        # prep attention mask
+        attn_mask, key_padding_mask = _prep_mask(attn_mask, key_padding_mask)
+
+        # add bias along batch dimension (currently second)
+        if self.bias_k is not None and self.bias_v is not None:
+            k, v, attn_mask, key_padding_mask = self._add_bias(k, v, attn_mask, key_padding_mask)
+        else:
+            assert self.bias_k is None and self.bias_v is None
+
+        # reshape q, k, v for multihead attention and make em batch first
+        q, k, v = self._reshape_qkv(q, k, v, batch_first)
+
+        if saved_state is not None:
+            k, v, key_padding_mask = self._update_saved_states(k, v, key_padding_mask, saved_state, bsz, static_kv)
+            incremental_state[self.name] = saved_state
+
+        # add zero attention along batch dimension (now first)
+        if self.add_zero_attn:
+            k, v, key_padding_mask, attn_mask = self._pad_zero_attn(k, v, key_padding_mask, attn_mask, bsz)
+
+        # (deep breath) calculate attention and out projection
+        attn_output, attn_output_weights = self._apply_attention(
+            q, k, v, bsz, attn_mask, query_padding_mask, key_padding_mask, incremental_state
+        )
+        if batch_first:
+            attn_output = (
+                attn_output.reshape(bsz, self.num_heads, -1, self.head_dim).transpose(1, 2).reshape(bsz, tgt_len, -1)
+            )
+        else:
+            attn_output = attn_output.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
+        attn_output = self.out_proj(attn_output)
+
+        attn_weights = None
+        if need_weights and attn_output_weights is not None:
+            attn_weights = self.calc_weight(attn_output_weights, need_head_weights)
+
+        return attn_output, attn_weights
+
+    def _input_shape_check(
+            self,
+            key: Tensor,
+            value: Tensor,
+            key_padding_mask: Optional[Tensor] = None,
+            batch_first: bool = False,
+    ):
+        if key is not None and value is not None:
+            assert key.shape[-1] == value.shape[-1] == self.embed_dim
+            assert key.shape[0] == value.shape[0] and key.shape[1] == value.shape[1]
+            if key_padding_mask is not None:
+                if batch_first:
+                    assert key.shape[0] == key_padding_mask.shape[0] and key.shape[1] == key_padding_mask.shape[1]
+                else:
+                    assert key.shape[0] == key_padding_mask.shape[1] and key.shape[1] == key_padding_mask.shape[0]
+
+    def _in_proj(
+            self,
+            query: Tensor,
+            key: Tensor,
+            value: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        # compute in-projection
+        q = self.q_proj(query) if query is not None else None
+        k = self.k_proj(key) if key is not None else None
+        v = self.v_proj(value) if value is not None else None
+        return q, k, v
+
+    def _add_bias(
+            self, k: Tensor, v: Tensor, attn_mask: Tensor, key_padding_mask: Tensor, batch_first: bool = False
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        bsz = key_padding_mask.shape[0]
+        pad_k = self.bias_k.repeat(bsz, 1, 1) if batch_first else self.bias_k.repeat(1, bsz, 1)
+        pad_v = self.bias_v.repeat(bsz, 1, 1) if batch_first else self.bias_v.repeat(1, bsz, 1)
+        k = torch.cat([k, pad_k])
+        v = torch.cat([v, pad_v])
+        if attn_mask is not None:
+            attn_mask = F.pad(attn_mask, (0, 1))
+        if key_padding_mask is not None:
+            key_padding_mask = F.pad(key_padding_mask, (0, 1))
+        return k, v, attn_mask, key_padding_mask
+
+    def _reshape_qkv(self, q: Tensor, k: Tensor, v: Tensor, batch_first: bool = False) -> Tuple[Tensor, Tensor, Tensor]:
+        if batch_first:
+            if q is not None:
+                q = q.reshape(q.shape[0], q.shape[1], -1, self.head_dim).transpose(1, 2)
+            if k is not None:
+                k = k.reshape(k.shape[0], k.shape[1], -1, self.head_dim).transpose(1, 2)
+            if v is not None:
+                v = v.reshape(v.shape[0], v.shape[1], -1, self.head_dim).transpose(1, 2)
+            return (
+                q.reshape(-1, q.shape[2], self.head_dim),
+                k.reshape(-1, k.shape[2], self.head_dim),
+                v.reshape(-1, v.shape[2], self.head_dim),
+            )
+        if q is not None:
+            q = q.contiguous().view(q.shape[0], -1, self.head_dim).transpose(0, 1)
+        if k is not None:
+            k = k.contiguous().view(k.shape[0], -1, self.head_dim).transpose(0, 1)
+        if v is not None:
+            v = v.contiguous().view(v.shape[0], -1, self.head_dim).transpose(0, 1)
+        return q, k, v
+
+    def _apply_attention(
+            self,
+            q: Tensor,
+            k: Tensor,
+            v: Tensor,
+            bsz: int,
+            attn_mask: Optional[Tensor] = None,
+            query_padding_mask: Optional[Tensor] = None,
+            key_padding_mask: Optional[Tensor] = None,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        r"""Computes scaled dot product attention on query, key and value tensors, using
+        an optional attention mask if passed, and applying dropout if a probability
+        greater than 0.0 is specified.
+        Returns a tensor pair containing attended values and attention weights.
+
+        Args:
+            q (Tensor): query tensors. :math:`(B, Nt, E)` where B is batch size, Nt is the sequence length of query,
+                and E is embedding dimension.
+            k (Tensor): key tensors. :math:`(B, Ns, E)` where B is batch size, Nt is the sequence length of key,
+                and E is embedding dimension.
+            v (Tensor): value tensors. :math:`(B, Ns, E)` where B is batch size, Nt is the sequence length of value,
+                and E is embedding dimension.
+            bsz (int): batch size
+            attn_mask (Optional[Tensor], optional): optional tensor containing mask values to be added to calculated
+                attention; either a 3D tensor of shape :math:`(B, Nt, Ns)` or a 2D tensor of
+                shape :math:`(Nt, Ns)`. Defaults to None.
+            query_padding_mask (Optional[Tensor], optional):  If specified, a mask of shape :math:`(B, Nt)` indicating
+                which elements within ``query`` to ignore for the purpose of attention (i.e. treat as "padding").
+                Binary and byte masks are supported. For a binary mask, a ``True`` value indicates that the corresponding
+                ``query`` value will be ignored for the purpose of attention. For a byte mask, a non-zero value
+                Indicates that the corresponding ``query`` value will be ignored. Defaults to None.
+            key_padding_mask (Optional[Tensor], optional): If specified, a mask of shape :math:`(B, NS)` indicating
+                which elements within ``key`` to ignore for the purpose of attention (i.e. treat as "padding").
+                Binary and byte masks are supported. For a binary mask, a ``True`` value indicates that the corresponding
+                ``key`` value will be ignored for the purpose of attention. For a byte mask, a non-zero value
+                Indicates that the corresponding ``key`` value will be ignored. Defaults to None.
+            incremental_state (Optional[Dict[str, Dict[str, Optional[Tensor]]]], optional): If specified, it caches historical
+                internal key, value and key_padding_mask states: saved_state=incremental_state[self.name], and saved_state
+                has three components: ``prev_key`` :math: `(B, N_{<=i}, E)`, ``prev_value`` :math: `(B, N_{<=i}, E)`, and
+                ``prev_key_padding_mask` :math: `(B, N_{<=i})`. Defaults to None.
+
+        Returns:
+            Tuple[Tensor, Tensor]: attention values have shape :math:`(B, Nt, E)`; attention weights
+                have shape :math:`(B, Nt, Ns)`
+        """
+        tgtlen, srclen = q.shape[1], k.shape[1]
+        q = q / math.sqrt(self.head_dim)
+        # (B, Nt, E) x (B, E, Ns) -> (B, Nt, Ns)
+        attn_weights = torch.bmm(q, k.transpose(1, 2))
+
+        if attn_mask is not None:
+            attn_weights = attn_weights + attn_mask
+
+        if key_padding_mask is not None:
+            # don't attend to padding symbols
+            attn_weights = attn_weights.view(bsz, self.num_heads, tgtlen, srclen)
+            attn_weights = attn_weights.masked_fill(
+                key_padding_mask.unsqueeze(1).unsqueeze(2).to(torch.bool),
+                float("-inf"),
+            )
+            attn_weights = attn_weights.view(bsz * self.num_heads, tgtlen, srclen)
+
+        attn_weights_float = F.softmax(
+            attn_weights,
+            dim=-1,
+        )
+        attn_weights = attn_weights_float.type_as(attn_weights)
+        attn_probs = F.dropout(attn_weights, p=self.dropout, training=self.training)
+
+        attn = torch.bmm(attn_probs, v)
+        return attn, attn_weights
+
+    def _pad_zero_attn(
+            self,
+            k: Tensor,
+            v: Tensor,
+            key_padding_mask: Tensor,
+            attn_mask: Tensor,
+            bsz: int,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        assert bsz == key_padding_mask.shape[0]
+        zero_attn_shape = (bsz * self.num_heads, 1, self.head_dim)
+        k = torch.cat([k, torch.zeros(zero_attn_shape, dtype=k.dtype, device=k.device)], dim=1)
+        v = torch.cat([v, torch.zeros(zero_attn_shape, dtype=v.dtype, device=v.device)], dim=1)
+        if attn_mask is not None:
+            attn_mask = F.pad(attn_mask, (0, 1))
+        if key_padding_mask is not None:
+            key_padding_mask = F.pad(key_padding_mask, (0, 1))
+        return k, v, key_padding_mask, attn_mask
+
+    def _get_saved_states(
+            self,
+            incremental_state: Dict[str, Dict[str, Optional[Tensor]]],
+            saved_state: Dict[str, Optional[Tensor]],
+            static_kv: bool,
+            key: Tensor,
+            value: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        if self.name in incremental_state:
+            for k, v in incremental_state[self.name].items():
+                saved_state[k] = v
+            if static_kv:
+                key = value = None
+        return key, value
+
+    def _update_saved_states(
+            self,
+            k: Tensor,
+            v: Tensor,
+            key_padding_mask: Tensor,
+            saved_state: Dict[str, Optional[Tensor]],
+            bsz: int,
+            static_kv: bool,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        if "prev_key" in saved_state:
+            _prev_key = saved_state["prev_key"]
+            prev_key = _prev_key.view(bsz * self.num_heads, -1, self.head_dim)
+            if static_kv:
+                k = prev_key
+            else:
+                k = torch.cat([prev_key, k], dim=1)
+        if "prev_value" in saved_state:
+            _prev_value = saved_state["prev_value"]
+            prev_value = _prev_value.view(bsz * self.num_heads, -1, self.head_dim)
+            if static_kv:
+                v = prev_value
+            else:
+                v = torch.cat([prev_value, v], dim=1)
+        prev_key_padding_mask: Optional[Tensor] = None
+        if "prev_key_padding_mask" in saved_state:
+            prev_key_padding_mask = saved_state["prev_key_padding_mask"]
+        key_padding_mask = _append_prev_key_padding_mask(
+            key_padding_mask=key_padding_mask,
+            prev_key_padding_mask=prev_key_padding_mask,
+            batch_size=bsz,
+            src_len=k.shape[1],
+            static_kv=static_kv,
+        )
+
+        saved_state["prev_key"] = k.view(bsz, self.num_heads, -1, self.head_dim)
+        saved_state["prev_value"] = v.view(bsz, self.num_heads, -1, self.head_dim)
+        saved_state["prev_key_padding_mask"] = key_padding_mask
+
+        return k, v, key_padding_mask
+
+    def calc_weight(self, attn_output_weights: Tensor, need_head_weights: bool):
+        bsz_hn, tgt_len, src_len = attn_output_weights.shape
+        attn_output_weights = attn_output_weights.view(
+            bsz_hn // self.num_heads, self.num_heads, tgt_len, src_len
+        ).transpose(0, 1)
+        if not need_head_weights:
+            # average attention weights over heads
+            attn_output_weights = attn_output_weights.mean(dim=0)
+        return attn_output_weights
+
+    @staticmethod
+    def add_attn_specific_args(parent_parser):
+        parser = parent_parser.add_argument_group("Attention")
+        return parent_parser
+
+
+def _prep_mask(
+        attn_mask: Optional[Tensor], key_padding_mask: Optional[Tensor]
+) -> Tuple[Optional[Tensor], Optional[Tensor]]:
+    if attn_mask is not None:
+        if attn_mask.dtype == torch.uint8:
+            warnings.warn(
+                "Byte tensor for attn_mask in nn.MultiheadAttention is deprecated. " "Use bool tensor instead."
+            )
+            attn_mask = attn_mask.to(torch.bool)
+        if attn_mask.dim() == 2:
+            attn_mask = attn_mask.unsqueeze(0)
+
+    if key_padding_mask is not None:
+        if key_padding_mask.dtype == torch.uint8:
+            warnings.warn(
+                "Byte tensor for key_padding_mask in nn.MultiheadAttention is deprecated. " "Use bool tensor instead."
+            )
+            key_padding_mask = key_padding_mask.to(torch.bool)
+    return attn_mask, key_padding_mask
+
+
+def _append_prev_key_padding_mask(
+        key_padding_mask: Optional[Tensor],
+        prev_key_padding_mask: Optional[Tensor],
+        batch_size: int,
+        src_len: int,
+        static_kv: bool,
+) -> Optional[Tensor]:
+    # saved key padding masks have shape (bsz, seq_len)
+    if prev_key_padding_mask is not None and static_kv:
+        new_key_padding_mask = prev_key_padding_mask
+    elif prev_key_padding_mask is not None and key_padding_mask is not None:
+        new_key_padding_mask = torch.cat([prev_key_padding_mask.float(), key_padding_mask.float()], dim=1)
+        # During incremental decoding, as the padding token enters and
+        # leaves the frame, there will be a time when prev or current
+        # is None
+    elif prev_key_padding_mask is not None:
+        if src_len > prev_key_padding_mask.shape[1]:
+            filler = torch.zeros(
+                (batch_size, src_len - prev_key_padding_mask.shape[1]),
+                device=prev_key_padding_mask.device,
+            )
+            new_key_padding_mask = torch.cat([prev_key_padding_mask.float(), filler.float()], dim=1)
+        else:
+            new_key_padding_mask = prev_key_padding_mask.float()
+    elif key_padding_mask is not None:
+        if src_len > key_padding_mask.shape[1]:
+            filler = torch.zeros(
+                (batch_size, src_len - key_padding_mask.shape[1]),
+                device=key_padding_mask.device,
+            )
+            new_key_padding_mask = torch.cat([filler.float(), key_padding_mask.float()], dim=1)
+        else:
+            new_key_padding_mask = key_padding_mask.float()
+    else:
+        new_key_padding_mask = prev_key_padding_mask
+    return new_key_padding_mask
+
+
+class AMLPCov(MultiheadAttention):
+
+    def __init__(self, ffn_dimension=16, conv_kernel_size=None, activation_fn=None, add_norm=False, *args, **kwargs):
+        super(AMLPCov, self).__init__(*args, **kwargs)
+        self.ffn_dimension = ffn_dimension
+        self.add_norm = add_norm
+        self.q_landmarks = self._create_landmark()
+        self.k_landmarks = self._create_landmark()
+
+        # TODO: remove these temperatures factor and merge them to landmarks
+        self.kv_temperature = self._create_temperature()
+        self.qq_temperature = self._create_temperature()
+        self.kk_temperature = self._create_temperature()
+        # self.w_norm = nn.LayerNorm(self.head_dim)
+        if self.add_norm:
+            self.q_norm, self.w_norm = nn.LayerNorm(self.head_dim), nn.LayerNorm(self.head_dim)
+            self.k_norm, self.v_norm = nn.LayerNorm(self.head_dim), nn.LayerNorm(self.head_dim)
+
+        if conv_kernel_size is not None and conv_kernel_size > 0:
+            self.conv = nn.Conv2d(
+                in_channels=self.num_heads,
+                out_channels=self.num_heads,
+                kernel_size=(conv_kernel_size, 1),
+                padding=(conv_kernel_size // 2, 0),
+                groups=self.num_heads,
+            )
+            self.drop = nn.Dropout(self.dropout)
+        else:
+            self.conv, self.drop = None, None
+        if activation_fn is None:
+            self.activation_fn = functools.partial(F.softmax, dim=-1)
+        elif activation_fn == "softmax":
+            self.activation_fn = functools.partial(F.softmax, dim=-1)
+        elif activation_fn == "sigmoid":
+            self.activation_fn = F.sigmoid
+        elif activation_fn == "relu":
+            self.activation_fn = F.relu
+        elif activation_fn == "identity":
+            self.activation_fn = lambda x: x
+        else:
+            raise ValueError("Other activation functions cannot converge")
+
+        # self.kv_norm = nn.LayerNorm(self.head_dim * self.head_dim)
+        # self.qq_norm = nn.LayerNorm(self.head_dim * self.head_dim)
+        # self.kk_norm = nn.LayerNorm(self.head_dim * self.head_dim)
+        # self.qlatent_norm = nn.LayerNorm(self.num_landmarks)
+        # self.qkv_norm = nn.LayerNorm(self.head_dim)
+        self.out_norm = nn.LayerNorm(self.head_dim)
+
+        # self.landmark_out_proj = nn.Linear(self.head_dim * 2, self.head_dim, bias=False)
+        # nn.init.xavier_normal_(self.landmark_out_proj.weight, gain=2 ** -.5)
+
+    def _create_temperature(self):
+        temperature = nn.Parameter(torch.ones([self.num_heads, 1, 1]))
+        nn.init.xavier_normal_(temperature, gain=2 ** -0.5)
+        return temperature
+        # nn.init.xavier_normal_(temperature, gain=2 ** -0.5)
+
+    def _create_landmark(self):
+        landmarks = nn.Parameter(torch.zeros((self.num_heads, self.ffn_dimension, self.head_dim)))
+        nn.init.xavier_normal_(landmarks, gain=2 ** -0.5)
+        return landmarks
+
+    def _apply_attention(
+            self,
+            q: Tensor,
+            k: Tensor,
+            v: Tensor,
+            bsz: int,
+            attn_mask: Optional[Tensor] = None,
+            query_padding_mask: Optional[Tensor] = None,
+            key_padding_mask: Optional[Tensor] = None,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""
+        Computes scaled dot product attention on query, key and value tensors, using
+        an optional attention mask if passed, and applying dropout if a probability
+        greater than 0.0 is specified.
+        Returns a tensor pair containing attended values and attention weights.
+        Args:
+            q, k, v: query, key and value tensors. See Shape section for shape details.
+            attn_mask: optional tensor containing mask values to be added to calculated
+                attention. May be 2D or 3D; see Shape section for details.
+        Shape:
+            - q: :math:`(B, Nt, E)` where B is batch size, Nt is the target sequence length,
+                and E is embedding dimension.
+            - key: :math:`(B, Ns, E)` where B is batch size, Ns is the source sequence length,
+                and E is embedding dimension.
+            - value: :math:`(B, Ns, E)` where B is batch size, Ns is the source sequence length,
+                and E is embedding dimension.
+            - attn_mask: either a 3D tensor of shape :math:`(B, Nt, Ns)` or a 2D tensor of
+                shape :math:`(1, Nt, Ns)`.
+            - Output: attention values have shape :math:`(B, Nt, E)`; attention weights
+                have shape :math:`(B, Nt, wsize)`
+        """
+        # assert attn_mask is None, 'causal attention is not supported!'
+        if self.add_norm:
+            q, k, v = self.q_norm(q), self.k_norm(k), self.v_norm(v)
+        # [bsz, d, c]
+        weight_qk = self._calc_qk_weight(q, k, query_padding_mask, key_padding_mask)
+
+        # print(torch.norm(latent_proj))
+        # [bsz, c, d]
+        weight_kv = self._calc_kv_weight(k, v, weight_qk, key_padding_mask)
+
+        # print(torch.norm(kv_stat))
+        # output = torch.softmax(q @ latent_proj, -1) @ kv_stat
+        output = self.activation_fn((q @ weight_qk) * (self.head_dim ** -0.5)) @ weight_kv
+        # output = F.normalize(q @ latent_proj, 2, -1) @ kv_stat  # nonlinear functions such as softmax, layer norm or tanh can be inserted into matmul
+        # print(torch.norm(output))
+        output = self.add_conv(output, q, query_padding_mask)
+
+        # print(torch.norm(output))
+        output = self.out_norm(output)
+
+        # print(torch.norm(output))
+        return output, None
+
+    def add_conv(self, output, q, query_padding_mask):
+        if self.conv is not None:
+            q = q.reshape(q.shape[0] // self.num_heads, self.num_heads, q.shape[1], q.shape[2])
+            if query_padding_mask is not None:
+                q = q.masked_fill(query_padding_mask[:, None, :, None].to(torch.bool), 0.0)
+            conv_out = self.conv(q)
+            conv_out = conv_out.reshape(q.shape[0] * self.num_heads, q.shape[2], q.shape[3])
+            conv_out = F.relu(conv_out)
+            conv_out = self.drop(conv_out)
+            output = output + conv_out
+        return output
+
+    def _calc_qk_weight(self, q, k, q_padding_mask, k_padding_mask) -> Tensor:
+        q = q.reshape(q.shape[0] // self.num_heads, self.num_heads, q.shape[1], self.head_dim)
+        k = k.reshape(k.shape[0] // self.num_heads, self.num_heads, k.shape[1], self.head_dim)
+        mus = [None, None]
+        for i, (x, padding_mask, landmark, temperature) in enumerate(
+                zip(
+                    [q, k],
+                    [q_padding_mask, k_padding_mask],
+                    [self.q_landmarks, self.k_landmarks],
+                    [self.qq_temperature, self.kk_temperature],
+                )
+        ):
+            # logits = torch.einsum(
+            #     'bhnd,hcd->bhcn',
+            #     x,
+            #     landmark
+            # )
+            if padding_mask is not None:
+                x = x.masked_fill(
+                    padding_mask.unsqueeze(1).unsqueeze(-1).to(torch.bool),
+                    0.0,
+                )
+            x = F.normalize(x, 2, 2)
+            cov = x.transpose(2, 3) @ x * temperature
+            # cov = x_norm(cov.reshape(cov.shape[0], cov.shape[1], -1)).reshape(cov.shape[0], cov.shape[1], self.head_dim, self.head_dim)
+            prob = F.softmax(cov, -1)
+            feat = torch.einsum("bhdk,hcd->bhck", prob, landmark)
+            # prob = F.softmax(logits, dim=-1)
+            # feat = torch.einsum(
+            #     'bhcn,bhnd->bhcd',
+            #     prob,
+            #     x
+            # )
+            mus[i] = feat
+        # mus = torch.cat(mus, dim=-1).reshape(-1, self.ffn_dimension, self.head_dim * 2)
+        # mu = self.landmark_out_proj(mus)
+        mu = (mus[0] + mus[1]).reshape(-1, self.ffn_dimension, self.head_dim)
+        if self.add_norm:
+            mu = self.w_norm(mu)  # it can be softmax, layer norm or tanh along dimension c or d
+        mu = F.relu(mu)
+        return mu.transpose(-1, -2)
+
+    def _calc_kv_weight(self, k: Tensor, v: Tensor, landmarks: Tensor, k_padding_mask: Tensor):
+
+        if k_padding_mask is not None:  # different activation function requires different activations
+            k = k.reshape(k.shape[0] // self.num_heads, self.num_heads, -1, self.head_dim)
+            v = v.reshape(v.shape[0] // self.num_heads, self.num_heads, -1, self.head_dim)
+            k = k.masked_fill(k_padding_mask.unsqueeze(1).unsqueeze(-1).to(torch.bool), 0.0)
+            v = v.masked_fill(k_padding_mask.unsqueeze(1).unsqueeze(-1).to(torch.bool), 0.0)
+        if len(k.shape) == 3:
+            k = k.reshape(k.shape[0] // self.num_heads, self.num_heads, -1, self.head_dim)
+            v = v.reshape(v.shape[0] // self.num_heads, self.num_heads, -1, self.head_dim)
+
+        k = F.normalize(k, 2, 2)
+        v = F.normalize(v, 2, 2)
+
+        cov_kv = torch.einsum("bhnk,bhnl->bhkl", k, v) * self.kv_temperature
+        prob = F.softmax(cov_kv, -1)
+        prob = prob.reshape(prob.shape[0] * self.num_heads, -1, self.head_dim)
+        kv_stat = prob @ landmarks
+
+        return kv_stat.transpose(-1, -2)
+
+
+class EMA(nn.Module):
+    def __init__(self, momentum):
+        super(EMA, self).__init__()
+        self.momentum = momentum
+        self.register_buffer("ema", torch.zeros(1))
+
+    def forward(self, x: torch.Tensor):
+        ema = x.mean(dim=1).mean(dim=0)
+        self.ema = self.momentum * self.ema + (1 - self.momentum) * ema
+        return x - self.ema
+
+
+class AMLPQuery(MultiheadAttention):
+
+    def __init__(
+            self,
+            *args,
+            ffn_dimension=16,
+            conv_kernel_size=None,
+            activation_fn=None,
+            add_norm=False,
+            scale=False,
+            add_ema=None,
+            **kwargs,
+    ):
+        super(AMLPQuery, self).__init__(*args, **kwargs)
+
+        self._reset_parameters()
+
+        self.ffn_dimension = ffn_dimension
+        self.add_norm = add_norm
+        if self.add_norm:
+            self.q_norm = nn.LayerNorm(self.head_dim)
+            self.k_norm = nn.LayerNorm(self.head_dim)
+            self.v_norm = nn.LayerNorm(self.head_dim)
+            self.w_norm = nn.LayerNorm(self.head_dim)
+        self.q_approx = self._create_approx()
+        self.k_approx = self._create_approx()
+        self.approx_out_proj = nn.Linear(2 * self.head_dim, self.head_dim)
+        # self.kv_temperature = self._create_temperature()
+        # self.qq_temperature = self._create_temperature()
+        # self.kk_temperature = self._create_temperature()
+
+        if add_ema is not None:
+            self.add_ema = True
+            self.beta = add_ema
+            self.ema_module = EMA(self.beta)
+        else:
+            self.add_ema = False
+
+        self.scale = self.head_dim ** -0.5 if scale else 1
+        if conv_kernel_size is not None and conv_kernel_size > 0:
+            self.conv = nn.Conv2d(
+                in_channels=self.num_heads,
+                out_channels=self.num_heads,
+                kernel_size=(conv_kernel_size, 1),
+                padding=(conv_kernel_size // 2, 0),
+                groups=self.num_heads,
+            )
+            self.drop = nn.Dropout(self.dropout)
+        else:
+            self.conv, self.drop = None, None
+        if activation_fn is None:
+            self.activation_fn = functools.partial(F.softmax, dim=-1)
+        elif activation_fn == "softmax":
+            self.activation_fn = functools.partial(F.softmax, dim=-1)
+        elif activation_fn == "sigmoid":
+            self.activation_fn = F.sigmoid
+        elif activation_fn == "relu":
+            self.activation_fn = F.relu
+        elif activation_fn == "identity":
+            self.activation_fn = lambda x: x
+        else:
+            raise ValueError("Other activation functions cannot converge")
+
+        self.out_norm = nn.LayerNorm(self.head_dim)
+
+    def add_conv(self, output, q, query_padding_mask):
+        if self.conv is not None:
+            q = q.reshape(q.shape[0] // self.num_heads, self.num_heads, q.shape[1], q.shape[2])
+            if query_padding_mask is not None:
+                q = q.masked_fill(query_padding_mask[:, None, :, None].to(torch.bool), 0.0)
+            conv_out = self.conv(q)
+            conv_out = conv_out.reshape(q.shape[0] * self.num_heads, q.shape[2], q.shape[3])
+            conv_out = F.relu(conv_out)
+            conv_out = self.drop(conv_out)
+            output = output + conv_out
+        return output
+
+    def _create_temperature(self):
+        temperature = nn.Parameter(torch.ones([self.num_heads, 1, 1]))
+        nn.init.xavier_normal_(temperature, gain=2 ** -0.5)
+        return temperature
+
+    def _create_approx(self):
+        landmarks = nn.Parameter(torch.zeros((self.num_heads, self.ffn_dimension, self.head_dim)))
+        nn.init.xavier_normal_(landmarks, gain=2 ** -0.5)
+        return landmarks
+
+    def _apply_attention(
+            self,
+            q: Tensor,
+            k: Tensor,
+            v: Tensor,
+            bsz: int,
+            attn_mask: Optional[Tensor] = None,
+            query_padding_mask: Optional[Tensor] = None,
+            key_padding_mask: Optional[Tensor] = None,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        if attn_mask is not None:
+            warnings.warn("AMLP does not support causal attention")
+        # assert attn_mask is None, 'causal attention is not supported!'
+        if self.add_norm:
+            q, k, v = self.q_norm(q), self.k_norm(k), self.v_norm(v)
+        if self.add_ema:
+            # temp_cumsum = torch.cumsum(q, -2)[:, 1:]  # b, n, d
+            # total = torch.arange(1, q.shape[-2]).to(q)[None, :, None].repeat(bsz * self.num_heads, 1, self.head_dim)
+            # # print(temp_cumsum.shape, total.shape)
+            # temp_cummean = torch.cat([torch.zeros((bsz * self.num_heads, 1, self.head_dim)).to(q), temp_cumsum / total], dim=-2)
+            # q = q * self.beta + (1 - self.beta) * temp_cummean
+            q = self.ema_module(q)
+        weight_qk = self._calc_qk_weight(q, k, query_padding_mask, key_padding_mask)
+
+        weight_kv = self._calc_kv_weight(k, v, weight_qk, key_padding_mask)
+
+        output = self.activation_fn(q @ weight_qk * self.scale) @ weight_kv
+
+        output = self.add_conv(output, q, query_padding_mask)
+
+        output = self.out_norm(output)
+
+        return output, None
+
+    def _calc_qk_weight(self, q, k, q_padding_mask, k_padding_mask) -> Tensor:
+        q = q.reshape(q.shape[0] // self.num_heads, self.num_heads, q.shape[1], self.head_dim)
+        k = k.reshape(k.shape[0] // self.num_heads, self.num_heads, k.shape[1], self.head_dim)
+        mus = [None, None]
+        for i, (x, padding_mask, approx) in enumerate(
+                zip([q, k], [q_padding_mask, k_padding_mask], [self.q_approx, self.k_approx])
+        ):
+            logits = torch.einsum("bhnd,hcd->bhcn", x, approx)
+            if padding_mask is not None:
+                logits = logits.masked_fill(
+                    padding_mask.unsqueeze(1).unsqueeze(1).to(torch.bool),
+                    float("-inf"),
+                )
+            prob = F.softmax(logits, dim=-1)
+            feat = torch.einsum("bhcn,bhnd->bhcd", prob, x)
+            mus[i] = feat
+        mus = torch.cat(mus, dim=-1).reshape(-1, self.ffn_dimension, self.head_dim * 2)
+        mu = self.approx_out_proj(mus)
+        if self.add_norm:
+            mu = self.w_norm(mu)  # it can be softmax, layer norm or tanh along dimension c or d
+        return mu.transpose(-1, -2)
+
+    def _calc_kv_weight(self, k, v, approx, k_padding_mask):
+        logits = torch.einsum("bmd,bdc->bcm", k, approx)
+        if k_padding_mask is not None:  # different activation function requires different activations
+            logits = logits.view(logits.shape[0] // self.num_heads, self.num_heads, self.ffn_dimension, logits.shape[2])
+            logits = logits.masked_fill(k_padding_mask.unsqueeze(1).unsqueeze(1).to(torch.bool), float("-inf"))
+            logits = logits.view(logits.shape[0] * self.num_heads, self.ffn_dimension, logits.shape[3])
+        prob = F.softmax(logits, dim=-1)  # softmax could be replaced with other nonlinear activations
+        kv_stat = prob @ v
+        return kv_stat
+
+
+def _prep_mask(
+        attn_mask: Optional[Tensor], key_padding_mask: Optional[Tensor]
+) -> Tuple[Optional[Tensor], Optional[Tensor]]:
+    if attn_mask is not None:
+        if attn_mask.dtype == torch.uint8:
+            warnings.warn(
+                "Byte tensor for attn_mask in nn.MultiheadAttention is deprecated. " "Use bool tensor instead."
+            )
+            attn_mask = attn_mask.to(torch.bool)
+        if attn_mask.dim() == 2:
+            attn_mask = attn_mask.unsqueeze(0)
+
+    if key_padding_mask is not None:
+        if key_padding_mask.dtype == torch.uint8:
+            warnings.warn(
+                "Byte tensor for key_padding_mask in nn.MultiheadAttention is deprecated. " "Use bool tensor instead."
+            )
+            key_padding_mask = key_padding_mask.to(torch.bool)
+    return attn_mask, key_padding_mask

--- a/phoonnx_train/optispeech/model/generator/modules/attentions/s4d.py
+++ b/phoonnx_train/optispeech/model/generator/modules/attentions/s4d.py
@@ -1,0 +1,515 @@
+"""
+This file is the implementation of State Space diagonal attention introduced in 
+"On the Parameterization and Initialization of Diagonal State Space Models".
+Supported pattern of the code: Noncausal Self.
+The code comes from:
+https://github.com/HazyResearch/state-spaces.
+"""
+
+import math
+import warnings
+from functools import partial
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+import opt_einsum as oe
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange, repeat
+from torch import Tensor
+
+contract = oe.contract
+contract_expression = oe.contract_expression
+_c2r = torch.view_as_real
+_r2c = torch.view_as_complex
+if tuple(map(int, torch.__version__.split(".")[:2])) >= (1, 10):
+    _resolve_conj = lambda x: x.conj().resolve_conj()
+else:
+    _resolve_conj = lambda x: x.conj()
+
+
+def Activation(activation=None, dim=-1):
+    if activation in [None, "id", "identity", "linear"]:
+        return nn.Identity()
+    elif activation == "tanh":
+        return nn.Tanh()
+    elif activation == "relu":
+        return nn.ReLU()
+    elif activation == "gelu":
+        return nn.GELU()
+    elif activation in ["swish", "silu"]:
+        return nn.SiLU()
+    elif activation == "glu":
+        return nn.GLU(dim=dim)
+    elif activation == "sigmoid":
+        return nn.Sigmoid()
+    else:
+        raise NotImplementedError("hidden activation '{}' is not implemented".format(activation))
+
+
+def LinearActivation(
+        d_input,
+        d_output,
+        bias=True,
+        transposed=False,
+        activation=None,
+        activate=False,  # Apply activation as part of this module
+        **kwargs,
+):
+    """Returns a linear nn.Module with control over axes order, initialization, and activation"""
+
+    # Construct core module
+    linear_cls = partial(nn.Conv1d, kernel_size=1) if transposed else nn.Linear
+    if activation == "glu":
+        d_output *= 2
+    linear = linear_cls(d_input, d_output, bias=bias, **kwargs)
+
+    if activate and activation is not None:
+        activation = Activation(activation, dim=-2 if transposed else -1)
+        linear = nn.Sequential(linear, activation)
+    return linear
+
+
+""" HiPPO utilities """
+
+
+def random_dplr(N, H=1, scaling="inverse", real_scale=1.0, imag_scale=1.0):
+    dtype = torch.cfloat
+
+    pi = torch.tensor(np.pi)
+    real_part = 0.5 * torch.ones(H, N // 2)
+    imag_part = repeat(torch.arange(N // 2), "n -> h n", h=H)
+
+    real_part = real_scale * real_part
+    if scaling == "random":
+        imag_part = torch.randn(H, N // 2)
+    elif scaling == "linear":
+        imag_part = pi * imag_part
+    elif scaling == "inverse":  # Based on asymptotics of the default HiPPO matrix
+        imag_part = 1 / pi * N * (N / (1 + 2 * imag_part) - 1)
+    else:
+        raise NotImplementedError
+    imag_part = imag_scale * imag_part
+    w = -real_part + 1j * imag_part
+
+    B = torch.randn(H, N // 2, dtype=dtype)
+
+    norm = -B / w  # (H, N) # Result if you integrate the kernel with constant 1 function
+    zeta = 2 * torch.sum(torch.abs(norm) ** 2, dim=-1, keepdim=True)  # Variance with a random C vector
+    B = B / zeta ** 0.5
+
+    return w, B
+
+
+class AbstractAttention(nn.Module):
+
+    def __init__(self, cross=False, causal=False, **kwargs) -> None:
+        super(AbstractAttention, self).__init__()
+        self.name = f"{self.__class__.__name__}.{hash(self)}"
+        self.causal = causal
+        self.cross = cross
+
+    def _reset_parameters(self):
+        raise NotImplementedError
+
+    def forward(
+            self,
+            query: Tensor,
+            key: Tensor,
+            value: Tensor,
+            query_padding_mask: Optional[Tensor] = None,
+            key_padding_mask: Optional[Tensor] = None,
+            need_weights: bool = True,
+            need_head_weights: bool = False,
+            attn_mask: Optional[Tensor] = None,
+            static_kv: bool = False,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+            **kwargs,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        raise NotImplementedError
+
+    def _get_input_buffer(
+            self, incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]]
+    ) -> Dict[str, Optional[Tensor]]:
+        return incremental_state[self.name] if incremental_state and self.name in incremental_state is not None else {}
+
+    def _set_input_buffer(
+            self,
+            incremental_state: Dict[str, Dict[str, Optional[Tensor]]],
+            buffer: Dict[str, Optional[Tensor]],
+    ):
+        incremental_state[self.name] = buffer
+        return incremental_state
+
+    def _apply_attention(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def _get_saved_states(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def _update_saved_states(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class SSKernelDiag(nn.Module):
+    """Version using (complex) diagonal state matrix. Note that it is slower and less memory efficient than the NPLR kernel because of lack of kernel support."""
+
+    def __init__(
+            self,
+            w,
+            C,
+            log_dt,
+            lr=None,
+    ):
+
+        super().__init__()
+
+        # Rank of low-rank correction
+        assert w.size(-1) == C.size(-1)
+        self.H = log_dt.size(-1)
+        self.N = w.size(-1)
+        assert self.H % w.size(0) == 0
+        self.copies = self.H // w.size(0)
+
+        # Broadcast everything to correct shapes
+        C = C.expand(torch.broadcast_shapes(C.shape, (1, self.H, self.N)))  # (H, C, N)
+
+        # Register parameters
+        self.C = nn.Parameter(_c2r(_resolve_conj(C)))
+        self.register("log_dt", log_dt, True, lr, 0.0)
+
+        log_w_real = torch.log(-w.real + 1e-4)
+        w_imag = w.imag
+        self.register("log_w_real", log_w_real, True, lr, 0.0)
+        self.register("w_imag", w_imag, True, lr, 0.0)
+
+    def _w(self):
+        # Get the internal w (diagonal) parameter
+        w_real = -torch.exp(self.log_w_real)
+        w_imag = self.w_imag
+        w = w_real + 1j * w_imag
+        w = repeat(w, "t n -> (v t) n", v=self.copies)  # (H N)
+        return w
+
+    def forward(self, L):
+        """
+        returns: (..., c, L) where c is number of channels (default 1)
+        """
+
+        dt = torch.exp(self.log_dt)  # (H)
+        C = _r2c(self.C)  # (C H N)
+        w = self._w()  # (H N)
+
+        # Incorporate dt into A
+        dtA = w * dt.unsqueeze(-1)  # (H N)
+
+        # Power up
+        K = dtA.unsqueeze(-1) * torch.arange(L, device=w.device)  # (H N L)
+        C = C * (torch.exp(dtA) - 1.0) / w
+        K = contract("chn, hnl -> chl", C, torch.exp(K))
+        K = 2 * K.real
+
+        return K
+
+    def setup_step(self):
+        dt = torch.exp(self.log_dt)  # (H)
+        C = _r2c(self.C)  # (C H N)
+        w = self._w()  # (H N)
+
+        # Incorporate dt into A
+        dtA = w * dt.unsqueeze(-1)  # (H N)
+        self.dA = torch.exp(dtA)  # (H N)
+        self.dC = C * (torch.exp(dtA) - 1.0) / w  # (C H N)
+        self.dB = self.dC.new_ones(self.H, self.N)  # (H N)
+
+    def default_state(self, *batch_shape):
+        C = _r2c(self.C)
+        state = torch.zeros(*batch_shape, self.H, self.N, dtype=C.dtype, device=C.device)
+        return state
+
+    def step(self, u, state):
+        next_state = contract("h n, b h n -> b h n", self.dA, state) + contract("h n, b h -> b h n", self.dB, u)
+        y = contract("c h n, b h n -> b c h", self.dC, next_state)
+        return 2 * y.real, next_state
+
+    def register(self, name, tensor, trainable=False, lr=None, wd=None):
+        """Utility method: register a tensor as a buffer or trainable parameter"""
+
+        if trainable:
+            self.register_parameter(name, nn.Parameter(tensor))
+        else:
+            self.register_buffer(name, tensor)
+
+        optim = {}
+        if trainable and lr is not None:
+            optim["lr"] = lr
+        if trainable and wd is not None:
+            optim["weight_decay"] = wd
+        if len(optim) > 0:
+            setattr(getattr(self, name), "_optim", optim)
+
+
+class S4DKernel(nn.Module):
+    """Wrapper around SSKernelDiag that generates the diagonal SSM parameters"""
+
+    def __init__(
+            self,
+            H,
+            N=64,
+            scaling="inverse",
+            channels=1,  # 1-dim to C-dim map; can think of C as having separate "heads"
+            dt_min=0.001,
+            dt_max=0.1,
+            lr=None,  # Hook to set LR of SSM parameters differently
+            n_ssm=1,  # Copies of the ODE parameters A and B. Must divide H
+            **kernel_args,
+    ):
+        super().__init__()
+        self.N = N
+        self.H = H
+        dtype = torch.float
+        cdtype = torch.cfloat
+        self.channels = channels
+        self.n_ssm = n_ssm
+
+        # Generate dt
+        log_dt = torch.rand(self.H, dtype=dtype) * (math.log(dt_max) - math.log(dt_min)) + math.log(dt_min)
+
+        # Compute the preprocessed representation
+        # Generate low rank correction p for the measure
+        w, B = random_dplr(self.N, H=n_ssm, scaling=scaling)
+
+        C = torch.randn(channels, self.H, self.N // 2, dtype=cdtype)
+
+        # Broadcast tensors to n_ssm copies
+        # These will be the parameters, so make sure tensors are materialized and contiguous
+        B = repeat(B, "t n -> (v t) n", v=self.n_ssm // B.size(-2)).clone().contiguous()
+        w = repeat(w, "t n -> (v t) n", v=self.n_ssm // w.size(-2)).clone().contiguous()
+
+        # Combine B and C using structure of diagonal SSM
+        C = C * repeat(B, "t n -> (v t) n", v=H // self.n_ssm)
+        self.kernel = SSKernelDiag(
+            w,
+            C,
+            log_dt,
+            lr=lr,
+            **kernel_args,
+        )
+
+    def forward(self, L=None):
+        k = self.kernel(L=L)
+        return k.float()
+
+    def setup_step(self):
+        self.kernel.setup_step()
+
+    def step(self, u, state, **kwargs):
+        u, state = self.kernel.step(u, state, **kwargs)
+        return u.float(), state
+
+    def default_state(self, *args, **kwargs):
+        return self.kernel.default_state(*args, **kwargs)
+
+
+class S4D(AbstractAttention):
+    r"""
+    Args:
+        embed_dim: Total dimension of the model.
+        d_state: the dimension of the state
+        num_heads: Number of parallel attention heads. Note that ``embed_dim`` will be split
+            across ``num_heads`` (i.e. each head will have dimension ``embed_dim // num_heads``).
+        dropout: Dropout probability on ``attn_output_weights``. Default: ``0.0`` (no dropout).
+        d_key: Total number of features for keys. Default: ``None``
+        d_values: Total number of features for values. Default: ``None``
+        has_outproj: Linearly transform the outputs of the attention mechanism
+        activation: Type of activation function
+        postact: Type of activation after FF
+        transposed: If false, input tensors take the last axis as dimension axis. Otherwise
+            input tensors take the last second axis as dimension axis.
+
+    Usage:
+
+    from efficient_attention import S4D
+    attn = S4D(embed_dim=embed_dim, d_state=inner_state, num_heads=num_heads, dropout=dropout)
+
+    result, _ = attn(query, batch_first=batch_first)
+
+    """
+
+    def __init__(
+            self,
+            embed_dim,
+            d_state=16,
+            num_heads=1,  # maps 1-dim to C-dim
+            bidirectional=False,
+            # Arguments for FF
+            activation="gelu",  # activation in between SS and FF
+            postact=None,  # activation after FF
+            dropout=0.0,
+            transposed=False,  # axis ordering (B, L, D) or (B, D, L)
+            # SSM Kernel arguments
+            **kwargs,
+    ):
+
+        super(S4D, self).__init__(**kwargs)
+
+        assert self.cross == False, f"{self.name.split('.')[0]} cannot do cross-attention now"
+        self.h = embed_dim
+        self.n = d_state
+        self.bidirectional = bidirectional
+        self.channels = num_heads
+        self.transposed = transposed
+        self.num_heads = num_heads
+        self.D = nn.Parameter(torch.randn(num_heads, self.h))
+
+        if self.bidirectional:
+            num_heads *= 2
+
+        # SSM Kernel
+        kernel_args = {key: value for key, value in kwargs.items() if key in ["w", "C", "log_dt", "lr"]}
+        self.kernel = S4DKernel(self.h, N=self.n, channels=num_heads, **kernel_args)
+
+        # Pointwise
+        self.activation = Activation(activation)
+        dropout_fn = nn.Dropout2d if self.transposed else nn.Dropout
+        self.dropout = dropout_fn(dropout) if dropout > 0.0 else nn.Identity()
+
+        # position-wise output transform to mix features
+        self.output_linear = LinearActivation(
+            self.h * self.channels,
+            self.h,
+            transposed=self.transposed,
+            activation=postact,
+            activate=True,
+        )
+
+    def forward(
+            self,
+            query,
+            key=None,
+            value=None,
+            query_padding_mask: Optional[Tensor] = None,
+            key_padding_mask: Optional[Tensor] = None,
+            need_weights: bool = True,
+            need_head_weights: bool = False,
+            attn_mask: Optional[Tensor] = None,
+            static_kv: bool = False,
+            incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+            batch_first=False,
+            **kwargs,
+    ):  # absorbs return_output and transformer src mask
+        r"""
+        Computes S4D on input tensors, using
+        an optional attention mask if passed, and applying dropout if a probability
+        greater than 0.0 is specified.
+        Returns a tensor pair containing attended values and attention weights.
+        Args:
+            q, k, v: query, key and value tensors. See Shape section for shape details.
+            attn_mask: optional tensor containing mask values to be added to calculated
+                attention. May be 2D or 3D; see Shape section for details.
+            key_padding_mask, query_padding_mask:  If specified, indicating which elements within ``key`` or ``query``
+                to ignore for the purpose of attention (i.e. treat as "padding"). Binary and byte masks are supported.
+                For a binary mask, a ``True`` value indicates that the corresponding ``key`` or ``query`` value will be
+                ignored for the purpose of attention. For a byte mask, a non-zero value indicates that the corresponding
+                ``key`` or ``query`` value will be ignored.
+            incremental_state: If specified, it caches historical internal key, value and key_padding_mask states:
+                saved_state=incremental_state[self.name], and saved_state has three components: ``prev_key``, ``prev_value``,
+                and ``prev_key_padding_mask`; see Shape section for details
+
+        Shape:
+            - q: :math:`(B, Nt, E)` where B is batch size, Nt is the sequence length of query,
+                and E is embedding dimension.
+            - k: :math:`(B, Ns, E)` where B is batch size, Ns is the sequence length of key,
+                and E is embedding dimension.
+            - v: :math:`(B, Ns, E)` where B is batch size, Ns is the sequence length of value,
+                and E is embedding dimension.
+            - attn_mask: either a 3D tensor of shape :math:`(B, Nt, Ns)` or a 2D tensor of
+                shape :math:`(Nt, Ns)`.
+            - key_padding_mask: :math:`(B, Ns)` where B is the batch size
+                and Ns is the source sequence length,
+            - query_padding_mask: :math:`(B, Nt)` where B is the batch size
+                and Nt is the target sequence length,
+            - prev_key: :math: `(B, N_{<=i}, E)` where B is the batch size, N_{<=i} is the source
+                sequence length up to now, and E is embedding dimension.
+            - prev_value: :math: `(B, N_{<=i}, E)` where B is the batch size, N_{<=i} is the source
+                sequence length up to now, and E is embedding dimension.
+            - prev_padding_mask: :math: `(B, N_{<=i})` where B is the batch size, N_{<=i} is the source
+                sequence length up to now
+            - Output: attention values have shape :math:`(B, Nt, E)`; attention weights
+                have shape :math:`(B, Nt, Ns)`
+        """
+        if attn_mask is not None:
+            warnings.warn("`attn_mask` arguments make no sense in `S4D`")
+        # S4D only requires query input
+        if not batch_first:
+            query = query.transpose(0, 1)
+        if not self.transposed:
+            query = query.transpose(-1, -2)
+        L = query.size(-1)
+
+        # Compute SS Kernel
+        k = self.kernel(L=L)  # (C H L) (B C H L)
+
+        # Convolution
+        if self.bidirectional:
+            k0, k1 = rearrange(k, "(s c) h l -> s c h l", s=2)
+            k = F.pad(k0, (0, L)) + F.pad(k1.flip(-1), (L, 0))
+        k_f = torch.fft.rfft(k, n=2 * L)  # (C H L)
+        u_f = torch.fft.rfft(query, n=2 * L)  # (B H L)
+        y_f = contract("bhl,chl->bchl", u_f, k_f)  # k_f.unsqueeze(-4) * u_f.unsqueeze(-3) # (B C H L)
+
+        y = torch.fft.irfft(y_f, n=2 * L)[..., :L]  # (B C H L)
+
+        # Compute D term in state space equation - essentially a skip connection
+        y = y + contract("bhl,ch->bchl", query, self.D)  # u.unsqueeze(-3) * self.D.unsqueeze(-1)
+
+        # Reshape to flatten channels
+        y = rearrange(y, "... c h l -> ... (c h) l")
+
+        y = self.dropout(self.activation(y))
+
+        if not self.transposed:
+            y = y.transpose(-1, -2)
+
+        y = self.output_linear(y)
+        if not batch_first:
+            y = y.transpose(0, 1)
+        return y, None  # Return a None to satisfy this repo's interface, but this can be modified
+
+    def setup_step(self):
+        self.kernel.setup_step()
+
+    def step(self, u, state):
+        """Step one time step as a recurrent model. Intended to be used during validation.
+        Shape
+            u: :math:`(B, H)`
+            state: math:`(B H N)`
+            output math:`(B H)`
+        """
+        assert not self.training
+
+        y, next_state = self.kernel.step(u, state)  # (B C H)
+        y = y + u.unsqueeze(-2) * self.D
+        y = rearrange(y, "... c h -> ... (c h)")
+        y = self.activation(y)
+        if self.transposed:
+            y = self.output_linear(y.unsqueeze(-1)).squeeze(-1)
+        else:
+            y = self.output_linear(y)
+        return y, next_state
+
+    def default_state(self, *batch_shape, device=None):
+        return self.kernel.default_state(*batch_shape)
+
+    @property
+    def d_state(self):
+        return self.h * self.n
+
+    @property
+    def d_output(self):
+        return self.h
+
+    @property
+    def state_to_tensor(self):
+        return lambda state: rearrange("... h n -> ... (h n)", state)

--- a/phoonnx_train/optispeech/model/generator/modules/conformer.py
+++ b/phoonnx_train/optispeech/model/generator/modules/conformer.py
@@ -1,0 +1,27 @@
+import torch
+from torch import nn
+
+from ._conformer.encoder import Encoder as ConformerEncoder
+from ._transformer.initialize import initialize
+
+
+class Conformer(nn.Module):
+    """Wraps espnet  conformer module."""
+
+    def __init__(self, dim, **kwargs):
+        super().__init__()
+        init_type = kwargs.pop("init_type")
+        kwargs.update(
+            dict(
+                idim=0,
+                attention_dim=dim,
+                input_layer=None,
+            )
+        )
+        self.conformer = ConformerEncoder(**kwargs)
+        initialize(self, init_type)
+
+    def forward(self, x: torch.Tensor, padding_mask: torch.Tensor) -> torch.Tensor:
+        mask = ~padding_mask.unsqueeze(1)
+        x, __ = self.conformer(x, mask)
+        return x

--- a/phoonnx_train/optispeech/model/generator/modules/convnext.py
+++ b/phoonnx_train/optispeech/model/generator/modules/convnext.py
@@ -1,0 +1,131 @@
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+class ConvNeXtBlock(nn.Module):
+    """
+    ConvNeXt Block adapted from https://github.com/facebookresearch/ConvNeXt to 1D audio signal.
+
+    Args:
+        dim (int): Number of input channels.
+        intermediate_dim (int): Dimensionality of the intermediate layer.
+        drop_path (float): Stochastic depth rate. Default: 0.0
+        layer_scale_init_value (float, optional): Initial value for the layer scale. None means no scaling.
+            Defaults to None.
+    """
+
+    def __init__(self, dim: int, intermediate_dim: int, drop_path: float = 0.0, layer_scale_init_value: float = None):
+        super().__init__()
+        self.dwconv = nn.Conv1d(dim, dim, kernel_size=7, padding=3, groups=dim)  # depthwise conv
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, intermediate_dim)  # pointwise/1x1 convs, implemented with linear layers
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(intermediate_dim, dim)
+        self.gamma = (
+            nn.Parameter(layer_scale_init_value * torch.ones(dim), requires_grad=True)
+            if layer_scale_init_value > 0
+            else None
+        )
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.dwconv(x)
+        x = x.transpose(1, 2)  # (B, C, T) -> (B, T, C)
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+        if self.gamma is not None:
+            x = self.gamma * x
+        x = x.transpose(1, 2)  # (B, T, C) -> (B, C, T)
+
+        x = residual + self.drop_path(x)
+        return x
+
+
+class ConvNeXtBackbone(nn.Module):
+    """
+    Backbone module built with ConvNeXt blocks.
+
+    Args:
+        dim (int): Hidden dimension of the model.
+        intermediate_dim (int): Intermediate dimension used in ConvNeXtBlock.
+        num_layers (int): Number of ConvNeXtBlock layers.
+        layer_scale_init_value (float, optional): Initial value for layer scaling. Defaults to `1 / num_layers`.
+    """
+
+    def __init__(
+            self,
+            dim: int,
+            intermediate_dim: int,
+            num_layers: int,
+            drop_path: float = 0.0,
+            layer_scale_init_value: Optional[float] = None,
+    ):
+        super().__init__()
+        layer_scale_init_value = layer_scale_init_value or 1 / num_layers
+        # Apply stochastic depth as in ConvNeXt-TTS
+        drop_ppath_rates = [x.item() for x in torch.linspace(0, drop_path, num_layers)]
+        self.convnext = nn.ModuleList(
+            [
+                ConvNeXtBlock(
+                    dim=dim,
+                    intermediate_dim=intermediate_dim,
+                    drop_path=dpr,
+                    layer_scale_init_value=layer_scale_init_value,
+                )
+                for dpr in drop_ppath_rates
+            ]
+        )
+        self.final_layer_norm = nn.LayerNorm(dim, eps=1e-6)
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, (nn.Conv1d, nn.Linear)):
+            nn.init.trunc_normal_(m.weight, std=0.02)
+            nn.init.constant_(m.bias, 0)
+
+    def forward(self, x: torch.Tensor, padding_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        x = x.transpose(1, 2)
+        if padding_mask is not None:
+            mask = 1 - padding_mask.float().unsqueeze(1)
+        else:
+            mask = None
+        for conv_block in self.convnext:
+            x = conv_block(x)
+            if mask is not None:
+                x = x * mask
+        x = self.final_layer_norm(x.transpose(1, 2))
+        return x
+
+
+class DropPath(nn.Module):
+    """
+    Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks).
+    """
+
+    def __init__(self, drop_prob: float = 0.0, scale_by_keep: bool = True):
+        super().__init__()
+
+        self.drop_prob = drop_prob
+        self.scale_by_keep = scale_by_keep
+
+    def forward(self, x):
+        return self._drop_path(x, self.drop_prob, self.training, self.scale_by_keep)
+
+    @staticmethod
+    def _drop_path(x, drop_prob: float = 0.0, training: bool = False, scale_by_keep: bool = True):
+        if drop_prob == 0.0 or not training:
+            return x
+        keep_prob = 1 - drop_prob
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)  # work with diff dim tensors, not just 2D ConvNets
+        random_tensor = x.new_empty(shape).bernoulli_(keep_prob)
+        if keep_prob > 0.0 and scale_by_keep:
+            random_tensor.div_(keep_prob)
+        return x * random_tensor
+
+    def extra_repr(self):
+        return f"drop_prob={round(self.drop_prob, 3):0.3f}"

--- a/phoonnx_train/optispeech/model/generator/modules/core.py
+++ b/phoonnx_train/optispeech/model/generator/modules/core.py
@@ -1,0 +1,180 @@
+import math
+
+import torch
+from torch import nn
+
+from .layers import LayerNorm, ScaledSinusoidalEmbedding
+from .lightspeech_transformer import DEFAULT_MAX_SOURCE_POSITIONS
+
+
+class TextEmbedding(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            n_vocab: int,
+            dropout: float = 0.0,
+            padding_idx: int = 0,
+            max_source_positions: int = DEFAULT_MAX_SOURCE_POSITIONS,
+    ):
+        super().__init__()
+        self.embed_scale = math.sqrt(dim)
+        self.embed_tokens = nn.Embedding(n_vocab, dim, padding_idx)
+        self.embed_positions = ScaledSinusoidalEmbedding(dim, theta=max_source_positions)
+        self.emb_dropout = nn.Dropout(dropout)
+
+    def forward(self, src_tokens):
+        """embed tokens and positions."""
+        embed = self.embed_scale * self.embed_tokens(src_tokens)
+        positions = self.embed_positions(src_tokens)
+        x = embed + positions
+        x = self.emb_dropout(x)
+        return x, embed
+
+
+class VariancePredictor(torch.nn.Module):
+    """
+    This is a module of variance predictor described in `FastSpeech 2:
+    Fast and High-Quality End-to-End Text to Speech`_.
+
+    Copyright 2020 Tomoki Hayashi
+    .. _`FastSpeech 2: Fast and High-Quality End-to-End Text to Speech`:
+        https://arxiv.org/abs/2006.04558
+    """
+
+    def __init__(
+            self,
+            dim: int,
+            num_layers: int,
+            intermediate_dim: int,
+            kernel_size: int,
+            dropout: float = 0.1,
+            conv_layer_class: type = torch.nn.Conv1d,
+    ):
+        """
+        Args:
+            dim (int): Input/output dimension.
+            num_layers (int): Number of convolutional layers.
+            intermediate_dim (int): Number of channels of inner convolutional layers.
+            kernel_size (int): Kernel size of convolutional layers.
+            dropout (float): Dropout rate.
+            conv_layer_class: 1d convolution layer type
+        """
+        super().__init__()
+        self.dim = dim
+        self.conv_layer_class = conv_layer_class
+        self.conv = torch.nn.ModuleList()
+        for idx in range(num_layers):
+            input_dim = dim if idx == 0 else intermediate_dim
+            self.conv += [
+                torch.nn.Sequential(
+                    self.conv_layer_class(
+                        input_dim,
+                        intermediate_dim,
+                        kernel_size,
+                        padding=(kernel_size - 1) // 2,
+                    ),
+                    torch.nn.ReLU(),
+                    LayerNorm(intermediate_dim, dim=1),
+                    torch.nn.Dropout(dropout),
+                )
+            ]
+        self.linear = torch.nn.Linear(intermediate_dim, 1)
+
+    def forward(self, x: torch.Tensor, padding_mask) -> torch.Tensor:
+        """
+        Args:
+            x (Tensor): Batch of input sequences (B, Tmax, dim).
+            padding_mask (ByteTensor): Batch of masks indicating padded part (B, Tmax).
+
+        Returns:
+            Tensor: Batch of predicted sequences (B, Tmax, 1).
+        """
+        x = x.transpose(1, -1)  # (B, dim, Tmax)
+        for f in self.conv:
+            x = f(x)  # (B, C, Tmax)
+        x = self.linear(x.transpose(1, 2)).squeeze(-1)
+        x = x.masked_fill(padding_mask, 0.0)
+        return x
+
+
+class DurationPredictor(VariancePredictor):
+    """
+    This is the duration predictor module described in `FastSpeech: Fast, Robust and Controllable Text to Speech`_.
+    The duration predictor predicts a duration of each frame in log domain from the hidden embeddings of encoder.
+    .. _`FastSpeech: Fast, Robust and Controllable Text to Speech`:
+        https://arxiv.org/pdf/1905.09263.pdf
+    Note:
+        The calculation domain of outputs is different between in `forward` and in `inference`. In `forward`,
+        the outputs are calculated in log domain but in `inference`, those are calculated in linear domain.
+    """
+
+    def __init__(self, *args, clip_val=1e-8, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.clip_val = clip_val
+
+    @torch.inference_mode()
+    def infer(self, x, mask, factor=1.0):
+        """
+        Inference duration in linear domain.
+        Args:
+            x (Tensor):  (B, Tmax, H).
+            mask (ByteTensor, optional): Batch of masks indicating padded part (B, Tmax).
+            factor (float, optional): durations scale to control speech rate.
+        Returns:
+            LongTensor: Batch of predicted durations in linear domain (B, Tmax).
+        """
+        log_durations = self(x, mask)
+        # linear domain
+        durations = torch.exp(log_durations) - self.clip_val
+        durations = torch.ceil(durations * factor)
+        # avoid negative values
+        durations = torch.clamp(durations.long(), min=0)
+        durations = durations.masked_fill(mask, 0)
+        return durations
+
+
+class PitchPredictor(torch.nn.Module):
+    def __init__(self, *args, embed_kernel_size=9, embed_dropout=0.1, **kwargs):
+        super().__init__()
+        self.predictor = VariancePredictor(*args, **kwargs)
+        self.dim = kwargs["dim"]
+        self.conv_layer_class = kwargs["conv_layer_class"]
+        self.embed = torch.nn.Sequential(
+            self.conv_layer_class(
+                in_channels=1,
+                out_channels=self.dim,
+                kernel_size=embed_kernel_size,
+                padding=(embed_kernel_size - 1) // 2,
+            ),
+            torch.nn.Dropout(embed_dropout),
+        )
+
+    def forward(self, x: torch.Tensor, padding_mask: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x (Tensor):  (B, Tmax, H).
+            padding_mask (ByteTensor, optional): Batch of masks indicating padded part (B, Tmax).
+            target (torch.tensor): target values [B, T].
+        Returns:
+            x: input + pitch embedding
+        """
+        preds = self.predictor(x, padding_mask)
+        # Teacher forceing during training
+        emb = self.embed(target.unsqueeze(1))
+        x = x + emb.transpose(1, 2)
+        x = x * (1 - padding_mask.float())[..., None]
+        return x, preds
+
+    @torch.inference_mode()
+    def infer(self, x, padding_mask, factor=1.0):
+        preds = self.predictor(x, padding_mask)
+        # Optional scaling
+        preds = preds * factor
+        emb = self.embed(preds.unsqueeze(1))
+        x = x + emb.transpose(1, 2)
+        x = x * (1 - padding_mask.float())[..., None]
+        return x, preds
+
+
+class EnergyPredictor(PitchPredictor):
+    pass

--- a/phoonnx_train/optispeech/model/generator/modules/layers.py
+++ b/phoonnx_train/optispeech/model/generator/modules/layers.py
@@ -1,0 +1,587 @@
+import math
+
+import torch
+import torch.nn.functional as F
+from torch import einsum, nn
+from torch.nn import Parameter
+
+from phoonnx_train.optispeech.utils.model import (
+    build_activation,
+    get_incremental_state,
+    set_incremental_state,
+    softmax,
+)
+
+
+def Linear(in_features, out_features, bias=True):
+    m = nn.Linear(in_features, out_features, bias)
+    nn.init.xavier_uniform_(m.weight)
+    if bias:
+        nn.init.constant_(m.bias, 0.0)
+    return m
+
+
+class LayerNorm(torch.nn.LayerNorm):
+    """Layer normalization module.
+    :param int nout: output dim size
+    :param int dim: dimension to be normalized
+    """
+
+    def __init__(self, nout, dim=-1):
+        """Construct an LayerNorm object."""
+        super().__init__(nout, eps=1e-12)
+        self.dim = dim
+
+    def forward(self, x):
+        """Apply layer normalization.
+        :param torch.Tensor x: input tensor
+        :return: layer normalized tensor
+        :rtype torch.Tensor
+        """
+        if self.dim == -1:
+            return super().forward(x)
+        return super().forward(x.transpose(1, -1)).transpose(1, -1)
+
+
+class ScaledSinusoidalEmbedding(nn.Module):
+    def __init__(self, dim, theta=10000):
+        super().__init__()
+        assert (dim % 2) == 0
+        self.scale = nn.Parameter(torch.ones(1) * dim ** -0.5).float()
+
+        half_dim = dim // 2
+        freq_seq = torch.arange(half_dim).float() / half_dim
+        inv_freq = theta ** -freq_seq.float()
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, x, pos=None, seq_start_pos=None):
+        seq_len = x.size(1)
+        device = x.device
+
+        if pos is None:
+            pos = torch.arange(seq_len, device=device)
+
+        if seq_start_pos is not None:
+            pos = pos - seq_start_pos[..., None]
+
+        emb = einsum("i, j -> i j", pos.float(), self.inv_freq)
+        emb = torch.cat((emb.sin(), emb.cos()), dim=-1)
+        return emb * self.scale
+
+
+class MultiheadAttention(nn.Module):
+    def __init__(
+            self,
+            embed_dim,
+            num_heads,
+            kdim=None,
+            vdim=None,
+            dropout=0.0,
+            bias=True,
+            add_bias_kv=False,
+            add_zero_attn=False,
+            self_attention=False,
+            encoder_decoder_attention=False,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.kdim = kdim if kdim is not None else embed_dim
+        self.vdim = vdim if vdim is not None else embed_dim
+        self.qkv_same_dim = self.kdim == embed_dim and self.vdim == embed_dim
+
+        self.num_heads = num_heads
+        self.dropout = dropout
+        self.head_dim = embed_dim // num_heads
+        assert self.head_dim * num_heads == self.embed_dim, "embed_dim must be divisible by num_heads"
+        self.scaling = self.head_dim ** -0.5
+
+        self.self_attention = self_attention
+        self.encoder_decoder_attention = encoder_decoder_attention
+
+        assert not self.self_attention or self.qkv_same_dim, (
+            "Self-attention requires query, key and " "value to be of the same size"
+        )
+
+        if self.qkv_same_dim:
+            self.in_proj_weight = Parameter(torch.Tensor(3 * embed_dim, embed_dim))
+        else:
+            self.k_proj_weight = Parameter(torch.Tensor(embed_dim, self.kdim))
+            self.v_proj_weight = Parameter(torch.Tensor(embed_dim, self.vdim))
+            self.q_proj_weight = Parameter(torch.Tensor(embed_dim, embed_dim))
+
+        if bias:
+            self.in_proj_bias = Parameter(torch.Tensor(3 * embed_dim))
+        else:
+            self.register_parameter("in_proj_bias", None)
+
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+
+        if add_bias_kv:
+            self.bias_k = Parameter(torch.Tensor(1, 1, embed_dim))
+            self.bias_v = Parameter(torch.Tensor(1, 1, embed_dim))
+        else:
+            self.bias_k = self.bias_v = None
+
+        self.add_zero_attn = add_zero_attn
+
+        self.reset_parameters()
+
+        self.enable_torch_version = False
+        if hasattr(F, "multi_head_attention_forward"):
+            self.enable_torch_version = True
+        else:
+            self.enable_torch_version = False
+
+    def reset_parameters(self):
+        if self.qkv_same_dim:
+            nn.init.xavier_uniform_(self.in_proj_weight)
+        else:
+            nn.init.xavier_uniform_(self.k_proj_weight)
+            nn.init.xavier_uniform_(self.v_proj_weight)
+            nn.init.xavier_uniform_(self.q_proj_weight)
+
+        nn.init.xavier_uniform_(self.out_proj.weight)
+        if self.in_proj_bias is not None:
+            nn.init.constant_(self.in_proj_bias, 0.0)
+            nn.init.constant_(self.out_proj.bias, 0.0)
+        if self.bias_k is not None:
+            nn.init.xavier_normal_(self.bias_k)
+        if self.bias_v is not None:
+            nn.init.xavier_normal_(self.bias_v)
+
+    def forward(
+            self,
+            query,
+            key,
+            value,
+            key_padding_mask=None,
+            incremental_state=None,
+            need_weights=True,
+            static_kv=False,
+            attn_mask=None,
+            before_softmax=False,
+            need_head_weights=False,
+            enc_dec_attn_constraint_mask=None,
+    ):
+        """Input shape: Time x Batch x Channel
+
+        Args:
+            key_padding_mask (ByteTensor, optional): mask to exclude
+                keys that are pads, of shape `(batch, src_len)`, where
+                padding elements are indicated by 1s.
+            need_weights (bool, optional): return the attention weights,
+                averaged over heads (default: False).
+            attn_mask (ByteTensor, optional): typically used to
+                implement causal attention, where the mask prevents the
+                attention from looking forward in time (default: None).
+            before_softmax (bool, optional): return the raw attention
+                weights and values before the attention softmax.
+            need_head_weights (bool, optional): return the attention
+                weights for each head. Implies *need_weights*. Default:
+                return the average attention weights over all heads.
+        """
+        if need_head_weights:
+            need_weights = True
+
+        tgt_len, bsz, embed_dim = query.size()
+        assert embed_dim == self.embed_dim
+        assert list(query.size()) == [tgt_len, bsz, embed_dim]
+
+        if self.enable_torch_version and incremental_state is None and not static_kv:
+            if self.qkv_same_dim:
+                return F.multi_head_attention_forward(
+                    query,
+                    key,
+                    value,
+                    self.embed_dim,
+                    self.num_heads,
+                    self.in_proj_weight,
+                    self.in_proj_bias,
+                    self.bias_k,
+                    self.bias_v,
+                    self.add_zero_attn,
+                    self.dropout,
+                    self.out_proj.weight,
+                    self.out_proj.bias,
+                    self.training,
+                    key_padding_mask,
+                    need_weights,
+                    attn_mask,
+                )
+            else:
+                return F.multi_head_attention_forward(
+                    query,
+                    key,
+                    value,
+                    self.embed_dim,
+                    self.num_heads,
+                    torch.empty([0]),
+                    self.in_proj_bias,
+                    self.bias_k,
+                    self.bias_v,
+                    self.add_zero_attn,
+                    self.dropout,
+                    self.out_proj.weight,
+                    self.out_proj.bias,
+                    self.training,
+                    key_padding_mask,
+                    need_weights,
+                    attn_mask,
+                    use_separate_proj_weight=True,
+                    q_proj_weight=self.q_proj_weight,
+                    k_proj_weight=self.k_proj_weight,
+                    v_proj_weight=self.v_proj_weight,
+                )
+
+        if incremental_state is not None:
+            saved_state = self._get_input_buffer(incremental_state)
+            if "prev_key" in saved_state:
+                # previous time steps are cached - no need to recompute
+                # key and value if they are static
+                if static_kv:
+                    assert self.encoder_decoder_attention and not self.self_attention
+                    key = value = None
+        else:
+            saved_state = None
+
+        if self.self_attention:
+            # self-attention
+            q, k, v = self.in_proj_qkv(query)
+        elif self.encoder_decoder_attention:
+            # encoder-decoder attention
+            q = self.in_proj_q(query)
+            if key is None:
+                assert value is None
+                k = v = None
+            else:
+                k = self.in_proj_k(key)
+                v = self.in_proj_v(key)
+
+        else:
+            q = self.in_proj_q(query)
+            k = self.in_proj_k(key)
+            v = self.in_proj_v(value)
+        q *= self.scaling
+
+        if self.bias_k is not None:
+            assert self.bias_v is not None
+            k = torch.cat([k, self.bias_k.repeat(1, bsz, 1)])
+            v = torch.cat([v, self.bias_v.repeat(1, bsz, 1)])
+            if attn_mask is not None:
+                attn_mask = torch.cat([attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1)
+            if key_padding_mask is not None:
+                key_padding_mask = torch.cat(
+                    [key_padding_mask, key_padding_mask.new_zeros(key_padding_mask.size(0), 1)], dim=1
+                )
+
+        q = q.contiguous().view(tgt_len, bsz * self.num_heads, self.head_dim).transpose(0, 1)
+        if k is not None:
+            k = k.contiguous().view(-1, bsz * self.num_heads, self.head_dim).transpose(0, 1)
+        if v is not None:
+            v = v.contiguous().view(-1, bsz * self.num_heads, self.head_dim).transpose(0, 1)
+
+        if saved_state is not None:
+            # saved states are stored with shape (bsz, num_heads, seq_len, head_dim)
+            if "prev_key" in saved_state:
+                prev_key = saved_state["prev_key"].view(bsz * self.num_heads, -1, self.head_dim)
+                if static_kv:
+                    k = prev_key
+                else:
+                    k = torch.cat((prev_key, k), dim=1)
+            if "prev_value" in saved_state:
+                prev_value = saved_state["prev_value"].view(bsz * self.num_heads, -1, self.head_dim)
+                if static_kv:
+                    v = prev_value
+                else:
+                    v = torch.cat((prev_value, v), dim=1)
+            if "prev_key_padding_mask" in saved_state and saved_state["prev_key_padding_mask"] is not None:
+                prev_key_padding_mask = saved_state["prev_key_padding_mask"]
+                if static_kv:
+                    key_padding_mask = prev_key_padding_mask
+                else:
+                    key_padding_mask = torch.cat((prev_key_padding_mask, key_padding_mask), dim=1)
+
+            saved_state["prev_key"] = k.view(bsz, self.num_heads, -1, self.head_dim)
+            saved_state["prev_value"] = v.view(bsz, self.num_heads, -1, self.head_dim)
+            saved_state["prev_key_padding_mask"] = key_padding_mask
+
+            self._set_input_buffer(incremental_state, saved_state)
+
+        src_len = k.size(1)
+
+        # This is part of a workaround to get around fork/join parallelism
+        # not supporting Optional types.
+        if key_padding_mask is not None and key_padding_mask.shape == torch.Size([]):
+            key_padding_mask = None
+
+        if key_padding_mask is not None:
+            assert key_padding_mask.size(0) == bsz
+            assert key_padding_mask.size(1) == src_len
+
+        if self.add_zero_attn:
+            src_len += 1
+            k = torch.cat([k, k.new_zeros((k.size(0), 1) + k.size()[2:])], dim=1)
+            v = torch.cat([v, v.new_zeros((v.size(0), 1) + v.size()[2:])], dim=1)
+            if attn_mask is not None:
+                attn_mask = torch.cat([attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1)
+            if key_padding_mask is not None:
+                key_padding_mask = torch.cat(
+                    [key_padding_mask, torch.zeros(key_padding_mask.size(0), 1).type_as(key_padding_mask)], dim=1
+                )
+
+        attn_weights = torch.bmm(q, k.transpose(1, 2))
+        attn_weights = self.apply_sparse_mask(attn_weights, tgt_len, src_len, bsz)
+
+        assert list(attn_weights.size()) == [bsz * self.num_heads, tgt_len, src_len]
+
+        if attn_mask is not None:
+            attn_mask = attn_mask.unsqueeze(0)
+            attn_weights += attn_mask
+
+        if enc_dec_attn_constraint_mask is not None:  # bs x head x L_kv
+            attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
+            attn_weights = attn_weights.masked_fill(
+                enc_dec_attn_constraint_mask.unsqueeze(2).bool(),
+                float("-inf"),
+            )
+            attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
+
+        if key_padding_mask is not None:
+            # don't attend to padding symbols
+            attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
+            attn_weights = attn_weights.masked_fill(
+                key_padding_mask.unsqueeze(1).unsqueeze(2),
+                float("-inf"),
+            )
+            attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
+
+        attn_logits = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
+
+        if before_softmax:
+            return attn_weights, v
+
+        attn_weights_float = softmax(attn_weights, dim=-1)
+        attn_weights = attn_weights_float.type_as(attn_weights)
+        attn_probs = F.dropout(attn_weights_float.type_as(attn_weights), p=self.dropout, training=self.training)
+
+        attn = torch.bmm(attn_probs, v)
+        assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
+        attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
+        attn = self.out_proj(attn)
+
+        if need_weights:
+            attn_weights = attn_weights_float.view(bsz, self.num_heads, tgt_len, src_len).transpose(1, 0)
+            if not need_head_weights:
+                # average attention weights over heads
+                attn_weights = attn_weights.mean(dim=0)
+        else:
+            attn_weights = None
+
+        return attn, (attn_weights, attn_logits)
+
+    def in_proj_qkv(self, query):
+        return self._in_proj(query).chunk(3, dim=-1)
+
+    def in_proj_q(self, query):
+        if self.qkv_same_dim:
+            return self._in_proj(query, end=self.embed_dim)
+        else:
+            bias = self.in_proj_bias
+            if bias is not None:
+                bias = bias[: self.embed_dim]
+            return F.linear(query, self.q_proj_weight, bias)
+
+    def in_proj_k(self, key):
+        if self.qkv_same_dim:
+            return self._in_proj(key, start=self.embed_dim, end=2 * self.embed_dim)
+        else:
+            weight = self.k_proj_weight
+            bias = self.in_proj_bias
+            if bias is not None:
+                bias = bias[self.embed_dim: 2 * self.embed_dim]
+            return F.linear(key, weight, bias)
+
+    def in_proj_v(self, value):
+        if self.qkv_same_dim:
+            return self._in_proj(value, start=2 * self.embed_dim)
+        else:
+            weight = self.v_proj_weight
+            bias = self.in_proj_bias
+            if bias is not None:
+                bias = bias[2 * self.embed_dim:]
+            return F.linear(value, weight, bias)
+
+    def _in_proj(self, input, start=0, end=None):
+        weight = self.in_proj_weight
+        bias = self.in_proj_bias
+        weight = weight[start:end, :]
+        if bias is not None:
+            bias = bias[start:end]
+        return F.linear(input, weight, bias)
+
+    def _get_input_buffer(self, incremental_state):
+        return (
+                get_incremental_state(
+                    self,
+                    incremental_state,
+                    "attn_state",
+                )
+                or {}
+        )
+
+    def _set_input_buffer(self, incremental_state, buffer):
+        set_incremental_state(
+            self,
+            incremental_state,
+            "attn_state",
+            buffer,
+        )
+
+    def apply_sparse_mask(self, attn_weights, tgt_len, src_len, bsz):
+        return attn_weights
+
+    def clear_buffer(self, incremental_state=None):
+        if incremental_state is not None:
+            saved_state = self._get_input_buffer(incremental_state)
+            if "prev_key" in saved_state:
+                del saved_state["prev_key"]
+            if "prev_value" in saved_state:
+                del saved_state["prev_value"]
+            self._set_input_buffer(incremental_state, saved_state)
+
+
+class ConvSeparable(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, padding=0, dropout=0):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.padding = padding
+        self.depthwise_conv = nn.Conv1d(
+            in_channels, in_channels, self.kernel_size, padding=padding, groups=in_channels, bias=False
+        )
+        self.pointwise_conv = nn.Conv1d(in_channels, out_channels, 1)
+        std = math.sqrt((4 * (1.0 - dropout)) / (kernel_size * out_channels))
+        nn.init.normal_(self.depthwise_conv.weight, mean=0, std=std)
+        nn.init.normal_(self.pointwise_conv.weight, mean=0, std=std)
+        nn.init.constant_(self.pointwise_conv.bias, 0)
+
+    def forward(self, x):
+        # x : B * C * T
+        x = self.depthwise_conv(x)
+        x = self.pointwise_conv(x)
+        return x
+
+
+class EncSepConvLayer(nn.Module):
+    def __init__(self, c, kernel_size, dropout, activation):
+        super().__init__()
+        self.layer_norm = nn.LayerNorm(c, eps=1e-6, elementwise_affine=True)
+        self.dropout = dropout
+        self.activation_fn = build_activation(activation)
+        self.conv1 = ConvSeparable(c, c, kernel_size, padding=kernel_size // 2, dropout=dropout)
+        self.conv2 = ConvSeparable(c, c, kernel_size, padding=kernel_size // 2, dropout=dropout)
+
+    def forward(self, x, encoder_padding_mask=None):
+        residual = x
+        x = self.layer_norm(x)
+        if encoder_padding_mask is not None:
+            x = x.masked_fill(encoder_padding_mask.t().unsqueeze(-1), 0)
+        x = x.permute(1, 2, 0)
+        x = self.conv1(x)
+        x = self.activation_fn(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+
+        x = self.activation_fn(self.conv2(x))
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = x.permute(2, 0, 1)
+        x = residual + x
+
+        return x
+
+
+class EncTransformerAttnLayer(nn.Module):
+    def __init__(self, c, num_heads, dropout, attention_dropout=0.0):
+        super().__init__()
+        self.dropout = dropout
+        self.self_attn = MultiheadAttention(c, num_heads, self_attention=True, dropout=attention_dropout, bias=False)
+        self.self_attn_layer_norm = nn.LayerNorm(c, eps=1e-6, elementwise_affine=True)
+
+    def forward(self, x, encoder_padding_mask=None, **kwargs):
+        """
+        LayerNorm is applied either before or after the self-attention/ffn
+        modules similar to the original Transformer imlementation.
+        """
+        layer_norm_training = kwargs.get("layer_norm_training", None)
+        if layer_norm_training is not None:
+            self.self_attn_layer_norm.training = layer_norm_training
+        residual = x
+        x = self.self_attn_layer_norm(x)
+        if encoder_padding_mask is not None:
+            x = x.masked_fill(encoder_padding_mask.t().unsqueeze(-1), 0)
+        x, attn = self.self_attn(
+            query=x,
+            key=x,
+            value=x,
+            key_padding_mask=encoder_padding_mask,
+        )
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = residual + x
+        return x
+
+
+class EncTransformerFFNLayer(nn.Module):
+    def __init__(self, hidden_size, filter_size, kernel_size, dropout, activation, padding="SAME"):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.dropout = dropout
+        self.activation_fn = build_activation(activation)
+        self.layer_norm = nn.LayerNorm(hidden_size, eps=1e-6, elementwise_affine=True)
+        if padding == "SAME":
+            self.ffn_1 = nn.Conv1d(hidden_size, filter_size, kernel_size, padding=kernel_size // 2)
+        elif padding == "LEFT":
+            self.ffn_1 = nn.Sequential(
+                nn.ConstantPad1d((kernel_size - 1, 0), 0.0), nn.Conv1d(hidden_size, filter_size, kernel_size)
+            )
+        self.ffn_2 = Linear(filter_size, hidden_size)
+
+    def forward(self, x, encoder_padding_mask=None):
+        residual = x
+        x = self.layer_norm(x)
+        if encoder_padding_mask is not None:
+            x = x.masked_fill(encoder_padding_mask.t().unsqueeze(-1), 0)
+        x = self.ffn_1(x.permute(1, 2, 0)).permute(2, 0, 1)
+        x = self.activation_fn(x)
+        x = F.dropout(x, self.dropout, training=self.training)
+        x = self.ffn_2(x)
+        x = F.dropout(x, self.dropout, training=self.training)
+        x = residual + x
+        return x
+
+
+class IdentityLayer(nn.Module):
+    def __init__(
+            self,
+    ):
+        super().__init__()
+
+    def forward(self, x, *args, **kwargs):
+        return x
+
+
+"""
+LAYERS = {
+    1: lambda : EncSepConvLayer(hparams['hidden_size'], 1, hparams['dropout'], hparams['activation']),  # h, num_heads, dropout
+    2: lambda : EncSepConvLayer(hparams['hidden_size'], 5, hparams['dropout'], hparams['activation']),
+    3: lambda : EncSepConvLayer(hparams['hidden_size'], 9, hparams['dropout'], hparams['activation']),
+    4: lambda : EncSepConvLayer(hparams['hidden_size'], 13, hparams['dropout'], hparams['activation']),
+    5: lambda : EncSepConvLayer(hparams['hidden_size'], 17, hparams['dropout'], hparams['activation']),
+    6: lambda : EncSepConvLayer(hparams['hidden_size'], 21, hparams['dropout'], hparams['activation']),
+    7: lambda : EncSepConvLayer(hparams['hidden_size'], 25, hparams['dropout'], hparams['activation']),
+    8: lambda : EncTransformerAttnLayer(hparams['hidden_size'], 2, hparams['dropout']),
+    9: lambda : EncTransformerAttnLayer(hparams['hidden_size'], 4, hparams['dropout']),
+    10: lambda : EncTransformerAttnLayer(hparams['hidden_size'], 8, hparams['dropout']),
+    11: lambda : EncTransformerFFNLayer(hparams['hidden_size'], hparams['filter_size'], hparams['ffn_kernel_size'], hparams['dropout'], hparams['activation']),
+    12: lambda : IdentityLayer(),
+}
+"""

--- a/phoonnx_train/optispeech/model/generator/modules/leanspeech.py
+++ b/phoonnx_train/optispeech/model/generator/modules/leanspeech.py
@@ -1,0 +1,93 @@
+import torch
+from torch import nn
+
+from .convnext import DropPath
+from .layers import ConvSeparable, LayerNorm
+
+DEFAULT_CONV_LAYER_CLS = ConvSeparable
+
+
+class LeanSpeechBackbone(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            kernel_size: int,
+            num_layers: int,
+            drop_path: float = 0.0,
+            conv_layer_cls: type = DEFAULT_CONV_LAYER_CLS
+    ):
+        super().__init__()
+        drop_ppath_rates = [x.item() for x in torch.linspace(0, drop_path, num_layers)]
+        self.layers = nn.ModuleList([
+            LeanSpeechBlock(
+                dim=dim,
+                kernel_size=kernel_size,
+                drop_path=dp_rate,
+                conv_layer_cls=conv_layer_cls
+            )
+            for dp_rate in drop_ppath_rates
+        ])
+
+    def forward(self, x, padding_mask):
+        for layer in self.layers:
+            x = layer(x, padding_mask)
+        return x
+
+
+class LeanSpeechBlock(nn.Module):
+    def __init__(
+            self,
+            dim: int,
+            kernel_size: int,
+            drop_path: float = 0.0,
+            conv_layer_cls: type = DEFAULT_CONV_LAYER_CLS
+    ):
+        super().__init__()
+        self.lstm = nn.LSTM(
+            dim, dim, num_layers=1, batch_first=True
+        )
+        self.conv = ConvGLU(dim, kernel_size, conv_layer_cls=conv_layer_cls)
+        self.final_layer_norm = nn.LayerNorm(dim)
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+
+    def forward(self, x, padding_mask):
+        residual = x
+        mask = 1 - padding_mask.float().unsqueeze(1)
+        lx, hx = self.lstm(x)
+        lx = lx.tanh()
+        cx = self.conv(x.transpose(1, 2)) * mask
+        x = lx + cx.transpose(1, 2)
+        x = self.final_layer_norm(x)
+        x = residual + self.drop_path(x)
+        return x
+
+
+class ConvGLU(nn.Module):
+    """Conv1d - LayerNorm - GLU."""
+
+    def __init__(self,
+                 channels: int,
+                 kernel_size: int,
+                 conv_layer_cls=DEFAULT_CONV_LAYER_CLS
+                 ):
+        """
+        Args:
+            channels: size of the input channels.
+            kernel_size: size of the convolutional kernels.
+        """
+        super().__init__()
+        self.conv = nn.Sequential(
+            conv_layer_cls(channels, channels * 2, kernel_size, padding=kernel_size // 2),
+            LayerNorm(channels * 2, 1),
+            nn.GLU(dim=1)
+        )
+
+    def forward(self, inputs: torch.Tensor):
+        """Transform the inputs with given conditions.
+        Args:
+            inputs: [torch.float32; [B, channels, T]], input channels.
+        Returns:
+            [torch.float32; [B, channels, T]], transformed.
+        """
+        # [B, channels, T]
+        return inputs + self.conv(inputs)

--- a/phoonnx_train/optispeech/model/generator/modules/lightspeech_transformer.py
+++ b/phoonnx_train/optispeech/model/generator/modules/lightspeech_transformer.py
@@ -1,0 +1,92 @@
+from torch import nn
+
+from .layers import EncSepConvLayer, LayerNorm, ScaledSinusoidalEmbedding
+
+DEFAULT_MAX_SOURCE_POSITIONS = 2000
+DEFAULT_MAX_TARGET_POSITIONS = 2000
+
+
+class LightSpeechTransformerEncoder(nn.Module):
+    def __init__(
+            self,
+            dim,
+            kernel_sizes,
+            activation="relu",
+            dropout=0.0,
+    ):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [EncSepConvLayer(dim, kernel_size, dropout, activation) for kernel_size in kernel_sizes]
+        )
+        self.layer_norm = LayerNorm(dim)
+
+    def forward(self, x, padding_mask):
+        """
+        :param x: [B, T, H]
+        :param padding_mask: [B, T]
+        :return:
+            x: [T x B x C]
+        """
+        # B x T x C -> T x B x C
+        x = x.transpose(0, 1)
+
+        # encoder layers
+        for layer in self.layers:
+            x = layer(x, encoder_padding_mask=padding_mask)
+
+        x = self.layer_norm(x)
+        x = x * (1 - padding_mask.float()).transpose(0, 1)[..., None]
+
+        # T x B x C - > B x T x C
+        x = x.transpose(0, 1)
+
+        return x
+
+
+class LightSpeechTransformerDecoder(nn.Module):
+    def __init__(
+            self,
+            dim,
+            kernel_sizes,
+            activation="relu",
+            dropout=0.2,
+            max_source_positions=DEFAULT_MAX_TARGET_POSITIONS,
+    ):
+        super().__init__()
+        self.pos_emb = ScaledSinusoidalEmbedding(dim, theta=max_source_positions)
+        self.layers = nn.ModuleList(
+            [EncSepConvLayer(dim, kernel_size, dropout, activation) for kernel_size in kernel_sizes]
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.layer_norm = nn.LayerNorm(dim)
+
+    def forward(self, x, padding_mask, *, require_w=False):
+        """
+        :param x: [B, T, C]
+        :param padding_mask: [B, T]
+        :param require_w: True if this module needs to return weight matrix
+        :return: [B, T, C]
+        """
+        positions = self.pos_emb(x[..., 0])
+        x = x + positions
+        x = x * (1 - padding_mask.float())[..., None]
+        x = self.dropout(x)
+
+        # B x T x C -> T x B x C
+        x = x.transpose(0, 1)
+
+        # decoder layers
+        attn_w = []
+        if require_w:
+            for layer in self.layers:
+                x, attn_w_i = layer(x, encoder_padding_mask=padding_mask, require_w=require_w)
+                attn_w.append(attn_w_i)
+        else:
+            for layer in self.layers:
+                # remember to assign back to x
+                x = layer(x, encoder_padding_mask=padding_mask)
+
+        x = self.layer_norm(x)
+        x = x.transpose(0, 1)
+
+        return (x, attn_w) if require_w else x

--- a/phoonnx_train/optispeech/model/generator/modules/transformer.py
+++ b/phoonnx_train/optispeech/model/generator/modules/transformer.py
@@ -1,0 +1,27 @@
+import torch
+from torch import nn
+
+from ._transformer.embedding import PositionalEncoding, ScaledPositionalEncoding
+from ._transformer.encoder import Encoder as FS2Transformer
+from ._transformer.initialize import initialize
+
+
+class Transformer(nn.Module):
+    """Wraps espnet  transformer module."""
+
+    def __init__(self, dim, **kwargs):
+        super().__init__()
+        use_scaled_pos_enc = kwargs.pop("use_scaled_pos_enc")
+        init_alpha = kwargs.pop("init_alpha")
+        init_type = kwargs.pop("init_type")
+        pos_enc_class = ScaledPositionalEncoding if use_scaled_pos_enc else PositionalEncoding
+        kwargs.update(dict(idim=0, attention_dim=dim, input_layer=None, pos_enc_class=pos_enc_class))
+        self.transformer = FS2Transformer(**kwargs)
+        initialize(self, init_type)
+        if use_scaled_pos_enc:
+            self.transformer.embed[-1].alpha.data = torch.tensor(init_alpha)
+
+    def forward(self, x: torch.Tensor, padding_mask: torch.Tensor) -> torch.Tensor:
+        mask = ~padding_mask.unsqueeze(1)
+        x, __ = self.transformer(x, mask)
+        return x

--- a/phoonnx_train/optispeech/model/optispeech.py
+++ b/phoonnx_train/optispeech/model/optispeech.py
@@ -1,0 +1,152 @@
+import torch
+
+from phoonnx_train.optispeech.model.base_lightning_module import BaseLightningModule
+from phoonnx_train.optispeech.model.generator import OptiSpeechGenerator
+from phoonnx_train.optispeech.model.vocoder.wavenext import WaveNeXt
+from phoonnx_train.optispeech.model.vocoder.wavenext.disc import VocosDiscriminator
+from phoonnx_train.optispeech.values import InferenceInputs, InferenceOutputs
+
+
+class OptiSpeech(BaseLightningModule):
+    def __init__(
+            self,
+            dim: int,  # 256
+            generator: OptiSpeechGenerator,
+            vocoder: WaveNeXt,
+            discriminator: VocosDiscriminator,
+            train_args,
+            data_args,
+            inference_args,
+            optimizer: torch.optim.AdamW = None,
+            scheduler=None,  # transformers.get_cosine_schedule_with_warmup
+    ):
+        super().__init__()
+        self.save_hyperparameters(logger=False)
+
+        # Sanity checks
+        if (train_args.gradient_accumulate_batches is not None) and (train_args.gradient_accumulate_batches <= 0):
+            raise ValueError("gradient_accumulate_batches should be a positive number")
+
+        if data_args.num_speakers < 1:
+            raise ValueError("num_speakers should be a positive integer >= 1")
+
+        self.train_args = train_args
+        self.data_args = data_args
+        self.inference_args = inference_args
+
+        self.text_processor = self.data_args.text_processor
+
+        self.num_speakers = data_args.num_speakers
+        self.sample_rate = data_args.feature_extractor.sample_rate
+        self.hop_length = data_args.feature_extractor.hop_length
+
+        # GAN training requires this
+        self.automatic_optimization = False
+
+        self.generator = generator(
+            dim=dim,
+            vocoder=vocoder,
+            feature_extractor=data_args.feature_extractor,
+            data_statistics=data_args.data_statistics,
+            num_speakers=self.data_args.num_speakers,
+            num_languages=self.text_processor.num_languages,
+        )
+        self.discriminator = discriminator(feature_extractor=data_args.feature_extractor)
+
+    @torch.inference_mode()
+    def synthesise(self, inputs: InferenceInputs) -> InferenceOutputs:
+        inputs = inputs.as_torch()
+        inputs = inputs.to(self.device)
+        synth_outputs = self.generator.synthesise(
+            x=inputs.x,
+            x_lengths=inputs.x_lengths.to("cpu"),
+            sids=inputs.sids,
+            lids=inputs.lids,
+            d_factor=inputs.d_factor,
+            p_factor=inputs.p_factor,
+            e_factor=inputs.e_factor
+        )
+        return InferenceOutputs(
+            wav=synth_outputs["wav"],
+            wav_lengths=synth_outputs["wav_lengths"],
+            durations=synth_outputs["durations"],
+            pitch=synth_outputs["pitch"],
+            energy=synth_outputs["energy"],
+            latency=synth_outputs["latency"],
+            rtf=synth_outputs["rtf"],
+            am_rtf=synth_outputs["am_rtf"],
+            v_rtf=synth_outputs["v_rtf"],
+        )
+
+    def prepare_input(
+            self,
+            text: str,
+            *,
+            language: str | None = None,
+            speaker: str | int | None = None,
+            d_factor: float = None,
+            p_factor: float = None,
+            e_factor: float = None,
+            split_sentences: bool = True,
+    ) -> InferenceInputs:
+        """
+        Convenient helper.
+
+        Args:
+            text (str): input text
+            language (str|None): language of input text
+            speaker (int|str|None): speaker name
+            d_factor (float|None): scaling value for duration
+            p_factor (float|None): scaling value for pitch
+            e_factor (float|None): scaling value for energy
+            split_sentences (bool): split text into sentences (each sentence is an element in the batch)
+
+        Returns:
+            InferenceInputs
+        """
+        languages = self.text_processor.languages
+        if language is None:
+            language = languages[0]
+        if self.num_speakers > 1:
+            if speaker is None:
+                sid = 0
+            elif type(speaker) is str:
+                try:
+                    sid = self.speakers.index(speaker)
+                except IndexError:
+                    raise ValueError(f"A speaker with the given name `{speaker}` was not found in speaker list")
+            elif type(speaker) is int:
+                sid = speaker
+        else:
+            sid = None
+        if self.text_processor.is_multi_language:
+            try:
+                lid = languages.index(language)
+            except IndexError:
+                raise ValueError(f"A language with the given name `{language}` was not found in language list")
+        else:
+            lid = None
+
+        input_ids, clean_text = self.text_processor(text, lang=language, split_sentences=split_sentences)
+        if split_sentences:
+            lengths = [len(phids) for phids in input_ids]
+        else:
+            lengths = [len(input_ids)]
+            input_ids = [input_ids]
+
+        sids = [sid] * len(input_ids) if sid is not None else None
+        lids = [lid] * len(input_ids) if lid is not None else None
+
+        inputs = InferenceInputs.from_ids_and_lengths(
+            ids=input_ids,
+            lengths=lengths,
+            clean_text=clean_text,
+            sids=sids,
+            lids=lids,
+            d_factor=d_factor or self.inference_args.d_factor,
+            p_factor=p_factor or self.inference_args.p_factor,
+            e_factor=e_factor or self.inference_args.e_factor
+        )
+        inputs = inputs.as_torch()
+        inputs = inputs.to(self.device)
+        return inputs

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/__init__.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/__init__.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference (https://github.com/kan-bayashi/ParallelWaveGAN/)
+# Reference (https://github.com/jik876/hifi-gan)
+
+"""HiFi-GAN Modules. (Causal)"""
+
+import logging
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.modules.conv_layer import CausalConv1d, \
+    CausalConvTranspose1d
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.modules.multi_fusion import MultiReceptiveField, \
+    MultiGroupConv1d
+from .modules.discriminator import HiFiGANMultiPeriodDiscriminator
+from .modules.discriminator import HiFiGANMultiScaleDiscriminator
+
+
+class Generator(nn.Module):
+    """HiFiGAN causal generator module."""
+
+    def __init__(
+            self,
+            in_channels=80,
+            out_channels=1,
+            channels=512,
+            kernel_size=7,
+            upsample_scales=(8, 8, 2, 2),
+            upsample_kernel_sizes=(16, 16, 4, 4),
+            resblock_kernel_sizes=(3, 7, 11),
+            resblock_dilations=[(1, 3, 5), (1, 3, 5), (1, 3, 5)],
+            groups=1,
+            bias=True,
+            use_additional_convs=True,
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.1},
+            use_weight_norm=True,
+            stats=None,
+    ):
+        """Initialize HiFiGANGenerator module.
+
+        Args:
+            in_channels (int): Number of input channels.
+            out_channels (int): Number of output channels.
+            channels (int): Number of hidden representation channels.
+            kernel_size (int): Kernel size of initial and final conv layer.
+            upsample_scales (list): List of upsampling scales.
+            upsample_kernel_sizes (list): List of kernel sizes for upsampling layers.
+            resblock_kernel_sizes (list): List of kernel sizes for residual blocks.
+            resblock_dilations (list): List of dilation list for residual blocks.
+            groups (int): Number of groups of residual conv
+            bias (bool): Whether to add bias parameter in convolution layers.
+            use_additional_convs (bool): Whether to use additional conv layers in residual blocks.
+            nonlinear_activation (str): Activation function module name.
+            nonlinear_activation_params (dict): Hyperparameters for activation function.
+            use_weight_norm (bool): Whether to use weight norm.
+                If set to true, it will be applied to all of the conv layers.
+            stats (str): File name of the statistic file
+
+        """
+        super().__init__()
+
+        # check hyperparameters are valid
+        assert kernel_size % 2 == 1, "Kernel size must be odd number."
+        assert len(upsample_scales) == len(upsample_kernel_sizes)
+        assert len(resblock_dilations) == len(resblock_kernel_sizes)
+
+        # Group conv or MRF
+        if (len(resblock_dilations) == len(resblock_kernel_sizes) == 1) and (groups > 1):
+            multi_fusion = MultiGroupConv1d
+        else:
+            multi_fusion = MultiReceptiveField
+
+        # define modules
+        self.num_upsamples = len(upsample_kernel_sizes)
+        self.input_conv = CausalConv1d(
+            in_channels,
+            channels,
+            kernel_size,
+            stride=1,
+        )
+        self.upsamples = nn.ModuleList()
+        self.blocks = nn.ModuleList()
+        self.activation_upsamples = getattr(torch.nn, nonlinear_activation)(**nonlinear_activation_params)
+        for i in range(len(upsample_kernel_sizes)):
+            assert upsample_kernel_sizes[i] == 2 * upsample_scales[i]
+            self.upsamples += [
+                CausalConvTranspose1d(
+                    channels // (2 ** i),
+                    channels // (2 ** (i + 1)),
+                    kernel_size=upsample_kernel_sizes[i],
+                    stride=upsample_scales[i],
+                )
+            ]
+            self.blocks += [
+                multi_fusion(
+                    channels=channels // (2 ** (i + 1)),
+                    resblock_kernel_sizes=resblock_kernel_sizes,
+                    resblock_dilations=resblock_dilations,
+                    groups=groups,
+                    bias=bias,
+                    use_additional_convs=use_additional_convs,
+                    nonlinear_activation=nonlinear_activation,
+                    nonlinear_activation_params=nonlinear_activation_params,
+                )
+            ]
+        self.activation_output1 = nn.LeakyReLU()
+        self.activation_output2 = nn.Tanh()
+        self.output_conv = CausalConv1d(
+            channels // (2 ** (i + 1)),
+            out_channels,
+            kernel_size,
+            stride=1,
+        )
+
+        # load stats
+        if stats is not None:
+            self.register_stats(stats)
+            self.norm = True
+        else:
+            self.norm = False
+        logging.info(f"Input normalization: {self.norm}")
+
+        # apply weight norm
+        if use_weight_norm:
+            self.apply_weight_norm()
+
+        # reset parameters
+        self.reset_parameters()
+
+    def forward(self, c):
+        """Calculate forward propagation.
+
+        Args:
+            c (Tensor): Input tensor (B, in_channels, T).
+
+        Returns:
+            Tensor: Output tensor (B, out_channels, T).
+
+        """
+        if self.norm:
+            c = (c.transpose(2, 1) - self.mean) / self.scale
+            c = c.transpose(2, 1)
+        c = self.input_conv(c)
+        for i in range(self.num_upsamples):
+            c = self.upsamples[i](self.activation_upsamples(c))
+            c = self.blocks[i](c)
+        c = self.output_conv(self.activation_output1(c))
+        c = self.activation_output2(c)
+
+        return c
+
+    def reset_parameters(self):
+        """Reset parameters.
+
+        This initialization follows the official implementation manner.
+        https://github.com/jik876/hifi-gan/blob/master/models.py
+
+        """
+
+        def _reset_parameters(m):
+            if isinstance(m, (nn.Conv1d, nn.ConvTranspose1d)):
+                m.weight.data.normal_(0.0, 0.01)
+                logging.debug(f"Reset parameters in {m}.")
+
+        self.apply(_reset_parameters)
+
+    def remove_weight_norm(self):
+        """Remove weight normalization module from all of the layers."""
+
+        def _remove_weight_norm(m):
+            try:
+                logging.debug(f"Weight norm is removed from {m}.")
+                nn.utils.remove_weight_norm(m)
+            except ValueError:  # this module didn't have weight norm
+                return
+
+        self.apply(_remove_weight_norm)
+
+    def apply_weight_norm(self):
+        """Apply weight normalization module from all of the layers."""
+
+        def _apply_weight_norm(m):
+            if isinstance(m, nn.Conv1d) or isinstance(
+                    m, nn.ConvTranspose1d
+            ):
+                nn.utils.weight_norm(m)
+                logging.debug(f"Weight norm is applied to {m}.")
+
+        self.apply(_apply_weight_norm)
+
+    def register_stats(self, stats):
+        """Register stats for de-normalization as buffer.
+
+        Args:
+            stats (str): Path of statistics file (".npy" or ".h5").
+
+        """
+        assert stats.endswith(".h5") or stats.endswith(".npy")
+        assert os.path.exists(stats), f"Stats {stats} does not exist!"
+        mean = np.load(stats)[0].reshape(-1)
+        scale = np.load(stats)[1].reshape(-1)
+        self.register_buffer("mean", torch.from_numpy(mean).float())
+        self.register_buffer("scale", torch.from_numpy(scale).float())
+        logging.info("Successfully registered stats as buffer.")
+
+
+class StreamGenerator(Generator):
+    """HiFiGAN streaming generator."""
+
+    def __init__(
+            self,
+            in_channels=80,
+            out_channels=1,
+            channels=512,
+            kernel_size=7,
+            upsample_scales=(8, 8, 2, 2),
+            upsample_kernel_sizes=(16, 16, 4, 4),
+            resblock_kernel_sizes=(3, 7, 11),
+            resblock_dilations=[(1, 3, 5), (1, 3, 5), (1, 3, 5)],
+            groups=1,
+            bias=True,
+            use_additional_convs=True,
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.1},
+            use_weight_norm=True,
+            stats=None,
+    ):
+
+        super(StreamGenerator, self).__init__(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            channels=channels,
+            kernel_size=kernel_size,
+            upsample_scales=upsample_scales,
+            upsample_kernel_sizes=upsample_kernel_sizes,
+            resblock_kernel_sizes=resblock_kernel_sizes,
+            resblock_dilations=resblock_dilations,
+            groups=groups,
+            bias=bias,
+            use_additional_convs=use_additional_convs,
+            nonlinear_activation=nonlinear_activation,
+            nonlinear_activation_params=nonlinear_activation_params,
+            use_weight_norm=use_weight_norm,
+            stats=stats,
+        )
+        self.reset_buffer()
+
+    def initial_decoder(self, c):
+        self.decode(c)
+
+    def decode(self, c):
+        c = self.decode_norm(c)
+        c = self.decode_input(c.transpose(2, 1))
+        c = self.decode_upsample(c)
+        c = self.decode_output(c)
+        return c
+
+    def decode_norm(self, c):
+        if self.norm:
+            c = (c - self.mean) / self.scale
+        return c
+
+    def decode_input(self, c):
+        c = self.input_conv.inference(c)
+        return c
+
+    def decode_upsample(self, c):
+        for i in range(self.num_upsamples):
+            c = self.upsamples[i].inference(self.activation_upsamples(c))
+            c = self.blocks[i].inference(c)
+        return c
+
+    def decode_output(self, c):
+        c = self.output_conv.inference(self.activation_output1(c))
+        return self.activation_output2(c)
+
+    def reset_buffer(self):
+        """Apply weight normalization module from all layers."""
+
+        def _reset_buffer(m):
+            if isinstance(m, CausalConv1d) or isinstance(m, CausalConvTranspose1d):
+                m.reset_buffer()
+
+        self.apply(_reset_buffer)
+
+
+class Discriminator(nn.Module):
+    """HiFi-GAN multi-scale + multi-period discriminator module."""
+
+    def __init__(
+            self,
+            # Multi-scale discriminator related
+            scales=3,
+            scale_downsample_pooling="AvgPool1d",
+            scale_downsample_pooling_params={
+                "kernel_size": 4,
+                "stride": 2,
+                "padding": 2,
+            },
+            scale_discriminator_params={
+                "in_channels": 1,
+                "out_channels": 1,
+                "kernel_sizes": [15, 41, 5, 3],
+                "channels": 128,
+                "max_downsample_channels": 1024,
+                "max_groups": 16,
+                "bias": True,
+                "downsample_scales": [2, 2, 4, 4, 1],
+                "nonlinear_activation": "LeakyReLU",
+                "nonlinear_activation_params": {"negative_slope": 0.1},
+            },
+            follow_official_norm=True,
+            # Multi-period discriminator related
+            periods=[2, 3, 5, 7, 11],
+            period_discriminator_params={
+                "in_channels": 1,
+                "out_channels": 1,
+                "kernel_sizes": [5, 3],
+                "channels": 32,
+                "downsample_scales": [3, 3, 3, 3, 1],
+                "max_downsample_channels": 1024,
+                "bias": True,
+                "nonlinear_activation": "LeakyReLU",
+                "nonlinear_activation_params": {"negative_slope": 0.1},
+                "use_weight_norm": True,
+                "use_spectral_norm": False,
+            },
+    ):
+        """Initilize HiFiGAN multi-scale + multi-period discriminator module.
+
+        Args:
+            scales (int): Number of multi-scales.
+            scale_downsample_pooling (str): Pooling module name for downsampling of the inputs.
+            scale_downsample_pooling_params (dict): Parameters for the above pooling module.
+            scale_discriminator_params (dict): Parameters for hifi-gan scale discriminator module.
+            follow_official_norm (bool): Whether to follow the norm setting of the official
+                implementaion. The first discriminator uses spectral norm and the other
+                discriminators use weight norm.
+            periods (list): List of periods.
+            period_discriminator_params (dict): Parameters for hifi-gan period discriminator module.
+                The period parameter will be overwritten.
+
+        """
+        super().__init__()
+        self.msd = HiFiGANMultiScaleDiscriminator(
+            scales=scales,
+            downsample_pooling=scale_downsample_pooling,
+            downsample_pooling_params=scale_downsample_pooling_params,
+            discriminator_params=scale_discriminator_params,
+            follow_official_norm=follow_official_norm,
+        )
+        self.mpd = HiFiGANMultiPeriodDiscriminator(
+            periods=periods,
+            discriminator_params=period_discriminator_params,
+        )
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Input noise signal (B, C, T).
+
+        Returns:
+            List: List of list of each discriminator outputs,
+                which consists of each layer output tensors.
+                Multi scale and multi period ones are concatenated.
+
+        """
+        (batch, channel, time) = x.size()
+        if channel != 1:
+            x = x.reshape(batch * channel, 1, time)
+        msd_outs = self.msd(x)
+        mpd_outs = self.mpd(x)
+        return msd_outs + mpd_outs

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/discriminators.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/discriminators.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference (https://github.com/kan-bayashi/ParallelWaveGAN/)
+# Reference (https://github.com/jik876/hifi-gan)
+# Reference (https://github.com/chomeyama/SiFiGAN)
+
+"""GAN-based Discriminators"""
+
+import copy
+import logging
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchaudio.functional import spectrogram
+
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.modules.conv_layer import NonCausalConv1d, NonCausalConv2d
+
+
+class HiFiGANPeriodDiscriminator(nn.Module):
+    """HiFiGAN period discriminator module."""
+
+    def __init__(
+            self,
+            in_channels=1,
+            out_channels=1,
+            period=3,
+            kernel_sizes=[5, 3],
+            channels=32,
+            downsample_scales=[3, 3, 3, 3, 1],
+            max_downsample_channels=1024,
+            bias=True,
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.1},
+            use_weight_norm=True,
+            use_spectral_norm=False,
+    ):
+        """Initialize HiFiGANPeriodDiscriminator module.
+
+        Args:
+            in_channels (int): Number of input channels.
+            out_channels (int): Number of output channels.
+            period (int): Period.
+            kernel_sizes (list): Kernel sizes of initial conv layers and the final conv layer.
+            channels (int): Number of initial channels.
+            downsample_scales (list): List of downsampling scales.
+            max_downsample_channels (int): Number of maximum downsampling channels.
+            use_additional_convs (bool): Whether to use additional conv layers in residual blocks.
+            bias (bool): Whether to add bias parameter in convolution layers.
+            nonlinear_activation (str): Activation function module name.
+            nonlinear_activation_params (dict): Hyperparameters for activation function.
+            use_weight_norm (bool): Whether to use weight norm.
+                If set to true, it will be applied to all of the conv layers.
+            use_spectral_norm (bool): Whether to use spectral norm.
+                If set to true, it will be applied to all of the conv layers.
+
+        """
+        super().__init__()
+        assert len(kernel_sizes) == 2
+        assert kernel_sizes[0] % 2 == 1, "Kernel size must be odd number."
+        assert kernel_sizes[1] % 2 == 1, "Kernel size must be odd number."
+
+        self.period = period
+        self.convs = nn.ModuleList()
+        in_chs = in_channels
+        out_chs = channels
+        for downsample_scale in downsample_scales:
+            self.convs += [
+                nn.Sequential(
+                    NonCausalConv2d(
+                        in_chs,
+                        out_chs,
+                        (kernel_sizes[0], 1),
+                        stride=(downsample_scale, 1),
+                        padding=((kernel_sizes[0] - 1) // 2, 0),
+                    ),
+                    getattr(torch.nn, nonlinear_activation)(
+                        **nonlinear_activation_params
+                    ),
+                )
+            ]
+            in_chs = out_chs
+            # NOTE(kan-bayashi): Use downsample_scale + 1?
+            out_chs = min(out_chs * 4, max_downsample_channels)
+        self.output_conv = NonCausalConv2d(
+            out_chs,
+            out_channels,
+            (kernel_sizes[1] - 1, 1),
+            stride=1,
+            padding=((kernel_sizes[1] - 1) // 2, 0),
+        )
+
+        if use_weight_norm and use_spectral_norm:
+            raise ValueError("Either use use_weight_norm or use_spectral_norm.")
+
+        # apply weight norm
+        if use_weight_norm:
+            self.apply_weight_norm()
+
+        # apply spectral norm
+        if use_spectral_norm:
+            self.apply_spectral_norm()
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            c (Tensor): Input tensor (B, in_channels, T).
+
+        Returns:
+            list: List of each layer's tensors.
+
+        """
+        # transform 1d to 2d -> (B, C, T/P, P)
+        b, c, t = x.shape
+        if t % self.period != 0:
+            n_pad = self.period - (t % self.period)
+            x = F.pad(x, (0, n_pad), "reflect")
+            t += n_pad
+        x = x.view(b, c, t // self.period, self.period)
+
+        # forward conv
+        outs = []
+        for layer in self.convs:
+            x = layer(x)
+            outs += [x]
+        x = self.output_conv(x)
+        x = torch.flatten(x, 1, -1)
+        outs += [x]
+
+        return outs
+
+    def apply_weight_norm(self):
+        """Apply weight normalization module from all of the layers."""
+
+        def _apply_weight_norm(m):
+            if isinstance(m, nn.Conv2d):
+                nn.utils.weight_norm(m)
+                logging.debug(f"Weight norm is applied to {m}.")
+
+        self.apply(_apply_weight_norm)
+
+    def apply_spectral_norm(self):
+        """Apply spectral normalization module from all of the layers."""
+
+        def _apply_spectral_norm(m):
+            if isinstance(m, nn.Conv2d):
+                nn.utils.spectral_norm(m)
+                logging.debug(f"Spectral norm is applied to {m}.")
+
+        self.apply(_apply_spectral_norm)
+
+
+class HiFiGANMultiPeriodDiscriminator(nn.Module):
+    """HiFiGAN multi-period discriminator module."""
+
+    def __init__(
+            self,
+            periods=[2, 3, 5, 7, 11],
+            discriminator_params={
+                "in_channels": 1,
+                "out_channels": 1,
+                "kernel_sizes": [5, 3],
+                "channels": 32,
+                "downsample_scales": [3, 3, 3, 3, 1],
+                "max_downsample_channels": 1024,
+                "bias": True,
+                "nonlinear_activation": "LeakyReLU",
+                "nonlinear_activation_params": {"negative_slope": 0.1},
+                "use_weight_norm": True,
+                "use_spectral_norm": False,
+            },
+    ):
+        """Initialize HiFiGANMultiPeriodDiscriminator module.
+
+        Args:
+            periods (list): List of periods.
+            discriminator_params (dict): Parameters for hifi-gan period discriminator module.
+                The period parameter will be overwritten.
+
+        """
+        super().__init__()
+        self.discriminators = nn.ModuleList()
+        for period in periods:
+            params = copy.deepcopy(discriminator_params)
+            params["period"] = period
+            self.discriminators += [HiFiGANPeriodDiscriminator(**params)]
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Input noise signal (B, 1, T).
+
+        Returns:
+            List: List of list of each discriminator outputs, which consists of each layer output tensors.
+
+        """
+        outs = []
+        for f in self.discriminators:
+            outs += [f(x)]
+
+        return outs
+
+
+class HiFiGANScaleDiscriminator(nn.Module):
+    """HiFi-GAN scale discriminator module."""
+
+    def __init__(
+            self,
+            in_channels=1,
+            out_channels=1,
+            kernel_sizes=[15, 41, 5, 3],
+            channels=128,
+            max_downsample_channels=1024,
+            max_groups=16,
+            bias=True,
+            downsample_scales=[2, 2, 4, 4, 1],
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.1},
+            use_weight_norm=True,
+            use_spectral_norm=False,
+    ):
+        """Initilize HiFiGAN scale discriminator module.
+
+        Args:
+            in_channels (int): Number of input channels.
+            out_channels (int): Number of output channels.
+            kernel_sizes (list): List of four kernel sizes. The first will be used for the first conv layer,
+                and the second is for downsampling part, and the remaining two are for output layers.
+            channels (int): Initial number of channels for conv layer.
+            max_downsample_channels (int): Maximum number of channels for downsampling layers.
+            bias (bool): Whether to add bias parameter in convolution layers.
+            downsample_scales (list): List of downsampling scales.
+            nonlinear_activation (str): Activation function module name.
+            nonlinear_activation_params (dict): Hyperparameters for activation function.
+            use_weight_norm (bool): Whether to use weight norm.
+                If set to true, it will be applied to all of the conv layers.
+            use_spectral_norm (bool): Whether to use spectral norm.
+                If set to true, it will be applied to all of the conv layers.
+
+        """
+        super().__init__()
+        self.layers = nn.ModuleList()
+
+        # check kernel size is valid
+        assert len(kernel_sizes) == 4
+        for ks in kernel_sizes:
+            assert ks % 2 == 1
+
+        # add first layer
+        self.layers += [
+            nn.Sequential(
+                NonCausalConv1d(
+                    in_channels,
+                    channels,
+                    # NOTE(kan-bayashi): Use always the same kernel size
+                    kernel_sizes[0],
+                    bias=bias,
+                    padding=(kernel_sizes[0] - 1) // 2,
+                ),
+                getattr(torch.nn, nonlinear_activation)(**nonlinear_activation_params),
+            )
+        ]
+
+        # add downsample layers
+        in_chs = channels
+        out_chs = channels
+        # NOTE(kan-bayashi): Remove hard coding?
+        groups = 4
+        for downsample_scale in downsample_scales:
+            self.layers += [
+                nn.Sequential(
+                    NonCausalConv1d(
+                        in_chs,
+                        out_chs,
+                        kernel_sizes[1],
+                        stride=downsample_scale,
+                        padding=(kernel_sizes[1] - 1) // 2,
+                        groups=groups,
+                        bias=bias,
+                    ),
+                    getattr(torch.nn, nonlinear_activation)(
+                        **nonlinear_activation_params
+                    ),
+                )
+            ]
+            in_chs = out_chs
+            # NOTE(kan-bayashi): Remove hard coding?
+            out_chs = min(in_chs * 2, max_downsample_channels)
+            # NOTE(kan-bayashi): Remove hard coding?
+            groups = min(groups * 4, max_groups)
+
+        # add final layers
+        out_chs = min(in_chs * 2, max_downsample_channels)
+        self.layers += [
+            nn.Sequential(
+                NonCausalConv1d(
+                    in_chs,
+                    out_chs,
+                    kernel_sizes[2],
+                    stride=1,
+                    padding=(kernel_sizes[2] - 1) // 2,
+                    bias=bias,
+                ),
+                getattr(torch.nn, nonlinear_activation)(**nonlinear_activation_params),
+            )
+        ]
+        self.layers += [
+            NonCausalConv1d(
+                out_chs,
+                out_channels,
+                kernel_sizes[3],
+                stride=1,
+                padding=(kernel_sizes[3] - 1) // 2,
+                bias=bias,
+            ),
+        ]
+
+        if use_weight_norm and use_spectral_norm:
+            raise ValueError("Either use use_weight_norm or use_spectral_norm.")
+
+        # apply weight norm
+        if use_weight_norm:
+            self.apply_weight_norm()
+
+        # apply spectral norm
+        if use_spectral_norm:
+            self.apply_spectral_norm()
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Input noise signal (B, 1, T).
+
+        Returns:
+            List: List of output tensors of each layer.
+
+        """
+        outs = []
+        for f in self.layers:
+            x = f(x)
+            outs += [x]
+
+        return outs
+
+    def apply_weight_norm(self):
+        """Apply weight normalization module from all of the layers."""
+
+        def _apply_weight_norm(m):
+            if isinstance(m, nn.Conv2d):
+                nn.utils.weight_norm(m)
+                logging.debug(f"Weight norm is applied to {m}.")
+
+        self.apply(_apply_weight_norm)
+
+    def apply_spectral_norm(self):
+        """Apply spectral normalization module from all of the layers."""
+
+        def _apply_spectral_norm(m):
+            if isinstance(m, nn.Conv2d):
+                nn.utils.spectral_norm(m)
+                logging.debug(f"Spectral norm is applied to {m}.")
+
+        self.apply(_apply_spectral_norm)
+
+
+class HiFiGANMultiScaleDiscriminator(nn.Module):
+    """HiFi-GAN multi-scale discriminator module."""
+
+    def __init__(
+            self,
+            scales=3,
+            downsample_pooling="AvgPool1d",
+            # follow the official implementation setting
+            downsample_pooling_params={
+                "kernel_size": 4,
+                "stride": 2,
+                "padding": 2,
+            },
+            discriminator_params={
+                "in_channels": 1,
+                "out_channels": 1,
+                "kernel_sizes": [15, 41, 5, 3],
+                "channels": 128,
+                "max_downsample_channels": 1024,
+                "max_groups": 16,
+                "bias": True,
+                "downsample_scales": [2, 2, 4, 4, 1],
+                "nonlinear_activation": "LeakyReLU",
+                "nonlinear_activation_params": {"negative_slope": 0.1},
+            },
+            follow_official_norm=False,
+    ):
+        """Initilize HiFiGAN multi-scale discriminator module.
+
+        Args:
+            scales (int): Number of multi-scales.
+            downsample_pooling (str): Pooling module name for downsampling of the inputs.
+            downsample_pooling_params (dict): Parameters for the above pooling module.
+            discriminator_params (dict): Parameters for hifi-gan scale discriminator module.
+            follow_official_norm (bool): Whether to follow the norm setting of the official
+                implementaion. The first discriminator uses spectral norm and the other
+                discriminators use weight norm.
+
+        """
+        super().__init__()
+        self.discriminators = nn.ModuleList()
+
+        # add discriminators
+        for i in range(scales):
+            params = copy.deepcopy(discriminator_params)
+            if follow_official_norm:
+                if i == 0:
+                    params["use_weight_norm"] = False
+                    params["use_spectral_norm"] = True
+                else:
+                    params["use_weight_norm"] = True
+                    params["use_spectral_norm"] = False
+            self.discriminators += [HiFiGANScaleDiscriminator(**params)]
+        self.pooling = getattr(torch.nn, downsample_pooling)(
+            **downsample_pooling_params
+        )
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Input noise signal (B, 1, T).
+
+        Returns:
+            List: List of list of each discriminator outputs, which consists of each layer output tensors.
+
+        """
+        outs = []
+        for f in self.discriminators:
+            outs += [f(x)]
+            x = self.pooling(x)
+
+        return outs
+
+
+class UnivNetSpectralDiscriminator(nn.Module):
+    """UnivNet spectral discriminator module."""
+
+    def __init__(
+            self,
+            fft_size,
+            hop_size,
+            win_length,
+            window="hann_window",
+            kernel_sizes=[(3, 9), (3, 9), (3, 9), (3, 9), (3, 3), (3, 3)],
+            strides=[(1, 1), (1, 2), (1, 2), (1, 2), (1, 1), (1, 1)],
+            channels=32,
+            bias=True,
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.2},
+            use_weight_norm=True,
+    ):
+        """Initilize HiFiGAN scale discriminator module.
+        Args:
+            fft_size (list): FFT size.
+            hop_size (int): Hop size.
+            win_length (int): Window length.
+            window (stt): Name of window function.
+            kernel_sizes (list): List of kernel sizes in down-sampling CNNs.
+            strides (list): List of stride sizes in down-sampling CNNs.
+            channels (int): Number of channels for conv layer.
+            bias (bool): Whether to add bias parameter in convolution layers.
+            nonlinear_activation (str): Activation function module name.
+            nonlinear_activation_params (dict): Hyperparameters for activation function.
+            use_weight_norm (bool): Whether to use weight norm.
+                If set to true, it will be applied to all of the conv layers.
+        """
+        super().__init__()
+
+        self.fft_size = fft_size
+        self.hop_size = hop_size
+        self.win_length = win_length
+        self.register_buffer("window", getattr(torch, window)(win_length))
+
+        self.layers = nn.ModuleList()
+
+        # check kernel size is valid
+        assert len(kernel_sizes) == len(strides)
+
+        # add first layer
+        self.layers += [
+            nn.Sequential(
+                NonCausalConv2d(
+                    1,
+                    channels,
+                    kernel_sizes[0],
+                    stride=strides[0],
+                    bias=bias,
+                ),
+                getattr(nn, nonlinear_activation)(**nonlinear_activation_params),
+            )
+        ]
+
+        for i in range(1, len(kernel_sizes) - 2):
+            self.layers += [
+                nn.Sequential(
+                    NonCausalConv2d(
+                        channels,
+                        channels,
+                        kernel_sizes[i],
+                        stride=strides[i],
+                        bias=bias,
+                    ),
+                    getattr(nn, nonlinear_activation)(**nonlinear_activation_params),
+                )
+            ]
+
+        # add final layers
+        self.layers += [
+            nn.Sequential(
+                NonCausalConv2d(
+                    channels,
+                    channels,
+                    kernel_sizes[-2],
+                    stride=strides[-2],
+                    bias=bias,
+                ),
+                getattr(nn, nonlinear_activation)(**nonlinear_activation_params),
+            )
+        ]
+        self.layers += [
+            NonCausalConv2d(
+                channels,
+                1,
+                kernel_sizes[-1],
+                stride=strides[-1],
+                bias=bias,
+            )
+        ]
+
+        # apply weight norm
+        if use_weight_norm:
+            self.apply_weight_norm()
+
+    def forward(self, x):
+        """Calculate forward propagation.
+        Args:
+            x (Tensor): Input noise signal (B, 1, T).
+        Returns:
+            List: List of output tensors of each layer.
+        """
+        x = spectrogram(
+            x,
+            pad=self.win_length // 2,
+            window=self.window,
+            n_fft=self.fft_size,
+            hop_length=self.hop_size,
+            win_length=self.win_length,
+            power=1.0,
+            normalized=False,
+        ).transpose(-1, -2)
+        outs = []
+        for f in self.layers:
+            x = f(x)
+            outs += [x]
+
+        return outs
+
+    def apply_weight_norm(self):
+        """Apply weight normalization module from all of the layers."""
+
+        def _apply_weight_norm(m):
+            if isinstance(m, nn.Conv2d):
+                nn.utils.weight_norm(m)
+                logging.debug(f"Weight norm is applied to {m}.")
+
+        self.apply(_apply_weight_norm)
+
+
+class UnivNetMultiResolutionSpectralDiscriminator(nn.Module):
+    """UnivNet multi-resolution spectral discriminator module."""
+
+    def __init__(
+            self,
+            fft_sizes=[1024, 2048, 512],
+            hop_sizes=[120, 240, 50],
+            win_lengths=[600, 1200, 240],
+            window="hann_window",
+            discriminator_params={
+                "channels": 32,
+                "kernel_sizes": [(3, 9), (3, 9), (3, 9), (3, 9), (3, 3), (3, 3)],
+                "strides": [(1, 1), (1, 2), (1, 2), (1, 2), (1, 1), (1, 1)],
+                "bias": True,
+                "nonlinear_activation": "LeakyReLU",
+                "nonlinear_activation_params": {"negative_slope": 0.2},
+            },
+    ):
+        """Initilize UnivNetMultiResolutionSpectralDiscriminator module.
+        Args:
+            fft_sizes (list): FFT sizes for each spectral discriminator.
+            hop_sizes (list): Hop sizes for each spectral discriminator.
+            win_lengths (list): Window lengths for each spectral discriminator.
+            window (stt): Name of window function.
+            discriminator_params (dict): Parameters for univ-net spectral discriminator module.
+        """
+        super().__init__()
+        assert len(fft_sizes) == len(hop_sizes) == len(win_lengths)
+        self.discriminators = nn.ModuleList()
+
+        # add discriminators
+        for i in range(len(fft_sizes)):
+            params = copy.deepcopy(discriminator_params)
+            self.discriminators += [
+                UnivNetSpectralDiscriminator(
+                    fft_size=fft_sizes[i],
+                    hop_size=hop_sizes[i],
+                    win_length=win_lengths[i],
+                    window=window,
+                    **params,
+                )
+            ]
+
+    def forward(self, x):
+        """Calculate forward propagation.
+        Args:
+            x (Tensor): Input noise signal (B, 1, T).
+        Returns:
+            List: List of list of each discriminator outputs, which consists of each layer output tensors.
+        """
+        outs = []
+        for f in self.discriminators:
+            out = f(x)
+            outs.append(out)
+
+        return outs

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/__init__.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/__init__.py
@@ -1,0 +1,23 @@
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.disc.base_vocoder_disc import BaseVocoderDiscriminator, \
+    LossOutput
+
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.disc.loss.adversarial_loss import *  # NOQA
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.disc.loss.feat_match_loss import *  # NOQA
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.disc.loss.mel_loss import *  # NOQA
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.disc.loss.stft_loss import *  # NOQA
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.disc.loss.waveform_loss import *  # NOQA
+
+
+class HiFiGANDiscriminator(BaseVocoderDiscriminator):
+
+    def __init__(self):
+        ...
+
+    def forward_disc(self, wav, wav_hat) -> LossOutput:
+        """Calculate discriminator's loss for training batch"""
+
+    def forward_gen(self, wav, wav_hat) -> LossOutput:
+        """Calculate adversarial loss for training batch"""
+
+    def forward_val(self, wav, wav_hat) -> LossOutput:
+        """Calculate loss for validation batch."""

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/adversarial_loss.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/adversarial_loss.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Tomoki Hayashi
+#  MIT License (https://opensource.org/licenses/MIT)
+
+"""Adversarial loss modules."""
+
+import torch
+import torch.nn.functional as F
+
+
+class GeneratorAdversarialLoss(torch.nn.Module):
+    """Generator adversarial loss module."""
+
+    def __init__(
+            self,
+            average_by_discriminators=False,
+            loss_type="mse",
+    ):
+        """Initialize GeneratorAversarialLoss module."""
+        super().__init__()
+        self.average_by_discriminators = average_by_discriminators
+        assert loss_type in ["mse", "hinge"], f"{loss_type} is not supported."
+        if loss_type == "mse":
+            self.criterion = self._mse_loss
+        else:
+            self.criterion = self._hinge_loss
+
+    def forward(self, outputs):
+        """Calcualate generator adversarial loss.
+
+        Args:
+            outputs (Tensor or list): Discriminator outputs or list of
+                discriminator outputs.
+
+        Returns:
+            Tensor: Generator adversarial loss value.
+
+        """
+        if isinstance(outputs, (tuple, list)):
+            adv_loss = 0.0
+            for i, outputs_ in enumerate(outputs):
+                if isinstance(outputs_, (tuple, list)):
+                    # NOTE(kan-bayashi): case including feature maps
+                    outputs_ = outputs_[-1]
+                adv_loss += self.criterion(outputs_)
+            if self.average_by_discriminators:
+                adv_loss /= i + 1
+        else:
+            adv_loss = self.criterion(outputs)
+
+        return adv_loss
+
+    def _mse_loss(self, x):
+        return F.mse_loss(x, x.new_ones(x.size()))
+
+    def _hinge_loss(self, x):
+        return -x.mean()
+
+
+class DiscriminatorAdversarialLoss(torch.nn.Module):
+    """Discriminator adversarial loss module."""
+
+    def __init__(
+            self,
+            average_by_discriminators=True,
+            loss_type="mse",
+    ):
+        """Initialize DiscriminatorAversarialLoss module."""
+        super().__init__()
+        self.average_by_discriminators = average_by_discriminators
+        assert loss_type in ["mse", "hinge"], f"{loss_type} is not supported."
+        if loss_type == "mse":
+            self.fake_criterion = self._mse_fake_loss
+            self.real_criterion = self._mse_real_loss
+        else:
+            self.fake_criterion = self._hinge_fake_loss
+            self.real_criterion = self._hinge_real_loss
+
+    def forward(self, outputs_hat, outputs):
+        """Calcualate discriminator adversarial loss.
+
+        Args:
+            outputs_hat (Tensor or list): Discriminator outputs or list of
+                discriminator outputs calculated from generator outputs.
+            outputs (Tensor or list): Discriminator outputs or list of
+                discriminator outputs calculated from groundtruth.
+
+        Returns:
+            Tensor: Discriminator real loss value.
+            Tensor: Discriminator fake loss value.
+
+        """
+        if isinstance(outputs, (tuple, list)):
+            real_loss = 0.0
+            fake_loss = 0.0
+            for i, (outputs_hat_, outputs_) in enumerate(zip(outputs_hat, outputs)):
+                if isinstance(outputs_hat_, (tuple, list)):
+                    # NOTE(kan-bayashi): case including feature maps
+                    outputs_hat_ = outputs_hat_[-1]
+                    outputs_ = outputs_[-1]
+                real_loss += self.real_criterion(outputs_)
+                fake_loss += self.fake_criterion(outputs_hat_)
+            if self.average_by_discriminators:
+                fake_loss /= i + 1
+                real_loss /= i + 1
+        else:
+            real_loss = self.real_criterion(outputs)
+            fake_loss = self.fake_criterion(outputs_hat)
+
+        return real_loss, fake_loss
+
+    def _mse_real_loss(self, x):
+        return F.mse_loss(x, x.new_ones(x.size()))
+
+    def _mse_fake_loss(self, x):
+        return F.mse_loss(x, x.new_zeros(x.size()))
+
+    def _hinge_real_loss(self, x):
+        return -torch.mean(torch.min(x - 1, x.new_zeros(x.size())))
+
+    def _hinge_fake_loss(self, x):
+        return -torch.mean(torch.min(-x - 1, x.new_zeros(x.size())))

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/feat_match_loss.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/feat_match_loss.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Tomoki Hayashi
+#  MIT License (https://opensource.org/licenses/MIT)
+
+"""Feature matching loss modules."""
+
+import torch
+import torch.nn.functional as F
+
+
+class FeatureMatchLoss(torch.nn.Module):
+    """Feature matching loss module."""
+
+    def __init__(
+            self,
+            average_by_layers=True,
+            average_by_discriminators=True,
+            include_final_outputs=False,
+    ):
+        """Initialize FeatureMatchLoss module."""
+        super().__init__()
+        self.average_by_layers = average_by_layers
+        self.average_by_discriminators = average_by_discriminators
+        self.include_final_outputs = include_final_outputs
+
+    def forward(self, feats_hat, feats):
+        """Calcualate feature matching loss.
+
+        Args:
+            feats_hat (list): List of list of discriminator outputs
+                calcuated from generater outputs.
+            feats (list): List of list of discriminator outputs
+                calcuated from groundtruth.
+
+        Returns:
+            Tensor: Feature matching loss value.
+
+        """
+        feat_match_loss = 0.0
+        for i, (feats_hat_, feats_) in enumerate(zip(feats_hat, feats)):
+            feat_match_loss_ = 0.0
+            if not self.include_final_outputs:
+                feats_hat_ = feats_hat_[:-1]
+                feats_ = feats_[:-1]
+            for j, (feat_hat_, feat_) in enumerate(zip(feats_hat_, feats_)):
+                feat_match_loss_ += F.l1_loss(feat_hat_, feat_.detach())
+            if self.average_by_layers:
+                feat_match_loss_ /= j + 1
+            feat_match_loss += feat_match_loss_
+        if self.average_by_discriminators:
+            feat_match_loss /= i + 1
+
+        return feat_match_loss

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/mel_loss.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/mel_loss.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference (https://github.com/kan-bayashi/ParallelWaveGAN/)
+
+"""Mel-spectrogram loss modules."""
+
+import librosa
+import torch
+import torch.nn.functional as F
+
+
+class MelSpectrogram(torch.nn.Module):
+    """Calculate Mel-spectrogram."""
+
+    def __init__(
+            self,
+            fs=22050,
+            fft_size=1024,
+            hop_size=256,
+            win_length=None,
+            window="hann_window",
+            num_mels=80,
+            fmin=80,
+            fmax=7600,
+            center=True,
+            normalized=False,
+            onesided=True,
+            eps=1e-10,
+            log_base=10.0,
+    ):
+        """Initialize MelSpectrogram module."""
+        super().__init__()
+        self.fft_size = fft_size
+        self.hop_size = hop_size
+        if win_length is not None:
+            self.win_length = win_length
+        else:
+            self.win_length = fft_size
+        self.center = center
+        self.normalized = normalized
+        self.onesided = onesided
+        self.register_buffer("window", getattr(torch, window)(self.win_length))
+        self.eps = eps
+
+        fmin = 0 if fmin is None else fmin
+        fmax = fs / 2 if fmax is None else fmax
+        melmat = librosa.filters.mel(
+            sr=fs,
+            n_fft=fft_size,
+            n_mels=num_mels,
+            fmin=fmin,
+            fmax=fmax,
+        )
+        self.register_buffer("melmat", torch.from_numpy(melmat.T).float())
+
+        self.log_base = log_base
+        if self.log_base is None:
+            self.log = torch.log
+        elif self.log_base == 2.0:
+            self.log = torch.log2
+        elif self.log_base == 10.0:
+            self.log = torch.log10
+        else:
+            raise ValueError(f"log_base: {log_base} is not supported.")
+
+    def forward(self, x):
+        """Calculate Mel-spectrogram.
+
+        Args:
+            x (Tensor): Input waveform tensor (B, T) or (B, C, T).
+
+        Returns:
+            Tensor: Mel-spectrogram (B, #mels, #frames).
+
+        """
+        if x.dim() == 3:
+            # (B, C, T) -> (B*C, T)
+            x = x.reshape(-1, x.size(2))
+
+        x_stft = torch.stft(x, self.fft_size, self.hop_size, self.win_length, self.window, return_complex=True)
+        x_power = x_stft.real ** 2 + x_stft.imag ** 2
+        x_amp = torch.sqrt(torch.clamp(x_power, min=self.eps)).transpose(2, 1)  # (B, D, T') -> (B, T', D)
+        x_mel = torch.matmul(x_amp, self.melmat)
+        x_mel = torch.clamp(x_mel, min=self.eps)
+
+        return self.log(x_mel).transpose(1, 2)  # (B, D, T')
+
+
+class MultiMelSpectrogramLoss(torch.nn.Module):
+    """Multi resolution Mel-spectrogram loss."""
+
+    def __init__(
+            self,
+            fs=22050,
+            fft_sizes=[1024, 2048, 512],
+            hop_sizes=[120, 240, 50],
+            win_lengths=[600, 1200, 240],
+            window="hann_window",
+            num_mels=80,
+            fmin=80,
+            fmax=7600,
+            center=True,
+            normalized=False,
+            onesided=True,
+            eps=1e-10,
+            log_base=10.0,
+    ):
+        """Initialize Mel-spectrogram loss."""
+        super().__init__()
+        assert len(fft_sizes) == len(hop_sizes) == len(win_lengths)
+        self.mel_transfers = torch.nn.ModuleList()
+        for fft_size, hop_size, win_length in zip(fft_sizes, hop_sizes, win_lengths):
+            self.mel_transfers += [
+                MelSpectrogram(
+                    fs=fs,
+                    fft_size=fft_size,
+                    hop_size=hop_size,
+                    win_length=win_length,
+                    window=window,
+                    num_mels=num_mels,
+                    fmin=fmin,
+                    fmax=fmax,
+                    center=center,
+                    normalized=normalized,
+                    onesided=onesided,
+                    eps=eps,
+                    log_base=log_base,
+                )
+            ]
+
+    def forward(self, y_hat, y):
+        """Calculate Mel-spectrogram loss.
+
+        Args:
+            y_hat (Tensor): Generated single tensor (B, C, T).
+            y (Tensor): Groundtruth single tensor (B, C, T).
+
+        Returns:
+            Tensor: Mel-spectrogram loss value.
+
+        """
+        mel_loss = 0.0
+        for f in self.mel_transfers:
+            mel_loss += F.l1_loss(f(y_hat), f(y))
+        mel_loss /= len(self.mel_transfers)
+
+        return mel_loss

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/stft_loss.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/stft_loss.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference (https://github.com/kan-bayashi/ParallelWaveGAN/)
+
+"""STFT-based loss modules."""
+
+import torch
+import torch.nn.functional as F
+
+
+def stft(x, fft_size, hop_size, win_length, window, eps=1e-7):
+    """Perform STFT and convert to magnitude spectrogram.
+
+    Args:
+        x (Tensor): Input signal tensor (B, T).
+        fft_size (int): FFT size.
+        hop_size (int): Hop size.
+        win_length (int): Window length.
+        window (str): Window function type.
+
+    Returns:
+        Tensor: Magnitude spectrogram (B, #frames, fft_size // 2 + 1).
+
+    """
+    x_stft = torch.stft(x, fft_size, hop_size, win_length, window, return_complex=True)
+    x_power = x_stft.real ** 2 + x_stft.imag ** 2
+    return torch.sqrt(torch.clamp(x_power, min=eps)).transpose(2, 1)
+
+
+class SpectralConvergenceLoss(torch.nn.Module):
+    """Spectral convergence loss module."""
+
+    def __init__(self):
+        """Initilize spectral convergence loss module."""
+        super(SpectralConvergenceLoss, self).__init__()
+
+    def forward(self, x_mag, y_mag):
+        """Calculate forward propagation.
+
+        Args:
+            x_mag (Tensor): Magnitude spectrogram of predicted signal (B, #frames, #freq_bins).
+            y_mag (Tensor): Magnitude spectrogram of groundtruth signal (B, #frames, #freq_bins).
+
+        Returns:
+            Tensor: Spectral convergence loss value.
+
+        """
+        return torch.norm(y_mag - x_mag, p="fro") / torch.norm(y_mag, p="fro")
+
+
+class LogSTFTMagnitudeLoss(torch.nn.Module):
+    """Log STFT magnitude loss module."""
+
+    def __init__(self):
+        """Initilize los STFT magnitude loss module."""
+        super(LogSTFTMagnitudeLoss, self).__init__()
+
+    def forward(self, x_mag, y_mag):
+        """Calculate forward propagation.
+
+        Args:
+            x_mag (Tensor): Magnitude spectrogram of predicted signal (B, #frames, #freq_bins).
+            y_mag (Tensor): Magnitude spectrogram of groundtruth signal (B, #frames, #freq_bins).
+
+        Returns:
+            Tensor: Log STFT magnitude loss value.
+
+        """
+        return F.l1_loss(torch.log(y_mag), torch.log(x_mag))
+
+
+class STFTLoss(torch.nn.Module):
+    """STFT loss module."""
+
+    def __init__(
+            self,
+            fft_size=1024,
+            hop_size=120,
+            win_length=600,
+            window="hann_window",
+    ):
+        """Initialize STFT loss module."""
+        super(STFTLoss, self).__init__()
+        self.fft_size = fft_size
+        self.hop_size = hop_size
+        self.win_length = win_length
+        self.spectral_convergence_loss = SpectralConvergenceLoss()
+        self.log_stft_magnitude_loss = LogSTFTMagnitudeLoss()
+        self.register_buffer("window", getattr(torch, window)(win_length))
+
+    def forward(self, x, y):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Predicted signal (B, T).
+            y (Tensor): Groundtruth signal (B, T).
+
+        Returns:
+            Tensor: Spectral convergence loss value.
+            Tensor: Log STFT magnitude loss value.
+
+        """
+        x_mag = stft(x, self.fft_size, self.hop_size, self.win_length, self.window)
+        y_mag = stft(y, self.fft_size, self.hop_size, self.win_length, self.window)
+        sc_loss = self.spectral_convergence_loss(x_mag, y_mag)
+        mag_loss = self.log_stft_magnitude_loss(x_mag, y_mag)
+
+        return sc_loss, mag_loss
+
+
+class MultiResolutionSTFTLoss(torch.nn.Module):
+    """Multi resolution STFT loss module."""
+
+    def __init__(
+            self,
+            fft_sizes=[1024, 2048, 512],
+            hop_sizes=[120, 240, 50],
+            win_lengths=[600, 1200, 240],
+            window="hann_window",
+    ):
+        """Initialize Multi resolution STFT loss module.
+
+        Args:
+            fft_sizes (list): List of FFT sizes.
+            hop_sizes (list): List of hop sizes.
+            win_lengths (list): List of window lengths.
+            window (str): Window function type.
+
+        """
+        super(MultiResolutionSTFTLoss, self).__init__()
+        assert len(fft_sizes) == len(hop_sizes) == len(win_lengths)
+        self.stft_losses = torch.nn.ModuleList()
+        for fft_size, hop_size, win_length in zip(fft_sizes, hop_sizes, win_lengths):
+            self.stft_losses += [STFTLoss(fft_size, hop_size, win_length, window)]
+
+    def forward(self, x, y):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Predicted signal (B, T) or (B, #subband, T).
+            y (Tensor): Groundtruth signal (B, T) or (B, #subband, T).
+
+        Returns:
+            Tensor: Multi resolution spectral convergence loss value.
+            Tensor: Multi resolution log STFT magnitude loss value.
+
+        """
+        if len(x.shape) == 3:
+            x = x.view(-1, x.size(2))  # (B, C, T) -> (B x C, T)
+            y = y.view(-1, y.size(2))  # (B, C, T) -> (B x C, T)
+        sc_loss = 0.0
+        mag_loss = 0.0
+        for f in self.stft_losses:
+            sc_l, mag_l = f(x, y)
+            sc_loss += sc_l
+            mag_loss += mag_l
+        sc_loss /= len(self.stft_losses)
+        mag_loss /= len(self.stft_losses)
+
+        return sc_loss, mag_loss

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/waveform_loss.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/disc/loss/waveform_loss.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Waveform-based loss modules."""
+
+import torch
+
+
+class WaveformShapeLoss(torch.nn.Module):
+    """Waveform shape loss."""
+
+    def __init__(self, winlen):
+        super().__init__()
+        self.loss = torch.nn.L1Loss()
+        self.winlen = winlen
+        self.maxpool = torch.nn.MaxPool1d(self.winlen)
+
+    def forward(self, y_hat, y):
+        """Calculate L1 loss.
+
+        Args:
+            y_hat (Tensor): Generated single tensor (B, 1, T).
+            y (Tensor): Groundtruth single tensor (B, 1, T).
+
+        Returns:
+            Tensor: L1 loss value.
+
+        """
+        ys = self.maxpool(torch.abs(y))
+        ys_hat = self.maxpool(torch.abs(y_hat))
+        loss = self.loss(ys_hat, ys)
+        return loss
+
+
+class MultiWindowShapeLoss(torch.nn.Module):
+    """Multi-window-lengthe waveform shape loss."""
+
+    def __init__(
+            self,
+            winlen=[300, 200, 100],
+    ):
+        """Initialize Multi window shape loss module.
+
+        Args:
+            winlen (list): List of window lengths.
+
+        """
+        super(MultiWindowShapeLoss, self).__init__()
+        self.shape_losses = torch.nn.ModuleList()
+        for wl in winlen:
+            self.shape_losses += [WaveformShapeLoss(wl)]
+
+    def forward(self, y_hat, y):
+        """Calculate L1 loss.
+
+        Args:
+            y_hat (Tensor): Generated single tensor (B, 1, T).
+            y (Tensor): Groundtruth single tensor (B, 1, T).
+
+        Returns:
+            Tensor: L2 loss value.
+
+        """
+        loss = 0.0
+        for f in self.shape_losses:
+            loss += f(y_hat, y)
+        loss /= len(self.shape_losses)
+
+        return loss

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/modules/conv_layer.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/modules/conv_layer.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference (https://github.com/kan-bayashi/ParallelWaveGAN/)
+
+"""Convolution layers."""
+
+import math
+
+import torch
+import torch.nn as nn
+
+
+def int2tuple(variable, length):
+    if isinstance(variable, int):
+        return (variable,) * length
+    else:
+        assert len(variable) == length, f"The length of {variable} is not {length}!"
+        return variable
+
+
+class Conv1d1x1(nn.Conv1d):
+    """1x1 Conv1d."""
+
+    def __init__(self, in_channels, out_channels, bias=True):
+        super(Conv1d1x1, self).__init__(in_channels, out_channels, kernel_size=1, bias=bias)
+
+
+class NonCausalConv1d(nn.Module):
+    """1D noncausal convloution w/ 2-sides padding."""
+
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=1,
+            padding=-1,
+            dilation=1,
+            groups=1,
+            bias=True):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        if padding < 0:
+            padding = (kernel_size - 1) // 2 * dilation
+        self.dilation = dilation
+        self.conv = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+        )
+
+    def forward(self, x):
+        """
+        Args:
+            x (Tensor): Float tensor variable with the shape  (B, C, T).
+        Returns:
+            Tensor: Float tensor variable with the shape (B, C, T).
+        """
+        x = self.conv(x)
+        return x
+
+
+class NonCausalConvTranspose1d(nn.Module):
+    """1D noncausal transpose convloution."""
+
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride,
+            padding=-1,
+            output_padding=-1,
+            groups=1,
+            bias=True,
+    ):
+        super().__init__()
+        if padding < 0:
+            padding = (stride + 1) // 2
+        if output_padding < 0:
+            output_padding = 1 if stride % 2 else 0
+        self.deconv = nn.ConvTranspose1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            output_padding=output_padding,
+            groups=groups,
+            bias=bias,
+        )
+
+    def forward(self, x):
+        """
+        Args:
+            x (Tensor): Float tensor variable with the shape  (B, C, T).
+        Returns:
+            Tensor: Float tensor variable with the shape (B, C', T').
+        """
+        x = self.deconv(x)
+        return x
+
+
+class CausalConv1d(NonCausalConv1d):
+    """1D causal convloution w/ 1-side padding."""
+
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=1,
+            dilation=1,
+            groups=1,
+            bias=True,
+            pad_buffer=None,
+    ):
+        super(CausalConv1d, self).__init__(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+        )
+        self.stride = stride
+        self.pad_length = (kernel_size - 1) * dilation
+        if pad_buffer is None:
+            pad_buffer = torch.zeros(1, in_channels, self.pad_length)
+        self.register_buffer("pad_buffer", pad_buffer)
+
+    def forward(self, x):
+        pad = nn.ConstantPad1d((self.pad_length, 0), 0.0)
+        x = pad(x)
+        return self.conv(x)
+
+    def inference(self, x):
+        x = torch.cat((self.pad_buffer, x), -1)
+        self.pad_buffer = x[:, :, -self.pad_length:]
+        return self.conv(x)
+
+    def reset_buffer(self):
+        self.pad_buffer.zero_()
+
+
+class CausalConvTranspose1d(NonCausalConvTranspose1d):
+    """1D causal transpose convloution."""
+
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride,
+            bias=True,
+            pad_buffer=None,
+    ):
+        super(CausalConvTranspose1d, self).__init__(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=0,
+            output_padding=0,
+            bias=bias,
+        )
+        self.stride = stride
+        self.pad_length = (math.ceil(kernel_size / stride) - 1)
+        if pad_buffer is None:
+            pad_buffer = torch.zeros(1, in_channels, self.pad_length)
+        self.register_buffer("pad_buffer", pad_buffer)
+
+    def forward(self, x):
+        pad = nn.ReplicationPad1d((self.pad_length, 0))
+        x = pad(x)
+        return self.deconv(x)[:, :, self.stride: -self.stride]
+
+    def inference(self, x):
+        x = torch.cat((self.pad_buffer, x), -1)
+        self.pad_buffer = x[:, :, -self.pad_length:]
+        return self.deconv(x)[:, :, self.stride: -self.stride]
+
+    def reset_buffer(self):
+        self.pad_buffer.zero_()
+
+
+class NonCausalConv2d(nn.Module):
+    """2D noncausal convloution w/ 4-sides padding."""
+
+    def __init__(
+            self,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=1,
+            padding=-1,
+            dilation=1,
+            groups=1,
+            bias=True):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = int2tuple(kernel_size, 2)
+        self.dilation = int2tuple(dilation, 2)
+        if isinstance(padding, int) and padding < 0:
+            padding_0 = (self.kernel_size[0] - 1) // 2 * self.dilation[0]
+            padding_1 = (self.kernel_size[1] - 1) // 2 * self.dilation[1]
+            padding = (padding_0, padding_1)
+
+        self.conv = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+        )
+
+    def forward(self, x):
+        """
+        Args:
+            x (Tensor): Float tensor variable with the shape  (B, C, T).
+        Returns:
+            Tensor: Float tensor variable with the shape (B, C, T).
+        """
+        x = self.conv(x)
+        return x

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/modules/multi_fusion.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/modules/multi_fusion.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference (https://github.com/kan-bayashi/ParallelWaveGAN/)
+# Reference (https://github.com/r9y9/wavenet_vocoder)
+# Reference (https://github.com/jik876/hifi-gan)
+
+"""Multi-fusion modules."""
+
+import torch.nn as nn
+
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.modules.conv_layer import Conv1d1x1
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.modules.residual_block import HiFiGANResidualBlock
+
+
+class MultiReceptiveField(nn.Module):
+    """Multi-receptive field module in HiFiGAN."""
+
+    def __init__(
+            self,
+            channels=512,
+            resblock_kernel_sizes=(3, 7, 11),
+            resblock_dilations=[(1, 3, 5), (1, 3, 5), (1, 3, 5)],
+            groups=1,
+            bias=True,
+            use_additional_convs=True,
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.1},
+    ):
+        assert len(resblock_kernel_sizes) == len(resblock_dilations)
+        super().__init__()
+        self.num_blocks = len(resblock_kernel_sizes)
+
+        self.blocks = nn.ModuleList()
+        for i in range(self.num_blocks):
+            self.blocks += [
+                HiFiGANResidualBlock(
+                    kernel_size=resblock_kernel_sizes[i],
+                    channels=channels,
+                    dilations=resblock_dilations[i],
+                    groups=groups,
+                    bias=bias,
+                    use_additional_convs=use_additional_convs,
+                    nonlinear_activation=nonlinear_activation,
+                    nonlinear_activation_params=nonlinear_activation_params,
+                )
+            ]
+
+    def forward(self, c):
+        """Calculate forward propagation.
+
+        Args:
+            c (Tensor): Input tensor (B, channels, T).
+
+        Returns:
+            Tensor: Output tensor (B, channels, T).
+
+        """
+        cs = 0.0  # initialize
+        for i in range(self.num_blocks):
+            cs += self.blocks[i](c)
+        c = cs / self.num_blocks
+
+        return c
+
+    def inference(self, c):
+        cs = 0.0  # initialize
+        for i in range(self.num_blocks):
+            cs += self.blocks[i].inference(c)
+        c = cs / self.num_blocks
+
+        return c
+
+
+class MultiGroupConv1d(HiFiGANResidualBlock):
+    """Multi-group convolution module."""
+
+    def __init__(
+            self,
+            channels=512,
+            resblock_kernel_sizes=(3,),
+            resblock_dilations=[(1, 3, 5)],
+            groups=3,
+            bias=True,
+            use_additional_convs=True,
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.1},
+    ):
+        assert len(resblock_kernel_sizes) == len(resblock_dilations) == 1
+        super(MultiGroupConv1d, self).__init__(
+            kernel_size=resblock_kernel_sizes[0],
+            channels=channels * groups,
+            dilations=resblock_dilations[0],
+            groups=groups,
+            bias=bias,
+            use_additional_convs=use_additional_convs,
+            nonlinear_activation=nonlinear_activation,
+            nonlinear_activation_params=nonlinear_activation_params,
+        )
+        self.groups = groups
+        self.conv_out = Conv1d1x1(
+            in_channels=channels * groups,
+            out_channels=channels,
+            bias=False,
+        )
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Input tensor (B, channels, T).
+
+        Returns:
+            Tensor: Output tensor (B, channels, T).
+
+        """
+        x = x.repeat(1, self.groups, 1)  # (B, n*C, T)
+        for idx in range(self.num_layer):
+            xt = self.convs1[idx](self.activation(x))
+            if self.use_additional_convs:
+                xt = self.convs2[idx](self.activation(xt))
+            x = xt + x
+        x = self.conv_out(x)  # (B, C, T)
+        return x
+
+    def inference(self, x):
+        x = x.repeat(1, self.groups, 1)  # (B, n*C, T)
+        for idx in range(self.num_layer):
+            xt = self.convs1[idx].inference(self.activation(x))
+            if self.use_additional_convs:
+                xt = self.convs2[idx].inference(self.activation(xt))
+            x = xt + x
+        x = self.conv_out(x)  # (B, C, T)
+        return x

--- a/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/modules/residual_block.py
+++ b/phoonnx_train/optispeech/model/vocoder/streaming_hifigan/modules/residual_block.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference (https://github.com/kan-bayashi/ParallelWaveGAN/)
+# Reference (https://github.com/r9y9/wavenet_vocoder)
+# Reference (https://github.com/jik876/hifi-gan)
+
+"""Residual block modules."""
+
+import torch.nn as nn
+
+from phoonnx_train.optispeech.model.vocoder.streaming_hifigan.modules.conv_layer import CausalConv1d
+
+
+class HiFiGANResidualBlock(nn.Module):
+    """Causal Residual block module in HiFiGAN."""
+
+    def __init__(
+            self,
+            kernel_size=3,
+            channels=512,
+            dilations=(1, 3, 5),
+            groups=1,
+            bias=True,
+            use_additional_convs=True,
+            nonlinear_activation="LeakyReLU",
+            nonlinear_activation_params={"negative_slope": 0.1},
+    ):
+        """Initialize CausalResidualBlock module.
+
+        Args:
+            kernel_size (int): Kernel size of dilation convolution layer.
+            channels (int): Number of channels for convolution layer.
+            dilations (List[int]): List of dilation factors.
+            use_additional_convs (bool): Whether to use additional convolution layers.
+            groups (int): The group number of conv1d (default: 1)
+            bias (bool): Whether to add bias parameter in convolution layers.
+            nonlinear_activation (str): Activation function module name.
+            nonlinear_activation_params (dict): Hyperparameters for activation function.
+
+        """
+        super().__init__()
+        self.use_additional_convs = use_additional_convs
+        self.convs1 = nn.ModuleList()
+        if use_additional_convs:
+            self.convs2 = nn.ModuleList()
+        assert kernel_size % 2 == 1, "Kernel size must be odd number."
+        self.activation = getattr(nn, nonlinear_activation)(**nonlinear_activation_params)
+        for dilation in dilations:
+            self.convs1 += [
+                CausalConv1d(
+                    in_channels=channels,
+                    out_channels=channels,
+                    kernel_size=kernel_size,
+                    stride=1,
+                    dilation=dilation,
+                    groups=groups,
+                    bias=bias,
+                )
+            ]
+            if use_additional_convs:
+                self.convs2 += [
+                    CausalConv1d(
+                        in_channels=channels,
+                        out_channels=channels,
+                        kernel_size=kernel_size,
+                        stride=1,
+                        dilation=1,
+                        groups=groups,
+                        bias=bias,
+                    )
+                ]
+        self.num_layer = len(self.convs1)
+
+    def forward(self, x):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Input tensor (B, channels, T).
+
+        Returns:
+            Tensor: Output tensor (B, channels, T).
+
+        """
+        for idx in range(self.num_layer):
+            xt = self.convs1[idx](self.activation(x))
+            if self.use_additional_convs:
+                xt = self.convs2[idx](self.activation(xt))
+            x = xt + x
+        return x
+
+    def inference(self, x):
+        for idx in range(self.num_layer):
+            xt = self.convs1[idx].inference(self.activation(x))
+            if self.use_additional_convs:
+                xt = self.convs2[idx].inference(self.activation(xt))
+            x = xt + x
+        return x

--- a/phoonnx_train/optispeech/model/vocoder/wavenext/__init__.py
+++ b/phoonnx_train/optispeech/model/vocoder/wavenext/__init__.py
@@ -1,0 +1,86 @@
+from typing import Optional
+
+import torch
+from torch import nn
+
+from phoonnx_train.optispeech.model.generator.modules import ConvNeXtBackbone
+
+
+class WaveNeXtHead(nn.Module):
+    """
+    A module for predicting waveform samples.
+
+    Args:
+        dim (int): Hidden dimension of the model.
+        n_fft (int): Size of Fourier transform.
+        hop_length (int): The distance between neighboring sliding window frames, which should align with
+                          the resolution of the input features.
+    """
+
+    def __init__(self, dim: int, n_fft: int, hop_length: int):
+        super().__init__()
+        l_fft = n_fft + 2
+        l_shift = hop_length
+        self.linear_1 = torch.nn.Linear(dim, l_fft)
+        self.linear_2 = torch.nn.Linear(l_fft, l_shift, bias=False)
+
+        # W init
+        nn.init.trunc_normal_(self.linear_1.weight, std=0.02)
+        nn.init.trunc_normal_(self.linear_2.weight, std=0.02)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass of the WaveNextHead module.
+
+        Args:
+            x (Tensor): Input tensor of shape (B, L, H), where B is the batch size,
+                        L is the sequence length, and H denotes the model dimension.
+
+        Returns:
+            Tensor: Reconstructed time-domain audio signal of shape (B, T), where T is the length of the output signal.
+        """
+        B, C, T = x.shape
+        x = self.linear_1(x)
+        x = self.linear_2(x)
+        audio = x.view(B, -1)  # / 100
+        # print("max amplitude: ", audio.max().item())
+        audio = torch.clip(audio, min=-1.0, max=1.0)
+        return audio
+
+
+class WaveNeXt(nn.Module):
+    def __init__(
+            self,
+            input_channels: int,
+            dim: int,
+            # backbone
+            intermediate_dim: int,
+            num_layers: int,
+            # head
+            n_fft: int,
+            hop_length: int,
+            sample_rate: int,
+            drop_path: float = 0.0,
+            layer_scale_init_value: Optional[float] = None,
+    ):
+        super().__init__()
+        self.embed = nn.Conv1d(input_channels, dim, kernel_size=7, padding=3)
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.backbone = ConvNeXtBackbone(
+            dim=dim,
+            intermediate_dim=intermediate_dim,
+            num_layers=num_layers,
+            drop_path=drop_path,
+            layer_scale_init_value=layer_scale_init_value,
+        )
+        self.head = WaveNeXtHead(
+            dim=dim,
+            n_fft=n_fft,
+            hop_length=hop_length,
+        )
+
+    def forward(self, x, f0, padding_mask=None):
+        x = self.embed(x)
+        x = self.norm(x.transpose(1, 2))
+        x = self.backbone(x, padding_mask)
+        return self.head(x)

--- a/phoonnx_train/optispeech/model/vocoder/wavenext/disc/__init__.py
+++ b/phoonnx_train/optispeech/model/vocoder/wavenext/disc/__init__.py
@@ -1,0 +1,109 @@
+from phoonnx_train.optispeech.model.discriminator import BaseVocoderDiscriminator
+
+from phoonnx_train.optispeech.model.vocoder.wavenext.disc._discriminators import MultiPeriodDiscriminator, \
+    MultiResolutionDiscriminator
+from phoonnx_train.optispeech.model.vocoder.wavenext.disc.loss import (
+    DiscriminatorLoss,
+    FeatureMatchingLoss,
+    GeneratorLoss,
+    MelSpecReconstructionLoss,
+    MultiResolutionSTFTLoss,
+)
+
+
+class VocosDiscriminator(BaseVocoderDiscriminator):
+    def __init__(self, feature_extractor, loss_coeffs):
+        super().__init__()
+        self.feature_extractor = feature_extractor
+
+        self.loss_coeffs = loss_coeffs
+        self.lambda_mel = self.loss_coeffs.lambda_mel
+        self.lambda_mr_stft = self.loss_coeffs.lambda_mr_stft
+
+        # sub-discriminators
+        self.multiperioddisc = MultiPeriodDiscriminator()
+        self.multiresddisc = MultiResolutionDiscriminator()
+
+        # Losses
+        self.gen_loss = GeneratorLoss()
+        self.disc_loss = DiscriminatorLoss()
+        self.feat_matching_loss = FeatureMatchingLoss()
+        self.melspec_loss = MelSpecReconstructionLoss(
+            sample_rate=self.feature_extractor.sample_rate,
+            n_fft=self.feature_extractor.n_fft,
+            hop_length=self.feature_extractor.hop_length,
+            win_length=self.feature_extractor.win_length,
+            n_mels=self.feature_extractor.n_feats,
+            f_min=self.feature_extractor.f_min,
+            f_max=self.feature_extractor.f_max,
+        )
+        self.mr_stft_loss = MultiResolutionSTFTLoss()
+
+    def forward_disc(self, wav, wav_hat):
+        real_score_mp, gen_score_mp, _, _ = self.multiperioddisc(y=wav, y_hat=wav_hat)
+        real_score_mrd, gen_score_mrd, _, _ = self.multiresddisc(
+            y=wav,
+            y_hat=wav_hat,
+        )
+        loss_mp, loss_mp_real, _ = self.disc_loss(disc_real_outputs=real_score_mp, disc_generated_outputs=gen_score_mp)
+        loss_mrd, loss_mrd_real, _ = self.disc_loss(
+            disc_real_outputs=real_score_mrd, disc_generated_outputs=gen_score_mrd
+        )
+        loss_mp /= len(loss_mp_real)
+        loss_mrd /= len(loss_mrd_real)
+        loss = (
+                loss_mp
+                + (loss_mrd * self.loss_coeffs.lambda_mrd)
+        )
+        log_dict = dict(loss_mp=loss_mp.item(), loss_mrd=loss_mrd.item())
+        return loss, log_dict
+
+    def forward_gen(self, wav, wav_hat):
+        _, gen_score_mp, fmap_rs_mp, fmap_gs_mp = self.multiperioddisc(
+            y=wav,
+            y_hat=wav_hat,
+        )
+        _, gen_score_mrd, fmap_rs_mrd, fmap_gs_mrd = self.multiresddisc(
+            y=wav,
+            y_hat=wav_hat,
+        )
+        loss_gen_mp, list_loss_gen_mp = self.gen_loss(disc_outputs=gen_score_mp)
+        loss_gen_mrd, list_loss_gen_mrd = self.gen_loss(disc_outputs=gen_score_mrd)
+        loss_gen_mp = loss_gen_mp / len(list_loss_gen_mp)
+        loss_gen_mrd = loss_gen_mrd / len(list_loss_gen_mrd)
+        loss_fm_mp = self.feat_matching_loss(fmap_r=fmap_rs_mp, fmap_g=fmap_gs_mp) / len(fmap_rs_mp)
+        loss_fm_mrd = self.feat_matching_loss(fmap_r=fmap_rs_mrd, fmap_g=fmap_gs_mrd) / len(fmap_rs_mrd)
+        mel_loss = self._get_mel_loss(wav, wav_hat)
+        mr_stft_loss = self._get_mr_stft_loss(wav, wav_hat)
+        loss = (
+                loss_gen_mp
+                + (loss_gen_mrd * self.loss_coeffs.lambda_mrd)
+                + loss_fm_mp
+                + (loss_fm_mrd * self.loss_coeffs.lambda_mrd)
+                + mel_loss
+                + mr_stft_loss
+        )
+        log_dict = dict(
+            loss_gen_mp=loss_gen_mp.item(),
+            loss_gen_mrd=loss_gen_mrd.item(),
+            loss_fm_mp=loss_fm_mp.item(),
+            loss_fm_mrd=loss_fm_mrd.item(),
+            mel_loss=mel_loss.item(),
+            mr_stft_loss=mr_stft_loss.item(),
+        )
+        return loss, log_dict
+
+    def forward_val(self, wav, wav_hat):
+        mel_loss = self._get_mel_loss(wav, wav_hat)
+        mr_stft_loss = self._get_mr_stft_loss(wav, wav_hat)
+        loss = mel_loss + mr_stft_loss
+        log_dict = dict(mel_loss=mel_loss.item(), mr_stft_loss=mr_stft_loss.item())
+        return loss, log_dict
+
+    def _get_mel_loss(self, wav, wav_hat):
+        mel_loss = self.melspec_loss(wav_hat, wav)
+        return mel_loss * self.lambda_mel
+
+    def _get_mr_stft_loss(self, wav, wav_hat):
+        spec_converge_loss, mr_mag_loss = self.mr_stft_loss(wav_hat, wav)
+        return (spec_converge_loss + mr_mag_loss) * self.lambda_mr_stft

--- a/phoonnx_train/optispeech/model/vocoder/wavenext/disc/_discriminators.py
+++ b/phoonnx_train/optispeech/model/vocoder/wavenext/disc/_discriminators.py
@@ -1,0 +1,216 @@
+from typing import List, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn import Conv2d
+from torch.nn.utils import weight_norm
+
+
+class MultiPeriodDiscriminator(nn.Module):
+    """
+    Multi-Period Discriminator module adapted from
+    https://github.com/jik876/hifi-gan.
+
+    Args:
+        periods (tuple[int]): Tuple of periods for each discriminator.
+    """
+
+    def __init__(self, periods: Tuple[int] = (2, 3, 5, 7, 11)):
+        super().__init__()
+        self.discriminators = nn.ModuleList([DiscriminatorP(period=p) for p in periods])
+
+    def forward(
+            self, y: torch.Tensor, y_hat: torch.Tensor
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor], List[List[torch.Tensor]], List[List[torch.Tensor]]]:
+        y_d_rs = []
+        y_d_gs = []
+        fmap_rs = []
+        fmap_gs = []
+        for d in self.discriminators:
+            y_d_r, fmap_r = d(x=y)
+            y_d_g, fmap_g = d(x=y_hat)
+            y_d_rs.append(y_d_r)
+            fmap_rs.append(fmap_r)
+            y_d_gs.append(y_d_g)
+            fmap_gs.append(fmap_g)
+
+        return y_d_rs, y_d_gs, fmap_rs, fmap_gs
+
+
+class DiscriminatorP(nn.Module):
+    def __init__(
+            self,
+            period: int,
+            kernel_size: int = 5,
+            stride: int = 3,
+            lrelu_slope: float = 0.1,
+    ):
+        super().__init__()
+        self.period = period
+        self.convs = nn.ModuleList(
+            [
+                weight_norm(Conv2d(1, 32, (kernel_size, 1), (stride, 1), padding=(kernel_size // 2, 0))),
+                weight_norm(Conv2d(32, 128, (kernel_size, 1), (stride, 1), padding=(kernel_size // 2, 0))),
+                weight_norm(Conv2d(128, 512, (kernel_size, 1), (stride, 1), padding=(kernel_size // 2, 0))),
+                weight_norm(Conv2d(512, 1024, (kernel_size, 1), (stride, 1), padding=(kernel_size // 2, 0))),
+                weight_norm(Conv2d(1024, 1024, (kernel_size, 1), (1, 1), padding=(kernel_size // 2, 0))),
+            ]
+        )
+        self.conv_post = weight_norm(Conv2d(1024, 1, (3, 1), 1, padding=(1, 0)))
+        self.lrelu_slope = lrelu_slope
+
+    def forward(self, x: Tensor) -> tuple[Tensor, list[Tensor]]:
+        """
+        Args:
+            x :: (B, T)
+        """
+
+        # Padding and Reshape :: (B, T) -> (B, 1, T) -> (B, 1, Frame, Period)
+        x = x.unsqueeze(1)
+        b, c, t = x.shape
+        ## Tail padding
+        if t % self.period != 0:
+            n_pad = self.period - (t % self.period)
+            x = F.pad(x, (0, n_pad), "reflect")
+            t = t + n_pad
+        ## Period
+        x = x.view(b, c, t // self.period, self.period)
+
+        # Conv :: (B, 1, Frame=frm, Period=prd) -> (B, Feat, Frame<frm, Period=prd)
+        fmap = []
+        for i, conv in enumerate(self.convs):
+            x = conv(x)
+            x = F.leaky_relu(x, self.lrelu_slope)
+            if i > 0:
+                fmap.append(x)
+
+        h = 0
+        # :: (B, Feat, Frame<frm, Period=prd) ->  (B, 1, Frame<frm, Period=prd)
+        x = self.conv_post(x)
+        fmap.append(x)
+        x += h
+
+        # :: (B, 1, Frame<frm, Period=prd) -> (B, FramePeriod=<frm*prd)
+        x = torch.flatten(x, 1, -1)
+
+        return x, fmap
+
+
+class MultiResolutionDiscriminator(nn.Module):
+    def __init__(
+            self,
+            resolutions: tuple[tuple[int, int, int]] = ((1024, 256, 1024), (2048, 512, 2048), (512, 128, 512)),
+    ):
+        """
+        Multi-Resolution Discriminator module adapted from https://github.com/mindslab-ai/univnet.
+
+        Args:
+            resolutions    - triplet (nfft, hop, winLength) for each discriminator. Default: 3/4 overlaped nfft=512/1024/2048
+        """
+        super().__init__()
+
+        self.discriminators = nn.ModuleList([DiscriminatorR(resolution=r) for r in resolutions])
+
+    def forward(
+            self, y: Tensor, y_hat: Tensor
+    ) -> tuple[list[Tensor], list[Tensor], list[list[Tensor]], list[list[Tensor]]]:
+        """
+        Args:
+            y     :: (B, T)
+            y_hat :: (B, T)
+        """
+        y_d_rs = []
+        y_d_gs = []
+        fmap_rs = []
+        fmap_gs = []
+
+        for d in self.discriminators:
+            y_d_r, fmap_r = d(x=y)
+            y_d_g, fmap_g = d(x=y_hat)
+            y_d_rs.append(y_d_r)
+            fmap_rs.append(fmap_r)
+            y_d_gs.append(y_d_g)
+            fmap_gs.append(fmap_g)
+
+        return y_d_rs, y_d_gs, fmap_rs, fmap_gs
+
+
+class DiscriminatorR(nn.Module):
+    def __init__(
+            self,
+            resolution: Tuple[int, int, int],
+            channels: int = 64,
+            lrelu_slope: float = 0.1,
+    ):
+        """
+        Args:
+            resolution - n_fft/hop_length/win_length
+        """
+        super().__init__()
+        self.resolution = resolution
+        self.lrelu_slope = lrelu_slope
+
+        self.convs = nn.ModuleList(
+            [
+                weight_norm(nn.Conv2d(1, channels, kernel_size=(7, 5), stride=(2, 2), padding=(3, 2))),
+                weight_norm(nn.Conv2d(channels, channels, kernel_size=(5, 3), stride=(2, 1), padding=(2, 1))),
+                weight_norm(nn.Conv2d(channels, channels, kernel_size=(5, 3), stride=(2, 2), padding=(2, 1))),
+                weight_norm(nn.Conv2d(channels, channels, kernel_size=3, stride=(2, 1), padding=1)),
+                weight_norm(nn.Conv2d(channels, channels, kernel_size=3, stride=(2, 2), padding=1)),
+            ]
+        )
+        self.conv_post = weight_norm(nn.Conv2d(channels, 1, (3, 3), padding=(1, 1)))
+
+    def forward(self, x: Tensor) -> tuple[Tensor, list[Tensor]]:
+        """wave -> (STFT) -> spec -> (Nx[conv2d-LReLU]) -> feat -> (conv2d) -> (cond) -> o_disc.
+
+        Args:
+            x :: (B, T)
+        Returns:
+              :: (B, FreqFrame)
+        """
+        fmap = []
+
+        # wave2spec :: (B, T) -> (B, Freq, Frame) -> (B, 1, Freq, Frame)
+        x = self.spectrogram(x).unsqueeze(1)
+
+        # conv :: (B, 1, Freq=freq, Frame=frm) -> (B, Feat, Freq<freq, Frame<frm)
+        for conv2d in self.convs:
+            x = conv2d(x)
+            x = F.leaky_relu(x, self.lrelu_slope)
+            fmap.append(x)
+
+        h = 0
+        # :: (B, Feat, Freq<freq, Frame<frm) -> (B, 1, Freq<freq, Frame<frm)
+        x = self.conv_post(x)
+        fmap.append(x)
+
+        x += h
+
+        # :: (B, 1, Freq<freq, Frame<frm) -> (B, FreqFrame=<freq*<frm)
+        x = torch.flatten(x, 1, -1)
+
+        return x, fmap
+
+    def spectrogram(self, x: Tensor) -> Tensor:
+        """
+        Args:
+            x :: (B, T)
+        Returns:
+              :: (B, Freq, Frame)
+        """
+        n_fft, hop_length, win_length = self.resolution
+
+        # NOTE: interestingly rectangular window kind of works here
+        mag_spec = torch.stft(
+            x,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=torch.ones(n_fft, device=x.device),
+            center=True,
+            return_complex=True,
+        ).abs()
+
+        return mag_spec

--- a/phoonnx_train/optispeech/model/vocoder/wavenext/disc/loss.py
+++ b/phoonnx_train/optispeech/model/vocoder/wavenext/disc/loss.py
@@ -1,0 +1,270 @@
+from typing import List, Tuple
+
+import torch
+import torch.nn.functional as F
+import torchaudio
+from torch import Tensor, nn
+
+from phoonnx_train.optispeech.utils import safe_log
+
+
+class GeneratorLoss(nn.Module):
+    """
+    Generator Loss module. Calculates the loss for the generator based on discriminator outputs.
+    """
+
+    def forward(self, disc_outputs: list[Tensor]) -> tuple[Tensor, list[Tensor]]:
+        """
+        Args:
+            disc_outputs :: (B, FreqFrame)[] - List of discriminator outputs.
+
+        Returns:
+                         - Tuple containing the total loss and a list of loss values from the sub-discriminators
+        """
+        loss = 0
+        gen_losses = []
+        for dg in disc_outputs:
+            # :: (B, FreqFrame) -> (1,)
+            mean_loss = torch.mean(torch.clamp(1 - dg, min=0))
+            gen_losses.append(mean_loss)
+            loss += mean_loss
+
+        return loss, gen_losses
+
+
+class DiscriminatorLoss(nn.Module):
+    """
+    Discriminator Loss module. Calculates the loss for the discriminator based on real and generated outputs.
+    """
+
+    def forward(
+            self, disc_real_outputs: List[torch.Tensor], disc_generated_outputs: List[torch.Tensor]
+    ) -> Tuple[Tensor, list[Tensor], list[Tensor]]:
+        """
+        Args:
+            disc_real_outputs      :: (B, FreqFrame)[] - List of discriminator outputs for real samples.
+            disc_generated_outputs :: (B, FreqFrame)[] - List of discriminator outputs for fake samples.
+
+        Returns:
+            - (tuple)
+                the total loss
+                a list of loss values from the sub-discriminators for real outputs
+                a list of loss values for generated outputs
+        """
+        loss = 0
+        r_losses = []
+        g_losses = []
+        for dr, dg in zip(disc_real_outputs, disc_generated_outputs):
+            # :: (B, FreqFrame) -> (1,)
+            r_loss = torch.mean(torch.clamp(1 - dr, min=0))
+            g_loss = torch.mean(torch.clamp(1 + dg, min=0))
+            loss += r_loss + g_loss
+            r_losses.append(r_loss.item())
+            g_losses.append(g_loss.item())
+
+        return loss, r_losses, g_losses
+
+
+class FeatureMatchingLoss(nn.Module):
+    """Feature Matching Loss module. Calculates the feature matching loss between feature maps of the sub-discriminators."""
+
+    def forward(self, fmap_r: list[list[Tensor]], fmap_g: list[list[Tensor]]) -> Tensor:
+        """
+        Args:
+            fmap_r - List of feature maps from real      samples.
+            fmap_g - List of feature maps from generated samples.
+
+        Returns:
+            - The calculated feature matching loss.
+        """
+        loss = 0
+        for dr, dg in zip(fmap_r, fmap_g):
+            for rl, gl in zip(dr, dg):
+                loss += torch.mean(torch.abs(rl - gl))
+
+        return loss
+
+
+class MelSpecReconstructionLoss(nn.Module):
+    """L1 distance of real/fake sample's mel-frequency log-magnitude spectrogram."""
+
+    def __init__(self, sample_rate, n_fft, hop_length, win_length, n_mels, f_min, f_max, clip_val=1e-7):
+        super().__init__()
+        self.clip_val = clip_val
+        self.mel_spec = torchaudio.transforms.MelSpectrogram(
+            sample_rate=sample_rate,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            n_mels=n_mels,
+            f_min=f_min,
+            f_max=f_max,
+            center=True,
+            power=1,
+            window_fn=torch.hann_window,
+            norm=None,
+            mel_scale="htk",
+        )
+
+    def forward(self, y_hat: Tensor, y: Tensor) -> Tensor:
+        """
+        Args:
+            y_hat :: (B, T) - Predicted audio waveform
+            y     - Ground truth audio waveform
+        Returns:
+                  - The mel loss
+        """
+        mel_hat = safe_log(self.mel_spec(y_hat), clip_val=self.clip_val)
+        mel = safe_log(self.mel_spec(y), clip_val=self.clip_val)
+        loss = torch.nn.functional.l1_loss(mel, mel_hat)
+        return loss
+
+
+def stft(x, fft_size, hop_size, win_length, window):
+    """Perform STFT and convert to magnitude spectrogram.
+
+    Args:
+        x (Tensor): Input signal tensor (B, T).
+        fft_size (int): FFT size.
+        hop_size (int): Hop size.
+        win_length (int): Window length.
+        window (str): Window function type.
+
+    Returns:
+        Tensor: Magnitude spectrogram (B, #frames, fft_size // 2 + 1).
+
+    """
+    x_stft = torch.stft(x, fft_size, hop_size, win_length, window, return_complex=False)
+    real = x_stft[..., 0]
+    imag = x_stft[..., 1]
+
+    # NOTE(kan-bayashi): clamp is needed to avoid nan or inf
+    return torch.sqrt(torch.clamp(real ** 2 + imag ** 2, min=1e-7)).transpose(2, 1)
+
+
+class MultiResolutionSTFTLoss(torch.nn.Module):
+    """Multi resolution STFT loss module."""
+
+    def __init__(
+            self,
+            fft_sizes=[1024, 2048, 512],
+            hop_sizes=[120, 240, 50],
+            win_lengths=[600, 1200, 240],
+            window="hann_window",
+    ):
+        """Initialize Multi resolution STFT loss module.
+
+        Args:
+            fft_sizes (list): List of FFT sizes.
+            hop_sizes (list): List of hop sizes.
+            win_lengths (list): List of window lengths.
+            window (str): Window function type.
+
+        """
+        super().__init__()
+        assert len(fft_sizes) == len(hop_sizes) == len(win_lengths)
+        self.stft_losses = torch.nn.ModuleList()
+        for fs, ss, wl in zip(fft_sizes, hop_sizes, win_lengths):
+            self.stft_losses += [STFTLoss(fs, ss, wl, window)]
+
+    def forward(self, x, y):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Predicted signal (B, T) or (B, #subband, T).
+            y (Tensor): Groundtruth signal (B, T) or (B, #subband, T).
+
+        Returns:
+            Tensor: Multi resolution spectral convergence loss value.
+            Tensor: Multi resolution log STFT magnitude loss value.
+
+        """
+        if len(x.shape) == 3:
+            x = x.view(-1, x.size(2))  # (B, C, T) -> (B x C, T)
+            y = y.view(-1, y.size(2))  # (B, C, T) -> (B x C, T)
+        sc_loss = 0.0
+        mag_loss = 0.0
+        for f in self.stft_losses:
+            sc_l, mag_l = f(x, y)
+            sc_loss += sc_l
+            mag_loss += mag_l
+        sc_loss /= len(self.stft_losses)
+        mag_loss /= len(self.stft_losses)
+
+        return sc_loss, mag_loss
+
+
+class STFTLoss(torch.nn.Module):
+    """STFT loss module."""
+
+    def __init__(self, fft_size=1024, shift_size=120, win_length=600, window="hann_window"):
+        """Initialize STFT loss module."""
+        super().__init__()
+        self.fft_size = fft_size
+        self.shift_size = shift_size
+        self.win_length = win_length
+        self.spectral_convergence_loss = SpectralConvergenceLoss()
+        self.log_stft_magnitude_loss = LogSTFTMagnitudeLoss()
+        # NOTE(kan-bayashi): Use register_buffer to fix #223
+        self.register_buffer("window", getattr(torch, window)(win_length))
+
+    def forward(self, x, y):
+        """Calculate forward propagation.
+
+        Args:
+            x (Tensor): Predicted signal (B, T).
+            y (Tensor): Groundtruth signal (B, T).
+
+        Returns:
+            Tensor: Spectral convergence loss value.
+            Tensor: Log STFT magnitude loss value.
+
+        """
+        x_mag = stft(x, self.fft_size, self.shift_size, self.win_length, self.window)
+        y_mag = stft(y, self.fft_size, self.shift_size, self.win_length, self.window)
+        sc_loss = self.spectral_convergence_loss(x_mag, y_mag)
+        mag_loss = self.log_stft_magnitude_loss(x_mag, y_mag)
+
+        return sc_loss, mag_loss
+
+
+class SpectralConvergenceLoss(torch.nn.Module):
+    """Spectral convergence loss module."""
+
+    def __init__(self):
+        """Initilize spectral convergence loss module."""
+        super().__init__()
+
+    def forward(self, x_mag, y_mag):
+        """Calculate forward propagation.
+
+        Args:
+            x_mag (Tensor): Magnitude spectrogram of predicted signal (B, #frames, #freq_bins).
+            y_mag (Tensor): Magnitude spectrogram of groundtruth signal (B, #frames, #freq_bins).
+
+        Returns:
+            Tensor: Spectral convergence loss value.
+
+        """
+        return torch.norm(y_mag - x_mag, p="fro") / torch.norm(y_mag, p="fro")
+
+
+class LogSTFTMagnitudeLoss(torch.nn.Module):
+    """Log STFT magnitude loss module."""
+
+    def __init__(self):
+        """Initilize los STFT magnitude loss module."""
+        super().__init__()
+
+    def forward(self, x_mag, y_mag):
+        """Calculate forward propagation.
+
+        Args:
+            x_mag (Tensor): Magnitude spectrogram of predicted signal (B, #frames, #freq_bins).
+            y_mag (Tensor): Magnitude spectrogram of groundtruth signal (B, #frames, #freq_bins).
+
+        Returns:
+            Tensor: Log STFT magnitude loss value.
+
+        """
+        return F.l1_loss(torch.log(y_mag), torch.log(x_mag))

--- a/phoonnx_train/optispeech/text/__init__.py
+++ b/phoonnx_train/optispeech/text/__init__.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+from .normalization import UNICODE_NORM_FORM
+from .tokenizers import BaseTokenizer
+
+
+class TextProcessor:
+    def __init__(
+        self, tokenizer: str|Any, add_blank: str, add_bos_eos: str, normalize_text: bool, languages: list[str]
+    ):
+        self.tokenizer_ref = tokenizer
+        self.add_blank = add_blank
+        self.add_bos_eos = add_bos_eos
+        self.normalize_text = normalize_text
+        self.languages = [l.strip().lower() for l in languages]
+        if isinstance(self.tokenizer_ref, str):
+            tokenizer_cls = BaseTokenizer.get_tokenizer_by_name(self.tokenizer_ref)
+        else:
+            # The user passed a class which is partially initialized by hydra
+            tokenizer_cls = self.tokenizer_ref
+        self.tokenizer = tokenizer_cls(add_blank=add_blank, add_bos_eos=add_bos_eos, normalize_text=normalize_text)
+        self.num_languages = len(languages)
+        self.is_multi_language = self.num_languages > 1
+        self.default_language = languages[0].strip().lower()
+
+    def __call__(self, text, lang, split_sentences: bool = False):
+        # handle special value
+        if lang is None:
+            lang = self.default_language
+        lang = lang.strip().lower()
+        if lang not in self.languages:
+            raise ValueError(f"Language {lang} does not exist in the supported language list.")
+        return self.tokenizer(text, language=lang, split_sentences=split_sentences)
+
+    @classmethod
+    def from_dict(cls, kwargs):
+        return cls(**kwargs)
+
+    def asdict(self):
+        return dict(
+            tokenizer=self.tokenizer.name,
+            add_blank=self.add_blank,
+            add_bos_eos=self.add_bos_eos,
+            normalize_text=self.normalize_text,
+            languages=self.languages,
+        )

--- a/phoonnx_train/optispeech/text/normalization.py
+++ b/phoonnx_train/optispeech/text/normalization.py
@@ -1,0 +1,24 @@
+import re
+import unicodedata
+
+UNICODE_NORM_FORM = "NFKC"
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def preprocess_text(text: str, language: str = None, *, normalize: bool = False) -> str:
+    if normalize:
+        text = unicodedata.normalize(UNICODE_NORM_FORM, text)
+    text = collapse_whitespace(text)
+    return text
+
+
+def collapse_whitespace(text):
+    text = re.sub(WHITESPACE_RE, " ", text)
+    return text
+
+
+def intersperse(lst, item):
+    # Adds blank symbol
+    result = [item] * (len(lst) * 2 + 1)
+    result[1::2] = lst
+    return result

--- a/phoonnx_train/optispeech/text/symbols.py
+++ b/phoonnx_train/optispeech/text/symbols.py
@@ -1,0 +1,200 @@
+SYMBOLS = [
+    "_",
+    "^",
+    "$",
+    " ",
+    "!",
+    '"',
+    "#",
+    "'",
+    "(",
+    ")",
+    ",",
+    "-",
+    ".",
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    ":",
+    ";",
+    "?",
+    "X",
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+    "æ",
+    "ç",
+    "ð",
+    "ø",
+    "ħ",
+    "ŋ",
+    "œ",
+    "ǀ",
+    "ǁ",
+    "ǂ",
+    "ǃ",
+    "ɐ",
+    "ɑ",
+    "ɒ",
+    "ɓ",
+    "ɔ",
+    "ɕ",
+    "ɖ",
+    "ɗ",
+    "ɘ",
+    "ə",
+    "ɚ",
+    "ɛ",
+    "ɜ",
+    "ɞ",
+    "ɟ",
+    "ɠ",
+    "ɡ",
+    "ɢ",
+    "ɣ",
+    "ɤ",
+    "ɥ",
+    "ɦ",
+    "ɧ",
+    "ɨ",
+    "ɪ",
+    "ɫ",
+    "ɬ",
+    "ɭ",
+    "ɮ",
+    "ɯ",
+    "ɰ",
+    "ɱ",
+    "ɲ",
+    "ɳ",
+    "ɴ",
+    "ɵ",
+    "ɶ",
+    "ɸ",
+    "ɹ",
+    "ɺ",
+    "ɻ",
+    "ɽ",
+    "ɾ",
+    "ʀ",
+    "ʁ",
+    "ʂ",
+    "ʃ",
+    "ʄ",
+    "ʈ",
+    "ʉ",
+    "ʊ",
+    "ʋ",
+    "ʌ",
+    "ʍ",
+    "ʎ",
+    "ʏ",
+    "ʐ",
+    "ʑ",
+    "ʒ",
+    "ʔ",
+    "ʕ",
+    "ʘ",
+    "ʙ",
+    "ʛ",
+    "ʜ",
+    "ʝ",
+    "ʟ",
+    "ʡ",
+    "ʢ",
+    "ʦ",
+    "ʰ",
+    "ʲ",
+    "ˈ",
+    "ˌ",
+    "ː",
+    "ˑ",
+    "˞",
+    "ˤ",
+    "̃",
+    "̊",
+    "̝",
+    "̧",
+    "̩",
+    "̪",
+    "̯",
+    "̺",
+    "̻",
+    "β",
+    "ε",
+    "θ",
+    "χ",
+    "ᵻ",
+    "↑",
+    "↓",
+    "ⱱ",
+]
+
+
+# Special symbols
+PAD = "_"
+BOS = "^"
+EOS = "$"
+
+# Special symbol ids
+PAD_ID = SYMBOLS.index(PAD)
+BOS_ID = SYMBOLS.index(BOS)
+EOS_ID = SYMBOLS.index(EOS)
+SPACE_ID = SYMBOLS.index(" ")
+
+# Mappings from symbol to numeric ID and vice versa:
+SYMBOL_TO_ID = {s: i for i, s in enumerate(SYMBOLS)}
+ID_TO_SYMBOL = {i: s for i, s in enumerate(SYMBOLS)}  # pylint: disable=unnecessary-comprehension
+
+
+def phonemes_to_ids(text):
+    """Converts a string of text to a sequence of IDs corresponding to the symbols in the text.
+    Args:
+      text: string to convert to a sequence
+    Returns:
+      List of integers corresponding to the symbols in the text
+    """
+    sequence = []
+    for symbol in text:
+        symbol_id = SYMBOL_TO_ID[symbol]
+        sequence.append(symbol_id)
+    return sequence
+
+
+def ids_to_phonemes(sequence):
+    """Converts a sequence of IDs back to a string"""
+    result = ""
+    for symbol_id in sequence:
+        s = ID_TO_SYMBOL[symbol_id]
+        result += s
+    return result

--- a/phoonnx_train/optispeech/text/tokenizers.py
+++ b/phoonnx_train/optispeech/text/tokenizers.py
@@ -1,0 +1,97 @@
+from abc import ABC, abstractmethod
+
+from . import symbols
+from .normalization import UNICODE_NORM_FORM, collapse_whitespace, intersperse, preprocess_text
+# TODO - re-use the phoonnx phonemizer code
+# tokenizer registry
+_TOKENIZERS = {}
+
+
+class BaseTokenizer(ABC):
+    name: str
+    input_symbols: dict[str, int]
+    special_symbols: dict[str, int]
+
+    def __init_subclass__(cls, /, **kwargs):
+        _TOKENIZERS.setdefault(cls.name, cls)
+
+    @classmethod
+    def get_tokenizer_by_name(cls, name):
+        try:
+            return _TOKENIZERS[name]
+        except KeyError:
+            raise ValueError(f"Tokenizer `{name}` does not exist.")
+
+    def __init__(
+        self,
+        add_blank: bool,
+        add_bos_eos: bool,
+        normalize_text: bool,
+    ):
+        self.add_blank = add_blank
+        self.add_bos_eos = add_bos_eos
+        self.normalize_text = normalize_text
+
+    @abstractmethod
+    def __call__(
+        self, text: str, language: str, *, split_sentences: bool = True
+    ) -> tuple[list[int] | list[list[int]], str]:
+        """Return input IDs."""
+
+    def preprocess_text(self, text: str, language: str = None) -> str:
+        return preprocess_text(text, language, normalize=self.normalize_text)
+
+
+class IPATokenizer(BaseTokenizer):
+    name = "ipa"
+    input_symbols = symbols.SYMBOL_TO_ID
+    special_symbols = dict(
+        pad=symbols.PAD,
+        bos=symbols.BOS,
+        eos=symbols.EOS,
+    )
+
+    def __call__(
+        self, text: str, language: str, *, split_sentences: bool = True
+    ) -> tuple[list[int] | list[list[int]], str]:
+        phonemes, normalized_text = self.phonemize_text(text, language)
+        if not split_sentences:
+            phonemes = [phoneme for sentence_phonemes in phonemes for phoneme in sentence_phonemes]
+            phonemes = list(collapse_whitespace("".join(phonemes)))
+            phoneme_ids = symbols.phonemes_to_ids(phonemes)
+            if self.add_blank:
+                phoneme_ids = intersperse(phoneme_ids, 0)
+            if self.add_bos_eos:
+                phoneme_ids = [
+                    symbols.BOS_ID,
+                    *phoneme_ids,
+                    symbols.EOS_ID,
+                ]
+        else:
+            phoneme_ids = []
+            for sent_ph in phonemes:
+                sent_phonemes = list(collapse_whitespace("".join(sent_ph)))
+                phids = symbols.phonemes_to_ids(sent_phonemes)
+                if self.add_blank:
+                    phids = intersperse(phids, 0)
+                if self.add_bos_eos:
+                    phids = [symbols.BOS_ID, *phids, symbols.EOS_ID]
+                phoneme_ids.append(phids)
+        return phoneme_ids, normalized_text
+
+    def phonemize_text(self, text: str, language: str) -> str:
+        try:
+            from piper_phonemize import phonemize_espeak
+        except ImportError:
+            raise ImportError(
+                "piper-phonemize package is needed for the IPA tokenizer.\n"
+                "pip install piper-phonemize\n"
+                "or build it yourself from the following repository:\n"
+                "https://github.com/rhasspy/piper-phonemize"
+            )
+
+        # Preprocess
+        text = self.preprocess_text(text, language)
+        # Phonemize
+        phonemes = phonemize_espeak(text, language)
+        return phonemes, text

--- a/phoonnx_train/optispeech/utils/__init__.py
+++ b/phoonnx_train/optispeech/utils/__init__.py
@@ -1,0 +1,19 @@
+from phoonnx_train.optispeech.utils.generic import (
+    get_phoneme_durations,
+    intersperse,
+    plot_attention,
+    plot_spectrogram_to_numpy,
+    plot_tensor,
+)
+from phoonnx_train.optispeech.utils.model import (
+    denormalize,
+    duration_loss,
+    fix_len_compatibility,
+    generate_path,
+    normalize,
+    pad_list,
+    safe_log,
+    sequence_mask,
+    trim_or_pad_to_target_length,
+)
+from phoonnx_train.optispeech.utils.pylogger import get_pylogger, get_script_logger

--- a/phoonnx_train/optispeech/utils/__init__.py
+++ b/phoonnx_train/optispeech/utils/__init__.py
@@ -1,8 +1,6 @@
 from phoonnx_train.optispeech.utils.generic import (
     get_phoneme_durations,
     intersperse,
-    plot_attention,
-    plot_spectrogram_to_numpy,
     plot_tensor,
 )
 from phoonnx_train.optispeech.utils.model import (

--- a/phoonnx_train/optispeech/utils/audio.py
+++ b/phoonnx_train/optispeech/utils/audio.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pyloudnorm as pyln
+import torch
+import torch.utils.data
+from scipy.io.wavfile import read
+
+MAX_WAV_VALUE = 32768.0
+
+
+def load_wav(full_path):
+    sampling_rate, data = read(full_path)
+    return data, sampling_rate
+
+
+def dynamic_range_compression(x, C=1, clip_val=1e-5):
+    return np.log(np.clip(x, a_min=clip_val, a_max=None) * C)
+
+
+def dynamic_range_decompression(x, C=1):
+    return np.exp(x) / C
+
+
+def dynamic_range_compression_torch(x, C=1, clip_val=1e-5):
+    return torch.log(torch.clamp(x, min=clip_val) * C)
+
+
+def dynamic_range_decompression_torch(x, C=1):
+    return torch.exp(x) / C
+
+
+def spectral_normalize_torch(magnitudes):
+    output = dynamic_range_compression_torch(magnitudes)
+    return output
+
+
+def spectral_de_normalize_torch(magnitudes):
+    output = dynamic_range_decompression_torch(magnitudes)
+    return output
+
+
+def normalize_loudness(
+        audio: np.ndarray, sample_rate: int, target_db: float | None = -24.0
+):
+    """
+    Normalizes the loudness of an input monaural audio signal.
+
+    Args:
+        audio (ndarray): Input audio waveform.
+        sample_rate (int): Sampling frequency of the audio.
+        target_db (float, optional): Target loudness in decibels (default: -24.0).
+
+    Returns:
+        ndarray: Loudness-normalized audio waveform.
+    """
+    meter = pyln.Meter(sample_rate)
+    loudness = meter.integrated_loudness(audio)
+    normed_audio = pyln.normalize.loudness(audio, loudness, target_db)
+    return normed_audio

--- a/phoonnx_train/optispeech/utils/generic.py
+++ b/phoonnx_train/optispeech/utils/generic.py
@@ -1,19 +1,12 @@
 import io
-import warnings
-from importlib.util import find_spec
 from math import ceil
-from typing import Any, Callable, Dict, Tuple
 
-import matplotlib
-import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
 from phoonnx_train.optispeech.utils import pylogger
 
 log = pylogger.get_pylogger(__name__)
-
-matplotlib.use("Agg")
 
 
 def intersperse(lst, item):
@@ -23,79 +16,28 @@ def intersperse(lst, item):
     return result
 
 
-def save_figure_to_numpy(fig):
-    data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep="")
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-    return data
-
-
-def plot_attention(attn):
-    fig = plt.figure(figsize=(12, 6))
-    plt.imshow(attn.T, interpolation="nearest", aspect="auto")
-    fig.canvas.draw()
-    data = save_figure_to_numpy(fig)
-    plt.close(fig)
-    return data
-
-
 def plot_tensor(tensor):
+    """Render a 2D tensor to an RGB numpy image for TensorBoard logging.
+
+    matplotlib is imported lazily so the training package stays importable in
+    environments without a plotting stack (e.g. CI); it is only needed when
+    validation actually logs spectrogram images.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
     plt.style.use("default")
     fig, ax = plt.subplots(figsize=(12, 3))
     im = ax.imshow(tensor, aspect="auto", origin="lower", interpolation="none")
     plt.colorbar(im, ax=ax)
     plt.tight_layout()
     fig.canvas.draw()
-    data = save_figure_to_numpy(fig)
-    plt.close()
-    return data
-
-
-def save_plot(tensor, savepath):
-    plt.style.use("default")
-    fig, ax = plt.subplots(figsize=(12, 3))
-    im = ax.imshow(tensor, aspect="auto", origin="lower", interpolation="none")
-    plt.colorbar(im, ax=ax)
-    plt.tight_layout()
-    fig.canvas.draw()
-    plt.savefig(savepath)
-    plt.close()
-
-
-def to_numpy(tensor):
-    if isinstance(tensor, np.ndarray):
-        return tensor
-    elif isinstance(tensor, torch.Tensor):
-        return tensor.detach().cpu().numpy()
-    elif isinstance(tensor, list):
-        return np.array(tensor)
-    else:
-        raise TypeError("Unsupported type for conversion to numpy array")
-
-
-def save_figure_to_numpy(fig: plt.Figure) -> np.ndarray:
-    """
-    Save a matplotlib figure to a numpy array.
-
-    Args:
-        fig (Figure): Matplotlib figure object.
-
-    Returns:
-        ndarray: Numpy array representing the figure.
-    """
     data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep="")
     data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    plt.close()
     return data
-
-
-def plot_spectrogram_to_numpy(spectrogram, filename):
-    fig, ax = plt.subplots(figsize=(12, 3))
-    im = ax.imshow(spectrogram, aspect="auto", origin="lower", interpolation="none")
-    plt.colorbar(im, ax=ax)
-    plt.xlabel("Frames")
-    plt.ylabel("Channels")
-    plt.title("Synthesised Mel-Spectrogram")
-    fig.canvas.draw()
-    plt.savefig(filename)
 
 
 def get_phoneme_durations(durations, phones):

--- a/phoonnx_train/optispeech/utils/generic.py
+++ b/phoonnx_train/optispeech/utils/generic.py
@@ -1,0 +1,148 @@
+import io
+import warnings
+from importlib.util import find_spec
+from math import ceil
+from typing import Any, Callable, Dict, Tuple
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from phoonnx_train.optispeech.utils import pylogger
+
+log = pylogger.get_pylogger(__name__)
+
+matplotlib.use("Agg")
+
+
+def intersperse(lst, item):
+    # Adds blank symbol
+    result = [item] * (len(lst) * 2 + 1)
+    result[1::2] = lst
+    return result
+
+
+def save_figure_to_numpy(fig):
+    data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep="")
+    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    return data
+
+
+def plot_attention(attn):
+    fig = plt.figure(figsize=(12, 6))
+    plt.imshow(attn.T, interpolation="nearest", aspect="auto")
+    fig.canvas.draw()
+    data = save_figure_to_numpy(fig)
+    plt.close(fig)
+    return data
+
+
+def plot_tensor(tensor):
+    plt.style.use("default")
+    fig, ax = plt.subplots(figsize=(12, 3))
+    im = ax.imshow(tensor, aspect="auto", origin="lower", interpolation="none")
+    plt.colorbar(im, ax=ax)
+    plt.tight_layout()
+    fig.canvas.draw()
+    data = save_figure_to_numpy(fig)
+    plt.close()
+    return data
+
+
+def save_plot(tensor, savepath):
+    plt.style.use("default")
+    fig, ax = plt.subplots(figsize=(12, 3))
+    im = ax.imshow(tensor, aspect="auto", origin="lower", interpolation="none")
+    plt.colorbar(im, ax=ax)
+    plt.tight_layout()
+    fig.canvas.draw()
+    plt.savefig(savepath)
+    plt.close()
+
+
+def to_numpy(tensor):
+    if isinstance(tensor, np.ndarray):
+        return tensor
+    elif isinstance(tensor, torch.Tensor):
+        return tensor.detach().cpu().numpy()
+    elif isinstance(tensor, list):
+        return np.array(tensor)
+    else:
+        raise TypeError("Unsupported type for conversion to numpy array")
+
+
+def save_figure_to_numpy(fig: plt.Figure) -> np.ndarray:
+    """
+    Save a matplotlib figure to a numpy array.
+
+    Args:
+        fig (Figure): Matplotlib figure object.
+
+    Returns:
+        ndarray: Numpy array representing the figure.
+    """
+    data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep="")
+    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    return data
+
+
+def plot_spectrogram_to_numpy(spectrogram, filename):
+    fig, ax = plt.subplots(figsize=(12, 3))
+    im = ax.imshow(spectrogram, aspect="auto", origin="lower", interpolation="none")
+    plt.colorbar(im, ax=ax)
+    plt.xlabel("Frames")
+    plt.ylabel("Channels")
+    plt.title("Synthesised Mel-Spectrogram")
+    fig.canvas.draw()
+    plt.savefig(filename)
+
+
+def get_phoneme_durations(durations, phones):
+    prev = durations[0]
+    merged_durations = []
+    # Convolve with stride 2
+    for i in range(1, len(durations), 2):
+        if i == len(durations) - 2:
+            # if it is last take full value
+            next_half = durations[i + 1]
+        else:
+            next_half = ceil(durations[i + 1] / 2)
+
+        curr = prev + durations[i] + next_half
+        prev = durations[i + 1] - next_half
+        merged_durations.append(curr)
+
+    assert len(phones) == len(merged_durations)
+    assert len(merged_durations) == (len(durations) - 1) // 2
+
+    merged_durations = torch.cumsum(torch.tensor(merged_durations), 0, dtype=torch.long)
+    start = torch.tensor(0)
+    duration_json = []
+    for i, duration in enumerate(merged_durations):
+        duration_json.append(
+            {
+                phones[i]: {
+                    "starttime": start.item(),
+                    "endtime": duration.item(),
+                    "duration": duration.item() - start.item(),
+                }
+            }
+        )
+        start = duration
+
+    assert list(duration_json[-1].values())[0]["endtime"] == sum(
+        durations
+    ), f"{list(duration_json[-1].values())[0]['endtime'], sum(durations)}"
+    return duration_json
+
+
+def get_model_size_mb(model):
+    buf = io.BytesIO()
+    torch.save(model.state_dict(), buf)
+    num_bytes = len(buf.getbuffer())
+    return num_bytes // 1e6
+
+
+def count_parameters(model):
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)

--- a/phoonnx_train/optispeech/utils/model.py
+++ b/phoonnx_train/optispeech/utils/model.py
@@ -1,0 +1,278 @@
+from collections import defaultdict
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+INCREMENTAL_STATE_INSTANCE_ID = defaultdict(int)
+
+
+def sequence_mask(length, max_length=None):
+    if max_length is None:
+        max_length = length.max()
+    x = torch.arange(max_length, dtype=length.dtype, device=length.device)
+    return x.unsqueeze(0) < length.unsqueeze(1)
+
+
+def make_non_pad_mask(lengths):
+    max_length = lengths.max()
+    return sequence_mask(lengths, max_length).unsqueeze(1).bool()
+
+
+def make_pad_mask(lengths, max_len=None):
+    max_length = max_len if max_len is not None else lengths.max()
+    return ~sequence_mask(lengths, max_length).bool()
+
+
+def fix_len_compatibility(length, num_downsamplings_in_unet=2):
+    factor = torch.scalar_tensor(2).pow(num_downsamplings_in_unet)
+    length = (length / factor).ceil() * factor
+    if not torch.onnx.is_in_onnx_export():
+        return length.int().item()
+    else:
+        return length
+
+
+def get_padding(kernel_size, dilation=1):
+    return int((kernel_size * dilation - dilation) / 2)
+
+
+def convert_pad_shape(pad_shape):
+    inverted_shape = pad_shape[::-1]
+    pad_shape = [item for sublist in inverted_shape for item in sublist]
+    return pad_shape
+
+
+def generate_path(duration, mask):
+    device = duration.device
+
+    b, t_x, t_y = mask.shape
+    cum_duration = torch.cumsum(duration, 1)
+    path = torch.zeros(b, t_x, t_y, dtype=mask.dtype).to(device=device)
+
+    cum_duration_flat = cum_duration.view(b * t_x)
+    path = sequence_mask(cum_duration_flat, t_y).to(mask.dtype)
+    path = path.view(b, t_x, t_y)
+    path = path - torch.nn.functional.pad(path, convert_pad_shape([[0, 0], [1, 0], [0, 0]]))[:, :-1]
+    path = path * mask
+    return path
+
+
+def invert_log_norm(data, mu, std):
+    # log -> normalise inverse := denormalise -> exp
+    data = denormalize(data, mu, std)
+    return torch.exp(data) - 1.0
+
+
+def duration_loss(logw, logw_, lengths):
+    loss = torch.sum((logw - logw_) ** 2) / torch.sum(lengths)
+    return loss
+
+
+def normalize(data, mu, std):
+    if not isinstance(mu, (float, int)):
+        if isinstance(mu, list):
+            mu = torch.tensor(mu, dtype=data.dtype, device=data.device)
+        elif isinstance(mu, torch.Tensor):
+            mu = mu.to(data.device)
+        elif isinstance(mu, np.ndarray):
+            mu = torch.from_numpy(mu).to(data.device)
+        mu = mu.unsqueeze(-1)
+
+    if not isinstance(std, (float, int)):
+        if isinstance(std, list):
+            std = torch.tensor(std, dtype=data.dtype, device=data.device)
+        elif isinstance(std, torch.Tensor):
+            std = std.to(data.device)
+        elif isinstance(std, np.ndarray):
+            std = torch.from_numpy(std).to(data.device)
+        std = std.unsqueeze(-1)
+
+    return (data - mu) / std
+
+
+def denormalize(data, mu, std):
+    if not isinstance(mu, float):
+        if isinstance(mu, list):
+            mu = torch.tensor(mu, dtype=data.dtype, device=data.device)
+        elif isinstance(mu, torch.Tensor):
+            mu = mu.to(data.device)
+        elif isinstance(mu, np.ndarray):
+            mu = torch.from_numpy(mu).to(data.device)
+        mu = mu.unsqueeze(-1)
+
+    if not isinstance(std, float):
+        if isinstance(std, list):
+            std = torch.tensor(std, dtype=data.dtype, device=data.device)
+        elif isinstance(std, torch.Tensor):
+            std = std.to(data.device)
+        elif isinstance(std, np.ndarray):
+            std = torch.from_numpy(std).to(data.device)
+        std = std.unsqueeze(-1)
+
+    return data * std + mu
+
+
+def expand_lengths(enc_out, durations, pace: float = 1.0):
+    """If target=None, then predicted durations are applied"""
+    dtype = enc_out.dtype
+    reps = durations.float() / pace
+    reps = (reps + 0.5).long()
+    dec_lens = reps.sum(dim=1)
+
+    max_len = dec_lens.max()
+    reps_cumsum = torch.cumsum(F.pad(reps, (1, 0, 0, 0), value=0.0), dim=1)[:, None, :]
+    reps_cumsum = reps_cumsum.to(dtype)
+
+    range_ = torch.arange(max_len, device=enc_out.device)[None, :, None]
+    mult = (reps_cumsum[:, :, :-1] <= range_) & (reps_cumsum[:, :, 1:] > range_)
+    mult = mult.to(dtype)
+    enc_rep = torch.matmul(mult, enc_out)
+
+    return enc_rep, dec_lens
+
+
+def expand_lengths_slow(x, durations):
+    # x: B x T x C, durations: B x T
+    out_lens = durations.sum(dim=1)
+    max_len = out_lens.max()
+    bsz, seq_len, dim = x.size()
+    out = x.new_zeros((bsz, max_len, dim))
+
+    for b in range(bsz):
+        indices = []
+        for t in range(seq_len):
+            indices.extend([t] * durations[b, t].item())
+        indices = torch.tensor(indices, dtype=torch.long).to(x.device)
+        out_len = out_lens[b].item()
+        out[b, :out_len] = x[b].index_select(0, indices)
+
+    return out, out_lens
+
+
+def trim_or_pad_to_target_length(data_1d_or_2d: np.ndarray, target_length: int) -> np.ndarray:
+    assert len(data_1d_or_2d.shape) in {1, 2}
+    delta = data_1d_or_2d.shape[0] - target_length
+    if delta >= 0:  # trim if being longer
+        data_1d_or_2d = data_1d_or_2d[:target_length]
+    else:  # pad if being shorter
+        if len(data_1d_or_2d.shape) == 1:
+            data_1d_or_2d = np.concatenate([data_1d_or_2d, np.zeros(-delta)], axis=0)
+        else:
+            data_1d_or_2d = np.concatenate([data_1d_or_2d, np.zeros((-delta, data_1d_or_2d.shape[1]))], axis=0)
+    return data_1d_or_2d
+
+
+def safe_log(x: torch.Tensor, clip_val: float = 1e-7) -> torch.Tensor:
+    """
+    Computes the element-wise logarithm of the input tensor with clipping to avoid near-zero values.
+
+    Args:
+        x (Tensor): Input tensor.
+        clip_val (float, optional): Minimum value to clip the input tensor. Defaults to 1e-7.
+
+    Returns:
+        Tensor: Element-wise logarithm of the input tensor with clipping applied.
+    """
+    return torch.log(torch.clip(x, min=float(clip_val)))
+
+
+def safe_log_numpy(x: np.ndarray, clip_val: float = 1e-8) -> np.ndarray:
+    return np.log(np.clip(x, clip_val, None))
+
+
+def symlog(x: torch.Tensor) -> torch.Tensor:
+    return torch.sign(x) * torch.log1p(x.abs())
+
+
+def symexp(x: torch.Tensor) -> torch.Tensor:
+    return torch.sign(x) * (torch.exp(x.abs()) - 1)
+
+
+def pad_list(xs, pad_value, max_len=None):
+    """Perform padding for the list of tensors.
+    Args:
+        xs (List): List of Tensors [(T_1, `*`), (T_2, `*`), ..., (T_B, `*`)].
+        pad_value (float): Value for padding.
+    Returns:
+        Tensor: Padded tensor (B, Tmax, `*`).
+    Examples:
+        >>> x = [torch.ones(4), torch.ones(2), torch.ones(1)]
+        >>> x
+        [tensor([1., 1., 1., 1.]), tensor([1., 1.]), tensor([1.])]
+        >>> pad_list(x, 0)
+        tensor([[1., 1., 1., 1.],
+                [1., 1., 0., 0.],
+                [1., 0., 0., 0.]])
+    """
+    n_batch = len(xs)
+    if max_len is None:
+        max_len = max(x.size(0) for x in xs)
+    pad = xs[0].new(n_batch, max_len, *xs[0].size()[1:]).fill_(pad_value)
+
+    for i in range(n_batch):
+        pad[i, : min(xs[i].size(0), max_len)] = xs[i][:max_len]
+
+    return pad
+
+
+def build_activation(act_func, inplace=True):
+    if act_func == "relu":
+        return nn.ReLU(inplace=inplace)
+    elif act_func == "relu6":
+        return nn.ReLU6(inplace=inplace)
+    elif act_func == "gelu":
+        return torch.nn.GELU()
+    elif act_func == "tanh":
+        return nn.Tanh()
+    elif act_func == "sigmoid":
+        return nn.Sigmoid()
+    elif act_func is None:
+        return None
+    else:
+        raise ValueError("do not support: %s" % act_func)
+
+
+def make_positions(tensor, padding_idx):
+    """Replace non-padding symbols with their position numbers.
+
+    Position numbers begin at padding_idx+1. Padding symbols are ignored.
+    """
+    # The series of casts and type-conversions here are carefully
+    # balanced to both work with ONNX export and XLA. In particular XLA
+    # prefers ints, cumsum defaults to output longs, and ONNX doesn't know
+    # how to handle the dtype kwarg in cumsum.
+    mask = tensor.ne(padding_idx).int()
+    return (torch.cumsum(mask, dim=1).type_as(mask) * mask).long() + padding_idx
+
+
+def softmax(x, dim):
+    return F.softmax(x, dim=dim, dtype=torch.float32)
+
+
+def _get_full_incremental_state_key(module_instance, key):
+    module_name = module_instance.__class__.__name__
+
+    # assign a unique ID to each module instance, so that incremental state is
+    # not shared across module instances
+    if not hasattr(module_instance, "_instance_id"):
+        INCREMENTAL_STATE_INSTANCE_ID[module_name] += 1
+        module_instance._instance_id = INCREMENTAL_STATE_INSTANCE_ID[module_name]
+
+    return f"{module_name}.{module_instance._instance_id}.{key}"
+
+
+def get_incremental_state(module, incremental_state, key):
+    """Helper for getting incremental state for an nn.Module."""
+    full_key = _get_full_incremental_state_key(module, key)
+    if incremental_state is None or full_key not in incremental_state:
+        return None
+    return incremental_state[full_key]
+
+
+def set_incremental_state(module, incremental_state, key, value):
+    """Helper for setting incremental state for an nn.Module."""
+    if incremental_state is not None:
+        full_key = _get_full_incremental_state_key(module, key)
+        incremental_state[full_key] = value

--- a/phoonnx_train/optispeech/utils/pylogger.py
+++ b/phoonnx_train/optispeech/utils/pylogger.py
@@ -1,0 +1,36 @@
+import logging
+
+from pytorch_lightning.utilities import rank_zero_only
+
+MESSAGE_FORMAT = "%(levelname)s %(asctime)s:  %(message)s"
+DATE_FORMAT = "%Y/%m/%d %H:%M:%S"
+LG_FORMATTER = logging.Formatter(MESSAGE_FORMAT, datefmt=DATE_FORMAT)
+
+
+def get_script_logger(name: str = __name__) -> logging.Logger:
+    logger = logging.getLogger(name)
+
+    stderr_h = logging.StreamHandler()
+    stderr_h.setFormatter(LG_FORMATTER)
+    stderr_h.setLevel(logging.INFO)
+    logger.addHandler(stderr_h)
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def get_pylogger(name: str = __name__) -> logging.Logger:
+    """Initializes a multi-GPU-friendly python command line logger.
+
+    :param name: The name of the logger, defaults to ``__name__``.
+
+    :return: A logger object.
+    """
+    logger = logging.getLogger(name)
+
+    # this ensures all logging levels get marked with the rank zero decorator
+    # otherwise logs would get multiplied for each GPU process in multi-GPU setup
+    logging_levels = ("debug", "info", "warning", "error", "exception", "fatal", "critical")
+    for level in logging_levels:
+        setattr(logger, level, rank_zero_only(getattr(logger, level)))
+
+    return logger

--- a/phoonnx_train/optispeech/utils/segments.py
+++ b/phoonnx_train/optispeech/utils/segments.py
@@ -1,0 +1,72 @@
+# Copyright 2021 Tomoki Hayashi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Function to get random segments."""
+
+from typing import Tuple
+
+import numpy as np
+import torch
+
+
+def get_random_segments(
+        x: torch.Tensor,
+        x_lengths: torch.Tensor,
+        segment_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Get random segments.
+
+    Args:
+        x (Tensor): Input tensor (B, C, T).
+        x_lengths (Tensor): Length tensor (B,).
+        segment_size (int): Segment size.
+
+    Returns:
+        Tensor: Segmented tensor (B, C, segment_size).
+        Tensor: Start index tensor (B,).
+
+    """
+    batches = x.shape[0]
+    max_start_idx = x_lengths - segment_size
+    max_start_idx[max_start_idx < 0] = 0
+    start_idxs = (torch.rand([batches]).to(x.device) * max_start_idx).to(
+        dtype=torch.long,
+    )
+    segments = get_segments(x, start_idxs, segment_size)
+
+    return segments, start_idxs
+
+
+def get_segments(
+        x: torch.Tensor,
+        start_idxs: torch.Tensor,
+        segment_size: int,
+) -> torch.Tensor:
+    """Get segments.
+
+    Args:
+        x (Tensor): Input tensor (B, C, T).
+        start_idxs (Tensor): Start index tensor (B,).
+        segment_size (int): Segment size.
+
+    Returns:
+        Tensor: Segmented tensor (B, C, segment_size).
+
+    """
+    b, c, _ = x.size()
+    segments = x.new_zeros(b, c, segment_size)
+    for i, start_idx in enumerate(start_idxs):
+        segments[i] = x[i, :, start_idx: start_idx + segment_size]
+    return segments
+
+
+def get_segments_numpy(
+        x: np.ndarray,
+        start_idxs: np.ndarray,
+        segment_size: int,
+) -> np.ndarray:
+    b, c, _ = x.shape
+    segments = np.zeros((b, c, segment_size), dtype=np.float32)
+    for i, start_idx in enumerate(start_idxs):
+        segments[i] = x[i, :, start_idx: start_idx + segment_size]
+    return segments

--- a/phoonnx_train/optispeech/values.py
+++ b/phoonnx_train/optispeech/values.py
@@ -1,0 +1,168 @@
+import dataclasses
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import numpy as np
+
+_TORCH_AVAILABLE = True
+try:
+    import torch
+    from torch.nn.utils.rnn import unpad_sequence as torch_unpad_sequence
+except ImportError:
+    _TORCH_AVAILABLE = False
+
+if _TORCH_AVAILABLE:
+    FloatArray: TypeAlias = torch.FloatTensor | np.ndarray[np.float32]
+    IntArray: TypeAlias = torch.LongTensor | np.ndarray[np.int64]
+else:
+    FloatArray: TypeAlias = np.ndarray[np.float32]
+    IntArray: TypeAlias = np.ndarray[np.int64]
+
+
+@dataclass
+class BaseValueContainer:
+
+    def as_tuple(self):
+        return dataclasses.astuple(self)
+
+    def as_dict(self):
+        return dataclasses.asdict(self)
+
+    def as_torch(self):
+        if not _TORCH_AVAILABLE:
+            raise RuntimeError("`torch` is not installed")
+        data = self.as_dict()
+        kwargs = {}
+        for name, value in self.as_dict().items():
+            if _TORCH_AVAILABLE and isinstance(value, np.ndarray) or isinstance(value, torch.Tensor):
+                kwargs[name] = torch.as_tensor(value)
+            else:
+                kwargs[name] = value
+        cls = type(self)
+        return cls(**kwargs)
+
+    def as_numpy(self):
+        kwargs = {}
+        for name, value in self.as_dict().items():
+            if _TORCH_AVAILABLE and isinstance(value, torch.Tensor):
+                kwargs[name] = value.detach().cpu().numpy()
+            elif isinstance(value, np.ndarray):
+                kwargs[name] = np.asarray(value)
+            else:
+                kwargs[name] = value
+        cls = type(self)
+        return cls(**kwargs)
+
+    def to(self, device: str):
+        if not _TORCH_AVAILABLE:
+            raise RuntimeError("`torch` is not installed")
+        kwargs = {}
+        for name, value in self.as_dict().items():
+            if isinstance(value, torch.Tensor):
+                kwargs[name] = value.to(device)
+            else:
+                kwargs[name] = value
+        cls = type(self)
+        return cls(**kwargs)
+
+
+@dataclass(kw_only=True)
+class InferenceInputs(BaseValueContainer):
+    clean_text: str
+    x: IntArray
+    x_lengths: IntArray
+    sids: IntArray | None = None
+    lids: IntArray | None = None
+    d_factor: float = 1.0
+    p_factor: float = 1.0
+    e_factor: float = 1.0
+
+    @classmethod
+    def from_ids_and_lengths(cls, ids: list[int], lengths: list[int], **kwargs) -> "Self":
+        x = numpy_pad_sequences(ids).astype(np.int64)
+        x_lengths = np.array(lengths, dtype=np.int64)
+        instance = cls(x=x, x_lengths=x_lengths, **kwargs)
+        return instance.as_numpy()
+
+
+@dataclass(kw_only=True)
+class InferenceOutputs(BaseValueContainer):
+    wav: FloatArray
+    wav_lengths: FloatArray
+    latency: int
+    rtf: float
+    durations: FloatArray | None = None
+    pitch: FloatArray | None = None
+    energy: FloatArray | None = None
+    am_rtf: float | None = None
+    v_rtf: float | None = None
+
+    def __iter__(self):
+        return iter(self.unbatched_wavs())
+
+    def unbatched_wavs(self) -> list[FloatArray]:
+        if isinstance(self.wav, np.ndarray):
+            return numpy_unpad_sequences(self.wav, self.wav_lengths)
+        elif _TORCH_AVAILABLE and isinstance(self.wav, torch.Tensor):
+            return torch_unpad_sequence(self.wav, self.wav_lengths, batch_first=True)
+        else:
+            raise RuntimeError("Unsupported operation")
+
+
+def numpy_pad_sequences(sequences, maxlen=None, value=0):
+    """Pads a list of sequences to the same length using broadcasting.
+
+    Args:
+      sequences: A list of Python lists with variable lengths.
+      maxlen: The maximum length to pad the sequences to. If not specified,
+        the maximum length of all sequences in the list will be used.
+      value: The value to use for padding (default 0).
+
+    Returns:
+      A numpy array with shape [batch_size, maxlen] where the sequences are padded
+      with the specified value.
+    """
+
+    # Get the maximum length if not specified
+    if maxlen is None:
+        maxlen = max(len(seq) for seq in sequences)
+
+    # Create a numpy array with the specified value and broadcast
+    padded_seqs = np.full((len(sequences), maxlen), value)
+    for i, seq in enumerate(sequences):
+        padded_seqs[i, : len(seq)] = seq
+
+    return padded_seqs
+
+
+def numpy_unpad_sequences(sequences, lengths):
+    """Unpads a list of sequences based on a list of lengths.
+
+    Args:
+      sequences: A numpy array with shape [batch_size, feature_dim, max_len].
+      lengths: A numpy array with shape [batch_size] representing the lengths
+        of each sequence in the batch.
+
+    Returns:
+      A list of unpadded sequences. The i-th element of the list corresponds
+      to the i-th sequence in the batch. Each sequence is a numpy array with
+      variable length.
+    """
+
+    # Check if lengths argument is a list or 1D numpy array
+    if not isinstance(lengths, np.ndarray) or len(lengths.shape) != 1:
+        raise ValueError("lengths must be a 1D numpy array")
+
+    # Check if sequence lengths are within bounds
+    if np.any(lengths < 0) or np.any(lengths > sequences.shape[-1]):
+        raise ValueError("lengths must be between 0 and max_len")
+
+    # Get the batch size
+    batch_size = sequences.shape[0]
+
+    # Extract unpadded sequences
+    unpadded_seqs = []
+    for i in range(batch_size):
+        unpadded_seqs.append(sequences[i, : lengths[i]])
+
+    return unpadded_seqs

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -205,7 +205,11 @@ def main(
         **training_engine.trainer_kwargs(),
     )
     _LOGGER.info("Training started!")
-    trainer.fit(model, ckpt_path=fit_ckpt_path)
+    # torch>=2.6 defaults torch.load(weights_only=True), which rejects our own
+    # pickled Lightning checkpoints on ckpt_path resume.
+    from phoonnx_train.torch_compat import trusting_torch_load
+    with trusting_torch_load():
+        trainer.fit(model, ckpt_path=fit_ckpt_path)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ train-mixer = [
 # and are off by default, so they add no deps here.
 train-optispeech = [
     "pyworld>=0.3.2",
+    "pyloudnorm",
     "scipy",
     "torchaudio",
     "onnx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,19 @@ train-fastpitch = [
 train-mixer = [
     "pyworld>=0.3.2",
 ]
+# extra deps for the OptiSpeech training engine
+# (phoonnx_train/optispeech/ + phoonnx_train/engines/optispeech.py) on top of
+# [train]: pyworld for the DIO/Harvest F0 pitch extractor, scipy for pitch
+# interpolation, torchaudio for the vocoder-discriminator resampling / STFT
+# losses, and onnx to embed the inference metadata into the exported model.
+# The perceptual validation metrics (UTMOS / PESQ / periodicity) stay optional
+# and are off by default, so they add no deps here.
+train-optispeech = [
+    "pyworld>=0.3.2",
+    "scipy",
+    "torchaudio",
+    "onnx",
+]
 ar = ["epitran", "arbtok", "text2tashkeel"]
 ca = ["epitran"]
 gl = ["pycotovia>=0.1.0"]

--- a/tests/test_optispeech_training.py
+++ b/tests/test_optispeech_training.py
@@ -1,0 +1,335 @@
+"""Tests for the OptiSpeech training engine (phoonnx_train.engines.optispeech).
+
+These exercise real torch on tiny CPU-sized models: registration + preset
+consumption, model construction, a training step with an optimizer update,
+checkpoint save/load/resume (optimizer + scheduler + epoch round-trip),
+warm-starting from a partial checkpoint, and ONNX export that the phoonnx
+OptiSpeech inference adapter accepts.
+"""
+import logging
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
+import pytorch_lightning as pl
+
+from phoonnx_train.engines import get_engine, list_engines
+from phoonnx_train.engines.base import TrainingEngineConfig
+from phoonnx_train.engines.optispeech import (
+    OptiSpeechEngineConfig,
+    OptiSpeechTrainingEngine,
+    _QUALITY_PRESETS,
+)
+
+HOP = 256
+NFEATS = 40
+TMEL = 24
+TTEXT = 8
+
+
+def _tiny_extra(**over):
+    extra = {
+        "quality": "x-low",
+        "dim": 32,
+        "n_feats": NFEATS,
+        "hop_length": HOP,
+        "n_fft": 256,
+        "win_length": 256,
+        "encoder_intermediate_dim": 48,
+        "decoder_intermediate_dim": 48,
+        "encoder_num_layers": 2,
+        "decoder_num_layers": 2,
+        "vocoder_dim": 32,
+        "vocoder_intermediate_dim": 48,
+        "vocoder_num_layers": 2,
+        "duration_intermediate_dim": 32,
+        "pitch_intermediate_dim": 32,
+        "energy_intermediate_dim": 32,
+        "pitch_num_layers": 2,
+        "segment_size": 8,
+        "batch_size": 2,
+        "warmup_steps": 1,
+    }
+    extra.update(over)
+    return extra
+
+
+def _tiny_config(**over):
+    return TrainingEngineConfig(
+        num_symbols=40, num_speakers=1, sample_rate=22050, extra=_tiny_extra(**over)
+    )
+
+
+class _TinyDataset(Dataset):
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, idx):
+        return idx
+
+
+def _collate(batch):
+    b = len(batch)
+    return {
+        "x": torch.randint(1, 40, (b, TTEXT)),
+        "x_lengths": torch.tensor([TTEXT] * b),
+        "mel": torch.randn(b, NFEATS, TMEL),
+        "mel_lengths": torch.tensor([TMEL] * b),
+        "pitches": torch.randn(b, TMEL),
+        "energies": torch.randn(b, TMEL),
+        "sids": None,
+        "lids": None,
+        "wav": np.random.randn(b, TMEL * HOP).astype(np.float32),
+    }
+
+
+def _tiny_trainer(max_steps):
+    return pl.Trainer(
+        max_steps=max_steps,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+
+def _dim_of(model):
+    return model.generator.text_embedding.embed_tokens.embedding_dim
+
+
+class RegistrationTests(unittest.TestCase):
+    def test_registered(self):
+        self.assertIn("optispeech", list_engines())
+        self.assertIsInstance(get_engine("optispeech"), OptiSpeechTrainingEngine)
+
+    def test_quality_presets_exposed(self):
+        presets = get_engine("optispeech").quality_presets()
+        self.assertEqual({"x-low", "medium", "high"}, set(presets))
+
+
+class ConfigTests(unittest.TestCase):
+    def test_presets_change_constructed_model_dims(self):
+        eng = get_engine("optispeech")
+        low = eng.create_model(
+            TrainingEngineConfig(num_symbols=40, extra={"quality": "x-low", **_min()}), []
+        )
+        high = eng.create_model(
+            TrainingEngineConfig(num_symbols=40, extra={"quality": "high", **_min()}), []
+        )
+        # The preset drives the acoustic-model hidden width, so the two models
+        # differ structurally, not just in weights.
+        self.assertEqual(_dim_of(low), _QUALITY_PRESETS["x-low"]["dim"])
+        self.assertEqual(_dim_of(high), _QUALITY_PRESETS["high"]["dim"])
+        self.assertNotEqual(_dim_of(low), _dim_of(high))
+        self.assertLess(
+            sum(p.numel() for p in low.parameters()),
+            sum(p.numel() for p in high.parameters()),
+        )
+
+    def test_unknown_quality_falls_back_to_medium(self):
+        cfg = OptiSpeechEngineConfig.from_training_config(
+            TrainingEngineConfig(num_symbols=40, extra={"quality": "nonsense"})
+        )
+        self.assertEqual(cfg.dim, _QUALITY_PRESETS["medium"]["dim"])
+
+    def test_from_training_config_maps_shared_fields(self):
+        cfg = OptiSpeechEngineConfig.from_training_config(
+            TrainingEngineConfig(num_symbols=99, num_speakers=3, sample_rate=16000)
+        )
+        self.assertEqual(cfg.num_symbols, 99)
+        self.assertEqual(cfg.num_speakers, 3)
+        self.assertEqual(cfg.sample_rate, 16000)
+
+    def test_presets_not_mutated(self):
+        before = {k: dict(v) for k, v in _QUALITY_PRESETS.items()}
+        OptiSpeechEngineConfig.from_training_config(
+            TrainingEngineConfig(num_symbols=40, extra={"quality": "x-low", "dim": 999})
+        )
+        self.assertEqual(before, _QUALITY_PRESETS)
+
+
+class ConstructionTests(unittest.TestCase):
+    def test_tiny_model_builds(self):
+        model = get_engine("optispeech").create_model(_tiny_config(), [])
+        self.assertEqual(_dim_of(model), 32)
+        self.assertGreater(sum(p.numel() for p in model.parameters()), 0)
+        self.assertFalse(model.automatic_optimization)
+
+    def test_generator_forward_loss_finite(self):
+        model = get_engine("optispeech").create_model(_tiny_config(), [])
+        batch = _collate([0, 1])
+        out = model.generator(
+            x=batch["x"],
+            x_lengths=batch["x_lengths"],
+            mel=batch["mel"],
+            mel_lengths=batch["mel_lengths"],
+            pitches=batch["pitches"],
+            energies=batch["energies"],
+            sids=None,
+            lids=None,
+        )
+        self.assertTrue(torch.isfinite(out["loss"]).item())
+
+
+class TrainingStepTests(unittest.TestCase):
+    def test_training_step_updates_weights(self):
+        model = get_engine("optispeech").create_model(_tiny_config(), [])
+        before = {k: v.detach().clone() for k, v in model.generator.named_parameters()}
+        dl = DataLoader(_TinyDataset(), batch_size=2, collate_fn=_collate)
+        _tiny_trainer(max_steps=4).fit(model, dl)
+        # An optimizer step ran: the generator weights moved measurably.
+        total_delta = sum(
+            (v.detach() - before[k]).abs().sum().item()
+            for k, v in model.generator.named_parameters()
+        )
+        self.assertGreater(total_delta, 0.0)
+
+
+class CheckpointTests(unittest.TestCase):
+    def test_checkpoint_carries_optimizer_scheduler_epoch(self):
+        eng = get_engine("optispeech")
+        model = eng.create_model(_tiny_config(), [])
+        dl = DataLoader(_TinyDataset(), batch_size=2, collate_fn=_collate)
+        trainer = _tiny_trainer(max_steps=2)
+        trainer.fit(model, dl)
+        with tempfile.TemporaryDirectory() as td:
+            ckpt = Path(td) / "last.ckpt"
+            trainer.save_checkpoint(str(ckpt))
+            raw = torch.load(str(ckpt), map_location="cpu", weights_only=False)
+            # HARD rule: resumable + finetunable -> optimizer + scheduler + epoch.
+            self.assertIn("optimizer_states", raw)
+            self.assertEqual(len(raw["optimizer_states"]), 2)
+            self.assertIn("lr_schedulers", raw)
+            self.assertEqual(len(raw["lr_schedulers"]), 2)
+            self.assertIn("epoch", raw)
+            self.assertIn("global_step", raw)
+
+            # Full module rebuilds from the checkpoint's hyperparameters.
+            reloaded = eng.load_lightning_module(ckpt)
+            self.assertEqual(_dim_of(reloaded), _dim_of(model))
+
+    def test_resume_continues_from_checkpoint(self):
+        eng = get_engine("optispeech")
+        model = eng.create_model(_tiny_config(), [])
+        dl = DataLoader(_TinyDataset(), batch_size=2, collate_fn=_collate)
+        trainer = _tiny_trainer(max_steps=2)
+        trainer.fit(model, dl)
+        self.assertEqual(trainer.global_step, 2)
+        with tempfile.TemporaryDirectory() as td:
+            ckpt = Path(td) / "last.ckpt"
+            trainer.save_checkpoint(str(ckpt))
+            resumed = _tiny_trainer(max_steps=4)
+            resumed.fit(model, dl, ckpt_path=str(ckpt))
+            # Optimizer + scheduler state restored; training continued past the
+            # saved step rather than restarting.
+            self.assertEqual(resumed.global_step, 4)
+
+    def test_warm_start_partial_checkpoint(self):
+        eng = get_engine("optispeech")
+        donor = eng.create_model(_tiny_config(), [])
+        # Build a *partial* state dict (every other tensor) with recognisable
+        # values so we can prove the matching keys are actually loaded.
+        donor_state = donor.state_dict()
+        partial = {}
+        for i, (k, v) in enumerate(donor_state.items()):
+            if i % 2 == 0:
+                partial[k] = torch.full_like(v, 0.0) if v.dtype.is_floating_point else v
+        # A key the target model does not have -> must be reported as skipped.
+        partial["not_a_real_module.weight"] = torch.zeros(3)
+
+        target = eng.create_model(_tiny_config(), [])
+        with tempfile.TemporaryDirectory() as td:
+            ckpt = Path(td) / "partial.ckpt"
+            torch.save({"state_dict": partial}, str(ckpt))
+            with self.assertLogs(
+                "phoonnx_train.engines.optispeech", level="INFO"
+            ) as cm:
+                eng.load_checkpoint(target, ckpt)
+            joined = "\n".join(cm.output)
+            self.assertIn("warm-start", joined)
+            self.assertIn("skipped", joined)
+
+        # A float tensor present in the partial checkpoint was overwritten...
+        float_key = next(
+            k for k, v in partial.items() if v.dtype.is_floating_point
+        )
+        self.assertTrue(
+            torch.equal(target.state_dict()[float_key], partial[float_key])
+        )
+        # ...while a key absent from the partial kept its freshly-initialised value.
+        missing_key = next(k for k in donor_state if k not in partial)
+        self.assertIn(missing_key, target.state_dict())
+
+
+class ExportTests(unittest.TestCase):
+    def test_export_onnx_loads_in_adapter(self):
+        import onnxruntime as ort
+
+        from phoonnx.engines.optispeech import OptiSpeechAdapter
+
+        eng = get_engine("optispeech")
+        model = eng.create_model(_tiny_config(), [])
+        dl = DataLoader(_TinyDataset(), batch_size=2, collate_fn=_collate)
+        trainer = _tiny_trainer(max_steps=2)
+        trainer.fit(model, dl)
+        with tempfile.TemporaryDirectory() as td:
+            ckpt = Path(td) / "last.ckpt"
+            trainer.save_checkpoint(str(ckpt))
+            onnx_path = eng.export_onnx(ckpt, None, Path(td) / "onnx")
+            self.assertTrue(onnx_path.exists())
+
+            sess = ort.InferenceSession(str(onnx_path))
+            input_names = {i.name for i in sess.get_inputs()}
+            output_names = {o.name for o in sess.get_outputs()}
+            self.assertIn("x", input_names)
+            self.assertIn("x_lengths", input_names)
+            self.assertIn("scales", input_names)
+            self.assertEqual(
+                {"wav", "wav_lengths", "durations"}, output_names
+            )
+
+            adapter = OptiSpeechAdapter()
+            self.assertTrue(adapter.detect(session=sess))
+            meta = adapter.parse_onnx_meta(sess)
+            self.assertIn("text_processor", meta)
+            self.assertIn("input_symbols", meta)
+
+            # The adapter builds a feed dict from its request and the model runs.
+            from phoonnx.engines.base import AdapterSynthesisRequest
+
+            req = AdapterSynthesisRequest(
+                phoneme_ids=np.array([[1, 2, 3, 4, 5]], dtype=np.int64),
+                phoneme_lengths=np.array([5], dtype=np.int64),
+                params={"d_factor": 1.0, "p_factor": 1.0, "e_factor": 1.0},
+            )
+            feed = adapter.build_feed_dict(req, sess)
+            outputs = sess.run(None, feed)
+            self.assertEqual(len(outputs), 3)
+
+
+def _min():
+    """Minimal preset-independent overrides so `high` stays CPU-cheap."""
+    return {
+        "n_feats": NFEATS,
+        "hop_length": HOP,
+        "n_fft": 256,
+        "win_length": 256,
+        "segment_size": 8,
+        "encoder_num_layers": 1,
+        "decoder_num_layers": 1,
+        "vocoder_num_layers": 1,
+        "encoder_intermediate_dim": 32,
+        "decoder_intermediate_dim": 32,
+        "vocoder_intermediate_dim": 32,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_optispeech_training.py
+++ b/tests/test_optispeech_training.py
@@ -23,6 +23,7 @@ from phoonnx_train.engines.optispeech import (
     OptiSpeechTrainingEngine,
     _QUALITY_PRESETS,
 )
+from phoonnx_train.torch_compat import trusting_torch_load
 
 HOP = 256
 NFEATS = 40
@@ -226,7 +227,10 @@ class CheckpointTests(unittest.TestCase):
             ckpt = Path(td) / "last.ckpt"
             trainer.save_checkpoint(str(ckpt))
             resumed = _tiny_trainer(max_steps=4)
-            resumed.fit(model, dl, ckpt_path=str(ckpt))
+            # torch>=2.6 defaults weights_only=True; Lightning's own ckpt_path
+            # load must trust our checkpoint's pickled config objects.
+            with trusting_torch_load():
+                resumed.fit(model, dl, ckpt_path=str(ckpt))
             # Optimizer + scheduler state restored; training continued past the
             # saved step rather than restarting.
             self.assertEqual(resumed.global_step, 4)


### PR DESCRIPTION
## OptiSpeech training engine

Adds a full OptiSpeech training engine to `phoonnx_train`, alongside the
existing inference adapter (`phoonnx/engines/optispeech.py`).

OptiSpeech is a non-autoregressive, FastSpeech2-style acoustic model with a
GAN-trained WaveNeXt vocoder, exported as a single ONNX file whose waveform
comes straight out.

### What landed

- **Vendored, de-Hydra'd model tree** under `phoonnx_train/optispeech/`:
  generator (ConvNeXt encoder/decoder, duration/pitch/energy predictors,
  ForwardSum + Viterbi alignment, Gaussian upsampling), WaveNeXt vocoder,
  multi-period / multi-resolution discriminators, losses, text processing and
  feature extractors. Every Hydra/omegaconf import and `instantiate` call is
  removed — the model is built with plain Python, and the config namespaces
  become explicit dataclasses.
- **`phoonnx_train/engines/optispeech.py`**, following the matcha engine
  pattern: `OptiSpeechEngineConfig.from_training_config()` maps the shared
  training config + quality preset to explicit constructor kwargs; `create_model`
  assembles the vendored modules through `functools.partial` factories.
- **Functional quality presets** (`x-low` / `medium` / `high`) that change the
  constructed model's hidden width, encoder/decoder depth and vocoder size.
- **Resumable + finetunable checkpoints**: the LightningModule uses manual
  optimization (generator + discriminator) with cosine-warmup schedules;
  checkpoints carry optimizer state, scheduler state and epoch, and resume via
  `Trainer(ckpt_path=...)`. `load_checkpoint` warm-starts from a partial
  checkpoint by mapping matching tensors by name+shape, logging matched/skipped
  keys.
- **ONNX export** producing the `x` / `x_lengths` / `scales` -> `wav` /
  `wav_lengths` / `durations` contract with embedded `inference` metadata that
  the existing `OptiSpeechAdapter` loads.
- Registration in the engine registry, a `train-optispeech` pyproject extra
  (pyworld / scipy / torchaudio / onnx), CI wiring in build-tests and coverage,
  and a Training section in `docs/training/engines/optispeech.md`.

### Supersedes #112's approach

#112 vendored the same model tree but required an external Hydra YAML that was
never vendored, so the model could not be constructed. This engine replaces
Hydra `compose`/`instantiate` with explicit Python construction — presets and
dataclasses fully determine the model with no config files — and does not
regress dev's current `train.py` / `base.py`. The compiled `monotonic_align`
artifacts, tashkeel assets and `TRAINING.md` from that branch are not carried
over; the empty `silero_vad.onnx` placeholder is dropped in favour of a clear
error when silence trimming is enabled without a model.

### Test plan

`tests/test_optispeech_training.py` (real torch, tiny CPU models, no skips):

- engine registration + preset exposure
- presets consumed: `x-low` vs `high` build structurally different models
- tiny-config construction and a finite generator forward loss
- a training step runs and moves the generator weights
- checkpoint save/load/resume: optimizer + scheduler + epoch round-trip, and a
  resumed run continues past the saved step
- warm-start from a partial checkpoint: matching keys loaded, skipped keys logged
- ONNX export loads in onnxruntime and the phoonnx OptiSpeech adapter accepts
  its input/output names and runs a session

All 13 pass. Full suite: no new failures — the 16 remaining failures are the
known pre-existing styletts2 (transformers env) and matcha-golden cases.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OptiSpeech as a supported training engine with quality presets, checkpoint resumption, warm-starting, and ONNX export.
  * Added OptiSpeech text processing, audio preprocessing, pitch extraction, dataset handling, and vocoder support.
  * Added streaming audio generation capabilities.
* **Documentation**
  * Added comprehensive OptiSpeech training and export guidance.
* **Tests**
  * Added coverage for registration, training, checkpointing, resumption, and ONNX export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->