### PR TITLE
fix: matcha training pre-flight hardening

### DIFF
--- a/phoonnx_train/engines/matcha.py
+++ b/phoonnx_train/engines/matcha.py
@@ -278,9 +278,15 @@ class MatchaTrainingEngine(BaseTrainingEngine):
 
         n_timesteps = kwargs.get("n_timesteps", 5)
 
+        from phoonnx_train.torch_compat import trusting_torch_load
+
         _LOG.info("Loading Matcha checkpoint from %s", checkpoint_path)
-        # hyperparameters include SimpleNamespace config objects
-        with torch.serialization.safe_globals([SimpleNamespace]):
+        # hyper_parameters include SimpleNamespace config objects, so the
+        # checkpoint cannot be unpickled under weights_only=True. Loading a
+        # local training checkpoint is trusted; force weights_only=False in a
+        # version-portable way that does not rely on torch>=2.4 allowlisting
+        # APIs (this project supports torch>=2.1).
+        with trusting_torch_load():
             matcha = MatchaTTS.load_from_checkpoint(checkpoint_path, map_location="cpu")
         matcha.eval()
 
@@ -356,8 +362,12 @@ class MatchaTrainingEngine(BaseTrainingEngine):
         """Load Matcha weights, tolerating vocab/speaker-count mismatches."""
         import torch
 
-        with torch.serialization.safe_globals([SimpleNamespace]):
-            ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+        from phoonnx_train.torch_compat import trusting_torch_load
+
+        # weights_only=True rejects the SimpleNamespace config objects stored in
+        # the checkpoint hyper_parameters; a local checkpoint is trusted.
+        with trusting_torch_load():
+            ckpt = torch.load(checkpoint_path, map_location="cpu")
         state_dict = ckpt.get("state_dict", ckpt)
         model_state = model.state_dict()
         filtered = {

--- a/phoonnx_train/matcha/lightning.py
+++ b/phoonnx_train/matcha/lightning.py
@@ -253,7 +253,10 @@ class MatchaTTS(pl.LightningModule):  # 🍵
             y = y_cut
             y_mask = y_cut_mask
 
-        mu_y = torch.matmul(attn.squeeze(1).transpose(1, 2), mu_x.transpose(1, 2))
+        # attn is [b, t_text, t_mel]; a bare ``.squeeze(1)`` collapses the text
+        # axis for single-phoneme utterances (t_text == 1) and crashes the
+        # matmul. Transpose the last two axes directly instead.
+        mu_y = torch.matmul(attn.transpose(1, 2), mu_x.transpose(1, 2))
         mu_y = mu_y.transpose(1, 2)
 
         diff_loss, _ = self.decoder.compute_loss(x1=y, mask=y_mask, mu=mu_y, spks=spks, cond=cond)

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -156,13 +156,26 @@ def main(
     # ------------------------------------------------------------------
     # Resume from checkpoint (engine-specific logic)
     # ------------------------------------------------------------------
-    if resume_from_checkpoint:
+    # A plain --resume-from-checkpoint (same architecture, not discarding the
+    # encoder) is a *true resume*: optimizer state, LR scheduler, epoch and
+    # global_step must all continue from the checkpoint, otherwise Adam's
+    # moment estimates are lost, the epoch counter restarts and max_epochs is
+    # miscounted. Lightning only restores those when the checkpoint is handed to
+    # Trainer.fit(ckpt_path=...); a manual state_dict load copies weights only.
+    # The --discard-encoder and single-speaker paths intentionally change the
+    # architecture, so they stay weight-only warm starts (fit_ckpt_path=None).
+    fit_ckpt_path: Optional[str] = None
+    if resume_from_checkpoint and not discard_encoder:
+        fit_ckpt_path = resume_from_checkpoint
+        _LOGGER.info("Resuming full training state from checkpoint: %s",
+                     resume_from_checkpoint)
+    elif resume_from_checkpoint:
         training_engine.load_checkpoint(
             model,
             Path(resume_from_checkpoint),
             discard_encoder=discard_encoder,
         )
-        _LOGGER.info("Loaded checkpoint: %s", resume_from_checkpoint)
+        _LOGGER.info("Warm-started weights from checkpoint: %s", resume_from_checkpoint)
 
     if resume_from_single_speaker_checkpoint:
         training_engine.load_checkpoint(
@@ -192,7 +205,7 @@ def main(
         **training_engine.trainer_kwargs(),
     )
     _LOGGER.info("Training started!")
-    trainer.fit(model)
+    trainer.fit(model, ckpt_path=fit_ckpt_path)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,10 @@ matcha = [
     "scipy",
 ]
 train = [
-    "diffusers>=0.25.0",
+    # diffusers>=0.36 references torch.xpu at import time, which only exists on
+    # torch>=2.4; capping keeps the vendored matcha decoder importable across
+    # the whole supported torch>=2.1 range.
+    "diffusers>=0.25.0,<0.36",
     "einops",
     "huggingface_hub",
     "librosa>=0.9.2,<1",

--- a/tests/test_matcha_training_preflight.py
+++ b/tests/test_matcha_training_preflight.py
@@ -1,0 +1,302 @@
+"""Pre-flight regression tests for the Matcha-TTS training path.
+
+These guard the failure modes that would silently waste an expensive real
+training run: mel front-end parameter drift between preprocessing and
+training-time feature extraction, NaN/instability on degenerate batches,
+padded frames leaking into the losses, unresumable checkpoints (optimizer /
+epoch not restored), and a checkpoint loader that crashes on torch < 2.4.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+# diffusers>=0.36 references torch.xpu at import, which does not exist on
+# torch<2.4; the vendored matcha decoder imports diffusers, so skip the model
+# tests cleanly when the installed pair is incompatible rather than erroring.
+try:
+    from phoonnx_train.matcha import MatchaTTS  # noqa: F401
+    _MATCHA_IMPORTABLE = True
+except Exception as exc:  # pragma: no cover - environment dependent
+    _MATCHA_IMPORTABLE = False
+    _MATCHA_IMPORT_ERR = exc
+
+requires_matcha = pytest.mark.skipif(
+    not _MATCHA_IMPORTABLE,
+    reason=f"matcha model not importable: {_MATCHA_IMPORT_ERR if not _MATCHA_IMPORTABLE else ''}",
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Mel/audio parameter consistency
+# ---------------------------------------------------------------------------
+
+def test_mel_frontend_matches_norm_audio_defaults():
+    """The mel front-end Matcha trains on must use the same STFT geometry the
+    preprocess step cached the normalized audio / spectrogram with; a mismatch
+    trains and infers in different feature spaces."""
+    from phoonnx_train.matcha import dataset as mds
+    import inspect
+    from phoonnx_train.norm_audio import cache_norm_audio
+
+    sig = inspect.signature(cache_norm_audio)
+    assert mds.N_FFT == sig.parameters["filter_length"].default == 1024
+    assert mds.HOP_LENGTH == sig.parameters["hop_length"].default == 256
+    assert mds.WIN_LENGTH == sig.parameters["window_length"].default == 1024
+
+
+def test_mel_fmax_within_nyquist_for_default_sample_rate():
+    """fmax must not exceed Nyquist for the training sample rate."""
+    from phoonnx_train.matcha import dataset as mds
+    # default matcha training sample rate is 22050 -> Nyquist 11025
+    assert 0 <= mds.F_MIN < mds.F_MAX <= 22050 // 2
+
+
+# ---------------------------------------------------------------------------
+# Tiny model factory
+# ---------------------------------------------------------------------------
+
+def _tiny_model(n_vocab=20, n_feats=80, n_spks=1):
+    from phoonnx_train.engines.matcha import (
+        MatchaEngineConfig,
+        _build_model_kwargs,
+    )
+    from phoonnx_train.matcha import MatchaTTS
+
+    mcfg = MatchaEngineConfig(
+        n_vocab=n_vocab,
+        n_feats=n_feats,
+        n_spks=n_spks,
+        encoder_channels=64,
+        encoder_filter_channels=128,
+        encoder_filter_channels_dp=64,
+        encoder_n_heads=2,
+        encoder_n_layers=2,
+        decoder_channels=[64, 64],
+        decoder_num_heads=2,
+        decoder_num_mid_blocks=1,
+    )
+    model = MatchaTTS(
+        **_build_model_kwargs(mcfg),
+        data_statistics={"mel_mean": -3.0, "mel_std": 1.5},
+    )
+    model.eval()
+    return model
+
+
+def _batch(text_len, mel_len, n_feats=80, n_vocab=20, seed=0):
+    from phoonnx_train.matcha.utils import fix_len_compatibility
+
+    g = torch.Generator().manual_seed(seed)
+    y_max = fix_len_compatibility(mel_len)
+    x = torch.zeros(1, text_len, dtype=torch.long)
+    x[0, :text_len] = torch.randint(1, n_vocab, (text_len,), generator=g)
+    y = torch.zeros(1, n_feats, y_max)
+    y[0, :, :mel_len] = torch.randn(n_feats, mel_len, generator=g)
+    return {
+        "x": x,
+        "x_lengths": torch.LongTensor([text_len]),
+        "y": y,
+        "y_lengths": torch.LongTensor([mel_len]),
+        "spks": None,
+        "durations": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. NaN / instability on adversarial batches
+# ---------------------------------------------------------------------------
+
+@requires_matcha
+@pytest.mark.parametrize("text_len,mel_len", [(1, 4), (2, 4), (3, 8), (1, 1)])
+def test_losses_finite_on_short_and_degenerate_batches(text_len, mel_len):
+    """1-frame / single-phoneme clips must not produce NaN/Inf losses
+    (log-of-zero, div-by-zero in the duration/prior/diff paths)."""
+    model = _tiny_model()
+    torch.manual_seed(0)
+    batch = _batch(text_len, mel_len)
+    losses = model.get_losses(batch)
+    for name, loss in losses.items():
+        assert torch.isfinite(loss).all(), f"{name} is not finite: {loss}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Padded frames must be masked out of the losses
+# ---------------------------------------------------------------------------
+
+@requires_matcha
+def test_padding_does_not_change_prior_and_duration_loss():
+    """Appending zero-padded mel frames (with y_lengths unchanged) must not
+    change the deterministic (prior/duration) losses — proof padded frames are
+    masked out. If collate padding leaked into the loss, this diverges."""
+    model = _tiny_model()
+    from phoonnx_train.matcha.utils import fix_len_compatibility
+
+    text_len, mel_len, n_feats = 5, 12, 80
+    g = torch.Generator().manual_seed(3)
+    x = torch.randint(1, 20, (1, text_len), generator=g)
+    mel = torch.randn(n_feats, mel_len, generator=g)
+
+    def prior_dur(y_pad_to):
+        y = torch.zeros(1, n_feats, y_pad_to)
+        y[0, :, :mel_len] = mel
+        batch = {
+            "x": x, "x_lengths": torch.LongTensor([text_len]),
+            "y": y, "y_lengths": torch.LongTensor([mel_len]),
+            "spks": None, "durations": None,
+        }
+        with torch.no_grad():
+            dur, prior, _, _ = model(
+                x=batch["x"], x_lengths=batch["x_lengths"],
+                y=batch["y"], y_lengths=batch["y_lengths"], out_size=None,
+            )
+        return dur, prior
+
+    tight = fix_len_compatibility(mel_len)
+    dur_a, prior_a = prior_dur(tight)
+    dur_b, prior_b = prior_dur(tight + 16)  # extra padded frames
+    assert torch.allclose(prior_a, prior_b, atol=1e-5), (prior_a, prior_b)
+    assert torch.allclose(dur_a, dur_b, atol=1e-5), (dur_a, dur_b)
+
+
+# ---------------------------------------------------------------------------
+# 5. Checkpoint loader must not depend on torch>=2.4 APIs
+# ---------------------------------------------------------------------------
+
+@requires_matcha
+def test_load_checkpoint_is_torch_version_portable(tmp_path):
+    """load_checkpoint must round-trip a Matcha checkpoint without touching
+    torch.serialization.safe_globals (absent on torch<2.4) and tolerate the
+    SimpleNamespace config objects stored in hyper_parameters."""
+    from phoonnx_train.engines.matcha import MatchaTrainingEngine
+
+    model = _tiny_model()
+    ckpt_path = tmp_path / "m.ckpt"
+    # a lightning-style checkpoint carries a state_dict plus non-tensor hparams
+    torch.save({"state_dict": model.state_dict(),
+                "epoch": 7, "global_step": 42}, ckpt_path)
+
+    fresh = _tiny_model()
+    engine = MatchaTrainingEngine()
+    # must not raise AttributeError on torch<2.4
+    engine.load_checkpoint(fresh, ckpt_path)
+    # weights actually copied
+    for k, v in model.state_dict().items():
+        assert torch.equal(v, fresh.state_dict()[k]), k
+
+
+def test_matcha_engine_source_has_no_safe_globals_reference():
+    """Regression: torch.serialization.safe_globals does not exist on the
+    project's supported torch floor (>=2.1); the engine must not reference it."""
+    src = Path(__file__).resolve().parents[1] / "phoonnx_train" / "engines" / "matcha.py"
+    assert "safe_globals" not in src.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 3. Resume must restore optimizer / epoch / global_step (via ckpt_path)
+# ---------------------------------------------------------------------------
+
+def test_plain_resume_passes_ckpt_path_to_fit(tmp_path, monkeypatch):
+    """A plain --resume-from-checkpoint must hand the checkpoint to
+    Trainer.fit(ckpt_path=...) so Lightning restores optimizer state, epoch and
+    global_step. A weight-only manual load would silently reset them."""
+    import json
+    from click.testing import CliRunner
+    import phoonnx_train.train as train_mod
+
+    captured = {}
+
+    class FakeTrainer:
+        def __init__(self, *a, **k):
+            pass
+
+        def fit(self, model, ckpt_path=None):
+            captured["ckpt_path"] = ckpt_path
+
+    class FakeEngine:
+        def quality_presets(self):
+            return {"medium": {}}
+
+        def create_model(self, config, dataset_paths):
+            return object()
+
+        def trainer_kwargs(self):
+            return {}
+
+        def load_checkpoint(self, *a, **k):
+            captured["manual_load"] = True
+
+    monkeypatch.setattr(train_mod, "Trainer", FakeTrainer)
+    monkeypatch.setattr(train_mod, "get_engine", lambda name: FakeEngine())
+    monkeypatch.setattr(train_mod, "list_engines", lambda: ["matcha"])
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "config.json").write_text(json.dumps(
+        {"num_symbols": 30, "num_speakers": 1, "audio": {"sample_rate": 22050}}))
+    ckpt = tmp_path / "prev.ckpt"
+    ckpt.write_bytes(b"x")
+
+    runner = CliRunner()
+    result = runner.invoke(train_mod.main, [
+        "--dataset-dir", str(ds), "--engine", "matcha",
+        "--max-epochs", "1", "--resume-from-checkpoint", str(ckpt),
+    ])
+    assert result.exit_code == 0, result.output
+    assert captured.get("ckpt_path") == str(ckpt)
+    # a true resume must NOT do a weight-only manual load (that skips optimizer)
+    assert "manual_load" not in captured
+
+
+def test_discard_encoder_resume_is_weight_only(tmp_path, monkeypatch):
+    """--discard-encoder changes the architecture: it must stay a weight-only
+    warm start (no ckpt_path, so optimizer state is not force-loaded into a
+    mismatched param set)."""
+    import json
+    from click.testing import CliRunner
+    import phoonnx_train.train as train_mod
+
+    captured = {}
+
+    class FakeTrainer:
+        def __init__(self, *a, **k):
+            pass
+
+        def fit(self, model, ckpt_path=None):
+            captured["ckpt_path"] = ckpt_path
+
+    class FakeEngine:
+        def quality_presets(self):
+            return {"medium": {}}
+
+        def create_model(self, config, dataset_paths):
+            return object()
+
+        def trainer_kwargs(self):
+            return {}
+
+        def load_checkpoint(self, *a, **k):
+            captured["manual_load"] = True
+
+    monkeypatch.setattr(train_mod, "Trainer", FakeTrainer)
+    monkeypatch.setattr(train_mod, "get_engine", lambda name: FakeEngine())
+    monkeypatch.setattr(train_mod, "list_engines", lambda: ["matcha"])
+
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "config.json").write_text(json.dumps(
+        {"num_symbols": 30, "num_speakers": 1, "audio": {"sample_rate": 22050}}))
+    ckpt = tmp_path / "prev.ckpt"
+    ckpt.write_bytes(b"x")
+
+    runner = CliRunner()
+    result = runner.invoke(train_mod.main, [
+        "--dataset-dir", str(ds), "--engine", "matcha", "--max-epochs", "1",
+        "--resume-from-checkpoint", str(ckpt), "--discard-encoder",
+    ])
+    assert result.exit_code == 0, result.output
+    assert captured.get("ckpt_path") is None
+    assert captured.get("manual_load") is True

--- a/tests/test_tokenization_golden.py
+++ b/tests/test_tokenization_golden.py
@@ -181,8 +181,15 @@ def test_tokenization_optispeech():
 
 def test_tokenization_matcha():
     pytest.importorskip("matcha")
-    import matcha.text as mt
-    from matcha.text import symbols, cleaned_text_to_sequence
+    # matcha.text instantiates a global espeak-ng backend at import time, which
+    # raises RuntimeError (not ImportError) when the system espeak library is
+    # absent — importorskip on the top-level ``matcha`` package does not catch
+    # it. Skip cleanly so a CI box without espeak reports skip, not error.
+    try:
+        import matcha.text as mt
+        from matcha.text import symbols, cleaned_text_to_sequence
+    except (RuntimeError, OSError) as exc:
+        pytest.skip(f"matcha.text needs a system espeak backend: {exc}")
     # the Catalan Matxa voices use custom cleaners bundled with the model (not in
     # base matcha-tts), so we verify the *tokenizer* — symbol table + phoneme->id
     # mapping — which is language-agnostic and is what phoonnx reproduces.

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -154,21 +154,37 @@ class TestMainCliEngineSelection(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("does-not-exist", result.output)
 
-    def test_resume_from_checkpoint_with_nonexistent_path_reaches_engine(self):
-        # --resume-from-checkpoint has no click.Path(exists=True) constraint
-        # (checkpoints can be produced by an engine-specific loader), so a
-        # bad path must fail inside load_checkpoint, not silently no-op.
-        def _raise(model, checkpoint_path, **kwargs):
-            raise FileNotFoundError(str(checkpoint_path))
-
-        self.fake_engine.load_checkpoint = _raise
+    def test_plain_resume_hands_checkpoint_to_fit_for_full_state_restore(self):
+        # A plain --resume-from-checkpoint is a true resume: the path must be
+        # handed to Trainer.fit(ckpt_path=...) so Lightning restores optimizer
+        # state, epoch and global_step. A weight-only manual load would reset
+        # them, so load_checkpoint must NOT be called on this path.
         with self.runner.isolated_filesystem() as td:
             Path("ds").mkdir()
-            result, _, _ = self._run(
+            result, trainer_instance, _ = self._run(
                 Path(td), ["--resume-from-checkpoint", "no/such/file.ckpt"],
             )
-        self.assertNotEqual(result.exit_code, 0)
-        self.assertIsInstance(result.exception, FileNotFoundError)
+        self.assertEqual(result.exit_code, 0, result.output)
+        _, fit_kwargs = trainer_instance.fit.call_args
+        self.assertEqual(fit_kwargs.get("ckpt_path"), "no/such/file.ckpt")
+
+    def test_discard_encoder_resume_is_weight_only_not_ckpt_path(self):
+        # --discard-encoder changes the architecture: it stays a weight-only
+        # warm start via load_checkpoint, never Trainer.fit(ckpt_path=...).
+        loaded = []
+        self.fake_engine.load_checkpoint = (
+            lambda model, checkpoint_path, **kw: loaded.append(str(checkpoint_path)) or model
+        )
+        with self.runner.isolated_filesystem() as td:
+            Path("ds").mkdir()
+            result, trainer_instance, _ = self._run(
+                Path(td),
+                ["--resume-from-checkpoint", "no/such/file.ckpt", "--discard-encoder"],
+            )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(loaded, ["no/such/file.ckpt"])
+        _, fit_kwargs = trainer_instance.fit.call_args
+        self.assertIsNone(fit_kwargs.get("ckpt_path"))
 
     def test_invalid_quality_falls_back_with_warning_not_crash(self):
         with self.assertLogs("phoonnx_train", level="WARNING") as logs:


### PR DESCRIPTION
## Matcha training pre-flight hardening

Adversarial audit of the Matcha training path (preprocess → train → resume → export → ONNX inference), executed on a real synthetic dataset end-to-end. Every stage was run; the bugs below were all reproduced before fixing and are covered by regression tests.

### Confirmed bugs

| # | Location | Failure scenario (impact on a real run) | Fix |
|---|----------|------------------------------------------|-----|
| 1 | `phoonnx_train/engines/matcha.py` (load_checkpoint + export_onnx) | `torch.serialization.safe_globals` only exists on torch≥2.4, but the project supports torch≥2.1. On torch 2.2 both `--resume-from-checkpoint` and ONNX export crashed instantly with `AttributeError`. | Use the existing `trusting_torch_load()` helper (weights_only=False for a trusted local checkpoint), version-portable and tolerant of the `SimpleNamespace` config objects in the checkpoint. |
| 2 | `phoonnx_train/train.py` | `--resume-from-checkpoint` copied weights only and called `trainer.fit(model)` with no `ckpt_path`, so Lightning restored neither optimizer state, LR scheduler, epoch nor global_step. Adam moments were lost and `max_epochs` was recounted from zero on every resume — a resumed expensive run silently restarted its schedule and spiked. | Hand the checkpoint to `Trainer.fit(ckpt_path=...)` for a full-state resume. Architecture-changing paths (`--discard-encoder`, single-speaker conversion) stay weight-only warm starts. |
| 3 | `phoonnx_train/matcha/lightning.py:256` | In the loss forward the alignment tensor is `[b, t_text, t_mel]`; a bare `attn.squeeze(1)` collapses the text axis when `t_text == 1` (single-phoneme utterance), crashing the `mu_y` matmul with `IndexError`. One such utterance aborts the whole run. | Transpose the last two axes directly (`attn.transpose(1, 2)`), identical for `t_text > 1`. |
| 4 | `pyproject.toml` | `diffusers>=0.36` references `torch.xpu` at import, which only exists on torch≥2.4; with the `torch>=2.1` floor the vendored Matcha decoder failed to import at all. Matcha training was completely unlaunchable on torch<2.4. | Cap `diffusers>=0.25.0,<0.36`. |

### Mel/audio parameter consistency (verified, no drift)
Traced actual values: preprocess (`norm_audio`) caches audio + spectrograms with `n_fft=1024, hop=256, win=1024`; the training mel front-end (`matcha/dataset.py`) uses the identical `N_FFT=1024, HOP_LENGTH=256, WIN_LENGTH=1024, F_MIN=0, F_MAX=8000`; `fmax=8000 ≤ Nyquist(11025)` for the default 22050 Hz. Training `sample_rate` is read from the dataset `config.json`, so it tracks the preprocess `--sample-rate`. Locked in by regression tests.

### Padding / masking (verified correct)
A padded batch yields the same deterministic prior/duration losses as the tight batch — padded frames are masked out of the losses. `num_workers>0` dataloading exercised in the live run.

### Smoke-run evidence
Synthetic dataset (12 clips of sine+harmonics+noise, 22050 Hz), NVIDIA RTX 3060:
```
python -m phoonnx_train.preprocess -i <ds> -o <out> -l en --phoneme-type graphemes
  -> Wrote 12 valid utterances to dataset.jsonl   (mel_mean=-3.674 mel_std=1.584)

python -m phoonnx_train.train --engine matcha --quality x-low --max-epochs 4 --accelerator gpu
  -> loss/train 3.99, checkpoints epoch=0..3 saved; `Trainer.fit stopped: max_epochs=4 reached`

# resume from epoch=3 checkpoint, --max-epochs 6
  -> "Restored all states from the checkpoint"; continued epoch 4->6, global_step 12->15->18

python -m phoonnx_train.export_onnx <ckpt> --engine matcha -> model.onnx (36 MB)

# ONNX mel model + griffinlim vocoder
  -> mel out (1, 80, 18); SYNTHESIZED audio 4352 samples, all finite
```

### Matcha golden test root cause (environmental)
`tests/test_tokenization_golden.py::test_tokenization_matcha` failed because `import matcha.text` instantiates a global espeak-ng backend at import time, raising `RuntimeError` (not `ImportError`) when no system espeak library is installed — `importorskip("matcha")` does not catch it, so the test **errored** rather than skipping. It also downloads a voice over the network. It does **not** mask a tokenization bug: with an espeak library available I verified offline that phoonnx's tokenizer reproduces matcha's `cleaned_text_to_sequence` byte-for-byte (`[50, 83, 54, 156, 57, 135, 16, 65, 156, 85, 54, 46]` on both). The test is now environment-proofed to skip cleanly when the espeak backend is unavailable, so CI is green instead of red.

### Test plan
- New `tests/test_matcha_training_preflight.py` (11 tests): mel-param consistency, finite losses on short/degenerate batches, padding masked out of losses, torch-portable checkpoint load, resume-vs-warm-start wiring.
- Updated `tests/test_train_cli.py` to assert the corrected resume semantics.
- Full suite: **1215 passed, 7 skipped, 15 failed**. All 15 failures are pre-existing styletts2 `transformers` ImportErrors (transformers disables PyTorch on torch<2.4) — confirmed identical with these changes stashed. Zero new failures introduced.

### Unconfirmed (not fixed)
- The inference `MatchaAdapter.configure_from_params` only builds a vocoder when `vocoder_path` is set, so the path-less griffinlim vocoder cannot be selected via `engine_params` (had to inject it directly for the smoke test). Inference-side, out of this PR's training scope — flagged for follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume training now restores optimizer, scheduler, epoch, and step state when applicable.
  * Checkpoint loading and ONNX export work more reliably with varied checkpoint formats.
  * Warm-start training remains available when discarding the encoder.

* **Bug Fixes**
  * Fixed attention handling for single-phoneme inputs.
  * Improved checkpoint compatibility and training stability.

* **Tests**
  * Added coverage for checkpoint portability, resume behavior, padding, and numerical stability.
  * Tokenization tests now skip cleanly when system speech dependencies are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->