### PR TITLE
feat: standalone eval synthesis for matcha and optispeech engines

### DIFF
--- a/phoonnx_train/engines/base.py
+++ b/phoonnx_train/engines/base.py
@@ -165,3 +165,30 @@ class BaseTrainingEngine(ABC):
         }
         model.load_state_dict(filtered, strict=False)
         return model
+
+    def eval_synthesize(
+        self,
+        checkpoint_path: Path,
+        config: Optional[Dict[str, Any]],
+        *,
+        vocoder_path: Optional[str] = None,
+        device: str = "cpu",
+    ):
+        """
+        Build a standalone, checkpoint-only synthesis callable for held-out
+        evaluation (``phoonnx_train.eval_loop`` and friends).
+
+        Returns ``callable(ids: List[int], scales: List[float], sid:
+        Optional[int]) -> np.ndarray`` producing a 1-D float32 waveform.
+
+        ``vocoder_path`` is an optional ONNX vocoder for engines that emit a
+        mel spectrogram rather than a waveform directly; engines that
+        self-vocode (e.g. end-to-end GAN vocoders) ignore it.
+
+        Default implementation raises ``NotImplementedError`` — engines
+        must opt in explicitly since standalone synthesis needs bespoke
+        checkpoint loading + inference wiring per architecture.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support standalone eval_synthesize()"
+        )

--- a/phoonnx_train/engines/matcha.py
+++ b/phoonnx_train/engines/matcha.py
@@ -407,16 +407,13 @@ class MatchaTrainingEngine(BaseTrainingEngine):
         ``MatchaTTS.synthesise``); a third CFM step-count element may be
         supplied via ``config["n_timesteps"]`` (default 10).
         """
-        import contextlib
-
         import numpy as np
         import torch
 
         from phoonnx_train.matcha import MatchaTTS
+        from phoonnx_train.torch_compat import trusting_torch_load
 
-        safe_globals = getattr(torch.serialization, "safe_globals", None)
-        ctx = safe_globals([SimpleNamespace]) if safe_globals else contextlib.nullcontext()
-        with ctx:
+        with trusting_torch_load():
             matcha = MatchaTTS.load_from_checkpoint(
                 str(checkpoint_path), map_location=device
             )

--- a/phoonnx_train/engines/matcha.py
+++ b/phoonnx_train/engines/matcha.py
@@ -438,6 +438,9 @@ class MatchaTrainingEngine(BaseTrainingEngine):
         sample_rate = int(matcha.hparams.sample_rate)
 
         def _synth(ids: List[int], scales: List[float], sid: Optional[int]) -> "np.ndarray":
+            # scales=None/[] means engine defaults; when set it is
+            # [temperature, length_scale] (matcha semantics, NOT VITS's).
+            scales = scales or []
             x = torch.LongTensor(ids).unsqueeze(0).to(device)
             x_lengths = torch.LongTensor([len(ids)]).to(device)
             temperature = float(scales[0]) if len(scales) > 0 else 0.667

--- a/phoonnx_train/engines/matcha.py
+++ b/phoonnx_train/engines/matcha.py
@@ -379,3 +379,151 @@ class MatchaTrainingEngine(BaseTrainingEngine):
             _LOG.warning("dropped %d mismatched checkpoint keys", len(dropped))
         model.load_state_dict(filtered, strict=False)
         return model
+
+    # ------------------------------------------------------------------
+    # Standalone evaluation synthesis
+    # ------------------------------------------------------------------
+
+    def eval_synthesize(
+        self,
+        checkpoint_path: Path,
+        config: Optional[Dict[str, Any]],
+        *,
+        vocoder_path: Optional[str] = None,
+        device: str = "cpu",
+    ):
+        """Return ``callable(ids, scales, sid) -> np.ndarray`` for a Matcha checkpoint.
+
+        Matcha only emits a mel spectrogram, so a vocoder stage is required
+        to reach a waveform. When ``vocoder_path`` is given, that ONNX
+        vocoder converts mel -> audio (matching production quality). With no
+        vocoder, a Griffin-Lim fallback is used with the exact mel
+        parameters MatchaTTS trains on (``phoonnx_train.matcha.dataset``
+        module constants + ``n_feats``/``sample_rate`` read back from the
+        checkpoint hyper-parameters) — comparable across checkpoints of this
+        run, but not an absolute quality signal.
+
+        ``scales`` is ``[temperature, length_scale]`` (matching
+        ``MatchaTTS.synthesise``); a third CFM step-count element may be
+        supplied via ``config["n_timesteps"]`` (default 10).
+        """
+        import contextlib
+
+        import numpy as np
+        import torch
+
+        from phoonnx_train.matcha import MatchaTTS
+
+        safe_globals = getattr(torch.serialization, "safe_globals", None)
+        ctx = safe_globals([SimpleNamespace]) if safe_globals else contextlib.nullcontext()
+        with ctx:
+            matcha = MatchaTTS.load_from_checkpoint(
+                str(checkpoint_path), map_location=device
+            )
+        matcha = matcha.to(device)
+        matcha.eval()
+
+        n_timesteps = int((config or {}).get("n_timesteps", 10))
+        is_multi_speaker = matcha.n_spks > 1
+
+        vocoder = None
+        if vocoder_path:
+            from phoonnx.engines.vocoders import build_vocoder
+
+            vocoder = build_vocoder(
+                model_path=str(vocoder_path),
+                config=(config or {}).get("vocoder", {}),
+            )
+        else:
+            _warn_griffinlim_once()
+
+        n_feats = int(matcha.n_feats)
+        sample_rate = int(matcha.hparams.sample_rate)
+
+        def _synth(ids: List[int], scales: List[float], sid: Optional[int]) -> "np.ndarray":
+            x = torch.LongTensor(ids).unsqueeze(0).to(device)
+            x_lengths = torch.LongTensor([len(ids)]).to(device)
+            temperature = float(scales[0]) if len(scales) > 0 else 0.667
+            length_scale = float(scales[1]) if len(scales) > 1 else 1.0
+
+            spks = None
+            if is_multi_speaker:
+                spks = torch.LongTensor([sid if sid is not None else 0]).to(device)
+
+            with torch.no_grad():
+                out = matcha.synthesise(
+                    x, x_lengths, n_timesteps, temperature, spks, length_scale
+                )
+            mel = out["mel"].detach().cpu().numpy().astype(np.float32)  # [1, n_feats, T]
+
+            if vocoder is not None:
+                wav = vocoder.mel_to_audio(mel)
+            else:
+                wav = _griffinlim_from_matcha_mel(
+                    mel, n_feats=n_feats, sample_rate=sample_rate
+                )
+
+            wav = np.asarray(wav, dtype=np.float32).reshape(-1)
+            if not np.isfinite(wav).all():
+                raise RuntimeError(
+                    "Matcha eval_synthesize produced non-finite samples "
+                    "(NaN/Inf) — checkpoint or vocoder is likely broken"
+                )
+            return wav
+
+        return _synth
+
+
+_GRIFFINLIM_WARNED = False
+
+
+def _warn_griffinlim_once() -> None:
+    global _GRIFFINLIM_WARNED
+    if not _GRIFFINLIM_WARNED:
+        _LOG.warning(
+            "Matcha eval_synthesize: no vocoder_path given — falling back to "
+            "Griffin-Lim. Griffin-Lim scores are only meaningful relative to "
+            "each other (e.g. comparing checkpoints of the same run); they "
+            "are NOT comparable to absolute/neural-vocoder quality scores."
+        )
+        _GRIFFINLIM_WARNED = True
+
+
+def _griffinlim_from_matcha_mel(mel, *, n_feats: int, sample_rate: int):
+    """Invert a MatchaTTS natural-log mel (as returned by ``synthesise``) with
+    Griffin-Lim, using the exact STFT params Matcha trains on."""
+    import librosa
+    import numpy as np
+    import torch
+
+    from phoonnx_train.matcha.dataset import F_MAX, F_MIN, HOP_LENGTH, N_FFT, WIN_LENGTH
+
+    m = np.asarray(mel, dtype=np.float64)
+    if m.ndim == 3:
+        m = m[0]  # [n_feats, T]
+
+    # MatchaTTS.synthesise() already denormalizes (mel_mean/mel_std) but the
+    # mel itself is a *natural*-log magnitude (spectral_normalize_torch ==
+    # ln, see phoonnx_train.matcha.audio.dynamic_range_compression).
+    mel_linear = np.exp(m)
+
+    mel_basis = librosa.filters.mel(
+        sr=sample_rate, n_fft=N_FFT, n_mels=n_feats, fmin=F_MIN, fmax=F_MAX
+    )
+    inv_mel_basis = np.linalg.pinv(mel_basis)
+    linear_mag = np.maximum(1e-10, np.dot(inv_mel_basis, mel_linear))
+
+    # librosa.griffinlim seeds its random initial phase from the *global*
+    # numpy RNG, which torch.manual_seed does not touch — pin it to the
+    # active torch seed explicitly so eval_synthesize is reproducible under
+    # a fixed torch seed, as the rest of the callable already is.
+    rng = np.random.RandomState(torch.initial_seed() % (2**32))
+    audio = librosa.griffinlim(
+        linear_mag.astype(np.float32),
+        n_iter=60,
+        hop_length=HOP_LENGTH,
+        win_length=WIN_LENGTH,
+        n_fft=N_FFT,
+        random_state=rng,
+    )
+    return audio.astype(np.float32)

--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -687,6 +687,81 @@ class OptiSpeechTrainingEngine(BaseTrainingEngine):
         return model
 
     # ------------------------------------------------------------------
+    # Standalone evaluation synthesis
+    # ------------------------------------------------------------------
+
+    def eval_synthesize(
+        self,
+        checkpoint_path: Path,
+        config: Optional[Dict[str, Any]],
+        *,
+        vocoder_path: Optional[str] = None,
+        device: str = "cpu",
+    ):
+        """Return ``callable(ids, scales, sid) -> np.ndarray`` for an OptiSpeech checkpoint.
+
+        OptiSpeech is self-vocoding — the generator emits the waveform
+        directly (WaveNeXt head) — so ``vocoder_path`` never applies here
+        and is ignored with a debug log if given.
+
+        ``scales`` is ``[d_factor, p_factor, e_factor]`` (duration / pitch /
+        energy), matching ``OptiSpeechGenerator.synthesise`` and the
+        checkpoint's own ``inference_args`` defaults when omitted.
+        """
+        import numpy as np
+        import torch
+
+        if vocoder_path:
+            _LOG.debug(
+                "OptiSpeech is self-vocoding; ignoring vocoder_path=%s", vocoder_path
+            )
+
+        model = self.load_lightning_module(Path(checkpoint_path))
+        model = model.to(device)
+        model.eval()
+
+        gen = model.generator
+        is_multi_speaker = model.num_speakers > 1
+        is_multi_language = getattr(model.text_processor, "is_multi_language", False)
+
+        d0 = model.inference_args.d_factor
+        p0 = model.inference_args.p_factor
+        e0 = model.inference_args.e_factor
+
+        def _synth(ids: List[int], scales: List[float], sid: Optional[int]) -> "np.ndarray":
+            x = torch.LongTensor(ids).unsqueeze(0).to(device)
+            x_lengths = torch.LongTensor([len(ids)]).to(device)
+
+            d_factor = float(scales[0]) if len(scales) > 0 else d0
+            p_factor = float(scales[1]) if len(scales) > 1 else p0
+            e_factor = float(scales[2]) if len(scales) > 2 else e0
+
+            sids = None
+            if is_multi_speaker:
+                sids = torch.LongTensor([sid if sid is not None else 0]).to(device)
+            lids = torch.LongTensor([0]).to(device) if is_multi_language else None
+
+            with torch.no_grad():
+                out = gen.synthesise(
+                    x=x,
+                    x_lengths=x_lengths,
+                    sids=sids,
+                    lids=lids,
+                    d_factor=d_factor,
+                    p_factor=p_factor,
+                    e_factor=e_factor,
+                )
+            wav = out["wav"].detach().cpu().numpy().astype(np.float32).reshape(-1)
+            if not np.isfinite(wav).all():
+                raise RuntimeError(
+                    "OptiSpeech eval_synthesize produced non-finite samples "
+                    "(NaN/Inf) — checkpoint is likely broken"
+                )
+            return wav
+
+        return _synth
+
+    # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
 

--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -729,6 +729,10 @@ class OptiSpeechTrainingEngine(BaseTrainingEngine):
         e0 = model.inference_args.e_factor
 
         def _synth(ids: List[int], scales: List[float], sid: Optional[int]) -> "np.ndarray":
+            # scales=None/[] means the checkpoint's own inference defaults;
+            # when set it is [d_factor, p_factor, e_factor] (OptiSpeech
+            # semantics, NOT VITS's noise/length/noise_w).
+            scales = scales or []
             x = torch.LongTensor(ids).unsqueeze(0).to(device)
             x_lengths = torch.LongTensor([len(ids)]).to(device)
 

--- a/tests/test_engine_eval_synthesize.py
+++ b/tests/test_engine_eval_synthesize.py
@@ -105,6 +105,8 @@ def _export_tiny_raw_vocoder(tmp_path, n_feats: int, hop_length: int) -> Path:
     module.eval()
     dummy = torch.randn(1, n_feats, 10)
     onnx_path = tmp_path / "tiny_vocoder.onnx"
+    from phoonnx_train.torch_compat import onnx_export_kwargs
+
     torch.onnx.export(
         module,
         (dummy,),
@@ -113,6 +115,7 @@ def _export_tiny_raw_vocoder(tmp_path, n_feats: int, hop_length: int) -> Path:
         output_names=["wav"],
         dynamic_axes={"mels": {0: "batch", 2: "time"}, "wav": {0: "batch", 1: "time"}},
         opset_version=15,
+        **onnx_export_kwargs(),
     )
     return onnx_path
 

--- a/tests/test_engine_eval_synthesize.py
+++ b/tests/test_engine_eval_synthesize.py
@@ -1,0 +1,314 @@
+"""Tests for the standalone ``eval_synthesize`` interface added to
+``phoonnx_train.engines.base.BaseTrainingEngine`` and implemented by the
+Matcha-TTS and OptiSpeech training engines.
+
+Every test builds a tiny real (CPU-sized) model, trains it for a single
+step so a checkpoint exists, then drives ``eval_synthesize`` end to end —
+no mocking of the model internals.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import pytorch_lightning as pl
+from torch.utils.data import DataLoader, Dataset
+
+from phoonnx_train.engines import get_engine
+from phoonnx_train.engines.base import BaseTrainingEngine, TrainingEngineConfig
+
+
+def _tiny_trainer(max_steps=1):
+    return pl.Trainer(
+        max_steps=max_steps,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+
+# ----------------------------------------------------------------------
+# Matcha
+# ----------------------------------------------------------------------
+
+_M_NFEATS = 20
+_M_TX = 6
+_M_TY = 16
+
+
+class _MatchaDummyDataset(Dataset):
+    def __len__(self):
+        return 2
+
+    def __getitem__(self, idx):
+        return idx
+
+
+def _matcha_collate(batch):
+    b = len(batch)
+    return {
+        "x": torch.randint(1, 30, (b, _M_TX)),
+        "x_lengths": torch.tensor([_M_TX] * b),
+        "y": torch.randn(b, _M_NFEATS, _M_TY),
+        "y_lengths": torch.tensor([_M_TY] * b),
+    }
+
+
+def _build_matcha_checkpoint(tmp_path) -> Path:
+    eng = get_engine("matcha")
+    cfg = TrainingEngineConfig(
+        num_symbols=30,
+        num_speakers=1,
+        sample_rate=22050,
+        extra={
+            "quality": "x-low",
+            "n_feats": _M_NFEATS,
+            "mel_mean": 0.0,
+            "mel_std": 1.0,
+        },
+    )
+    model = eng.create_model(cfg, [])
+    dl = DataLoader(_MatchaDummyDataset(), batch_size=2, collate_fn=_matcha_collate)
+    trainer = _tiny_trainer(max_steps=1)
+    trainer.fit(model, dl)
+    ckpt = tmp_path / "matcha.ckpt"
+    trainer.save_checkpoint(str(ckpt))
+    return ckpt
+
+
+def _export_tiny_raw_vocoder(tmp_path, n_feats: int, hop_length: int) -> Path:
+    """A minimal torch module exported to ONNX with the 'raw waveform'
+    vocoder contract: single input mel [1, n_feats, T] -> single output
+    wav [1, T*hop_length]. Not trained — only exercises the eval_synthesize
+    ONNX-vocoder code path end to end."""
+
+    class TinyVocoder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.up = nn.ConvTranspose1d(
+                n_feats, 1, kernel_size=hop_length * 2, stride=hop_length,
+                padding=hop_length // 2,
+            )
+
+        def forward(self, mel):
+            wav = self.up(mel).squeeze(1)
+            return torch.tanh(wav)
+
+    module = TinyVocoder()
+    module.eval()
+    dummy = torch.randn(1, n_feats, 10)
+    onnx_path = tmp_path / "tiny_vocoder.onnx"
+    torch.onnx.export(
+        module,
+        (dummy,),
+        str(onnx_path),
+        input_names=["mels"],
+        output_names=["wav"],
+        dynamic_axes={"mels": {0: "batch", 2: "time"}, "wav": {0: "batch", 1: "time"}},
+        opset_version=15,
+    )
+    return onnx_path
+
+
+class MatchaEvalSynthesizeTests(unittest.TestCase):
+    def test_griffinlim_fallback_produces_finite_audio(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ckpt = _build_matcha_checkpoint(tmp_path)
+            eng = get_engine("matcha")
+            synth = eng.eval_synthesize(ckpt, config={"n_timesteps": 2})
+            torch.manual_seed(1234)
+            wav = synth([1, 2, 3, 4, 5], [0.667, 1.0], None)
+            self.assertIsInstance(wav, np.ndarray)
+            self.assertEqual(wav.dtype, np.float32)
+            self.assertEqual(wav.ndim, 1)
+            self.assertGreater(wav.size, 0)
+            self.assertTrue(np.isfinite(wav).all())
+
+    def test_onnx_vocoder_path_runs(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ckpt = _build_matcha_checkpoint(tmp_path)
+            vocoder_path = _export_tiny_raw_vocoder(
+                tmp_path, n_feats=_M_NFEATS, hop_length=256
+            )
+            eng = get_engine("matcha")
+            synth = eng.eval_synthesize(
+                ckpt,
+                config={"n_timesteps": 2, "vocoder": {"vocoder_type": "raw"}},
+                vocoder_path=str(vocoder_path),
+            )
+            torch.manual_seed(1234)
+            wav = synth([1, 2, 3, 4, 5], [0.667, 1.0], None)
+            self.assertIsInstance(wav, np.ndarray)
+            self.assertEqual(wav.ndim, 1)
+            self.assertGreater(wav.size, 0)
+            self.assertTrue(np.isfinite(wav).all())
+
+    def test_determinism_same_seed_same_output(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ckpt = _build_matcha_checkpoint(tmp_path)
+            eng = get_engine("matcha")
+            synth = eng.eval_synthesize(ckpt, config={"n_timesteps": 2})
+
+            torch.manual_seed(4242)
+            wav_a = synth([1, 2, 3, 4, 5], [0.667, 1.0], None)
+            torch.manual_seed(4242)
+            wav_b = synth([1, 2, 3, 4, 5], [0.667, 1.0], None)
+            np.testing.assert_array_equal(wav_a, wav_b)
+
+
+# ----------------------------------------------------------------------
+# OptiSpeech
+# ----------------------------------------------------------------------
+
+_O_NFEATS = 40
+_O_HOP = 256
+_O_TX = 8
+_O_TY = 24
+
+
+def _optispeech_tiny_extra(**over):
+    extra = {
+        "quality": "x-low",
+        "dim": 32,
+        "n_feats": _O_NFEATS,
+        "hop_length": _O_HOP,
+        "n_fft": 256,
+        "win_length": 256,
+        "encoder_intermediate_dim": 48,
+        "decoder_intermediate_dim": 48,
+        "encoder_num_layers": 2,
+        "decoder_num_layers": 2,
+        "vocoder_dim": 32,
+        "vocoder_intermediate_dim": 48,
+        "vocoder_num_layers": 2,
+        "duration_intermediate_dim": 32,
+        "pitch_intermediate_dim": 32,
+        "energy_intermediate_dim": 32,
+        "pitch_num_layers": 2,
+        "segment_size": 8,
+        "batch_size": 2,
+        "warmup_steps": 1,
+    }
+    extra.update(over)
+    return extra
+
+
+class _OptiDummyDataset(Dataset):
+    def __len__(self):
+        return 2
+
+    def __getitem__(self, idx):
+        return idx
+
+
+def _optispeech_collate(batch):
+    b = len(batch)
+    return {
+        "x": torch.randint(1, 30, (b, _O_TX)),
+        "x_lengths": torch.tensor([_O_TX] * b),
+        "mel": torch.randn(b, _O_NFEATS, _O_TY),
+        "mel_lengths": torch.tensor([_O_TY] * b),
+        "pitches": torch.randn(b, _O_TY),
+        "energies": torch.randn(b, _O_TY),
+        "sids": None,
+        "lids": None,
+        "wav": np.random.randn(b, _O_TY * _O_HOP).astype(np.float32),
+    }
+
+
+def _build_optispeech_checkpoint(tmp_path) -> Path:
+    eng = get_engine("optispeech")
+    cfg = TrainingEngineConfig(
+        num_symbols=30,
+        num_speakers=1,
+        sample_rate=22050,
+        extra=_optispeech_tiny_extra(),
+    )
+    model = eng.create_model(cfg, [])
+    dl = DataLoader(_OptiDummyDataset(), batch_size=2, collate_fn=_optispeech_collate)
+    trainer = _tiny_trainer(max_steps=1)
+    trainer.fit(model, dl)
+    ckpt = tmp_path / "optispeech.ckpt"
+    trainer.save_checkpoint(str(ckpt))
+    return ckpt
+
+
+class OptiSpeechEvalSynthesizeTests(unittest.TestCase):
+    def test_self_vocoding_produces_finite_audio(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ckpt = _build_optispeech_checkpoint(tmp_path)
+            eng = get_engine("optispeech")
+            synth = eng.eval_synthesize(ckpt, config={})
+            wav = synth([1, 2, 3, 4, 5, 6], [1.0, 1.0, 1.0], None)
+            self.assertIsInstance(wav, np.ndarray)
+            self.assertEqual(wav.dtype, np.float32)
+            self.assertEqual(wav.ndim, 1)
+            self.assertGreater(wav.size, 0)
+            self.assertTrue(np.isfinite(wav).all())
+
+    def test_vocoder_path_ignored_with_debug_log(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ckpt = _build_optispeech_checkpoint(tmp_path)
+            eng = get_engine("optispeech")
+            # Passing a bogus vocoder_path must not raise or be used —
+            # OptiSpeech self-vocodes.
+            synth = eng.eval_synthesize(
+                ckpt, config={}, vocoder_path="/nonexistent/vocoder.onnx"
+            )
+            wav = synth([1, 2, 3, 4, 5, 6], [1.0, 1.0, 1.0], None)
+            self.assertGreater(wav.size, 0)
+            self.assertTrue(np.isfinite(wav).all())
+
+    def test_determinism_same_seed_same_output(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ckpt = _build_optispeech_checkpoint(tmp_path)
+            eng = get_engine("optispeech")
+            synth = eng.eval_synthesize(ckpt, config={})
+
+            torch.manual_seed(99)
+            wav_a = synth([1, 2, 3, 4, 5, 6], [1.0, 1.0, 1.0], None)
+            torch.manual_seed(99)
+            wav_b = synth([1, 2, 3, 4, 5, 6], [1.0, 1.0, 1.0], None)
+            np.testing.assert_array_equal(wav_a, wav_b)
+
+
+# ----------------------------------------------------------------------
+# Default NotImplementedError path
+# ----------------------------------------------------------------------
+
+class _NoEvalSynthesisEngine(BaseTrainingEngine):
+    """Minimal concrete engine that does not override eval_synthesize."""
+
+    def create_model(self, config, dataset_paths, **kwargs):
+        raise NotImplementedError
+
+    def export_onnx(self, checkpoint_path, config_path, output_dir, **kwargs):
+        raise NotImplementedError
+
+    def quality_presets(self):
+        return {}
+
+
+class DefaultEvalSynthesizeTests(unittest.TestCase):
+    def test_unsupported_engine_raises_clear_error(self):
+        eng = _NoEvalSynthesisEngine()
+        with self.assertRaises(NotImplementedError) as ctx:
+            eng.eval_synthesize(Path("unused.ckpt"), config={})
+        self.assertIn("eval_synthesize", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `eval_synthesize(checkpoint_path, config, *, vocoder_path=None, device="cpu")` to `BaseTrainingEngine` (default raises `NotImplementedError`).
- Implements it for Matcha-TTS: loads the checkpoint on CPU, runs text -> mel, then either an ONNX vocoder (via the existing `phoonnx.engines.vocoders.build_vocoder`) or a Griffin-Lim fallback using Matcha's own mel parameters (module constants from `phoonnx_train.matcha.dataset` + `n_feats`/`sample_rate` read back from the checkpoint). Logs a one-time WARNING that Griffin-Lim scores are only comparable relative to each other.
- Implements it for OptiSpeech: self-vocoding generator (WaveNeXt head emits the waveform directly); `vocoder_path` is ignored with a debug log.
- Both honor `sid` for multi-speaker checkpoints, run under `model.eval()` + `no_grad`, and assert the returned waveform is finite 1-D float32 before returning.

## Branch order
This branch merges the not-yet-landed `feat/optispeech-training` (#247) in directly, since `dev` does not have the OptiSpeech training engine yet and this work needs `phoonnx_train/engines/optispeech.py` to exist. **Should merge after #247** to avoid duplicating that diff in dev's history; the rebase at that point is a no-op since the commits are identical.

This also pairs with the VITS-side `eval_synthesize` work landing on a parallel branch that adds the same base-class method — expect a small, mechanical reconcile on `phoonnx_train/engines/base.py` (same signature/docstring, additive).

## Test plan
- [x] `python -m unittest tests.test_engine_eval_synthesize -v` — 7/7 pass (Matcha Griffin-Lim + ONNX-vocoder + determinism; OptiSpeech self-vocoding + vocoder_path-ignored + determinism; default `NotImplementedError` path)
- [x] `python -m unittest discover -s tests` — 762 tests, all green (1 pre-existing skip), no new failures