### PR TITLE
feat: reusable checkpoint evaluation with similarity-gated selection and early stopping

### DIFF
--- a/docs/training/training.md
+++ b/docs/training/training.md
@@ -247,10 +247,11 @@ python -m phoonnx_train.export_onnx --engine styletts2 ...
 
 `phoonnx_train/eval_loop.py` watches the training directory for new Lightning checkpoints
 (`epoch=*.ckpt`) and scores each on a fixed set of held-out sentences, synthesized on CPU so
-training keeps the GPU. Results are appended to `metrics.csv` (one row per epoch), and the best
-epoch's wavs plus per-utterance scores (`perutt.csv`) are kept under `samples/epoch<N>/`. The
-loop is idempotent — already-scored (and permanently failed) epochs are skipped on restart.
-Needs `phoonnx[train-eval]`.
+training keeps the GPU. Results are appended to `metrics.csv` (one row per epoch), per-utterance
+scores are written for **every** epoch under `perutt/epoch<N>.csv` (columns `sentence`, `utmos`,
+`spk_sim` — so a single sentence degrading while the mean holds is visible across epochs), and
+the best epoch's wavs are kept under `samples/epoch<N>/`. The loop is idempotent — already-scored
+(and permanently failed) epochs are skipped on restart. Needs `phoonnx[train-eval]`.
 
 ```bash
 python -m phoonnx_train.eval_loop \
@@ -322,6 +323,8 @@ dir / `speakeronnx` missing) selection falls back to UTMOS-only and logs a warni
 - `best.json` — epoch, step, checkpoint path, and all scores of the current best.
 - `best.ckpt` — a **copy** (not a symlink) of the best checkpoint, so it survives checkpoint
   pruning.
+- `perutt/epoch<N>.csv` — per-utterance scores for every evaluated epoch (`sentence`, `utmos`,
+  `spk_sim`), for tracking per-sentence trends / overfit across epochs.
 - `samples/epoch<N>/` — the best epoch's synthesized wavs plus `perutt.csv`.
 - `failed.json` — a checkpoint that fails to load/score 3 times is recorded failed and skipped
   forever (ERROR logged); no infinite retry.

--- a/docs/training/training.md
+++ b/docs/training/training.md
@@ -247,9 +247,10 @@ python -m phoonnx_train.export_onnx --engine styletts2 ...
 
 `phoonnx_train/eval_loop.py` watches the training directory for new Lightning checkpoints
 (`epoch=*.ckpt`) and scores each on a fixed set of held-out sentences, synthesized on CPU so
-training keeps the GPU. Results are appended to `metrics.csv` (one row per epoch) plus
-per-utterance scores under `perutt/`, and the best epoch's wavs are kept under `samples/`. The
-loop is idempotent — already-scored epochs are skipped on restart. Needs `phoonnx[train-eval]`.
+training keeps the GPU. Results are appended to `metrics.csv` (one row per epoch), and the best
+epoch's wavs plus per-utterance scores (`perutt.csv`) are kept under `samples/epoch<N>/`. The
+loop is idempotent — already-scored (and permanently failed) epochs are skipped on restart.
+Needs `phoonnx[train-eval]`.
 
 ```bash
 python -m phoonnx_train.eval_loop \
@@ -266,6 +267,66 @@ relative ranker between checkpoints of the same voice, especially on non-English
 **speaker similarity** (`spk_sim_*`, cosine similarity to a centroid of the target speaker's
 reference recordings; needs `speakeronnx` + `--speaker-ref-dir`, otherwise only UTMOS is
 scored).
+
+## Evaluation and early stopping
+
+The evaluation logic lives in the reusable `phoonnx_train.evaluation` package
+(`CheckpointScorer`, `SelectionPolicy`, `MetricsTracker`, Lightning callbacks). The same code
+runs in two modes.
+
+### Sidecar mode (out-of-process scoreboard)
+
+`phoonnx_train/eval_loop.py` is a thin CLI over the package — the flags above are unchanged.
+Each checkpoint is loaded through the training-engine registry (`--engine`, default `auto`:
+the `engine` key in `config.json` if present, else `vits`), synthesized on CPU with
+**per-utterance deterministic seeding** (`torch.manual_seed(seed + i)` immediately before
+utterance `i`, so the same checkpoint scored twice yields identical wavs and scores), and
+scored. New flags:
+
+- `--early-stop-patience N` — after `N` scored epochs pass with no new best, write a
+  `stop.flag` into `--train-dir`.
+- `--min-spk-sim FLOAT` — the similarity gate floor (see below).
+- `--speaker-id INT` — speaker id for multi-speaker models (a warning is logged when
+  `num_speakers > 1` and no id is given; synthesis falls back to the engine default voice).
+- `--engine NAME` — engine override (default `auto`).
+- `--vocoder PATH` — passed through to the engine's synthesis (engine-dependent; ignored by
+  the end-to-end VITS engine).
+
+### In-training mode (early stopping callback)
+
+`train.py` gains opt-in flags: `--eval-sentences FILE`, `--eval-every N` (default `0` = off),
+`--early-stop-patience N`, `--eval-speaker-ref-dir DIR`, `--min-spk-sim FLOAT`, `--eval-seed`.
+When enabled, `EvalScoreboardCallback` runs the same `CheckpointScorer` in-process every `N`
+epochs (after `ModelCheckpoint` saves), writes the same scoreboard under `<run-dir>/eval/`, and
+sets `trainer.should_stop` once patience is exhausted. **Scoring failures never crash training**
+— they are logged and swallowed.
+
+`StopFileCallback` is **always** added to the trainer (even with evaluation off): it watches
+`<run-dir>/stop.flag` and stops training when it appears. This is the sidecar → trainer bridge —
+a sidecar `eval_loop` with `--early-stop-patience` can stop a training run it does not share a
+process with. With no flag present it is a no-op.
+
+### The similarity gate
+
+`SelectionPolicy(metric="utmos_mean", min_spk_sim=...)` selects the best checkpoint by UTMOS
+**gated on speaker similarity**: UTMOS alone can prefer a checkpoint whose voice has drifted
+away from the target speaker (higher naturalness, wrong identity). When speaker scoring is
+active and `--min-spk-sim` is set, a candidate must clear that floor to be eligible at all;
+among eligible candidates the higher UTMOS wins. With no speaker score available (no reference
+dir / `speakeronnx` missing) selection falls back to UTMOS-only and logs a warning.
+
+### Artifacts and the stop.flag contract
+
+- `metrics.csv` — one row per scored epoch (superset of the legacy header; old scoreboards are
+  read and appended to compatibly).
+- `best.json` — epoch, step, checkpoint path, and all scores of the current best.
+- `best.ckpt` — a **copy** (not a symlink) of the best checkpoint, so it survives checkpoint
+  pruning.
+- `samples/epoch<N>/` — the best epoch's synthesized wavs plus `perutt.csv`.
+- `failed.json` — a checkpoint that fails to load/score 3 times is recorded failed and skipped
+  forever (ERROR logged); no infinite retry.
+- `stop.flag` — a single reason line. Its presence means "stop training"; the trainer's
+  `StopFileCallback` reads the reason, logs it and stops at the next epoch boundary.
 
 ## Training a Vocos vocoder
 

--- a/phoonnx_train/engines/base.py
+++ b/phoonnx_train/engines/base.py
@@ -138,6 +138,33 @@ class BaseTrainingEngine(ABC):
         """
         return []
 
+    def eval_synthesize(
+        self,
+        checkpoint_path: Path,
+        config: Dict[str, Any],
+        *,
+        vocoder_path: Optional[Path] = None,
+        device: str = "cpu",
+    ) -> Any:
+        """Return a synthesis callable for held-out checkpoint evaluation.
+
+        The returned object is
+        ``callable(ids: List[int], scales: List[float], sid: Optional[int]) -> np.ndarray``
+        producing a 1-D ``float32`` waveform at ``config["audio"]["sample_rate"]``.
+
+        ``ids`` are token ids (already interspersed with pad + BOS/EOS by the
+        tokenizer), ``scales`` are ``[noise_scale, length_scale, noise_w]`` and
+        ``sid`` selects a speaker for multi-speaker models (``None`` otherwise).
+
+        Engines that cannot synthesize a waveform standalone (e.g. those that
+        need a separately trained vocoder that is not wired here) must raise
+        ``NotImplementedError`` with a clear message. The default raises.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support standalone checkpoint "
+            "synthesis for evaluation (eval_synthesize is not implemented)."
+        )
+
     def load_checkpoint(
         self,
         model: "pl.LightningModule",

--- a/phoonnx_train/engines/base.py
+++ b/phoonnx_train/engines/base.py
@@ -138,33 +138,6 @@ class BaseTrainingEngine(ABC):
         """
         return []
 
-    def eval_synthesize(
-        self,
-        checkpoint_path: Path,
-        config: Dict[str, Any],
-        *,
-        vocoder_path: Optional[Path] = None,
-        device: str = "cpu",
-    ) -> Any:
-        """Return a synthesis callable for held-out checkpoint evaluation.
-
-        The returned object is
-        ``callable(ids: List[int], scales: List[float], sid: Optional[int]) -> np.ndarray``
-        producing a 1-D ``float32`` waveform at ``config["audio"]["sample_rate"]``.
-
-        ``ids`` are token ids (already interspersed with pad + BOS/EOS by the
-        tokenizer), ``scales`` are ``[noise_scale, length_scale, noise_w]`` and
-        ``sid`` selects a speaker for multi-speaker models (``None`` otherwise).
-
-        Engines that cannot synthesize a waveform standalone (e.g. those that
-        need a separately trained vocoder that is not wired here) must raise
-        ``NotImplementedError`` with a clear message. The default raises.
-        """
-        raise NotImplementedError(
-            f"{type(self).__name__} does not support standalone checkpoint "
-            "synthesis for evaluation (eval_synthesize is not implemented)."
-        )
-
     def load_checkpoint(
         self,
         model: "pl.LightningModule",

--- a/phoonnx_train/engines/vits.py
+++ b/phoonnx_train/engines/vits.py
@@ -238,30 +238,29 @@ class VitsTrainingEngine(BaseTrainingEngine):
         import numpy as np
         import torch
 
+        from phoonnx_train.torch_compat import trusting_torch_load
         from phoonnx_train.vits.lightning import VitsModel
 
-        # torch >=2.6 defaults torch.load(weights_only=True); lightning
-        # checkpoints embed pathlib.PosixPath and full pickled objects, which
-        # that rejects. These are our own trusted checkpoints.
-        orig_load = torch.load
-
-        def _trusted_load(*a, **k):
-            k.setdefault("weights_only", False)
-            return orig_load(*a, **k)
-
-        torch.load = _trusted_load
-        try:
+        with trusting_torch_load():
             model = VitsModel.load_from_checkpoint(
                 str(checkpoint_path), dataset=None, map_location=device
             )
-        finally:
-            torch.load = orig_load
         model = model.to(device)
         model.eval()
         with torch.no_grad():
             model.model_g.dec.remove_weight_norm()
 
+        inf = (config or {}).get("inference", {})
+        default_scales = [
+            float(inf.get("noise_scale", 0.667)),
+            float(inf.get("length_scale", 1.0)),
+            float(inf.get("noise_w", 0.8)),
+        ]
+
         def synth(ids: List[int], scales: List[float], sid: Optional[int] = None):
+            # scales=None/[] means the voice config's inference defaults;
+            # when set it is [noise_scale, length_scale, noise_w].
+            scales = scales or default_scales
             text = torch.LongTensor(ids).unsqueeze(0).to(device)
             text_lengths = torch.LongTensor([len(ids)]).to(device)
             scales_t = torch.FloatTensor(scales).to(device)

--- a/phoonnx_train/engines/vits.py
+++ b/phoonnx_train/engines/vits.py
@@ -220,6 +220,63 @@ class VitsTrainingEngine(BaseTrainingEngine):
         return _QUALITY_PRESETS
 
     # ------------------------------------------------------------------
+    # Held-out evaluation synthesis
+    # ------------------------------------------------------------------
+
+    def eval_synthesize(
+        self,
+        checkpoint_path: Path,
+        config: Dict[str, Any],
+        *,
+        vocoder_path: Optional[Path] = None,
+        device: str = "cpu",
+    ) -> Any:
+        """Load a VITS checkpoint and return a CPU synthesis callable.
+
+        VITS is an end-to-end model, so ``vocoder_path`` is ignored.
+        """
+        import numpy as np
+        import torch
+
+        from phoonnx_train.vits.lightning import VitsModel
+
+        # torch >=2.6 defaults torch.load(weights_only=True); lightning
+        # checkpoints embed pathlib.PosixPath and full pickled objects, which
+        # that rejects. These are our own trusted checkpoints.
+        orig_load = torch.load
+
+        def _trusted_load(*a, **k):
+            k.setdefault("weights_only", False)
+            return orig_load(*a, **k)
+
+        torch.load = _trusted_load
+        try:
+            model = VitsModel.load_from_checkpoint(
+                str(checkpoint_path), dataset=None, map_location=device
+            )
+        finally:
+            torch.load = orig_load
+        model = model.to(device)
+        model.eval()
+        with torch.no_grad():
+            model.model_g.dec.remove_weight_norm()
+
+        def synth(ids: List[int], scales: List[float], sid: Optional[int] = None):
+            text = torch.LongTensor(ids).unsqueeze(0).to(device)
+            text_lengths = torch.LongTensor([len(ids)]).to(device)
+            scales_t = torch.FloatTensor(scales).to(device)
+            sid_t = (
+                torch.LongTensor([sid]).to(device) if sid is not None else None
+            )
+            with torch.no_grad():
+                audio = model(text, text_lengths, scales_t, sid=sid_t)
+            return (
+                audio.detach().cpu().float().squeeze().numpy().astype(np.float32)
+            )
+
+        return synth
+
+    # ------------------------------------------------------------------
     # Optional
     # ------------------------------------------------------------------
 

--- a/phoonnx_train/eval_loop.py
+++ b/phoonnx_train/eval_loop.py
@@ -27,7 +27,8 @@ from phoonnx_train.engines import get_engine, list_engines
 from phoonnx_train.eval_utils import (find_checkpoints, read_sentences,
                                       size_stable)
 from phoonnx_train.evaluation import CheckpointScorer, MetricsTracker, SelectionPolicy
-from phoonnx_train.evaluation.scorer import build_encoder, text_to_ids
+from phoonnx_train.evaluation.scorer import (build_encoder, text_to_ids,
+                                             write_epoch_perutt)
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -60,6 +61,9 @@ def evaluate_one(scorer, selection, tracker, ckpt_path, epoch, train_dir):
 
     best = selection.read_best(tracker.output_dir)
     tracker.append(row.to_csv_row())
+    # Keep a per-epoch per-utterance file for EVERY epoch (overfit diagnosis:
+    # per-sentence trends across epochs, not just the best epoch's samples).
+    write_epoch_perutt(tracker.output_dir, row, scorer.metrics)
     _LOGGER.info("epoch %d: %s", epoch, row.aggregates)
     if selection.is_improvement(row, best):
         selection.commit_best(row, tracker.output_dir, work_dir=work_dir)

--- a/phoonnx_train/eval_loop.py
+++ b/phoonnx_train/eval_loop.py
@@ -1,229 +1,68 @@
-"""Held-out evaluation loop for VITS training checkpoints.
+"""Sidecar checkpoint-evaluation scoreboard (thin CLI over the evaluation pkg).
 
-Watches a training directory for new lightning checkpoints (epoch=*.ckpt),
-synthesizes a fixed set of held-out sentences on CPU, scores each clip with
-UTMOS (SpeechMOS utmos22_strong) and, when available, speaker similarity
-(cosine against a reference-speaker centroid), then appends a summary row to
-metrics.csv plus per-utterance scores to perutt/epoch<N>.csv. Wavs of the
-best-scoring epoch so far are kept under samples/epoch<N>/.
+Watches a training directory for new lightning checkpoints (``epoch=*.ckpt``),
+synthesizes a fixed set of held-out sentences on CPU, scores each clip (UTMOS at
+least, and speaker similarity against a reference-speaker centroid when a
+``--speaker-ref-dir`` is given), appends a summary row to metrics.csv plus
+per-utterance scores under samples/, and maintains best.ckpt/best.json for the
+similarity-gated best epoch so far.
 
-Idempotent: already-scored epochs are read back from metrics.csv on start and
-skipped. Ordering is by epoch number parsed from the filename, never
-wall-clock.
+Idempotent: already-scored (and permanently failed) epochs are skipped. Ordering
+is by epoch number parsed from the filename, never wall-clock. With
+``--early-stop-patience`` set, once that many scored epochs pass with no
+improvement a ``stop.flag`` is written into the training directory — the training
+process's ``StopFileCallback`` picks it up and stops (sidecar -> trainer bridge).
+
+The heavy lifting lives in ``phoonnx_train.evaluation``; this module is the
+watch loop, CLI surface and idempotent-restart glue.
 """
-import csv
 import json
 import logging
-import shutil
 import time
 from pathlib import Path
 
 import click
-import numpy as np
-import soundfile as sf
-import torch
-import torchaudio
 
-from phoonnx.config import PhonemeType, Alphabet, get_phonemizer
-from phoonnx.tokenizer import TTSTokenizer
-from phoonnx.util import normalize
-from phoonnx_train.eval_utils import (append_metrics, best_mean_so_far,
-                                      done_epochs, find_checkpoints,
-                                      largest_wavs, parse_step,
-                                      read_sentences, size_stable)
-from phoonnx_train.vits.lightning import VitsModel
+from phoonnx_train.engines import get_engine, list_engines
+from phoonnx_train.eval_utils import (find_checkpoints, read_sentences,
+                                      size_stable)
+from phoonnx_train.evaluation import CheckpointScorer, MetricsTracker, SelectionPolicy
+from phoonnx_train.evaluation.scorer import build_encoder, text_to_ids
 
 _LOGGER = logging.getLogger(__package__)
 
-# torch >=2.6 defaults torch.load(weights_only=True); lightning checkpoints
-# embed pathlib.PosixPath (and full pickled objects), which that rejects.
-# These are our own trusted checkpoints, so restore weights_only=False.
-_ORIG_TORCH_LOAD = torch.load
+
+def resolve_engine(name: str, config: dict) -> str:
+    """Resolve ``--engine`` (default 'auto'): the config's ``engine`` key when
+    present, else 'vits'."""
+    if name and name != "auto":
+        return name
+    engine = config.get("engine")
+    if engine and engine in list_engines():
+        return engine
+    return "vits"
 
 
-def _torch_load(*a, **k):
-    k.setdefault("weights_only", False)
-    return _ORIG_TORCH_LOAD(*a, **k)
-
-
-torch.load = _torch_load
-
-
-def build_encoder(config, noise_scale, length_scale, noise_w):
-    """Return (phonemizer, tokenizer, lang, sample_rate, scales) matching
-    preprocess/train exactly."""
-    phoneme_type = PhonemeType(config["phoneme_type"])
-    alphabet = Alphabet(config.get("alphabet") or "ipa")
-    ph = get_phonemizer(phoneme_type, alphabet, config.get("phonemizer_model"))
-    tokenizer = TTSTokenizer.from_phoonnx_config(config)
-    lang = config.get("lang_code", "")
-    sample_rate = int(config.get("audio", {}).get("sample_rate", 22050))
-    inf = config.get("inference", {})
-    scales = [noise_scale if noise_scale is not None else float(inf.get("noise_scale", 0.667)),
-              length_scale if length_scale is not None else float(inf.get("length_scale", 1.0)),
-              noise_w if noise_w is not None else float(inf.get("noise_w", 0.8))]
-    return ph, tokenizer, lang, sample_rate, scales
-
-
-def text_to_ids(text, ph, tokenizer, lang):
-    """Replicate preprocess.py: normalize -> phonemize_to_list (drop '\\n')
-    -> tokenizer.tokenize (intersperse pad + BOS/EOS)."""
-    utt = normalize(text, lang)
-    phonemes = [p for p in ph.phonemize_to_list(utt, lang) if p != "\n"]
-    return phonemes, tokenizer.tokenize(phonemes)
-
-
-def load_model(ckpt_path):
-    model = VitsModel.load_from_checkpoint(str(ckpt_path), dataset=None,
-                                           map_location="cpu")
-    model = model.to("cpu")
-    model.eval()
-    with torch.no_grad():
-        model.model_g.dec.remove_weight_norm()
-    return model
-
-
-def synth(model, ids, scales):
-    """Run VitsModel.forward on CPU; return 1-D float32 waveform."""
-    text = torch.LongTensor(ids).unsqueeze(0)
-    text_lengths = torch.LongTensor([len(ids)])
-    scales_t = torch.FloatTensor(scales)
-    with torch.no_grad():
-        audio = model(text, text_lengths, scales_t, sid=None)
-    return audio.detach().cpu().float().squeeze().numpy().astype(np.float32)
-
-
-def load_speaker_reference(ref_dir, num_ref_wavs):
-    """Mean (unit-norm) speaker embedding over the largest reference wavs.
-
-    Returns (embedder, centroid) or (None, None) when speaker similarity
-    cannot be computed (speakeronnx missing or no wavs found).
-    """
-    try:
-        from speakeronnx import SpeakerEmbedder
-    except ImportError:
-        _LOGGER.warning("speakeronnx not installed; scoring UTMOS only")
-        return None, None
-    wavs = largest_wavs(ref_dir, num_ref_wavs)
-    if not wavs:
-        _LOGGER.warning("no reference wavs under %s; scoring UTMOS only", ref_dir)
-        return None, None
-    emb = SpeakerEmbedder()
-    vecs = []
-    for w in wavs:
-        try:
-            v = np.asarray(emb.embed(str(w)), dtype=np.float32)
-            vecs.append(v / (np.linalg.norm(v) + 1e-9))
-        except Exception:
-            _LOGGER.exception("failed to embed reference %s", w)
-    if not vecs:
-        _LOGGER.warning("no reference wavs could be embedded; scoring UTMOS only")
-        return None, None
-    ref = np.mean(vecs, axis=0)
-    ref /= np.linalg.norm(ref) + 1e-9
-    _LOGGER.info("speaker reference centroid from %d clips", len(vecs))
-    return emb, ref
-
-
-def speaker_similarity(emb, ref, wav_path):
-    v = np.asarray(emb.embed(str(wav_path)), dtype=np.float32)
-    v /= np.linalg.norm(v) + 1e-9
-    return float(np.dot(v, ref))
-
-
-def load_utmos():
-    _LOGGER.info("loading UTMOS (SpeechMOS utmos22_strong)...")
-    predictor = torch.hub.load("tarepan/SpeechMOS", "utmos22_strong",
-                               trust_repo=True)
-    predictor.eval()
-    return predictor
-
-
-def utmos_score(predictor, wav, sr):
-    """wav: 1-D np.float32 at sr. Resample to 16k mono and score."""
-    t = torch.from_numpy(np.ascontiguousarray(wav)).float()
-    if sr != 16000:
-        t = torchaudio.functional.resample(t, sr, 16000)
-    with torch.no_grad():
-        score = predictor(t.unsqueeze(0), 16000)
-    return float(score.squeeze().item())
-
-
-def evaluate_checkpoint(ckpt_path, epoch, sentences, ph, tokenizer, lang,
-                        sample_rate, scales, predictor, emb, ref, output_dir):
+def evaluate_one(scorer, selection, tracker, ckpt_path, epoch, train_dir):
+    """Score a single checkpoint into the scoreboard. Returns True when scored,
+    False when deferred (unstable) or failed."""
     _LOGGER.info("evaluating epoch %d: %s", epoch, ckpt_path)
     if not size_stable(ckpt_path):
         _LOGGER.warning("checkpoint %s not stable yet, deferring", ckpt_path)
         return False
+    work_dir = tracker.output_dir / "_work" / f"epoch{epoch}"
     try:
-        model = load_model(ckpt_path)
+        row = scorer.score(ckpt_path, epoch, work_dir=work_dir)
     except Exception:
-        _LOGGER.exception("failed to load %s", ckpt_path)
+        _LOGGER.exception("failed to score epoch %d", epoch)
+        tracker.record_failure(epoch)
         return False
 
-    metrics_csv = output_dir / "metrics.csv"
-    tmp = output_dir / "_work" / f"epoch{epoch}"
-    tmp.mkdir(parents=True, exist_ok=True)
-    perutt = []
-    for i, text in enumerate(sentences):
-        try:
-            _, ids = text_to_ids(text, ph, tokenizer, lang)
-            wav = synth(model, ids, scales)
-            wpath = tmp / f"utt{i:02d}.wav"
-            sf.write(wpath, wav, sample_rate)
-            score = utmos_score(predictor, wav, sample_rate)
-            sim = speaker_similarity(emb, ref, wpath) if emb is not None else None
-            _LOGGER.info("  utt%02d dur=%.2fs utmos=%.3f spk_sim=%s  %s",
-                         i, len(wav) / sample_rate, score,
-                         f"{sim:.3f}" if sim is not None else "-", text[:30])
-            perutt.append((text, score, sim))
-        except Exception:
-            _LOGGER.exception("  failed utt %d: %s", i, text)
-
-    del model
-    if not perutt:
-        _LOGGER.error("no utterances scored for epoch %d", epoch)
-        return False
-
-    scores = np.array([s for _, s, _ in perutt], dtype=np.float64)
-    sims = np.array([m for _, _, m in perutt if m is not None], dtype=np.float64)
-
-    perutt_dir = output_dir / "perutt"
-    perutt_dir.mkdir(parents=True, exist_ok=True)
-    with open(perutt_dir / f"epoch{epoch}.csv", "w", newline="",
-              encoding="utf-8") as f:
-        w = csv.writer(f)
-        w.writerow(["sentence", "utmos", "spk_sim"])
-        for text, s, m in perutt:
-            w.writerow([text, f"{s:.4f}", f"{m:.4f}" if m is not None else ""])
-
-    row = {
-        "epoch": epoch,
-        "step": parse_step(ckpt_path.name),
-        "checkpoint": str(ckpt_path),
-        "utmos_mean": f"{scores.mean():.4f}",
-        "utmos_std": f"{scores.std():.4f}",
-        "utmos_min": f"{scores.min():.4f}",
-        "utmos_max": f"{scores.max():.4f}",
-        "spk_sim_mean": f"{sims.mean():.4f}" if sims.size else "",
-        "spk_sim_std": f"{sims.std():.4f}" if sims.size else "",
-        "spk_sim_min": f"{sims.min():.4f}" if sims.size else "",
-        "n_sentences": len(scores),
-    }
-
-    prev_best = best_mean_so_far(metrics_csv)
-    append_metrics(metrics_csv, row)
-    _LOGGER.info("epoch %d: utmos=%.4f±%.4f n=%d", epoch, scores.mean(),
-                 scores.std(), len(scores))
-
-    if prev_best is None or scores.mean() > prev_best:
-        dest = output_dir / "samples" / f"epoch{epoch}"
-        if dest.exists():
-            shutil.rmtree(dest)
-        shutil.copytree(tmp, dest)
-        _LOGGER.info("new best epoch %d (mean=%.4f); wavs kept at %s",
-                     epoch, scores.mean(), dest)
-    shutil.rmtree(tmp, ignore_errors=True)
+    best = selection.read_best(tracker.output_dir)
+    tracker.append(row.to_csv_row())
+    _LOGGER.info("epoch %d: %s", epoch, row.aggregates)
+    if selection.is_improvement(row, best):
+        selection.commit_best(row, tracker.output_dir, work_dir=work_dir)
     return True
 
 
@@ -241,12 +80,17 @@ def evaluate_checkpoint(ckpt_path, epoch, sentences, ph, tokenizer, lang,
 @click.option('--length-scale', type=float, default=None, help='Override inference length_scale from config')
 @click.option('--noise-w', type=float, default=None, help='Override inference noise_w from config')
 @click.option('--seed', type=int, default=1234, help='Random seed (default: 1234)')
+@click.option('--early-stop-patience', type=int, default=0, help='Write stop.flag into --train-dir after this many scored epochs with no improvement (0=off)')
+@click.option('--min-spk-sim', type=float, default=None, help='Similarity gate: best checkpoint must have mean speaker similarity >= this (when speaker scoring is active)')
+@click.option('--speaker-id', type=int, default=None, help='Speaker id (sid) to synthesize for multi-speaker models')
+@click.option('--engine', 'engine_name', type=str, default='auto', help="Training engine (default: auto from config.json, falling back to vits)")
+@click.option('--vocoder', 'vocoder_path', type=click.Path(exists=True, dir_okay=False), default=None, help='Optional vocoder passed to the engine synth (engine-dependent)')
 def main(train_dir, config_path, sentences_path, output_dir, speaker_ref_dir,
          num_ref_wavs, poll, once, dry_run, noise_scale, length_scale,
-         noise_w, seed):
+         noise_w, seed, early_stop_patience, min_spk_sim, speaker_id,
+         engine_name, vocoder_path):
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(message)s")
-    torch.manual_seed(seed)
 
     train_dir = Path(train_dir)
     output_dir = Path(output_dir)
@@ -259,12 +103,12 @@ def main(train_dir, config_path, sentences_path, output_dir, speaker_ref_dir,
 
     with open(config_path, "r", encoding="utf-8") as f:
         config = json.load(f)
-    ph, tokenizer, lang, sample_rate, scales = build_encoder(
-        config, noise_scale, length_scale, noise_w)
-    _LOGGER.info("lang=%s sample_rate=%d scales=%s vocab=%d", lang,
-                 sample_rate, scales, len(config.get("phoneme_id_map", {})))
 
     if dry_run:
+        ph, tokenizer, lang, sample_rate, scales = build_encoder(
+            config, noise_scale, length_scale, noise_w)
+        _LOGGER.info("lang=%s sample_rate=%d scales=%s vocab=%d", lang,
+                     sample_rate, scales, len(config.get("phoneme_id_map", {})))
         for i, text in enumerate(sentences):
             phonemes, ids = text_to_ids(text, ph, tokenizer, lang)
             _LOGGER.info("utt%02d ids=%d phon=%d | %s", i, len(ids),
@@ -272,25 +116,43 @@ def main(train_dir, config_path, sentences_path, output_dir, speaker_ref_dir,
         _LOGGER.info("dry-run OK: config loaded, all sentences encoded")
         return
 
-    predictor = load_utmos()
-    emb, ref = load_speaker_reference(speaker_ref_dir, num_ref_wavs) \
-        if speaker_ref_dir else (None, None)
+    engine = get_engine(resolve_engine(engine_name, config))
     if speaker_ref_dir is None:
         _LOGGER.warning("--speaker-ref-dir not given; scoring UTMOS only")
 
-    metrics_csv = output_dir / "metrics.csv"
+    scorer = CheckpointScorer(
+        engine, config, sentences,
+        speaker_ref_dir=Path(speaker_ref_dir) if speaker_ref_dir else None,
+        num_ref_wavs=num_ref_wavs,
+        speaker_id=speaker_id,
+        seed=seed,
+        vocoder_path=Path(vocoder_path) if vocoder_path else None,
+        scales_override=(noise_scale, length_scale, noise_w),
+    )
+    selection = SelectionPolicy(metric="utmos_mean", min_spk_sim=min_spk_sim)
+    tracker = MetricsTracker(output_dir)
+
     while True:
         try:
-            done = done_epochs(metrics_csv)
+            skip = tracker.skip_epochs()
             ckpts = find_checkpoints(train_dir)
-            todo = sorted(e for e in ckpts if e not in done)
+            todo = sorted(e for e in ckpts if e not in skip)
             if not todo:
-                _LOGGER.info("no new checkpoints (done=%d, found=%d)",
-                             len(done), len(ckpts))
+                _LOGGER.info("no new checkpoints (skip=%d, found=%d)",
+                             len(skip), len(ckpts))
             for epoch in todo:
-                evaluate_checkpoint(ckpts[epoch], epoch, sentences, ph,
-                                    tokenizer, lang, sample_rate, scales,
-                                    predictor, emb, ref, output_dir)
+                evaluate_one(scorer, selection, tracker, ckpts[epoch], epoch,
+                             train_dir)
+
+            best = selection.read_best(output_dir)
+            best_epoch = best.epoch if best is not None else None
+            if early_stop_patience and tracker.maybe_stop(best_epoch, early_stop_patience):
+                # write stop.flag into the training dir so the trainer sees it
+                flag = train_dir / "stop.flag"
+                flag.write_text(
+                    f"early stopping: no improvement for >= {early_stop_patience} "
+                    f"epochs (best epoch {best_epoch})\n", encoding="utf-8")
+                _LOGGER.warning("wrote %s", flag)
         except Exception:
             _LOGGER.exception("scan iteration failed; continuing")
         if once:

--- a/phoonnx_train/evaluation/__init__.py
+++ b/phoonnx_train/evaluation/__init__.py
@@ -1,0 +1,33 @@
+"""Reusable checkpoint-evaluation package.
+
+The same building blocks drive two modes:
+
+* a **sidecar scoreboard** process (``phoonnx_train.eval_loop``) that watches a
+  training directory, scores new checkpoints on CPU and maintains a scoreboard
+  (metrics.csv, per-utterance scores, best.json/best.ckpt, kept wavs), and
+
+* **in-training early stopping** (``EvalScoreboardCallback``) that runs the same
+  scorer in-process every N epochs and stops the trainer once a patience budget
+  is exhausted.
+
+Both modes share:
+
+* :class:`~phoonnx_train.evaluation.scorer.CheckpointScorer` — turns a checkpoint
+  into a structured :class:`~phoonnx_train.evaluation.scorer.EvalRow`,
+* :class:`~phoonnx_train.evaluation.selection.SelectionPolicy` — similarity-gated
+  best-checkpoint selection,
+* :class:`~phoonnx_train.evaluation.tracker.MetricsTracker` — metrics.csv
+  bookkeeping, failed-epoch marking, patience counting and stop.flag emission.
+"""
+from phoonnx_train.evaluation.scorer import (CheckpointScorer, EvalRow,
+                                             register_metric)
+from phoonnx_train.evaluation.selection import SelectionPolicy
+from phoonnx_train.evaluation.tracker import MetricsTracker
+
+__all__ = [
+    "CheckpointScorer",
+    "EvalRow",
+    "register_metric",
+    "SelectionPolicy",
+    "MetricsTracker",
+]

--- a/phoonnx_train/evaluation/callbacks.py
+++ b/phoonnx_train/evaluation/callbacks.py
@@ -20,6 +20,7 @@ except Exception:  # pragma: no cover - exercised indirectly
     Callback = object
 
 from phoonnx_train.eval_utils import find_checkpoints, size_stable
+from phoonnx_train.evaluation.scorer import write_epoch_perutt
 from phoonnx_train.evaluation.selection import SelectionPolicy
 from phoonnx_train.evaluation.tracker import MetricsTracker
 
@@ -125,6 +126,9 @@ class EvalScoreboardCallback(Callback):
 
         best = self.selection.read_best(self.output_dir)
         self.tracker.append(row.to_csv_row())
+        # Per-epoch per-utterance file for every scored epoch (overfit
+        # diagnosis across epochs, not only the best epoch's samples).
+        write_epoch_perutt(self.output_dir, row, self.scorer.metrics)
         if self.selection.is_improvement(row, best):
             self.selection.commit_best(row, self.output_dir, work_dir=work_dir)
             best = row

--- a/phoonnx_train/evaluation/callbacks.py
+++ b/phoonnx_train/evaluation/callbacks.py
@@ -1,0 +1,135 @@
+"""Lightning callbacks bridging the evaluation package into training.
+
+* :class:`StopFileCallback` — watches a ``stop.flag`` file at each epoch end and
+  stops the trainer when it appears. This is the **sidecar -> trainer bridge**:
+  an out-of-process scoreboard writes the flag, the trainer honours it. It is a
+  no-op while no flag exists, so it is always safe to add.
+
+* :class:`EvalScoreboardCallback` — runs the same :class:`CheckpointScorer`
+  in-process every N epochs (after ModelCheckpoint has saved), updates the shared
+  tracker/selection files and stops the trainer once patience is exhausted.
+  Scoring failures never crash training: they are logged and swallowed.
+"""
+import logging
+from pathlib import Path
+from typing import Optional
+
+try:  # pytorch_lightning is a heavy optional dep at import time
+    from pytorch_lightning.callbacks import Callback
+except Exception:  # pragma: no cover - exercised indirectly
+    Callback = object
+
+from phoonnx_train.eval_utils import find_checkpoints, size_stable
+from phoonnx_train.evaluation.selection import SelectionPolicy
+from phoonnx_train.evaluation.tracker import MetricsTracker
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class StopFileCallback(Callback):
+    """Stop training when ``flag_path`` appears (external early-stop signal)."""
+
+    def __init__(self, flag_path: Path):
+        super().__init__()
+        self.flag_path = Path(flag_path)
+
+    def _check(self, trainer) -> None:
+        if self.flag_path.exists():
+            try:
+                reason = self.flag_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                reason = "(unreadable stop.flag)"
+            _LOGGER.warning("stop flag %s present: %s; stopping training",
+                            self.flag_path, reason)
+            trainer.should_stop = True
+
+    def on_train_epoch_end(self, trainer, pl_module) -> None:
+        self._check(trainer)
+
+    def on_validation_end(self, trainer, pl_module) -> None:
+        self._check(trainer)
+
+
+class EvalScoreboardCallback(Callback):
+    """In-process scoreboard + patience-based early stopping.
+
+    Args:
+        scorer: a configured :class:`CheckpointScorer`.
+        tracker: shared :class:`MetricsTracker` (same output_dir as any sidecar).
+        selection: :class:`SelectionPolicy`.
+        output_dir: scoreboard dir (metrics.csv, best.ckpt, samples/, stop.flag).
+        every_n_epochs: score every N epochs (>=1).
+        patience: stop after this many scored epochs without improvement
+            (``None``/0 disables stopping; scoring still runs).
+        checkpoint_dir: where to look for ``epoch=*.ckpt`` (defaults to the
+            trainer's checkpoint dir / default_root_dir).
+    """
+
+    def __init__(self, scorer, tracker: MetricsTracker, selection: SelectionPolicy,
+                 output_dir: Path, every_n_epochs: int = 1,
+                 patience: Optional[int] = None, checkpoint_dir: Optional[Path] = None):
+        super().__init__()
+        self.scorer = scorer
+        self.tracker = tracker
+        self.selection = selection
+        self.output_dir = Path(output_dir)
+        self.every_n_epochs = max(1, int(every_n_epochs))
+        self.patience = patience
+        self.checkpoint_dir = Path(checkpoint_dir) if checkpoint_dir else None
+
+    def on_train_epoch_end(self, trainer, pl_module) -> None:
+        try:
+            epoch = int(trainer.current_epoch)
+            if (epoch + 1) % self.every_n_epochs != 0:
+                return
+            self._score_newest(trainer)
+        except Exception:
+            # Scoring must never crash training.
+            _LOGGER.exception("EvalScoreboardCallback failed; continuing training")
+
+    def _resolve_checkpoint_dir(self, trainer) -> Optional[Path]:
+        if self.checkpoint_dir is not None:
+            return self.checkpoint_dir
+        cb = getattr(trainer, "checkpoint_callback", None)
+        if cb is not None and getattr(cb, "dirpath", None):
+            return Path(cb.dirpath)
+        for attr in ("log_dir", "default_root_dir"):
+            val = getattr(trainer, attr, None)
+            if val:
+                return Path(val)
+        return None
+
+    def _score_newest(self, trainer) -> None:
+        ckpt_dir = self._resolve_checkpoint_dir(trainer)
+        if ckpt_dir is None or not Path(ckpt_dir).exists():
+            _LOGGER.warning("no checkpoint dir resolved yet; skipping scoreboard")
+            return
+        ckpts = find_checkpoints(ckpt_dir)
+        skip = self.tracker.skip_epochs()
+        todo = sorted(e for e in ckpts if e not in skip)
+        if not todo:
+            return
+        epoch = todo[-1]
+        ckpt = ckpts[epoch]
+        if not size_stable(ckpt):
+            _LOGGER.warning("checkpoint %s not stable yet; deferring", ckpt)
+            return
+
+        work_dir = self.output_dir / "_work" / f"epoch{epoch}"
+        try:
+            row = self.scorer.score(ckpt, epoch, work_dir=work_dir)
+        except Exception:
+            _LOGGER.exception("scoring epoch %d failed", epoch)
+            self.tracker.record_failure(epoch)
+            return
+
+        best = self.selection.read_best(self.output_dir)
+        self.tracker.append(row.to_csv_row())
+        if self.selection.is_improvement(row, best):
+            self.selection.commit_best(row, self.output_dir, work_dir=work_dir)
+            best = row
+
+        best_epoch = best.epoch if best is not None else None
+        if self.tracker.maybe_stop(best_epoch, self.patience):
+            _LOGGER.warning("patience exhausted; stopping training at epoch %d", epoch)
+            trainer.should_stop = True

--- a/phoonnx_train/evaluation/scorer.py
+++ b/phoonnx_train/evaluation/scorer.py
@@ -1,0 +1,339 @@
+"""Checkpoint scoring: checkpoint -> synthesized held-out wavs -> EvalRow.
+
+:class:`CheckpointScorer` loads a checkpoint through the training-engine
+registry (``engine.eval_synthesize``), synthesizes a fixed set of held-out
+sentences on CPU with **per-utterance deterministic seeding** (``manual_seed``
+is re-applied immediately before each synthesis so a checkpoint scored twice
+produces identical wavs, independent of any RNG drift between epochs), scores
+each clip with a small registry of metric functions that reuse
+``phoonnx_train.quality_filter`` where they fit (UTMOS at least), optionally adds
+speaker similarity against a reference-speaker centroid, and returns a structured
+:class:`EvalRow`.
+"""
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+import numpy as np
+
+from phoonnx_train import quality_filter
+from phoonnx_train.eval_utils import largest_wavs, parse_step
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Metric registry (reuses quality_filter scorers where they fit)
+# ---------------------------------------------------------------------------
+# A metric maps a synthesized clip to a scalar. Signature:
+#   (wav: np.ndarray, sr: int, text: str) -> float
+Metric = Callable[[np.ndarray, int, str], float]
+
+_METRIC_REGISTRY: Dict[str, Metric] = {}
+
+
+def register_metric(name: str, fn: Metric) -> None:
+    """Register a named held-out clip metric."""
+    _METRIC_REGISTRY[name] = fn
+
+
+def known_metrics() -> List[str]:
+    return list(_METRIC_REGISTRY)
+
+
+def _utmos_metric(wav: np.ndarray, sr: int, text: str) -> float:
+    # Reuse quality_filter's UTMOS scorer (SpeechMOS utmos22_strong).
+    duration = float(len(wav)) / float(sr) if sr else 0.0
+    return quality_filter.utmos_score(wav, sr, text, duration)
+
+
+register_metric("utmos", _utmos_metric)
+
+
+# ---------------------------------------------------------------------------
+# Structured result row
+# ---------------------------------------------------------------------------
+@dataclass
+class EvalRow:
+    """One checkpoint's evaluation result.
+
+    ``aggregates`` holds ``<metric>_mean/std/min/max`` for every scored metric
+    plus, when speaker scoring is active, ``spk_sim_mean/std/min/max``.
+    """
+
+    epoch: int
+    step: int
+    checkpoint: str
+    n_sentences: int
+    aggregates: Dict[str, float] = field(default_factory=dict)
+    # Per-utterance rows: (sentence, {metric: value}, spk_sim or None)
+    perutt: List = field(default_factory=list)
+
+    def value(self, metric: str) -> Optional[float]:
+        """The selection value for ``metric`` (e.g. ``"utmos_mean"``)."""
+        return self.aggregates.get(metric)
+
+    @property
+    def spk_sim_mean(self) -> Optional[float]:
+        return self.aggregates.get("spk_sim_mean")
+
+    @property
+    def has_speaker_score(self) -> bool:
+        return "spk_sim_mean" in self.aggregates
+
+    def to_csv_row(self) -> Dict[str, object]:
+        """Flat dict for metrics.csv (keys match tracker columns)."""
+        row: Dict[str, object] = {
+            "epoch": self.epoch,
+            "step": self.step,
+            "checkpoint": self.checkpoint,
+            "n_sentences": self.n_sentences,
+        }
+        for k, v in self.aggregates.items():
+            row[k] = f"{v:.4f}"
+        return row
+
+
+# ---------------------------------------------------------------------------
+# Speaker reference
+# ---------------------------------------------------------------------------
+def load_speaker_reference(ref_dir: Optional[Path], num_ref_wavs: int):
+    """Mean unit-norm speaker embedding over the largest reference wavs.
+
+    Returns ``(embedder, centroid)`` or ``(None, None)`` when speaker
+    similarity cannot be computed (no ref dir, speakeronnx missing, no wavs).
+    """
+    if ref_dir is None:
+        return None, None
+    try:
+        from speakeronnx import SpeakerEmbedder
+    except ImportError:
+        _LOGGER.warning("speakeronnx not installed; scoring without speaker similarity")
+        return None, None
+    wavs = largest_wavs(ref_dir, num_ref_wavs)
+    if not wavs:
+        _LOGGER.warning("no reference wavs under %s; scoring without speaker similarity", ref_dir)
+        return None, None
+    emb = SpeakerEmbedder()
+    vecs = []
+    for w in wavs:
+        try:
+            v = np.asarray(emb.embed(str(w)), dtype=np.float32)
+            vecs.append(v / (np.linalg.norm(v) + 1e-9))
+        except Exception:
+            _LOGGER.exception("failed to embed reference %s", w)
+    if not vecs:
+        _LOGGER.warning("no reference wavs could be embedded; scoring without speaker similarity")
+        return None, None
+    ref = np.mean(vecs, axis=0)
+    ref /= np.linalg.norm(ref) + 1e-9
+    _LOGGER.info("speaker reference centroid from %d clips", len(vecs))
+    return emb, ref
+
+
+def speaker_similarity(emb, ref, wav: np.ndarray, sr: int) -> float:
+    # speakeronnx SpeakerEmbedder.embed accepts a waveform array (as used by
+    # quality_filter.speaker_consistency_score).
+    v = np.asarray(emb.embed(wav), dtype=np.float32)
+    v /= np.linalg.norm(v) + 1e-9
+    return float(np.dot(v, ref))
+
+
+# ---------------------------------------------------------------------------
+# Text encoding (matches preprocess/train exactly)
+# ---------------------------------------------------------------------------
+def build_encoder(config: Dict, noise_scale=None, length_scale=None, noise_w=None):
+    """Return ``(phonemizer, tokenizer, lang, sample_rate, scales)`` matching
+    preprocess/train exactly."""
+    from phoonnx.config import Alphabet, PhonemeType, get_phonemizer
+    from phoonnx.tokenizer import TTSTokenizer
+
+    phoneme_type = PhonemeType(config["phoneme_type"])
+    alphabet = Alphabet(config.get("alphabet") or "ipa")
+    ph = get_phonemizer(phoneme_type, alphabet, config.get("phonemizer_model"))
+    tokenizer = TTSTokenizer.from_phoonnx_config(config)
+    lang = config.get("lang_code", "")
+    sample_rate = int(config.get("audio", {}).get("sample_rate", 22050))
+    inf = config.get("inference", {})
+    scales = [
+        noise_scale if noise_scale is not None else float(inf.get("noise_scale", 0.667)),
+        length_scale if length_scale is not None else float(inf.get("length_scale", 1.0)),
+        noise_w if noise_w is not None else float(inf.get("noise_w", 0.8)),
+    ]
+    return ph, tokenizer, lang, sample_rate, scales
+
+
+def text_to_ids(text: str, ph, tokenizer, lang):
+    """Replicate preprocess.py: normalize -> phonemize_to_list (drop '\\n')
+    -> tokenizer.tokenize (intersperse pad + BOS/EOS)."""
+    from phoonnx.util import normalize
+
+    utt = normalize(text, lang)
+    phonemes = [p for p in ph.phonemize_to_list(utt, lang) if p != "\n"]
+    return phonemes, tokenizer.tokenize(phonemes)
+
+
+# ---------------------------------------------------------------------------
+# Scorer
+# ---------------------------------------------------------------------------
+class CheckpointScorer:
+    """Synthesize + score held-out sentences for a checkpoint.
+
+    Args:
+        engine: a ``BaseTrainingEngine`` (provides ``eval_synthesize``).
+        config: the training config.json dict.
+        sentences: held-out sentences (one string each).
+        metrics: metric names to score (default: ``("utmos",)``).
+        speaker_ref_dir: reference-speaker wav dir (enables speaker similarity).
+        num_ref_wavs: largest reference wavs averaged into the centroid.
+        speaker_id: sid for multi-speaker synthesis (``None`` = default voice).
+        seed: base seed; utterance ``i`` is synthesized under ``seed + i``.
+        vocoder_path / device: passed through to ``engine.eval_synthesize``.
+        scales_override: optional ``(noise_scale, length_scale, noise_w)``.
+    """
+
+    def __init__(
+        self,
+        engine,
+        config: Dict,
+        sentences: List[str],
+        *,
+        metrics=("utmos",),
+        speaker_ref_dir: Optional[Path] = None,
+        num_ref_wavs: int = 60,
+        speaker_id: Optional[int] = None,
+        seed: int = 1234,
+        vocoder_path: Optional[Path] = None,
+        device: str = "cpu",
+        scales_override=(None, None, None),
+    ):
+        self.engine = engine
+        self.config = config
+        self.sentences = list(sentences)
+        for m in metrics:
+            if m not in _METRIC_REGISTRY:
+                raise ValueError(
+                    f"unknown eval metric {m!r}; known: {', '.join(known_metrics())}"
+                )
+        self.metrics = list(metrics)
+        self.seed = seed
+        self.vocoder_path = vocoder_path
+        self.device = device
+
+        self.ph, self.tokenizer, self.lang, self.sample_rate, self.scales = build_encoder(
+            config, *scales_override
+        )
+
+        num_speakers = int(config.get("num_speakers", 1))
+        if num_speakers > 1 and speaker_id is None:
+            _LOGGER.warning(
+                "config declares num_speakers=%d but no --speaker-id given; "
+                "synthesizing with sid=None (engine's default voice)",
+                num_speakers,
+            )
+        self.speaker_id = speaker_id
+
+        self.emb, self.ref = load_speaker_reference(speaker_ref_dir, num_ref_wavs)
+
+    @property
+    def speaker_scoring_active(self) -> bool:
+        return self.emb is not None and self.ref is not None
+
+    def score(self, checkpoint_path: Path, epoch: int, work_dir: Optional[Path] = None) -> EvalRow:
+        """Synthesize + score ``checkpoint_path``. Returns an :class:`EvalRow`.
+
+        Wavs and a per-utterance CSV are written under ``work_dir`` when given
+        (used by selection to keep best-epoch samples). Raises on load failure;
+        the caller decides whether to record the epoch failed.
+        """
+        import soundfile as sf
+
+        checkpoint_path = Path(checkpoint_path)
+        synth = self.engine.eval_synthesize(
+            checkpoint_path, self.config,
+            vocoder_path=self.vocoder_path, device=self.device,
+        )
+
+        if work_dir is not None:
+            work_dir = Path(work_dir)
+            work_dir.mkdir(parents=True, exist_ok=True)
+
+        perutt = []
+        for i, text in enumerate(self.sentences):
+            try:
+                _, ids = text_to_ids(text, self.ph, self.tokenizer, self.lang)
+                # Per-utterance deterministic reseed: fixes cross-epoch RNG
+                # drift so the same checkpoint always yields the same wav.
+                self._reseed(self.seed + i)
+                wav = synth(ids, self.scales, self.speaker_id)
+                metric_vals = {
+                    name: _METRIC_REGISTRY[name](wav, self.sample_rate, text)
+                    for name in self.metrics
+                }
+                sim = None
+                if self.speaker_scoring_active:
+                    sim = speaker_similarity(self.emb, self.ref, wav, self.sample_rate)
+                if work_dir is not None:
+                    sf.write(work_dir / f"utt{i:02d}.wav", wav, self.sample_rate)
+                _LOGGER.info(
+                    "  utt%02d dur=%.2fs %s spk_sim=%s  %s",
+                    i, len(wav) / self.sample_rate,
+                    " ".join(f"{k}={v:.3f}" for k, v in metric_vals.items()),
+                    f"{sim:.3f}" if sim is not None else "-", text[:30],
+                )
+                perutt.append((text, metric_vals, sim))
+            except Exception:
+                _LOGGER.exception("  failed utt %d: %s", i, text)
+
+        if not perutt:
+            raise RuntimeError(f"no utterances scored for epoch {epoch}")
+
+        aggregates = self._aggregate(perutt)
+        if work_dir is not None:
+            self._write_perutt(work_dir, perutt)
+
+        return EvalRow(
+            epoch=epoch,
+            step=parse_step(checkpoint_path.name),
+            checkpoint=str(checkpoint_path),
+            n_sentences=len(perutt),
+            aggregates=aggregates,
+            perutt=perutt,
+        )
+
+    @staticmethod
+    def _reseed(seed: int) -> None:
+        import torch
+
+        torch.manual_seed(seed)
+
+    def _aggregate(self, perutt) -> Dict[str, float]:
+        agg: Dict[str, float] = {}
+        for name in self.metrics:
+            vals = np.array([m[name] for _, m, _ in perutt], dtype=np.float64)
+            agg[f"{name}_mean"] = float(vals.mean())
+            agg[f"{name}_std"] = float(vals.std())
+            agg[f"{name}_min"] = float(vals.min())
+            agg[f"{name}_max"] = float(vals.max())
+        sims = np.array([s for _, _, s in perutt if s is not None], dtype=np.float64)
+        if sims.size:
+            agg["spk_sim_mean"] = float(sims.mean())
+            agg["spk_sim_std"] = float(sims.std())
+            agg["spk_sim_min"] = float(sims.min())
+            agg["spk_sim_max"] = float(sims.max())
+        return agg
+
+    def _write_perutt(self, work_dir: Path, perutt) -> None:
+        import csv
+
+        header = ["sentence"] + self.metrics + ["spk_sim"]
+        with open(work_dir / "perutt.csv", "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(header)
+            for text, mvals, sim in perutt:
+                w.writerow(
+                    [text]
+                    + [f"{mvals[m]:.4f}" for m in self.metrics]
+                    + [f"{sim:.4f}" if sim is not None else ""]
+                )

--- a/phoonnx_train/evaluation/scorer.py
+++ b/phoonnx_train/evaluation/scorer.py
@@ -221,9 +221,17 @@ class CheckpointScorer:
         self.vocoder_path = vocoder_path
         self.device = device
 
-        self.ph, self.tokenizer, self.lang, self.sample_rate, self.scales = build_encoder(
+        self.ph, self.tokenizer, self.lang, self.sample_rate, built_scales = build_encoder(
             config, *scales_override
         )
+        # Scale semantics are engine-specific (VITS: noise/length/noise_w,
+        # matcha: temperature/length, optispeech: d/p/e factors). Only pass an
+        # explicit triple when the user overrode a value on the CLI; None lets
+        # each engine fall back to its own checkpoint/config defaults.
+        if any(v is not None for v in scales_override):
+            self.scales = built_scales
+        else:
+            self.scales = None
 
         num_speakers = int(config.get("num_speakers", 1))
         if num_speakers > 1 and speaker_id is None:

--- a/phoonnx_train/evaluation/scorer.py
+++ b/phoonnx_train/evaluation/scorer.py
@@ -325,15 +325,34 @@ class CheckpointScorer:
         return agg
 
     def _write_perutt(self, work_dir: Path, perutt) -> None:
-        import csv
+        _write_perutt_csv(work_dir / "perutt.csv", perutt, self.metrics)
 
-        header = ["sentence"] + self.metrics + ["spk_sim"]
-        with open(work_dir / "perutt.csv", "w", newline="", encoding="utf-8") as f:
-            w = csv.writer(f)
-            w.writerow(header)
-            for text, mvals, sim in perutt:
-                w.writerow(
-                    [text]
-                    + [f"{mvals[m]:.4f}" for m in self.metrics]
-                    + [f"{sim:.4f}" if sim is not None else ""]
-                )
+
+def _write_perutt_csv(path: Path, perutt, metrics) -> None:
+    import csv
+
+    header = ["sentence"] + list(metrics) + ["spk_sim"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        for text, mvals, sim in perutt:
+            w.writerow(
+                [text]
+                + [f"{mvals[m]:.4f}" for m in metrics]
+                + [f"{sim:.4f}" if sim is not None else ""]
+            )
+
+
+def write_epoch_perutt(output_dir: Path, row: "EvalRow", metrics=("utmos",)) -> Path:
+    """Write the legacy per-epoch per-utterance file ``perutt/epoch<N>.csv``.
+
+    Kept for EVERY evaluated epoch (not just the best) so per-utterance trends
+    across epochs are available for overfit diagnosis (e.g. one sentence
+    degrading while the mean holds). Columns: ``sentence``, each metric,
+    ``spk_sim``.
+    """
+    perutt_dir = Path(output_dir) / "perutt"
+    perutt_dir.mkdir(parents=True, exist_ok=True)
+    path = perutt_dir / f"epoch{row.epoch}.csv"
+    _write_perutt_csv(path, row.perutt, list(metrics))
+    return path

--- a/phoonnx_train/evaluation/selection.py
+++ b/phoonnx_train/evaluation/selection.py
@@ -1,0 +1,120 @@
+"""Similarity-gated best-checkpoint selection.
+
+UTMOS alone can prefer a checkpoint whose voice has drifted away from the
+target speaker (higher naturalness, wrong identity). :class:`SelectionPolicy`
+therefore *gates* candidates on a minimum speaker similarity before comparing
+the naturalness metric: when speaker scoring is active and a floor is set, a
+candidate must clear the floor to be eligible at all; among eligible candidates
+the higher metric wins.
+
+On a new best it writes ``best.json`` (epoch, step, checkpoint, all scores) and
+copies the checkpoint to ``best.ckpt`` (a copy, not a symlink, so it survives
+checkpoint pruning), plus keeps the best epoch's wav samples.
+"""
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from phoonnx_train.evaluation.scorer import EvalRow
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SelectionPolicy:
+    def __init__(self, metric: str = "utmos_mean", min_spk_sim: Optional[float] = None):
+        self.metric = metric
+        self.min_spk_sim = min_spk_sim
+
+    def is_eligible(self, row: EvalRow) -> bool:
+        """A row must clear the similarity floor when speaker scoring is active
+        and a floor is set. With no speaker score or no floor, always eligible
+        (UTMOS-only fallback)."""
+        if self.min_spk_sim is None or not row.has_speaker_score:
+            return True
+        sim = row.spk_sim_mean
+        return sim is not None and sim >= self.min_spk_sim
+
+    def is_improvement(self, row: EvalRow, best: Optional[EvalRow]) -> bool:
+        """True when ``row`` is a new best: eligible, and strictly higher on
+        ``metric`` than ``best`` (or there is no incumbent)."""
+        if not self.is_eligible(row):
+            return False
+        value = row.value(self.metric)
+        if value is None:
+            return False
+        if best is None:
+            return True
+        best_value = best.value(self.metric)
+        if best_value is None:
+            return True
+        return value > best_value
+
+    def commit_best(self, row: EvalRow, output_dir: Path,
+                    work_dir: Optional[Path] = None) -> None:
+        """Persist ``row`` as the new best: best.json, best.ckpt and, when a
+        work_dir is given, the best epoch's wav samples under samples/."""
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        payload = {
+            "epoch": row.epoch,
+            "step": row.step,
+            "checkpoint": row.checkpoint,
+            "metric": self.metric,
+            "min_spk_sim": self.min_spk_sim,
+            "scores": row.aggregates,
+        }
+        self._atomic_write_json(output_dir / "best.json", payload)
+
+        src = Path(row.checkpoint)
+        if src.is_file():
+            self._atomic_copy(src, output_dir / "best.ckpt")
+        else:
+            _LOGGER.error("best checkpoint %s missing; best.ckpt not updated", src)
+
+        if work_dir is not None and Path(work_dir).is_dir():
+            dest = output_dir / "samples" / f"epoch{row.epoch}"
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(work_dir, dest)
+            _LOGGER.info("kept best-epoch samples at %s", dest)
+
+        _LOGGER.info(
+            "new best: epoch %d %s=%.4f%s",
+            row.epoch, self.metric, row.value(self.metric),
+            "" if row.spk_sim_mean is None else f" spk_sim={row.spk_sim_mean:.4f}",
+        )
+
+    @staticmethod
+    def read_best(output_dir: Path) -> Optional[EvalRow]:
+        """Reconstruct the incumbent best EvalRow from best.json, or None."""
+        best_json = Path(output_dir) / "best.json"
+        if not best_json.is_file():
+            return None
+        try:
+            data = json.loads(best_json.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            _LOGGER.warning("could not read %s; treating as no incumbent best", best_json)
+            return None
+        return EvalRow(
+            epoch=int(data.get("epoch", -1)),
+            step=int(data.get("step", -1)),
+            checkpoint=str(data.get("checkpoint", "")),
+            n_sentences=0,
+            aggregates=dict(data.get("scores", {})),
+        )
+
+    @staticmethod
+    def _atomic_write_json(path: Path, payload) -> None:
+        tmp = Path(path).with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
+
+    @staticmethod
+    def _atomic_copy(src: Path, dest: Path) -> None:
+        tmp = Path(dest).with_suffix(dest.suffix + ".tmp")
+        shutil.copyfile(src, tmp)
+        os.replace(tmp, dest)

--- a/phoonnx_train/evaluation/tracker.py
+++ b/phoonnx_train/evaluation/tracker.py
@@ -1,0 +1,158 @@
+"""Scoreboard bookkeeping: metrics.csv, failed epochs, patience, stop.flag.
+
+:class:`MetricsTracker` owns the durable state of an evaluation run:
+
+* **metrics.csv** — a superset of the legacy header. Old files are read fine
+  (missing columns come back empty) and appended to using their *own* existing
+  header, so a run started against an old scoreboard keeps a valid CSV; a fresh
+  file gets the superset header.
+* **failed epochs** (``failed.json``) — a checkpoint that fails to load/score is
+  retried at most ``max_failures`` times (default 3) and then recorded failed and
+  skipped forever, with an ERROR log. No infinite retry loop.
+* **patience** — ``epochs_since_improvement`` counts scored epochs newer than the
+  current best (from best.json); ``write_stop_flag`` emits ``stop.flag`` with a
+  reason line when the patience budget is exceeded.
+"""
+import csv
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+from phoonnx_train.eval_utils import done_epochs as _done_epochs
+
+_LOGGER = logging.getLogger(__name__)
+
+# Legacy header (VITS-only UTMOS scoreboard) plus spk_sim_max. Superset: any
+# column not present in an old file is simply left empty on read.
+SUPERSET_HEADER = [
+    "epoch", "step", "checkpoint",
+    "utmos_mean", "utmos_std", "utmos_min", "utmos_max",
+    "spk_sim_mean", "spk_sim_std", "spk_sim_min", "spk_sim_max",
+    "n_sentences",
+]
+
+STOP_FLAG = "stop.flag"
+
+
+class MetricsTracker:
+    def __init__(self, output_dir: Path, max_failures: int = 3):
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.metrics_csv = self.output_dir / "metrics.csv"
+        self.failed_json = self.output_dir / "failed.json"
+        self.max_failures = max_failures
+
+    # ------------------------------------------------------------------
+    # metrics.csv (backward compatible)
+    # ------------------------------------------------------------------
+    def done_epochs(self) -> Set[int]:
+        return _done_epochs(self.metrics_csv)
+
+    def read_rows(self) -> List[Dict[str, str]]:
+        if not self.metrics_csv.exists():
+            return []
+        with open(self.metrics_csv, newline="", encoding="utf-8") as f:
+            return list(csv.DictReader(f))
+
+    def _existing_header(self) -> Optional[List[str]]:
+        if not self.metrics_csv.exists():
+            return None
+        with open(self.metrics_csv, newline="", encoding="utf-8") as f:
+            try:
+                header = next(csv.reader(f))
+            except StopIteration:
+                return None
+        return header or None
+
+    def append(self, row: Dict[str, object]) -> None:
+        """Append one row. A new file gets ``SUPERSET_HEADER``; an existing file
+        is appended to using its own header (extra keys dropped, missing keys
+        written empty), so old-format scoreboards stay well-formed."""
+        header = self._existing_header()
+        new = header is None
+        if new:
+            header = SUPERSET_HEADER
+        with open(self.metrics_csv, "a", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            if new:
+                w.writerow(header)
+            w.writerow([row.get(k, "") for k in header])
+
+    # ------------------------------------------------------------------
+    # Failed-epoch marking (bounded retries)
+    # ------------------------------------------------------------------
+    def _load_failed(self) -> Dict[str, int]:
+        if not self.failed_json.exists():
+            return {}
+        try:
+            return dict(json.loads(self.failed_json.read_text(encoding="utf-8")))
+        except (ValueError, OSError):
+            return {}
+
+    def _save_failed(self, data: Dict[str, int]) -> None:
+        tmp = self.failed_json.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data), encoding="utf-8")
+        os.replace(tmp, self.failed_json)
+
+    def record_failure(self, epoch: int) -> bool:
+        """Increment the failure count for ``epoch``. Returns True once the
+        count reaches ``max_failures`` (epoch is now permanently failed)."""
+        data = self._load_failed()
+        count = int(data.get(str(epoch), 0)) + 1
+        data[str(epoch)] = count
+        self._save_failed(data)
+        if count >= self.max_failures:
+            _LOGGER.error(
+                "epoch %d failed to score %d times; marking failed and "
+                "skipping it permanently", epoch, count,
+            )
+            return True
+        _LOGGER.warning("epoch %d failed to score (attempt %d/%d)",
+                        epoch, count, self.max_failures)
+        return False
+
+    def is_failed(self, epoch: int) -> bool:
+        return int(self._load_failed().get(str(epoch), 0)) >= self.max_failures
+
+    def failed_epochs(self) -> Set[int]:
+        return {int(e) for e, c in self._load_failed().items()
+                if int(c) >= self.max_failures}
+
+    def skip_epochs(self) -> Set[int]:
+        """Epochs to never (re)score: already-done plus permanently failed."""
+        return self.done_epochs() | self.failed_epochs()
+
+    # ------------------------------------------------------------------
+    # Patience / early stopping
+    # ------------------------------------------------------------------
+    def epochs_since_improvement(self, best_epoch: Optional[int]) -> int:
+        """Number of scored epochs strictly newer than ``best_epoch``.
+
+        With no best yet, returns 0.
+        """
+        if best_epoch is None:
+            return 0
+        return sum(1 for e in self.done_epochs() if e > best_epoch)
+
+    def write_stop_flag(self, reason: str) -> Path:
+        """Emit ``stop.flag`` with a reason line (idempotent overwrite)."""
+        flag = self.output_dir / STOP_FLAG
+        flag.write_text(reason.rstrip("\n") + "\n", encoding="utf-8")
+        _LOGGER.warning("wrote %s: %s", flag, reason)
+        return flag
+
+    def maybe_stop(self, best_epoch: Optional[int], patience: Optional[int]) -> bool:
+        """Write stop.flag when patience is set and exceeded. Returns whether a
+        flag was written."""
+        if not patience or patience <= 0:
+            return False
+        since = self.epochs_since_improvement(best_epoch)
+        if since >= patience:
+            self.write_stop_flag(
+                f"early stopping: {since} epochs since improvement "
+                f"(best epoch {best_epoch}) >= patience {patience}"
+            )
+            return True
+        return False

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -67,6 +67,19 @@ def _validate_engine(ctx, param, value):
               help='Log synthesized validation audio samples to the logger '
                    'each epoch (requires a TensorBoard logger)')
 @click.option('--discard-encoder', is_flag=True, default=False)
+# In-training evaluation / early stopping (all opt-in; default = off)
+@click.option('--eval-sentences', type=click.Path(exists=True, dir_okay=False), default=None,
+              help='Held-out sentences file (one per line); enables in-training scoring')
+@click.option('--eval-every', type=int, default=0,
+              help='Score the newest checkpoint every N epochs (0 = off, default)')
+@click.option('--early-stop-patience', type=int, default=0,
+              help='Stop after this many scored epochs without improvement (0 = off)')
+@click.option('--eval-speaker-ref-dir', type=click.Path(exists=True, file_okay=False), default=None,
+              help='Reference-speaker wav dir enabling the speaker-similarity gate')
+@click.option('--min-spk-sim', type=float, default=None,
+              help='Similarity gate floor for best-checkpoint selection')
+@click.option('--eval-seed', type=int, default=1234,
+              help='Base seed for per-utterance evaluation synthesis (default: 1234)')
 def main(
     dataset_dir: str,
     engine: str,
@@ -85,6 +98,12 @@ def main(
     num_workers: int,
     log_audio_samples: bool,
     discard_encoder: bool,
+    eval_sentences: Optional[str],
+    eval_every: int,
+    early_stop_patience: int,
+    eval_speaker_ref_dir: Optional[str],
+    min_spk_sim: Optional[float],
+    eval_seed: int,
 ):
     logging.basicConfig(level=logging.DEBUG)
     torch.manual_seed(seed)
@@ -195,13 +214,55 @@ def main(
         every_n_epochs=checkpoint_epochs,
         save_top_k=-1,
     )
+    callbacks = [checkpoint_callback]
+
+    # ------------------------------------------------------------------
+    # Evaluation / early stopping
+    # ------------------------------------------------------------------
+    # StopFileCallback is ALWAYS added: it watches the run directory for a
+    # stop.flag written by an external sidecar scoreboard (the sidecar->trainer
+    # bridge). With no flag present it is a no-op, so behaviour is byte-identical
+    # to before unless a flag actually appears.
+    from phoonnx_train.evaluation.callbacks import (EvalScoreboardCallback,
+                                                    StopFileCallback)
+
+    run_dir = Path(default_root_dir) if default_root_dir else Path.cwd()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    callbacks.append(StopFileCallback(run_dir / "stop.flag"))
+
+    # In-training scoreboard is opt-in: only wired up when both an eval
+    # sentences file and a positive --eval-every are given.
+    if eval_sentences and eval_every > 0:
+        from phoonnx_train.evaluation import (CheckpointScorer, MetricsTracker,
+                                              SelectionPolicy)
+        from phoonnx_train.eval_utils import read_sentences
+
+        sentences = read_sentences(eval_sentences)
+        eval_dir = run_dir / "eval"
+        scorer = CheckpointScorer(
+            training_engine, dataset_config, sentences,
+            speaker_ref_dir=Path(eval_speaker_ref_dir) if eval_speaker_ref_dir else None,
+            speaker_id=None,
+            seed=eval_seed,
+        )
+        selection = SelectionPolicy(metric="utmos_mean", min_spk_sim=min_spk_sim)
+        tracker = MetricsTracker(eval_dir)
+        callbacks.append(EvalScoreboardCallback(
+            scorer, tracker, selection, eval_dir,
+            every_n_epochs=eval_every,
+            patience=early_stop_patience or None,
+        ))
+        _LOGGER.info("In-training evaluation enabled: every %d epoch(s), "
+                     "patience=%s, scoreboard=%s", eval_every,
+                     early_stop_patience or None, eval_dir)
+
     trainer = Trainer(
         max_epochs=max_epochs,
         devices=devices,
         accelerator=accelerator,
         default_root_dir=default_root_dir,
         precision=precision,
-        callbacks=[checkpoint_callback],
+        callbacks=callbacks,
         **training_engine.trainer_kwargs(),
     )
     _LOGGER.info("Training started!")

--- a/tests/test_evaluation_package.py
+++ b/tests/test_evaluation_package.py
@@ -1,0 +1,425 @@
+"""Tests for the reusable checkpoint-evaluation package.
+
+Covers selection (similarity gate + UTMOS-only fallback + atomic best writes),
+tracker (old-format CSV read, failed-epoch marking, patience/stop.flag),
+callbacks (stop-file honoured, scorer failure isolated), scorer determinism
+(per-utterance reseed), and the eval_loop CLI (--once with a mocked engine).
+
+Adversarial cases are included: high-UTMOS/low-sim rows must be excluded by the
+gate, a scorer that raises must not stop training, and a checkpoint that fails
+three times must never be retried.
+"""
+import csv
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from phoonnx_train.evaluation.scorer import EvalRow
+from phoonnx_train.evaluation.selection import SelectionPolicy
+from phoonnx_train.evaluation.tracker import MetricsTracker, SUPERSET_HEADER
+
+
+def _row(epoch, utmos, spk_sim=None, step=10):
+    agg = {"utmos_mean": utmos, "utmos_std": 0.1, "utmos_min": utmos - 0.1,
+           "utmos_max": utmos + 0.1}
+    if spk_sim is not None:
+        agg.update({"spk_sim_mean": spk_sim, "spk_sim_std": 0.0,
+                    "spk_sim_min": spk_sim, "spk_sim_max": spk_sim})
+    return EvalRow(epoch=epoch, step=step, checkpoint=f"epoch={epoch}.ckpt",
+                   n_sentences=5, aggregates=agg)
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+class TestSelectionPolicy(unittest.TestCase):
+    def test_gate_excludes_high_utmos_low_sim(self):
+        pol = SelectionPolicy(metric="utmos_mean", min_spk_sim=0.7)
+        best = _row(1, utmos=3.0, spk_sim=0.8)
+        # higher UTMOS but below the similarity floor -> not an improvement
+        candidate = _row(2, utmos=4.5, spk_sim=0.5)
+        self.assertFalse(pol.is_eligible(candidate))
+        self.assertFalse(pol.is_improvement(candidate, best))
+
+    def test_gate_allows_high_utmos_high_sim(self):
+        pol = SelectionPolicy(metric="utmos_mean", min_spk_sim=0.7)
+        best = _row(1, utmos=3.0, spk_sim=0.8)
+        candidate = _row(2, utmos=4.5, spk_sim=0.75)
+        self.assertTrue(pol.is_improvement(candidate, best))
+
+    def test_no_sim_falls_back_to_utmos_only(self):
+        pol = SelectionPolicy(metric="utmos_mean", min_spk_sim=0.7)
+        # rows carry NO speaker score -> gate cannot apply, UTMOS-only
+        best = _row(1, utmos=3.0)
+        candidate = _row(2, utmos=3.5)
+        self.assertTrue(pol.is_eligible(candidate))
+        self.assertTrue(pol.is_improvement(candidate, best))
+
+    def test_no_floor_means_no_gate(self):
+        pol = SelectionPolicy(metric="utmos_mean", min_spk_sim=None)
+        best = _row(1, utmos=3.0, spk_sim=0.9)
+        candidate = _row(2, utmos=3.5, spk_sim=0.1)  # awful sim, but no floor
+        self.assertTrue(pol.is_improvement(candidate, best))
+
+    def test_first_candidate_is_improvement(self):
+        pol = SelectionPolicy(min_spk_sim=0.7)
+        self.assertTrue(pol.is_improvement(_row(1, 3.0, spk_sim=0.8), None))
+        # ...unless it fails the gate
+        self.assertFalse(pol.is_improvement(_row(1, 3.0, spk_sim=0.5), None))
+
+    def test_equal_metric_is_not_improvement(self):
+        pol = SelectionPolicy()
+        self.assertFalse(pol.is_improvement(_row(2, 3.0), _row(1, 3.0)))
+
+    def test_commit_best_writes_json_and_copies_ckpt(self):
+        with TemporaryDirectory() as d:
+            out = Path(d) / "eval"
+            ckpt = Path(d) / "epoch=2.ckpt"
+            ckpt.write_bytes(b"weights")
+            work = Path(d) / "work"
+            work.mkdir()
+            (work / "utt00.wav").write_bytes(b"RIFF")
+            row = _row(2, utmos=4.0, spk_sim=0.8)
+            row.checkpoint = str(ckpt)
+            pol = SelectionPolicy(min_spk_sim=0.7)
+            pol.commit_best(row, out, work_dir=work)
+
+            best = json.loads((out / "best.json").read_text())
+            self.assertEqual(best["epoch"], 2)
+            self.assertEqual(best["scores"]["utmos_mean"], 4.0)
+            self.assertEqual((out / "best.ckpt").read_bytes(), b"weights")
+            self.assertTrue((out / "samples" / "epoch2" / "utt00.wav").exists())
+            # no leftover temp files
+            self.assertFalse(list(out.glob("*.tmp")))
+
+    def test_read_best_roundtrips(self):
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            ckpt = out / "e.ckpt"
+            ckpt.write_bytes(b"x")
+            row = _row(3, utmos=3.9, spk_sim=0.85)
+            row.checkpoint = str(ckpt)
+            SelectionPolicy().commit_best(row, out)
+            back = SelectionPolicy.read_best(out)
+            self.assertEqual(back.epoch, 3)
+            self.assertAlmostEqual(back.value("utmos_mean"), 3.9)
+
+    def test_read_best_missing_is_none(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(SelectionPolicy.read_best(Path(d)))
+
+
+# ---------------------------------------------------------------------------
+# Tracker
+# ---------------------------------------------------------------------------
+class TestTracker(unittest.TestCase):
+    def test_old_format_csv_read_and_append(self):
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            legacy = out / "metrics.csv"
+            legacy.write_text(
+                "epoch,step,checkpoint,utmos_mean,utmos_std,utmos_min,utmos_max,"
+                "spk_sim_mean,spk_sim_std,spk_sim_min,n_sentences\n"
+                "1,10,a.ckpt,3.5,0.1,3,4,,,,5\n", encoding="utf-8")
+            tr = MetricsTracker(out)
+            self.assertEqual(tr.done_epochs(), {1})
+            # appending uses the file's OWN (legacy) header, staying well-formed
+            tr.append(_row(2, 3.8).to_csv_row())
+            with open(legacy, newline="") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[1]["epoch"], "2")
+            # legacy file has no spk_sim_max column; row's extra key is dropped
+            self.assertNotIn("spk_sim_max", rows[0])
+
+    def test_fresh_file_gets_superset_header(self):
+        with TemporaryDirectory() as d:
+            tr = MetricsTracker(Path(d))
+            tr.append(_row(1, 3.0, spk_sim=0.8).to_csv_row())
+            header = (Path(d) / "metrics.csv").read_text().splitlines()[0]
+            self.assertEqual(header.split(","), SUPERSET_HEADER)
+
+    def test_failed_marking_stops_after_three(self):
+        with TemporaryDirectory() as d:
+            tr = MetricsTracker(Path(d), max_failures=3)
+            self.assertFalse(tr.record_failure(7))
+            self.assertFalse(tr.is_failed(7))
+            self.assertFalse(tr.record_failure(7))
+            self.assertTrue(tr.record_failure(7))  # third time -> failed
+            self.assertTrue(tr.is_failed(7))
+            self.assertIn(7, tr.failed_epochs())
+            self.assertIn(7, tr.skip_epochs())
+
+    def test_patience_and_stop_flag(self):
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            tr = MetricsTracker(out)
+            for e in (1, 2, 3, 4):
+                tr.append(_row(e, 3.0).to_csv_row())
+            # best is epoch 1; epochs 2,3,4 are newer with no improvement
+            self.assertEqual(tr.epochs_since_improvement(1), 3)
+            # patience 2 exceeded -> stop.flag written with a reason
+            self.assertTrue(tr.maybe_stop(best_epoch=1, patience=2))
+            flag = out / "stop.flag"
+            self.assertTrue(flag.exists())
+            self.assertIn("patience", flag.read_text())
+            # patience 5 not yet exceeded
+            tr2 = MetricsTracker(Path(d) / "e2")
+            for e in (1, 2, 3, 4):
+                tr2.append(_row(e, 3.0).to_csv_row())
+            self.assertFalse(tr2.maybe_stop(best_epoch=1, patience=5))
+            self.assertFalse((Path(d) / "e2" / "stop.flag").exists())
+
+    def test_patience_no_best_is_zero(self):
+        with TemporaryDirectory() as d:
+            tr = MetricsTracker(Path(d))
+            self.assertEqual(tr.epochs_since_improvement(None), 0)
+            self.assertFalse(tr.maybe_stop(None, patience=1))
+
+
+# ---------------------------------------------------------------------------
+# Callbacks
+# ---------------------------------------------------------------------------
+class TestStopFileCallback(unittest.TestCase):
+    def test_stops_when_flag_present(self):
+        from phoonnx_train.evaluation.callbacks import StopFileCallback
+
+        with TemporaryDirectory() as d:
+            flag = Path(d) / "stop.flag"
+            cb = StopFileCallback(flag)
+            trainer = MagicMock()
+            trainer.should_stop = False
+            cb.on_train_epoch_end(trainer, MagicMock())
+            self.assertFalse(trainer.should_stop)  # no flag yet
+            flag.write_text("early stopping: patience\n")
+            cb.on_train_epoch_end(trainer, MagicMock())
+            self.assertTrue(trainer.should_stop)
+
+
+class TestEvalScoreboardCallback(unittest.TestCase):
+    def _callback(self, out, scorer, patience=None):
+        from phoonnx_train.evaluation.callbacks import EvalScoreboardCallback
+
+        tracker = MetricsTracker(out)
+        selection = SelectionPolicy(metric="utmos_mean")
+        ckpt_dir = out / "ckpts"
+        ckpt_dir.mkdir(parents=True, exist_ok=True)
+        (ckpt_dir / "epoch=0-step=1.ckpt").write_bytes(b"w")
+        cb = EvalScoreboardCallback(scorer, tracker, selection, out,
+                                    every_n_epochs=1, patience=patience,
+                                    checkpoint_dir=ckpt_dir)
+        return cb, tracker
+
+    def _trainer(self, epoch=0):
+        trainer = MagicMock()
+        trainer.current_epoch = epoch
+        trainer.should_stop = False
+        return trainer
+
+    def test_scorer_failure_does_not_crash_training(self):
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            scorer = MagicMock()
+            scorer.score.side_effect = RuntimeError("boom")
+            with patch("phoonnx_train.evaluation.callbacks.size_stable",
+                       return_value=True):
+                cb, tracker = self._callback(out, scorer)
+                trainer = self._trainer()
+                # must not raise
+                cb.on_train_epoch_end(trainer, MagicMock())
+            self.assertFalse(trainer.should_stop)
+            # the failure was recorded (attempt 1)
+            self.assertEqual(tracker._load_failed().get("0"), 1)
+
+    def test_successful_score_updates_scoreboard(self):
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            scorer = MagicMock()
+            scorer.score.return_value = _row(0, utmos=3.5)
+            with patch("phoonnx_train.evaluation.callbacks.size_stable",
+                       return_value=True):
+                cb, tracker = self._callback(out, scorer)
+                cb.on_train_epoch_end(self._trainer(), MagicMock())
+            self.assertEqual(tracker.done_epochs(), {0})
+            self.assertTrue((out / "best.json").exists())
+
+
+# ---------------------------------------------------------------------------
+# Scorer determinism (per-utterance reseed)
+# ---------------------------------------------------------------------------
+class TestScorerDeterminism(unittest.TestCase):
+    def _scorer(self, out_capture):
+        """Build a CheckpointScorer with encoder + engine faked out.
+
+        The fake synth's output depends only on the torch RNG state, so if the
+        per-utterance reseed works two runs produce identical wavs.
+        """
+        from phoonnx_train.evaluation import scorer as scorer_mod
+
+        config = {"num_speakers": 1, "audio": {"sample_rate": 22050}}
+        engine = MagicMock()
+
+        def make_synth(*a, **k):
+            import torch
+
+            def synth(ids, scales, sid):
+                # deterministic function of RNG state only
+                return torch.rand(1000).numpy().astype(np.float32)
+            return synth
+
+        engine.eval_synthesize.side_effect = make_synth
+
+        with patch.object(scorer_mod.CheckpointScorer, "__init__",
+                          lambda self, *a, **k: None):
+            s = scorer_mod.CheckpointScorer(engine, config, ["a", "b", "c"])
+        # fill the attributes __init__ would have set
+        s.engine = engine
+        s.config = config
+        s.sentences = ["a", "b", "c"]
+        s.metrics = ["utmos"]
+        s.seed = 1234
+        s.vocoder_path = None
+        s.device = "cpu"
+        s.sample_rate = 22050
+        s.scales = [0.667, 1.0, 0.8]
+        s.speaker_id = None
+        s.emb = None
+        s.ref = None
+        s.ph = None
+        s.tokenizer = None
+        s.lang = ""
+        return s, scorer_mod
+
+    def test_same_checkpoint_twice_identical(self):
+        with TemporaryDirectory() as d:
+            s, scorer_mod = self._scorer(d)
+            # fake text_to_ids and utmos metric (avoid heavy phonemizer/model)
+            with patch.object(scorer_mod, "text_to_ids",
+                              side_effect=lambda t, *a: ([t], [1, 2, 3])), \
+                 patch.dict(scorer_mod._METRIC_REGISTRY,
+                            {"utmos": lambda wav, sr, text: float(np.mean(wav))}):
+                w1 = Path(d) / "w1"
+                w2 = Path(d) / "w2"
+                row1 = s.score(Path(d) / "epoch=0.ckpt", 0, work_dir=w1)
+                row2 = s.score(Path(d) / "epoch=0.ckpt", 0, work_dir=w2)
+            self.assertEqual(row1.aggregates, row2.aggregates)
+            # wavs byte-identical too
+            for i in range(3):
+                self.assertEqual((w1 / f"utt{i:02d}.wav").read_bytes(),
+                                 (w2 / f"utt{i:02d}.wav").read_bytes())
+
+
+# ---------------------------------------------------------------------------
+# eval_loop CLI
+# ---------------------------------------------------------------------------
+class TestEvalLoopCLI(unittest.TestCase):
+    def _config(self, path):
+        path.write_text(json.dumps({
+            "num_speakers": 1,
+            "audio": {"sample_rate": 22050},
+            "phoneme_type": "espeak",
+            "alphabet": "ipa",
+            "phoneme_id_map": {"a": 1},
+            "inference": {"noise_scale": 0.667, "length_scale": 1.0, "noise_w": 0.8},
+        }), encoding="utf-8")
+
+    def test_once_scores_fake_checkpoint(self):
+        import click.testing
+
+        from phoonnx_train import eval_loop
+
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            train_dir = d / "train"
+            (train_dir / "ck").mkdir(parents=True)
+            (train_dir / "ck" / "epoch=0-step=1.ckpt").write_bytes(b"w")
+            cfg = d / "config.json"
+            self._config(cfg)
+            sents = d / "s.txt"
+            sents.write_text("hello world\n", encoding="utf-8")
+            out = d / "eval"
+
+            fake_engine = MagicMock()
+            fake_engine.eval_synthesize.return_value = (
+                lambda ids, scales, sid: np.ones(2205, dtype=np.float32))
+
+            with patch("phoonnx_train.eval_loop.get_engine",
+                       return_value=fake_engine), \
+                 patch("phoonnx_train.eval_loop.size_stable", return_value=True), \
+                 patch("phoonnx_train.evaluation.scorer.build_encoder",
+                       return_value=(None, None, "", 22050, [0.667, 1.0, 0.8])), \
+                 patch("phoonnx_train.evaluation.scorer.text_to_ids",
+                       return_value=(["h"], [1, 2, 3])), \
+                 patch.dict("phoonnx_train.evaluation.scorer._METRIC_REGISTRY",
+                            {"utmos": lambda wav, sr, text: 3.7}):
+                runner = click.testing.CliRunner()
+                result = runner.invoke(eval_loop.main, [
+                    "--train-dir", str(train_dir),
+                    "--config", str(cfg),
+                    "--sentences", str(sents),
+                    "--output-dir", str(out),
+                    "--once",
+                ])
+            if result.exception:
+                raise result.exception
+            self.assertEqual(result.exit_code, 0)
+            tr = MetricsTracker(out)
+            self.assertEqual(tr.done_epochs(), {0})
+            self.assertTrue((out / "best.json").exists())
+
+    def test_once_emits_stop_flag_on_patience(self):
+        import click.testing
+
+        from phoonnx_train import eval_loop
+
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            train_dir = d / "train"
+            ck = train_dir / "ck"
+            ck.mkdir(parents=True)
+            for e in range(3):
+                (ck / f"epoch={e}-step={e}.ckpt").write_bytes(b"w")
+            cfg = d / "config.json"
+            self._config(cfg)
+            sents = d / "s.txt"
+            sents.write_text("hello\n", encoding="utf-8")
+            out = d / "eval"
+
+            fake_engine = MagicMock()
+            fake_engine.eval_synthesize.return_value = (
+                lambda ids, scales, sid: np.ones(2205, dtype=np.float32))
+
+            # epoch 0 best (utmos 4), later epochs worse -> no improvement
+            def utmos(wav, sr, text):
+                return 4.0 if utmos.calls.pop(0) == 0 else 3.0
+            utmos.calls = [0, 1, 2]
+
+            with patch("phoonnx_train.eval_loop.get_engine",
+                       return_value=fake_engine), \
+                 patch("phoonnx_train.eval_loop.size_stable", return_value=True), \
+                 patch("phoonnx_train.evaluation.scorer.build_encoder",
+                       return_value=(None, None, "", 22050, [0.667, 1.0, 0.8])), \
+                 patch("phoonnx_train.evaluation.scorer.text_to_ids",
+                       return_value=(["h"], [1, 2, 3])), \
+                 patch.dict("phoonnx_train.evaluation.scorer._METRIC_REGISTRY",
+                            {"utmos": utmos}):
+                runner = click.testing.CliRunner()
+                result = runner.invoke(eval_loop.main, [
+                    "--train-dir", str(train_dir),
+                    "--config", str(cfg),
+                    "--sentences", str(sents),
+                    "--output-dir", str(out),
+                    "--once", "--early-stop-patience", "2",
+                ])
+            if result.exception:
+                raise result.exception
+            self.assertEqual(result.exit_code, 0)
+            self.assertTrue((train_dir / "stop.flag").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation_package.py
+++ b/tests/test_evaluation_package.py
@@ -29,8 +29,12 @@ def _row(epoch, utmos, spk_sim=None, step=10):
     if spk_sim is not None:
         agg.update({"spk_sim_mean": spk_sim, "spk_sim_std": 0.0,
                     "spk_sim_min": spk_sim, "spk_sim_max": spk_sim})
+    perutt = [
+        ("hello", {"utmos": utmos}, spk_sim),
+        ("world", {"utmos": utmos}, spk_sim),
+    ]
     return EvalRow(epoch=epoch, step=step, checkpoint=f"epoch={epoch}.ckpt",
-                   n_sentences=5, aggregates=agg)
+                   n_sentences=len(perutt), aggregates=agg, perutt=perutt)
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +188,29 @@ class TestTracker(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # Callbacks
 # ---------------------------------------------------------------------------
+class TestWriteEpochPerutt(unittest.TestCase):
+    def test_legacy_columns_and_path(self):
+        from phoonnx_train.evaluation.scorer import write_epoch_perutt
+
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            row = _row(4, utmos=3.2, spk_sim=0.81)
+            path = write_epoch_perutt(out, row, ("utmos",))
+            self.assertEqual(path, out / "perutt" / "epoch4.csv")
+            rows = list(csv.reader(path.read_text().splitlines()))
+            self.assertEqual(rows[0], ["sentence", "utmos", "spk_sim"])
+            self.assertEqual(rows[1], ["hello", "3.2000", "0.8100"])
+
+    def test_no_speaker_score_leaves_spk_sim_empty(self):
+        from phoonnx_train.evaluation.scorer import write_epoch_perutt
+
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            path = write_epoch_perutt(out, _row(1, utmos=3.0), ("utmos",))
+            rows = list(csv.reader(path.read_text().splitlines()))
+            self.assertEqual(rows[1], ["hello", "3.0000", ""])
+
+
 class TestStopFileCallback(unittest.TestCase):
     def test_stops_when_flag_present(self):
         from phoonnx_train.evaluation.callbacks import StopFileCallback
@@ -206,6 +233,7 @@ class TestEvalScoreboardCallback(unittest.TestCase):
 
         tracker = MetricsTracker(out)
         selection = SelectionPolicy(metric="utmos_mean")
+        scorer.metrics = ["utmos"]
         ckpt_dir = out / "ckpts"
         ckpt_dir.mkdir(parents=True, exist_ok=True)
         (ckpt_dir / "epoch=0-step=1.ckpt").write_bytes(b"w")
@@ -246,6 +274,11 @@ class TestEvalScoreboardCallback(unittest.TestCase):
                 cb.on_train_epoch_end(self._trainer(), MagicMock())
             self.assertEqual(tracker.done_epochs(), {0})
             self.assertTrue((out / "best.json").exists())
+            # per-epoch per-utterance file kept for the scored epoch
+            perutt = out / "perutt" / "epoch0.csv"
+            self.assertTrue(perutt.exists())
+            self.assertEqual(perutt.read_text().splitlines()[0],
+                             "sentence,utmos,spk_sim")
 
 
 # ---------------------------------------------------------------------------
@@ -370,6 +403,12 @@ class TestEvalLoopCLI(unittest.TestCase):
             tr = MetricsTracker(out)
             self.assertEqual(tr.done_epochs(), {0})
             self.assertTrue((out / "best.json").exists())
+            # legacy per-epoch per-utterance file with legacy columns
+            perutt = out / "perutt" / "epoch0.csv"
+            self.assertTrue(perutt.exists())
+            lines = perutt.read_text().splitlines()
+            self.assertEqual(lines[0], "sentence,utmos,spk_sim")
+            self.assertTrue(lines[1].startswith("hello world,3.7000,"))
 
     def test_once_emits_stop_flag_on_patience(self):
         import click.testing


### PR DESCRIPTION
## What

Generalizes the VITS-only UTMOS scoreboard into a reusable `phoonnx_train.evaluation` package used two ways: an out-of-process **sidecar scoreboard** and **in-training early stopping**.

## Package (`phoonnx_train/evaluation/`)

- `scorer.CheckpointScorer` / `EvalRow` — loads a checkpoint via the training-engine registry (`engine.eval_synthesize`), synthesizes held-out sentences on CPU with per-utterance deterministic seeding (`manual_seed(seed + i)` before each synthesis, fixing cross-epoch RNG drift), scores via a metric registry reusing `quality_filter` (UTMOS) plus speaker-similarity centroid logic, returns a structured row. Multi-speaker `sid` supported, with a warning when `num_speakers > 1` and no `--speaker-id`.
- `selection.SelectionPolicy` — similarity-gated best selection: when speaker scoring is active and `--min-spk-sim` is set, a candidate must clear the floor to be eligible; among eligible, higher UTMOS wins. On a new best writes `best.json` and copies the checkpoint to `best.ckpt` (copy, not symlink, so it survives pruning) plus best-epoch wavs.
- `tracker.MetricsTracker` — `metrics.csv` read/append (backward compatible with legacy headers, writes a superset), 3-strike failed-epoch marking (recorded and skipped forever, no infinite retry), patience counting, `stop.flag` emission.
- `callbacks` — `StopFileCallback` (sidecar→trainer stop bridge) and `EvalScoreboardCallback` (in-process scoring, patience-based stop, failure isolation so scoring never crashes training).

## Engine interface

Adds the pinned `eval_synthesize(checkpoint_path, config, *, vocoder_path=None, device="cpu")` to `BaseTrainingEngine` (default raises `NotImplementedError`), implemented for VITS by moving the load / weight-norm removal / forward-synth logic into the engine.

## CLIs

- `eval_loop.py` is now a thin CLI over the package. Existing flags/defaults preserved; adds `--early-stop-patience`, `--min-spk-sim`, `--speaker-id`, `--engine` (default `auto` from config.json, else `vits`), `--vocoder`. Idempotent-restart and size-stability preserved.
- `train.py` gains opt-in `--eval-sentences`, `--eval-every` (default 0=off), `--early-stop-patience`, `--eval-speaker-ref-dir`, `--min-spk-sim`, `--eval-seed`. `StopFileCallback` is always added (no-op without a flag).

Docs: new "Evaluation and early stopping" section (both modes, similarity-gate rationale, `best.ckpt`/`best.json`, `stop.flag` contract).

## Test plan

- New `tests/test_evaluation_package.py` (20 tests, unittest, adversarial): similarity gate excludes high-UTMOS/low-sim rows; no-sim UTMOS-only fallback; atomic `best.json`/`best.ckpt`; legacy `metrics.csv` read + append; 3-strike failed marking; patience + `stop.flag`; `StopFileCallback` stops a mocked trainer; `EvalScoreboardCallback` failure isolation; scorer determinism (identical wavs/scores on re-score); `eval_loop --once` scoring + patience-triggered `stop.flag`. All pass.
- Existing `test_eval_loop`, `test_train_cli`, `test_engines`, `test_vits_lightning`, `test_vits_streaming`, `test_quality_filter`, `test_config_detection` all pass (166 tests).