### PR TITLE
chore: ratchet CI coverage floor

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,4 +14,4 @@ jobs:
       coverage_source: 'phoonnx'
       test_path: 'tests/'
       install_extras: '-e .[test,train,train-styletts2,train-eval,train-data,train-optispeech]'
-      min_coverage: 0
+      min_coverage: 43

--- a/phoonnx/phonemizers/ar.py
+++ b/phoonnx/phonemizers/ar.py
@@ -126,7 +126,7 @@ class ArbtokPhonemizer(BasePhonemizer):
         return self._engine(self.get_lang(lang)).transcribe(text)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     from phoonnx.phonemizers.mul import EspeakPhonemizer
 
     espeak = EspeakPhonemizer()


### PR DESCRIPTION
## Coverage measurement

- Total coverage before pragma change: 44.80% (12991/28998 statements)
  - phoonnx: 60.80% (5149/8469)
  - phoonnx_train: 38.20% (7842/20529)
- Total coverage after excluding the ar.py demo block: 44.87%

## Floor chosen

min_coverage set to 43 in .github/workflows/coverage.yml (was 0), computed as floor(44.80) - 1 = 43, leaving one percentage point of headroom for run-to-run variance.

## Other change

Marked the `if __name__ == "__main__":` block in phoonnx/phonemizers/ar.py with `# pragma: no cover` — it is demo/example code, not library logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the minimum required pull request coverage to 43%.
  * Excluded the Arabic phonemizer’s command-line entry point from coverage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->