### PR TITLE
fix: inference-core audit findings — spellings parsing, config round-trip, dispatch order

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -566,6 +566,7 @@ class VoiceConfig:
             "num_langs": self.num_langs,
             "speaker_id_map": dict(self.speaker_id_map or {}),
             "lang_id_map": dict(self.lang_id_map or {}),
+            "lang_tokens": dict(self.lang_tokens or {}),
             "phonemizer_model": self.phonemizer_model,
             "inference": {
                 "noise_scale": self.noise_scale,

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -533,6 +533,7 @@ class VoiceConfig:
             # any locally-resolved paths the manager passes in (the latter win).
             engine_params={**(config.get("engine_params") or {}), **(engine_params or {})},
             lang_tokens=lang_tokens or config.get("lang_tokens") or {},
+            lang_id_map=config.get("lang_id_map", {}),
         )
 
     def to_native_dict(self) -> Dict[str, Any]:

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -560,6 +560,7 @@ class VoiceConfig:
             "alphabet": self.alphabet.value if self.alphabet else "unicode",
             "lang_code": self.lang_code,
             "audio": {"sample_rate": self.sample_rate},
+            "hop_length": self.hop_length,
             "num_symbols": self.num_symbols,
             "num_speakers": self.num_speakers,
             "num_langs": self.num_langs,

--- a/phoonnx/engines/glowtts.py
+++ b/phoonnx/engines/glowtts.py
@@ -36,11 +36,16 @@ class GlowTTSAdapter(BaseOnnxAdapter):
     """Adapter for GlowTTS / Larynx ONNX models (flow-matching mel + vocoder)."""
 
     # GlowTTS derives durations from the flow's log-determinant (``logw`` /
-    # ``w_ceil`` in the reference Coqui implementation). Standard Larynx/Coqui
-    # exports don't expose it as a graph output today, so this resolves to
-    # None on those checkpoints; listed so a re-export exposing it under one
-    # of these names lights up automatically (see docs/alignment.md).
-    DURATION_OUTPUT_NAMES = ["durations", "dur", "w_ceil", "logw"]
+    # ``w_ceil`` in the reference Coqui implementation). ``w_ceil`` is already
+    # the integer duration (ceil'd) and safe to consume directly. ``logw`` is
+    # log-domain and would need ``exp()`` + rounding before use as a duration;
+    # ``_find_duration_output`` has no such transform, so "logw" is
+    # deliberately NOT listed here — matching it would silently feed raw
+    # log-domain values through as if they were sample counts. Standard
+    # Larynx/Coqui exports don't expose either as a graph output today, so
+    # this resolves to None on those checkpoints; listed so a re-export
+    # exposing ``w_ceil`` lights up automatically (see docs/alignment.md).
+    DURATION_OUTPUT_NAMES = ["durations", "dur", "w_ceil"]
 
     def __init__(self, vocoder: Optional[BaseVocoder] = None):
         self.vocoder = vocoder

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -7,6 +7,7 @@ which means the same TTSVoice class works for VITS or
 any future architecture without code changes here.
 """
 import json
+import logging
 import os.path
 import re
 import wave
@@ -90,6 +91,12 @@ class PhoneticSpellings:
         with open(spellings_file) as f:
             lines = f.read().split("\n")
             for l in lines:
+                l = l.strip()
+                if not l or l.startswith("#"):
+                    continue
+                if ":" not in l:
+                    logging.warning(f"Skipping malformed phonetic spelling line: {l!r}")
+                    continue
                 word, spelling = l.split(":", 1)
                 replacements[word.strip()] = spelling.strip()
         return PhoneticSpellings(replacements)

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -507,7 +507,18 @@ class TTSVoice:
             # together per sentence so they can never fall out of alignment.
             lazy_lang_ids = getattr(
                 self.phonemizer, "phonemize_with_language_ids_lazy", None)
-            if lazy_lang_ids is not None:
+            if _PHONEME_BLOCK_PATTERN.search(text):
+                # Inline [[phoneme]] blocks are literal overrides that must bypass
+                # the phonemizer entirely — checked before any language-aware
+                # dispatch so they are never sent to it verbatim. Inline [[phoneme]]
+                # blocks merge into adjacent sentences; keep the (eager) whole-text
+                # handling that owns that merge logic.
+                if do_diacritics:
+                    text = self._diacritize(text, diacritizer_model)
+                for phonemes in self.phonemize(text):
+                    if phonemes:
+                        yield phonemes, self.phonemes_to_ids(phonemes), None
+            elif lazy_lang_ids is not None:
                 for part in self._text_parts(text, do_diacritics, diacritizer_model):
                     for phonemes, language_ids in lazy_lang_ids(part, lang):
                         if phonemes:
@@ -521,14 +532,6 @@ class TTSVoice:
                 for phonemes, language_ids in zip(sentence_phonemes, sentence_language_ids):
                     if phonemes:
                         yield phonemes, self.phonemes_to_ids(phonemes), language_ids
-            elif _PHONEME_BLOCK_PATTERN.search(text):
-                # Inline [[phoneme]] blocks merge into adjacent sentences; keep the
-                # (eager) whole-text handling that owns that merge logic.
-                if do_diacritics:
-                    text = self._diacritize(text, diacritizer_model)
-                for phonemes in self.phonemize(text):
-                    if phonemes:
-                        yield phonemes, self.phonemes_to_ids(phonemes), None
             else:
                 # Lazy per-sentence phonemization; a phonemizer without a lazy
                 # variant falls back to its eager whole-text phonemize().

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -494,8 +494,8 @@ class TTSVoice:
                     yield None, ids, None
             else:
                 # Already-phonemic input in the model's own alphabet: pass through.
-                if do_diacritics:
-                    text = self._diacritize(text, diacritizer_model)
+                # Diacritization is orthographic (grapheme-level) only; never
+                # apply it to already-phonemic input.
                 for phonemes in _phonemic_chunks(text, tgt_alphabet):
                     if phonemes:
                         yield phonemes, self.phonemes_to_ids(phonemes), None
@@ -545,9 +545,8 @@ class TTSVoice:
             return
 
         # Already-phonemic input in a different alphabet: transcode to the model's
-        # alphabet through the conversion graph.
-        if do_diacritics:
-            text = self._diacritize(text, diacritizer_model)
+        # alphabet through the conversion graph. Diacritization is orthographic
+        # (grapheme-level) only; never apply it to already-phonemic input.
         converted = alphabet_convert(
             text,
             lang=lang,

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -7,7 +7,6 @@ which means the same TTSVoice class works for VITS or
 any future architecture without code changes here.
 """
 import json
-import logging
 import os.path
 import re
 import wave
@@ -95,7 +94,7 @@ class PhoneticSpellings:
                 if not l or l.startswith("#"):
                     continue
                 if ":" not in l:
-                    logging.warning(f"Skipping malformed phonetic spelling line: {l!r}")
+                    LOG.warning(f"Skipping malformed phonetic spelling line: {l!r}")
                     continue
                 word, spelling = l.split(":", 1)
                 replacements[word.strip()] = spelling.strip()

--- a/tests/test_diacritize_grapheme_only.py
+++ b/tests/test_diacritize_grapheme_only.py
@@ -1,0 +1,56 @@
+"""_diacritize is orthographic (grapheme-level); it must never run over
+phonemic (e.g. IPA) input, regardless of add_diacritics.
+"""
+import types
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from phoonnx.config import Alphabet, SynthesisConfig
+from phoonnx.voice import TTSVoice
+
+
+def _make_voice(model_alphabet, diacritize_calls):
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.phonetic_spellings = None
+    voice.phonemizer = MagicMock()
+    voice.config = types.SimpleNamespace(
+        alphabet=model_alphabet,
+        lang_code="ar",
+        add_diacritics=True,
+        diacritizer_model="rawi-ensemble",
+        sample_rate=22050,
+    )
+    voice.adapter = MagicMock()
+    voice.phonemes_to_ids = lambda phonemes: [1] * len(phonemes)
+    voice.phoneme_ids_to_audio = lambda phoneme_ids, syn_config=None, language_ids=None, include_alignments=False: np.zeros(4, dtype=np.float32)
+
+    def _diacritize(text, diacritizer_model):
+        diacritize_calls.append(text)
+        return text
+
+    voice._diacritize = _diacritize
+    return voice
+
+
+class TestDiacritizeGraphemeOnly(unittest.TestCase):
+    def test_phonemic_ipa_input_is_never_diacritized(self):
+        calls = []
+        voice = _make_voice(Alphabet.IPA, calls)
+        syn_config = SynthesisConfig(alphabet=Alphabet.IPA, normalize_audio=False)
+
+        list(voice.synthesize("mafʕuːl", syn_config))
+
+        self.assertEqual(calls, [], f"diacritizer was called on phonemic input: {calls}")
+
+    def test_grapheme_input_is_still_diacritized_when_enabled(self):
+        calls = []
+        voice = _make_voice(Alphabet.IPA, calls)
+        syn_config = SynthesisConfig(alphabet=Alphabet.GRAPHEMES, normalize_audio=False)
+        voice.phonemizer.phonemize_lazy = None
+        voice.phonemizer.phonemize = MagicMock(return_value=[list("test")])
+
+        list(voice.synthesize("mrhba", syn_config))
+
+        self.assertEqual(calls, ["mrhba"])

--- a/tests/test_glowtts.py
+++ b/tests/test_glowtts.py
@@ -102,6 +102,20 @@ def test_parse_outputs_picks_up_named_durations():
     np.testing.assert_array_equal(res.extras["phoneme_id_samples"], [1, 2, 3, 4, 5])
 
 
+def test_parse_outputs_does_not_match_logw_as_duration():
+    """"logw" is log-domain and never transformed by _find_duration_output;
+    it must not be in DURATION_OUTPUT_NAMES or raw log values would be used
+    directly as sample-count durations."""
+    assert "logw" not in GlowTTSAdapter.DURATION_OUTPUT_NAMES
+    adapter = GlowTTSAdapter(vocoder=FakeVocoder())
+    mel = np.zeros((1, 80, 7), np.float32)
+    logw = np.array([[-0.1, -0.2, -0.3, -0.4, -0.5]], dtype=np.float32)
+    res = adapter.parse_outputs(
+        [mel, logw], _req(n=5), output_names=["output", "logw"]
+    )
+    assert "phoneme_id_samples" not in res.extras
+
+
 def test_default_params():
     assert GlowTTSAdapter().default_params() == {"noise_scale": 0.667, "length_scale": 1.0}
 

--- a/tests/test_inline_phoneme_blocks_dispatch.py
+++ b/tests/test_inline_phoneme_blocks_dispatch.py
@@ -1,0 +1,60 @@
+"""Inline [[phoneme]] override blocks must never reach a phonemizer verbatim,
+including language-aware phonemizers exposing phonemize_with_language_ids_lazy.
+"""
+import types
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from phoonnx.config import Alphabet, SynthesisConfig
+from phoonnx.voice import AudioChunk, TTSVoice
+
+
+class _LangAwarePhonemizer:
+    """Mock language-aware phonemizer recording every text it is asked to phonemize."""
+
+    def __init__(self, events):
+        self.events = events
+
+    def phonemize_with_language_ids_lazy(self, text, lang):
+        self.events.append(text)
+        for sentence in text.split(". "):
+            sentence = sentence.strip()
+            if sentence:
+                yield list(sentence), [0] * len(sentence)
+
+    def phonemize(self, text, lang):
+        # Non-language-aware fallback used by the inline-[[phoneme]]-block path.
+        self.events.append(text)
+        return [list(sentence.strip()) for sentence in text.split(". ") if sentence.strip()]
+
+
+def _make_voice(phonemizer):
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.phonetic_spellings = None
+    voice.phonemizer = phonemizer
+    voice.config = types.SimpleNamespace(
+        alphabet=Alphabet.IPA,
+        lang_code="en",
+        add_diacritics=False,
+        diacritizer_model=None,
+        sample_rate=22050,
+    )
+    voice.adapter = MagicMock()
+    voice.phonemes_to_ids = lambda phonemes: [1] * len(phonemes)
+    voice.phoneme_ids_to_audio = lambda phoneme_ids, syn_config=None, language_ids=None, include_alignments=False: np.zeros(4, dtype=np.float32)
+    return voice
+
+
+class TestInlinePhonemeBlockDispatchOrder(unittest.TestCase):
+    def test_inline_block_bypasses_language_aware_phonemizer(self):
+        events = []
+        voice = _make_voice(_LangAwarePhonemizer(events))
+        text = "hello [[wɜːld]] there."
+
+        list(voice.synthesize(text, SynthesisConfig(normalize_audio=False)))
+
+        for seen_text in events:
+            self.assertNotIn("[[", seen_text,
+                              f"inline phoneme block leaked into language-aware phonemizer input: {seen_text!r}")

--- a/tests/test_native_config.py
+++ b/tests/test_native_config.py
@@ -91,6 +91,18 @@ def test_piper_map_still_detected_as_piper():
     assert VoiceConfig.is_piper(cfg) is True
 
 
+def test_native_roundtrip_preserves_hop_length():
+    vocab = {"_": 0, "a": 1, "b": 2, "c": 3}
+    vc = VoiceConfig.from_dict({}, vocab=vocab,
+                               tokenizer_config={"add_blank": True, "language": "en", "pad_token": "_"},
+                               phoneme_type="graphemes", alphabet="unicode", lang_code="en")
+    vc.hop_length = 512
+    native = vc.to_native_dict()
+    assert native["hop_length"] == 512
+    vc2 = VoiceConfig.from_dict(dict(native))
+    assert vc2.hop_length == 512
+
+
 def test_canonical_coqui_config_compound_stress_tokens():
     # the espeak stressed-vowel compound keys (ˈV) fold via the tokenizer's
     # compound logic, matching the AhoTTS ca fused stressed-vowel tokens.

--- a/tests/test_native_config.py
+++ b/tests/test_native_config.py
@@ -115,6 +115,18 @@ def test_native_roundtrip_preserves_lang_tokens():
     assert vc2.lang_tokens == {"en": "[EN]", "fr": "[FR]"}
 
 
+def test_native_roundtrip_preserves_lang_id_map():
+    vocab = {"_": 0, "a": 1, "b": 2, "c": 3}
+    vc = VoiceConfig.from_dict({}, vocab=vocab,
+                               tokenizer_config={"add_blank": True, "language": "en", "pad_token": "_"},
+                               phoneme_type="graphemes", alphabet="unicode", lang_code="en")
+    vc.lang_id_map = {"en": 0, "fr": 1}
+    native = vc.to_native_dict()
+    assert native["lang_id_map"] == {"en": 0, "fr": 1}
+    vc2 = VoiceConfig.from_dict(dict(native))
+    assert vc2.lang_id_map == {"en": 0, "fr": 1}
+
+
 def test_canonical_coqui_config_compound_stress_tokens():
     # the espeak stressed-vowel compound keys (ˈV) fold via the tokenizer's
     # compound logic, matching the AhoTTS ca fused stressed-vowel tokens.

--- a/tests/test_native_config.py
+++ b/tests/test_native_config.py
@@ -103,6 +103,18 @@ def test_native_roundtrip_preserves_hop_length():
     assert vc2.hop_length == 512
 
 
+def test_native_roundtrip_preserves_lang_tokens():
+    vocab = {"_": 0, "a": 1, "b": 2, "c": 3}
+    vc = VoiceConfig.from_dict({}, vocab=vocab,
+                               tokenizer_config={"add_blank": True, "language": "en", "pad_token": "_"},
+                               phoneme_type="graphemes", alphabet="unicode", lang_code="en")
+    vc.lang_tokens = {"en": "[EN]", "fr": "[FR]"}
+    native = vc.to_native_dict()
+    assert native["lang_tokens"] == {"en": "[EN]", "fr": "[FR]"}
+    vc2 = VoiceConfig.from_dict(dict(native))
+    assert vc2.lang_tokens == {"en": "[EN]", "fr": "[FR]"}
+
+
 def test_canonical_coqui_config_compound_stress_tokens():
     # the espeak stressed-vowel compound keys (ˈV) fold via the tokenizer's
     # compound logic, matching the AhoTTS ca fused stressed-vowel tokens.

--- a/tests/test_phonetic_spellings.py
+++ b/tests/test_phonetic_spellings.py
@@ -16,14 +16,17 @@ def test_from_path_skips_blank_lines_comments_and_trailing_newline(tmp_path):
     assert ps.replacements == {"foo": "fuh", "bar": "bahr"}
 
 
-def test_from_path_skips_malformed_line_and_warns(tmp_path, caplog):
+def test_from_path_skips_malformed_line_and_warns(tmp_path):
+    from unittest.mock import patch
+
     spellings_file = tmp_path / "phonetic_spellings.txt"
     spellings_file.write_text(
         "foo:fuh\n"
         "this line has no colon\n"
         "bar:bahr\n"
     )
-    with caplog.at_level(logging.WARNING):
+    with patch("phoonnx.voice.LOG") as mock_log:
         ps = PhoneticSpellings.from_path(str(spellings_file))
     assert ps.replacements == {"foo": "fuh", "bar": "bahr"}
-    assert any("malformed" in r.message.lower() for r in caplog.records)
+    assert mock_log.warning.called
+    assert "malformed" in str(mock_log.warning.call_args).lower()

--- a/tests/test_phonetic_spellings.py
+++ b/tests/test_phonetic_spellings.py
@@ -1,0 +1,29 @@
+"""PhoneticSpellings.from_path parsing edge cases."""
+import logging
+
+from phoonnx.voice import PhoneticSpellings
+
+
+def test_from_path_skips_blank_lines_comments_and_trailing_newline(tmp_path):
+    spellings_file = tmp_path / "phonetic_spellings.txt"
+    spellings_file.write_text(
+        "foo:fuh\n"
+        "\n"
+        "# a comment line\n"
+        "bar:bahr\n"
+    )
+    ps = PhoneticSpellings.from_path(str(spellings_file))
+    assert ps.replacements == {"foo": "fuh", "bar": "bahr"}
+
+
+def test_from_path_skips_malformed_line_and_warns(tmp_path, caplog):
+    spellings_file = tmp_path / "phonetic_spellings.txt"
+    spellings_file.write_text(
+        "foo:fuh\n"
+        "this line has no colon\n"
+        "bar:bahr\n"
+    )
+    with caplog.at_level(logging.WARNING):
+        ps = PhoneticSpellings.from_path(str(spellings_file))
+    assert ps.replacements == {"foo": "fuh", "bar": "bahr"}
+    assert any("malformed" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
| # | Description | Fix | Test added |
|---|---|---|---|
| 1 | `PhoneticSpellings.from_path` crashed on trailing newline / blank / comment lines | strip lines, skip blank and `#` lines, skip malformed non-empty lines with a `logging.warning` instead of raising | `tests/test_phonetic_spellings.py` |
| 2 | `to_native_dict()` dropped `hop_length`, resetting non-256-hop models to the default on round-trip | added `hop_length` to the emitted dict (already read in `from_dict`) | `tests/test_native_config.py::test_native_roundtrip_preserves_hop_length` |
| 3 | `to_native_dict()` dropped `lang_tokens`, breaking chatterbox MTL dialect routing on round-trip | added `lang_tokens` to the emitted dict (already read in `from_dict`) | `tests/test_native_config.py::test_native_roundtrip_preserves_lang_tokens` |
| 4 | `lang_id_map` emitted by `to_native_dict()` but never passed into the `VoiceConfig(...)` constructor in `from_dict` (dead one-way field) | read `lang_id_map` back in `from_dict` | `tests/test_native_config.py::test_native_roundtrip_preserves_lang_id_map` |
| 5 | inline `[[phoneme]]` override blocks could reach a language-aware phonemizer verbatim | reordered dispatch so `_PHONEME_BLOCK_PATTERN` extraction runs before `phonemize_with_language_ids_lazy` / `phonemize_with_language_ids` | `tests/test_inline_phoneme_blocks_dispatch.py` |
| 6 | `_diacritize` could run over already-phonemic input | only diacritize grapheme-source text, both same-alphabet pass-through and cross-alphabet transcode paths | `tests/test_diacritize_grapheme_only.py` |
| 7 | `"logw"` listed in GlowTTS `DURATION_OUTPUT_NAMES` but never exp-transformed | removed `"logw"` (log-domain, needs `exp()`+rounding, consumer uses raw values); `"w_ceil"` (already integer) stays | `tests/test_glowtts.py::test_parse_outputs_does_not_match_logw_as_duration` |

## Findings 5/6/7 verdicts

- **#5 CONFIRMED and fixed** — a mocked language-aware phonemizer received the raw `[[...]]` block text before the fix; reproduced and verified with a regression test.
- **#6 CONFIRMED and fixed** — a mocked diacritizer was invoked on IPA-alphabet input with `add_diacritics=True`; reproduced and verified with a regression test.
- **#7 CONFIRMED and fixed** — `_find_duration_output` matches candidate names and consumes the tensor raw with no log-domain transform anywhere in the codebase, so a hypothetical export naming an output `logw` would silently produce garbage sample counts; removed from the candidate list.

## Test plan

Baseline: `python -m pytest -p no:ovoscope -q` → 16 failed, 1287 passed, 7 skipped (styletts2/PLBERT ImportError/RuntimeError cluster and one yourtts export test — pre-existing environment issue, not touched by this branch).

After changes: `python -m pytest -p no:ovoscope -q` → 16 failed (same tests), 1296 passed, 7 skipped. No new failures; the 9 additional passes are the new regression tests.