### PR TITLE
fix: training-stack audit findings — compile/resume matrix, eval integrity, featurizer caches

### DIFF
--- a/phoonnx_train/engines/base.py
+++ b/phoonnx_train/engines/base.py
@@ -156,7 +156,14 @@ class BaseTrainingEngine(ABC):
         """
         import torch
 
-        ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+        from phoonnx_train.torch_compat import trusting_torch_load
+
+        # Our Lightning checkpoints embed pickled hyper-parameters (dataclasses,
+        # partial factories) that torch>=2.6's default weights_only=True
+        # rejects. Loading our own checkpoint is trusted — use the same helper
+        # every other load path uses for consistency.
+        with trusting_torch_load():
+            ckpt = torch.load(checkpoint_path, map_location="cpu")
         state_dict = ckpt.get("state_dict", ckpt)
         model_state = model.state_dict()
         filtered = {

--- a/phoonnx_train/engines/base.py
+++ b/phoonnx_train/engines/base.py
@@ -166,6 +166,23 @@ class BaseTrainingEngine(ABC):
         model.load_state_dict(filtered, strict=False)
         return model
 
+    def eval_text_to_ids(
+        self,
+        text: str,
+        config: Optional[Dict[str, Any]],
+    ) -> Optional[List[int]]:
+        """Tokenize ``text`` to the exact model-input id sequence this engine's
+        training datamodule feeds the model, for held-out evaluation.
+
+        Returns ``None`` by default, which tells :class:`CheckpointScorer` to
+        fall back to its own phoonnx phonemizer/tokenizer pipeline. Engines
+        whose training tokenization differs from that pipeline (e.g. OptiSpeech,
+        which builds its own ``TextProcessor``) MUST override this so the
+        in-training scorer feeds the model the same ids it was trained on —
+        otherwise it scores garbage and selects the wrong best checkpoint.
+        """
+        return None
+
     def eval_synthesize(
         self,
         checkpoint_path: Path,

--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -687,6 +687,41 @@ class OptiSpeechTrainingEngine(BaseTrainingEngine):
         return model
 
     # ------------------------------------------------------------------
+    # Evaluation tokenization
+    # ------------------------------------------------------------------
+
+    def eval_text_to_ids(
+        self,
+        text: str,
+        config: Optional[Dict[str, Any]],
+    ) -> Optional[List[int]]:
+        """Tokenize ``text`` with the SAME OptiSpeech ``TextProcessor`` the
+        training datamodule uses, so in-training scoring feeds the model the
+        ids it was actually trained on rather than the generic phoonnx
+        phonemizer/tokenizer output (which uses a different phoneme set and
+        blank/BOS/EOS convention).
+        """
+        cfg = config or {}
+        tcfg = TrainingEngineConfig(
+            num_symbols=int(cfg.get("num_symbols", 178)),
+            num_speakers=int(cfg.get("num_speakers", 1)),
+            sample_rate=int(cfg.get("audio", {}).get("sample_rate", 22050)),
+            extra=dict(cfg.get("engine_params", {})),
+        )
+        ocfg = OptiSpeechEngineConfig.from_training_config(tcfg)
+        tp = _build_text_processor(ocfg)
+
+        lang = cfg.get("lang_code") or cfg.get("lang") or tp.default_language
+        lang = str(lang).strip().lower()
+        if lang not in tp.languages:
+            # config's lang_code may be coarser (e.g. "en") than the trained
+            # language list ("en-us"); fall back to the model's default rather
+            # than raising, matching how synthesis picks a voice.
+            lang = tp.default_language
+        ids, _ = tp(text, lang, split_sentences=False)
+        return list(ids)
+
+    # ------------------------------------------------------------------
     # Standalone evaluation synthesis
     # ------------------------------------------------------------------
 

--- a/phoonnx_train/eval_utils.py
+++ b/phoonnx_train/eval_utils.py
@@ -94,9 +94,16 @@ def read_sentences(path: Path) -> List[str]:
             Path(path).read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
-def size_stable(path: Path, wait: float = 5.0, tries: int = 6,
+def size_stable(path: Path, wait: float = 0.5, tries: int = 6,
                 sleep=time.sleep) -> bool:
-    """Wait until file size stops changing (guards against partial writes)."""
+    """Return True once the file size stops changing between two consecutive
+    stats (guards against partial writes).
+
+    A fully-written file settles on the very first re-check: stat, wait one
+    short interval, stat again, and if the size is unchanged (and non-zero) it
+    is stable — no multi-second stall on files that are already complete. Only
+    a file still growing incurs additional ``wait`` intervals, up to ``tries``.
+    """
     path = Path(path)
     last = -1
     for _ in range(max(1, tries)):
@@ -108,7 +115,12 @@ def size_stable(path: Path, wait: float = 5.0, tries: int = 6,
             return True
         last = s
         sleep(wait)
-    return False
+    # Final stat after the last sleep: a file that finished writing during the
+    # last interval is still reported stable rather than spuriously rejected.
+    try:
+        return path.stat().st_size == last and last > 0
+    except FileNotFoundError:
+        return False
 
 
 def largest_wavs(ref_dir: Path, n: int) -> Sequence[Path]:

--- a/phoonnx_train/evaluation/callbacks.py
+++ b/phoonnx_train/evaluation/callbacks.py
@@ -83,7 +83,7 @@ class EvalScoreboardCallback(Callback):
             epoch = int(trainer.current_epoch)
             if (epoch + 1) % self.every_n_epochs != 0:
                 return
-            self._score_newest(trainer)
+            self._score_pending(trainer)
         except Exception:
             # Scoring must never crash training.
             _LOGGER.exception("EvalScoreboardCallback failed; continuing training")
@@ -100,40 +100,50 @@ class EvalScoreboardCallback(Callback):
                 return Path(val)
         return None
 
-    def _score_newest(self, trainer) -> None:
+    def _score_pending(self, trainer) -> None:
         ckpt_dir = self._resolve_checkpoint_dir(trainer)
         if ckpt_dir is None or not Path(ckpt_dir).exists():
             _LOGGER.warning("no checkpoint dir resolved yet; skipping scoreboard")
             return
         ckpts = find_checkpoints(ckpt_dir)
         skip = self.tracker.skip_epochs()
+        # Score EVERY unscored checkpoint on disk, oldest first — not only the
+        # newest. With --checkpoint-epochs > 1 the gate ``(epoch+1) %
+        # every_n`` and the epochs actually written to disk diverge, so
+        # scoring just the newest would silently drop every checkpoint that
+        # never coincided with a gated firing.
         todo = sorted(e for e in ckpts if e not in skip)
         if not todo:
             return
-        epoch = todo[-1]
-        ckpt = ckpts[epoch]
-        if not size_stable(ckpt):
-            _LOGGER.warning("checkpoint %s not stable yet; deferring", ckpt)
-            return
 
-        work_dir = self.output_dir / "_work" / f"epoch{epoch}"
-        try:
-            row = self.scorer.score(ckpt, epoch, work_dir=work_dir)
-        except Exception:
-            _LOGGER.exception("scoring epoch %d failed", epoch)
-            self.tracker.record_failure(epoch)
-            return
+        for epoch in todo:
+            ckpt = ckpts[epoch]
+            if not size_stable(ckpt):
+                # Only the still-being-written newest checkpoint is expected to
+                # be unstable; defer it (and thus any later ones) to next firing.
+                _LOGGER.warning("checkpoint %s not stable yet; deferring", ckpt)
+                break
 
-        best = self.selection.read_best(self.output_dir)
-        self.tracker.append(row.to_csv_row())
-        # Per-epoch per-utterance file for every scored epoch (overfit
-        # diagnosis across epochs, not only the best epoch's samples).
-        write_epoch_perutt(self.output_dir, row, self.scorer.metrics)
-        if self.selection.is_improvement(row, best):
-            self.selection.commit_best(row, self.output_dir, work_dir=work_dir)
-            best = row
+            work_dir = self.output_dir / "_work" / f"epoch{epoch}"
+            try:
+                row = self.scorer.score(ckpt, epoch, work_dir=work_dir)
+            except Exception:
+                _LOGGER.exception("scoring epoch %d failed", epoch)
+                self.tracker.record_failure(epoch)
+                continue
 
-        best_epoch = best.epoch if best is not None else None
-        if self.tracker.maybe_stop(best_epoch, self.patience):
-            _LOGGER.warning("patience exhausted; stopping training at epoch %d", epoch)
-            trainer.should_stop = True
+            best = self.selection.read_best(self.output_dir)
+            self.tracker.append(row.to_csv_row())
+            # Per-epoch per-utterance file for every scored epoch (overfit
+            # diagnosis across epochs, not only the best epoch's samples).
+            write_epoch_perutt(self.output_dir, row, self.scorer.metrics)
+            if self.selection.is_improvement(row, best):
+                self.selection.commit_best(row, self.output_dir, work_dir=work_dir)
+                best = row
+
+            best_epoch = best.epoch if best is not None else None
+            if self.tracker.maybe_stop(best_epoch, self.patience):
+                _LOGGER.warning(
+                    "patience exhausted; stopping training at epoch %d", epoch)
+                trainer.should_stop = True
+                return

--- a/phoonnx_train/evaluation/scorer.py
+++ b/phoonnx_train/evaluation/scorer.py
@@ -242,7 +242,30 @@ class CheckpointScorer:
             )
         self.speaker_id = speaker_id
 
+        # Prefer the engine's own training-tokenization hook when it provides
+        # one. Engines whose datamodule tokenizes differently from the generic
+        # phoonnx phonemizer/tokenizer pipeline (e.g. OptiSpeech) override
+        # ``eval_text_to_ids`` so scoring feeds the model the exact ids it was
+        # trained on; otherwise the model would score garbage.
+        from phoonnx_train.engines.base import BaseTrainingEngine
+        base_hook = BaseTrainingEngine.eval_text_to_ids
+        engine_hook = getattr(type(engine), "eval_text_to_ids", base_hook)
+        self._uses_engine_tokenizer = engine_hook is not base_hook
+        if self._uses_engine_tokenizer:
+            _LOGGER.info(
+                "scorer using %s.eval_text_to_ids for evaluation tokenization",
+                type(engine).__name__,
+            )
+
         self.emb, self.ref = load_speaker_reference(speaker_ref_dir, num_ref_wavs)
+
+    def _text_to_ids(self, text: str) -> List[int]:
+        """Model-input ids for ``text``: the engine's training tokenization when
+        it provides one, else the generic phoonnx phonemizer/tokenizer pipeline."""
+        if getattr(self, "_uses_engine_tokenizer", False):
+            return self.engine.eval_text_to_ids(text, self.config)
+        _, ids = text_to_ids(text, self.ph, self.tokenizer, self.lang)
+        return ids
 
     @property
     def speaker_scoring_active(self) -> bool:
@@ -270,7 +293,7 @@ class CheckpointScorer:
         perutt = []
         for i, text in enumerate(self.sentences):
             try:
-                _, ids = text_to_ids(text, self.ph, self.tokenizer, self.lang)
+                ids = self._text_to_ids(text)
                 # Per-utterance deterministic reseed: fixes cross-epoch RNG
                 # drift so the same checkpoint always yields the same wav.
                 self._reseed(self.seed + i)

--- a/phoonnx_train/matcha/audio.py
+++ b/phoonnx_train/matcha/audio.py
@@ -6,6 +6,13 @@ from scipy.io.wavfile import read
 
 MAX_WAV_VALUE = 32768.0
 
+# Magnitude-floor epsilon added under the sqrt when converting the complex STFT
+# to a magnitude spectrogram. The vocos/matcha lineage pairs a 1e-9 STFT floor
+# with the 1e-5 spectral-compression clip; VITS/HiFi-GAN instead uses a larger
+# 1e-6 STFT floor (see vits/mel_processing.py's VITS_STFT_EPS). Keep this at
+# 1e-9 to preserve matcha numerics exactly.
+MEL_STFT_EPS = 1e-9
+
 
 def load_wav(full_path):
     sampling_rate, data = read(full_path)
@@ -49,10 +56,16 @@ def mel_spectrogram(y, n_fft, num_mels, sampling_rate, hop_size, win_size, fmin,
         print("max value is ", torch.max(y))
 
     global mel_basis, hann_window  # pylint: disable=global-statement
-    if f"{str(fmax)}_{str(y.device)}" not in mel_basis:
+    # Key the mel_basis cache on the FULL filterbank-defining parameter set,
+    # not fmax alone: two configs sharing fmax but differing in fmin / n_mels /
+    # n_fft / sample_rate produce different filterbanks and must not alias.
+    mel_key = (n_fft, num_mels, sampling_rate, fmin, fmax, str(y.device))
+    win_key = (win_size, str(y.device))
+    if mel_key not in mel_basis:
         mel = librosa_mel_fn(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
-        mel_basis[str(fmax) + "_" + str(y.device)] = torch.from_numpy(mel).float().to(y.device)
-        hann_window[str(y.device)] = torch.hann_window(win_size).to(y.device)
+        mel_basis[mel_key] = torch.from_numpy(mel).float().to(y.device)
+    if win_key not in hann_window:
+        hann_window[win_key] = torch.hann_window(win_size).to(y.device)
 
     y = torch.nn.functional.pad(
         y.unsqueeze(1), (int((n_fft - hop_size) / 2), int((n_fft - hop_size) / 2)), mode="reflect"
@@ -65,7 +78,7 @@ def mel_spectrogram(y, n_fft, num_mels, sampling_rate, hop_size, win_size, fmin,
             n_fft,
             hop_length=hop_size,
             win_length=win_size,
-            window=hann_window[str(y.device)],
+            window=hann_window[win_key],
             center=center,
             pad_mode="reflect",
             normalized=False,
@@ -74,9 +87,9 @@ def mel_spectrogram(y, n_fft, num_mels, sampling_rate, hop_size, win_size, fmin,
         )
     )
 
-    spec = torch.sqrt(spec.pow(2).sum(-1) + (1e-9))
+    spec = torch.sqrt(spec.pow(2).sum(-1) + MEL_STFT_EPS)
 
-    spec = torch.matmul(mel_basis[str(fmax) + "_" + str(y.device)], spec)
+    spec = torch.matmul(mel_basis[mel_key], spec)
     spec = spectral_normalize_torch(spec)
 
     return spec

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -278,15 +278,24 @@ def main(
         **training_engine.trainer_kwargs(),
     )
     if use_compile:
-        if hasattr(model, "model_g") and hasattr(model, "model_d"):
-            _LOGGER.info("Compiling model_g/model_d with torch.compile (mode=%s)", compile_mode)
-            model.model_g = torch.compile(model.model_g, mode=compile_mode)
-            model.model_d = torch.compile(model.model_d, mode=compile_mode)
-        elif hasattr(model, "model") and isinstance(getattr(model, "model"), torch.nn.Module):
-            _LOGGER.info("Compiling model with torch.compile (mode=%s)", compile_mode)
-            model.model = torch.compile(model.model, mode=compile_mode)
-        else:
-            _LOGGER.warning("compile not supported for engine %r yet — running uncompiled", engine)
+        # torch.compile can raise at call time on unsupported python/torch
+        # combinations (e.g. dynamo has no CPython 3.12 backend on torch<2.3).
+        # A compile failure must never abort a training run that would have
+        # been perfectly fine uncompiled: warn and continue.
+        try:
+            if hasattr(model, "model_g") and hasattr(model, "model_d"):
+                _LOGGER.info("Compiling model_g/model_d with torch.compile (mode=%s)", compile_mode)
+                model.model_g = torch.compile(model.model_g, mode=compile_mode)
+                model.model_d = torch.compile(model.model_d, mode=compile_mode)
+            elif hasattr(model, "model") and isinstance(getattr(model, "model"), torch.nn.Module):
+                _LOGGER.info("Compiling model with torch.compile (mode=%s)", compile_mode)
+                model.model = torch.compile(model.model, mode=compile_mode)
+            else:
+                _LOGGER.warning("compile not supported for engine %r yet — running uncompiled", engine)
+        except Exception as err:
+            _LOGGER.warning(
+                "torch.compile unavailable: %s — continuing uncompiled", err
+            )
 
     _LOGGER.info("Training started!")
     # torch>=2.6 defaults torch.load(weights_only=True), which rejects our own

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -245,9 +245,27 @@ def main(
     # In-training scoreboard is opt-in: only wired up when both an eval
     # sentences file and a positive --eval-every are given.
     if eval_sentences and eval_every > 0:
+        from phoonnx_train.engines.base import BaseTrainingEngine
         from phoonnx_train.evaluation import (CheckpointScorer, MetricsTracker,
                                               SelectionPolicy)
         from phoonnx_train.eval_utils import read_sentences
+
+        # In-training scoring loads each checkpoint through
+        # engine.eval_synthesize; engines that never implemented it would fail
+        # silently at the first scoring firing (deep inside a swallowed
+        # callback exception) after wasting a full training run. Fail loudly at
+        # startup instead, naming the engines that DO support it.
+        if type(training_engine).eval_synthesize is BaseTrainingEngine.eval_synthesize:
+            supported = sorted(
+                name for name in list_engines()
+                if type(get_engine(name)).eval_synthesize
+                is not BaseTrainingEngine.eval_synthesize
+            )
+            raise click.UsageError(
+                f"engine {engine!r} does not support in-training evaluation "
+                f"(--eval-sentences / --eval-every); it has no eval_synthesize "
+                f"implementation. Engines that do: {', '.join(supported) or 'none'}."
+            )
 
         sentences = read_sentences(eval_sentences)
         eval_dir = run_dir / "eval"

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -83,6 +83,9 @@ def _validate_engine(ctx, param, value):
               help='Reference-speaker wav dir enabling the speaker-similarity gate')
 @click.option('--min-spk-sim', type=float, default=None,
               help='Similarity gate floor for best-checkpoint selection')
+@click.option('--eval-speaker-id', type=int, default=None,
+              help='Speaker id used for in-training evaluation synthesis on '
+                   'multi-speaker models (default: None = engine default voice)')
 @click.option('--eval-seed', type=int, default=1234,
               help='Base seed for per-utterance evaluation synthesis (default: 1234)')
 @click.option('--compile', 'use_compile', is_flag=True, default=False,
@@ -113,6 +116,7 @@ def main(
     early_stop_patience: int,
     eval_speaker_ref_dir: Optional[str],
     min_spk_sim: Optional[float],
+    eval_speaker_id: Optional[int],
     eval_seed: int,
     use_compile: bool,
     compile_mode: str,
@@ -272,7 +276,7 @@ def main(
         scorer = CheckpointScorer(
             training_engine, dataset_config, sentences,
             speaker_ref_dir=Path(eval_speaker_ref_dir) if eval_speaker_ref_dir else None,
-            speaker_id=None,
+            speaker_id=eval_speaker_id,
             seed=eval_seed,
         )
         selection = SelectionPolicy(metric="utmos_mean", min_spk_sim=min_spk_sim)

--- a/phoonnx_train/vits/lightning.py
+++ b/phoonnx_train/vits/lightning.py
@@ -141,16 +141,53 @@ class VitsModel(pl.LightningModule):
         self._y = None
         self._y_hat = None
 
-    def on_load_checkpoint(self, checkpoint: dict) -> None:
-        # Checkpoints saved with torch.compile prefix every wrapped
-        # submodule's keys with "_orig_mod.". Strip it so a checkpoint
-        # loads cleanly regardless of whether compile is on or off, either
-        # direction.
+    # Submodules to reconcile against torch.compile's "._orig_mod." wrapping.
+    _COMPILE_WRAPPED_SUBMODULES = ("model_g", "model_d")
+
+    def _adapt_key_to_model(self, key: str) -> str:
+        """Rewrite a *clean* (uncompiled) state-dict key so it matches what the
+        CURRENT model expects. When ``self.model_g`` / ``self.model_d`` are
+        torch.compile ``OptimizedModule`` wrappers (exposing ``_orig_mod``),
+        their real parameters live under ``<name>._orig_mod.*``, so a bare
+        ``<name>.*`` key must gain that prefix; otherwise it is left as-is."""
+        for name in self._COMPILE_WRAPPED_SUBMODULES:
+            prefix = name + "."
+            submodule = getattr(self, name, None)
+            if (
+                key.startswith(prefix)
+                and submodule is not None
+                and hasattr(submodule, "_orig_mod")
+            ):
+                return prefix + "_orig_mod." + key[len(prefix):]
+        return key
+
+    def on_save_checkpoint(self, checkpoint: dict) -> None:
+        # Always persist CLEAN (uncompiled) keys: strip torch.compile's
+        # "._orig_mod." wrapping so a checkpoint written during a --compile run
+        # loads into an uncompiled consumer unchanged (old-consumer compat).
         state_dict = checkpoint.get("state_dict")
         if state_dict:
             checkpoint["state_dict"] = {
                 k.replace("._orig_mod.", "."): v for k, v in state_dict.items()
             }
+
+    def on_load_checkpoint(self, checkpoint: dict) -> None:
+        # Reconcile a checkpoint's keys with the CURRENT model in either
+        # direction. First normalize to clean keys (strip any "._orig_mod."),
+        # then re-insert the prefix only for submodules that are actually
+        # compiled right now. This covers the full save×load matrix:
+        # compiled/uncompiled checkpoints loading into compiled/uncompiled
+        # models — including the reverse case (clean checkpoint -> compiled
+        # model), whose strict restore would otherwise crash on resume.
+        state_dict = checkpoint.get("state_dict")
+        if not state_dict:
+            return
+        clean = {
+            k.replace("._orig_mod.", "."): v for k, v in state_dict.items()
+        }
+        checkpoint["state_dict"] = {
+            self._adapt_key_to_model(k): v for k, v in clean.items()
+        }
 
     def _load_datasets(
         self,

--- a/phoonnx_train/vits/mel_processing.py
+++ b/phoonnx_train/vits/mel_processing.py
@@ -4,6 +4,13 @@ from librosa.filters import mel as librosa_mel_fn
 
 MAX_WAV_VALUE = 32768.0
 
+# Magnitude-floor epsilon added under the sqrt when converting the complex STFT
+# to a magnitude spectrogram. VITS/HiFi-GAN pairs a 1e-6 STFT floor with the
+# 1e-5 spectral-compression clip (dynamic_range_compression_torch); the vocos
+# lineage instead pairs a smaller 1e-9 STFT floor (see matcha/audio.py's
+# MEL_STFT_EPS). Keep this at 1e-6 to preserve VITS numerics exactly.
+VITS_STFT_EPS = 1e-6
+
 
 def dynamic_range_compression_torch(x, C=1, clip_val=1e-5):
     """
@@ -71,21 +78,29 @@ def spectrogram_torch(y, n_fft, sampling_rate, hop_size, win_size, center=False)
         )
     )
 
-    spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
+    spec = torch.sqrt(spec.pow(2).sum(-1) + VITS_STFT_EPS)
 
     return spec
 
 
+def _mel_basis_key(n_fft, num_mels, sampling_rate, fmin, fmax, tensor):
+    # Key the mel_basis cache on the FULL filterbank-defining parameter set,
+    # not fmax alone: two configs sharing fmax but differing in fmin / n_mels /
+    # n_fft / sample_rate produce different filterbanks and must not alias to
+    # the same cached tensor.
+    return (n_fft, num_mels, sampling_rate, fmin, fmax,
+            str(tensor.dtype), str(tensor.device))
+
+
 def spec_to_mel_torch(spec, n_fft, num_mels, sampling_rate, fmin, fmax):
     global mel_basis
-    dtype_device = str(spec.dtype) + "_" + str(spec.device)
-    fmax_dtype_device = str(fmax) + "_" + dtype_device
-    if fmax_dtype_device not in mel_basis:
+    key = _mel_basis_key(n_fft, num_mels, sampling_rate, fmin, fmax, spec)
+    if key not in mel_basis:
         mel = librosa_mel_fn(
             sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax
         )
-        mel_basis[fmax_dtype_device] = torch.from_numpy(mel).type_as(spec)
-    spec = torch.matmul(mel_basis[fmax_dtype_device], spec)
+        mel_basis[key] = torch.from_numpy(mel).type_as(spec)
+    spec = torch.matmul(mel_basis[key], spec)
     spec = spectral_normalize_torch(spec)
     return spec
 
@@ -100,13 +115,13 @@ def mel_spectrogram_torch(
 
     global mel_basis, hann_window
     dtype_device = str(y.dtype) + "_" + str(y.device)
-    fmax_dtype_device = str(fmax) + "_" + dtype_device
+    key = _mel_basis_key(n_fft, num_mels, sampling_rate, fmin, fmax, y)
     wnsize_dtype_device = str(win_size) + "_" + dtype_device
-    if fmax_dtype_device not in mel_basis:
+    if key not in mel_basis:
         mel = librosa_mel_fn(
             sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax
         )
-        mel_basis[fmax_dtype_device] = torch.from_numpy(mel).type_as(y)
+        mel_basis[key] = torch.from_numpy(mel).type_as(y)
     if wnsize_dtype_device not in hann_window:
         hann_window[wnsize_dtype_device] = torch.hann_window(win_size).type_as(y)
 
@@ -131,9 +146,9 @@ def mel_spectrogram_torch(
         )
     )
 
-    spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
+    spec = torch.sqrt(spec.pow(2).sum(-1) + VITS_STFT_EPS)
 
-    spec = torch.matmul(mel_basis[fmax_dtype_device], spec)
+    spec = torch.matmul(mel_basis[key], spec)
     spec = spectral_normalize_torch(spec)
 
     return spec

--- a/tests/test_torch_compile_training.py
+++ b/tests/test_torch_compile_training.py
@@ -153,6 +153,17 @@ class TestCompileInvocation(unittest.TestCase):
 
 
 class TestCheckpointOrigModStripping(unittest.TestCase):
+    @staticmethod
+    def _uncompiled_model():
+        # A bare (uncompiled) VitsModel: on_load_checkpoint reconciles keys
+        # against the CURRENT model, so an uncompiled model strips "_orig_mod."
+        # exactly as before.
+        m = VitsModel.__new__(VitsModel)
+        torch.nn.Module.__init__(m)
+        m.model_g = torch.nn.Linear(2, 2)
+        m.model_d = torch.nn.Linear(2, 2)
+        return m
+
     def test_orig_mod_prefix_is_stripped(self):
         checkpoint = {
             "state_dict": {
@@ -161,7 +172,7 @@ class TestCheckpointOrigModStripping(unittest.TestCase):
                 "unrelated_key": torch.tensor([3.0]),
             }
         }
-        VitsModel.on_load_checkpoint(None, checkpoint)
+        self._uncompiled_model().on_load_checkpoint(checkpoint)
         keys = set(checkpoint["state_dict"].keys())
         self.assertEqual(
             keys,
@@ -176,12 +187,12 @@ class TestCheckpointOrigModStripping(unittest.TestCase):
             }
         }
         before = dict(checkpoint["state_dict"])
-        VitsModel.on_load_checkpoint(None, checkpoint)
+        self._uncompiled_model().on_load_checkpoint(checkpoint)
         self.assertEqual(set(checkpoint["state_dict"].keys()), set(before.keys()))
 
     def test_missing_state_dict_does_not_raise(self):
         checkpoint = {}
-        VitsModel.on_load_checkpoint(None, checkpoint)
+        self._uncompiled_model().on_load_checkpoint(checkpoint)
         self.assertEqual(checkpoint, {})
 
 

--- a/tests/test_training_audit_fixes.py
+++ b/tests/test_training_audit_fixes.py
@@ -1,0 +1,444 @@
+"""Regression tests for the training-stack audit fixes.
+
+Each test class targets one audit finding:
+
+  * ``TestCompileResumeMatrix`` — VitsModel checkpoint key reconciliation across
+    the full compiled/uncompiled save x compiled/uncompiled load matrix
+    (on_save_checkpoint always cleans; on_load_checkpoint adapts to the CURRENT
+    model, including the reverse clean-checkpoint -> compiled-model case).
+  * ``TestGuardedCompile`` — a failing torch.compile warns and continues
+    uncompiled instead of aborting the run.
+  * ``TestEvalWithoutSynthesizeGuard`` — enabling in-training eval on an engine
+    with no eval_synthesize fails loudly at startup.
+  * ``TestOptiSpeechEvalTokenization`` — the OptiSpeech eval hook tokenizes
+    differently from the generic phoonnx pipeline (proving the bug), and the
+    scorer prefers the hook.
+  * ``TestSizeStableFast`` — a fully-written file is judged stable quickly.
+  * ``TestScorePendingCheckpoints`` — every unscored on-disk checkpoint is
+    scored on a gated firing, not only the newest.
+  * ``TestMelBasisCacheKeys`` — mel_basis caches key on the full parameter set.
+"""
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+from click.testing import CliRunner
+
+from phoonnx_train import train as train_module
+from phoonnx_train.vits.lightning import VitsModel
+
+
+# ---------------------------------------------------------------------------
+# #1 compile x resume matrix
+# ---------------------------------------------------------------------------
+class _CompiledWrapper(torch.nn.Module):
+    """Stand-in for torch._dynamo OptimizedModule: exposes ``_orig_mod`` and
+    prefixes its state-dict keys with ``_orig_mod.`` exactly like the real one.
+    Used because torch.compile cannot dynamo-compile on this py/torch combo."""
+
+    def __init__(self, orig: torch.nn.Module):
+        super().__init__()
+        self._orig_mod = orig
+
+
+def _bare_model():
+    """A VitsModel instance without running __init__ (no dataset/torch build);
+    we only exercise the checkpoint hooks, which read model_g/model_d."""
+    m = VitsModel.__new__(VitsModel)
+    torch.nn.Module.__init__(m)
+    m.model_g = torch.nn.Linear(2, 2)
+    m.model_d = torch.nn.Linear(2, 2)
+    return m
+
+
+def _compile(model):
+    model.model_g = _CompiledWrapper(model.model_g)
+    model.model_d = _CompiledWrapper(model.model_d)
+    return model
+
+
+class TestCompileResumeMatrix(unittest.TestCase):
+    CLEAN = {
+        "model_g.enc.weight": torch.tensor([1.0]),
+        "model_d.disc.bias": torch.tensor([2.0]),
+        "unrelated": torch.tensor([3.0]),
+    }
+    COMPILED = {
+        "model_g._orig_mod.enc.weight": torch.tensor([1.0]),
+        "model_d._orig_mod.disc.bias": torch.tensor([2.0]),
+        "unrelated": torch.tensor([3.0]),
+    }
+
+    def _save(self, model, state):
+        ckpt = {"state_dict": dict(state)}
+        model.on_save_checkpoint(ckpt)
+        return set(ckpt["state_dict"])
+
+    def _load(self, model, state):
+        ckpt = {"state_dict": dict(state)}
+        model.on_load_checkpoint(ckpt)
+        return set(ckpt["state_dict"])
+
+    # on_save always produces clean keys, regardless of compile state
+    def test_save_uncompiled_is_clean(self):
+        self.assertEqual(self._save(_bare_model(), self.CLEAN), set(self.CLEAN))
+
+    def test_save_compiled_strips_to_clean(self):
+        self.assertEqual(
+            self._save(_compile(_bare_model()), self.COMPILED), set(self.CLEAN)
+        )
+
+    # on_load adapts to the CURRENT model — the four cells
+    def test_load_clean_into_uncompiled(self):
+        self.assertEqual(self._load(_bare_model(), self.CLEAN), set(self.CLEAN))
+
+    def test_load_compiled_into_uncompiled(self):
+        # compiled checkpoint, uncompiled model -> strip (old behaviour)
+        self.assertEqual(self._load(_bare_model(), self.COMPILED), set(self.CLEAN))
+
+    def test_load_compiled_into_compiled(self):
+        self.assertEqual(
+            self._load(_compile(_bare_model()), self.COMPILED), set(self.COMPILED)
+        )
+
+    def test_load_clean_into_compiled(self):
+        # THE reverse-direction bug: clean checkpoint must gain the _orig_mod
+        # prefix so a --compile resume's strict restore does not crash.
+        self.assertEqual(
+            self._load(_compile(_bare_model()), self.CLEAN), set(self.COMPILED)
+        )
+
+    def test_loaded_state_actually_restores_into_compiled_model(self):
+        # End-to-end: a clean checkpoint loads via load_state_dict into a
+        # compiled model without missing/unexpected keys.
+        model = _compile(_bare_model())
+        real = {
+            f"model_g._orig_mod.{k}": v
+            for k, v in torch.nn.Linear(2, 2).state_dict().items()
+        }
+        real.update(
+            {
+                f"model_d._orig_mod.{k}": v
+                for k, v in torch.nn.Linear(2, 2).state_dict().items()
+            }
+        )
+        clean = {k.replace("._orig_mod.", "."): v for k, v in real.items()}
+        ckpt = {"state_dict": clean}
+        model.on_load_checkpoint(ckpt)
+        combined = torch.nn.Module()
+        combined.model_g = model.model_g
+        combined.model_d = model.model_d
+        missing, unexpected = combined.load_state_dict(
+            ckpt["state_dict"], strict=False
+        )
+        self.assertEqual(list(missing), [])
+        self.assertEqual(list(unexpected), [])
+
+    def test_missing_state_dict_is_noop(self):
+        ckpt = {}
+        _bare_model().on_load_checkpoint(ckpt)
+        _bare_model().on_save_checkpoint(ckpt)
+        self.assertEqual(ckpt, {})
+
+
+# ---------------------------------------------------------------------------
+# #2 guarded torch.compile
+# ---------------------------------------------------------------------------
+class _FakeEngine:
+    def __init__(self, with_model_g_d=True):
+        self.with_model_g_d = with_model_g_d
+
+    def quality_presets(self):
+        return {"medium": {}}
+
+    def trainer_kwargs(self):
+        return {}
+
+    def create_model(self, config, dataset_paths, **kwargs):
+        m = SimpleNamespace()
+        if self.with_model_g_d:
+            m.model_g = torch.nn.Linear(2, 2)
+            m.model_d = torch.nn.Linear(2, 2)
+        return m
+
+    def load_checkpoint(self, model, path, **kwargs):
+        return model
+
+
+class _FakeTrainer:
+    instances = []
+
+    def __init__(self, *a, **k):
+        self.fit_calls = []
+        _FakeTrainer.instances.append(self)
+
+    def fit(self, model, ckpt_path=None):
+        self.fit_calls.append((model, ckpt_path))
+
+
+def _invoke_main(tmp_dir, extra_args, engine):
+    _FakeTrainer.instances = []
+    with mock.patch.object(train_module, "get_engine", return_value=engine), \
+         mock.patch.object(train_module, "Trainer", _FakeTrainer):
+        return CliRunner().invoke(
+            train_module.main,
+            ["--dataset-dir", tmp_dir, "--engine", "vits",
+             "--max-epochs", "1", *extra_args],
+        )
+
+
+class TestGuardedCompile(unittest.TestCase):
+    def test_compile_failure_warns_and_continues(self):
+        def boom(m, mode):
+            raise RuntimeError("dynamo has no CPython 3.12 backend")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch.object(train_module.torch, "compile", side_effect=boom), \
+                 self.assertLogs(train_module._LOGGER, level="WARNING") as logs:
+                result = _invoke_main(tmp_dir, ["--compile"], _FakeEngine())
+            self.assertEqual(result.exit_code, 0, result.output)
+            # Training still ran uncompiled instead of aborting.
+            self.assertEqual(len(_FakeTrainer.instances), 1)
+            self.assertEqual(len(_FakeTrainer.instances[0].fit_calls), 1)
+            self.assertTrue(
+                any("torch.compile unavailable" in m for m in logs.output)
+            )
+
+
+# ---------------------------------------------------------------------------
+# #3 eval-every on an engine without eval_synthesize
+# ---------------------------------------------------------------------------
+class TestEvalWithoutSynthesizeGuard(unittest.TestCase):
+    def test_usage_error_when_engine_lacks_eval_synthesize(self):
+        from phoonnx_train.engines.base import BaseTrainingEngine
+
+        # _FakeEngine does not implement eval_synthesize; patch the base check
+        # to see it as unsupported (it is not a BaseTrainingEngine subclass).
+        engine = _FakeEngine()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sents = Path(tmp_dir) / "s.txt"
+            sents.write_text("hello\n", encoding="utf-8")
+            # Make the engine look like it inherits the base (unimplemented)
+            # eval_synthesize by giving type(engine) the base method.
+            with mock.patch.object(
+                type(engine), "eval_synthesize",
+                BaseTrainingEngine.eval_synthesize, create=True
+            ):
+                result = _invoke_main(
+                    tmp_dir,
+                    ["--eval-sentences", str(sents), "--eval-every", "1"],
+                    engine,
+                )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("does not support in-training evaluation", result.output)
+
+
+# ---------------------------------------------------------------------------
+# #4 OptiSpeech eval tokenization
+# ---------------------------------------------------------------------------
+class TestOptiSpeechEvalTokenization(unittest.TestCase):
+    CONFIG = {
+        "num_symbols": 178,
+        "num_speakers": 1,
+        "audio": {"sample_rate": 22050},
+        "lang_code": "en-us",
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "phoneme_id_map": {"a": 1, "b": 2},
+        "engine_params": {"languages": ["en-us"]},
+    }
+
+    def test_engine_hook_differs_from_phoonnx_pipeline(self):
+        try:
+            import piper_phonemize  # noqa: F401
+        except ImportError:
+            self.skipTest("piper-phonemize required for the OptiSpeech IPA tokenizer")
+        from phoonnx_train.engines.optispeech import OptiSpeechTrainingEngine
+
+        engine = OptiSpeechTrainingEngine()
+        hook_ids = engine.eval_text_to_ids("hello world", self.CONFIG)
+        self.assertIsInstance(hook_ids, list)
+        self.assertTrue(all(isinstance(i, int) for i in hook_ids))
+
+        # The generic phoonnx pipeline produces a DIFFERENT id sequence for the
+        # same sentence (different phoneme set / blank / BOS-EOS handling) —
+        # feeding those to an OptiSpeech-trained model scores garbage.
+        from phoonnx_train.evaluation import scorer as scorer_mod
+        try:
+            ph, tok, lang, _sr, _sc = scorer_mod.build_encoder(self.CONFIG)
+            _, generic_ids = scorer_mod.text_to_ids("hello world", ph, tok, lang)
+        except Exception:
+            self.skipTest("generic phoonnx pipeline unavailable in this env")
+        self.assertNotEqual(hook_ids, generic_ids)
+
+    def test_scorer_prefers_engine_hook(self):
+        from phoonnx_train.evaluation import scorer as scorer_mod
+        from phoonnx_train.engines.base import BaseTrainingEngine
+
+        sentinel = [7, 7, 7]
+
+        class HookEngine(BaseTrainingEngine):
+            def create_model(self, *a, **k):
+                raise NotImplementedError
+
+            def export_onnx(self, *a, **k):
+                raise NotImplementedError
+
+            def quality_presets(self):
+                return {}
+
+            def eval_text_to_ids(self, text, config):
+                return list(sentinel)
+
+        s = scorer_mod.CheckpointScorer.__new__(scorer_mod.CheckpointScorer)
+        s.engine = HookEngine()
+        s.config = self.CONFIG
+        base = BaseTrainingEngine.eval_text_to_ids
+        s._uses_engine_tokenizer = (
+            getattr(type(s.engine), "eval_text_to_ids", base) is not base
+        )
+        self.assertTrue(s._uses_engine_tokenizer)
+        self.assertEqual(s._text_to_ids("anything"), sentinel)
+
+    def test_scorer_falls_back_without_hook(self):
+        from phoonnx_train.evaluation import scorer as scorer_mod
+        from phoonnx_train.engines.base import BaseTrainingEngine
+
+        class PlainEngine(BaseTrainingEngine):
+            def create_model(self, *a, **k):
+                raise NotImplementedError
+
+            def export_onnx(self, *a, **k):
+                raise NotImplementedError
+
+            def quality_presets(self):
+                return {}
+
+        s = scorer_mod.CheckpointScorer.__new__(scorer_mod.CheckpointScorer)
+        s.engine = PlainEngine()
+        base = BaseTrainingEngine.eval_text_to_ids
+        s._uses_engine_tokenizer = (
+            getattr(type(s.engine), "eval_text_to_ids", base) is not base
+        )
+        s.ph = s.tokenizer = None
+        s.lang = ""
+        self.assertFalse(s._uses_engine_tokenizer)
+        with mock.patch.object(scorer_mod, "text_to_ids",
+                               return_value=(["p"], [9, 9])):
+            self.assertEqual(s._text_to_ids("x"), [9, 9])
+
+
+# ---------------------------------------------------------------------------
+# #5 size_stable fast path
+# ---------------------------------------------------------------------------
+class TestSizeStableFast(unittest.TestCase):
+    def test_static_file_stable_under_two_seconds(self):
+        from phoonnx_train import eval_utils
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "ckpt"
+            p.write_bytes(b"complete-checkpoint-bytes")
+            start = time.monotonic()
+            # Real sleep, default wait — must not stall multiple seconds.
+            stable = eval_utils.size_stable(p)
+            elapsed = time.monotonic() - start
+        self.assertTrue(stable)
+        self.assertLess(elapsed, 2.0)
+
+
+# ---------------------------------------------------------------------------
+# #6 score every pending checkpoint on a gated firing
+# ---------------------------------------------------------------------------
+class TestScorePendingCheckpoints(unittest.TestCase):
+    def _make_row(self, epoch, mean):
+        from phoonnx_train.evaluation.scorer import EvalRow
+
+        return EvalRow(
+            epoch=epoch, step=epoch, checkpoint=f"epoch={epoch}.ckpt",
+            n_sentences=1, aggregates={"utmos_mean": mean, "utmos_std": 0.0,
+                                       "utmos_min": mean, "utmos_max": mean},
+            perutt=[("s", {"utmos": mean}, None)],
+        )
+
+    def test_all_unscored_epochs_scored_in_one_firing(self):
+        from phoonnx_train.evaluation.callbacks import EvalScoreboardCallback
+        from phoonnx_train.evaluation.selection import SelectionPolicy
+        from phoonnx_train.evaluation.tracker import MetricsTracker
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            ckpt_dir = d / "ck"
+            ckpt_dir.mkdir()
+            # --checkpoint-epochs 2 style: epochs 1, 3, 5 on disk.
+            for e in (1, 3, 5):
+                (ckpt_dir / f"epoch={e}-step={e}.ckpt").write_bytes(b"w")
+
+            scored = []
+
+            scorer = SimpleNamespace(metrics=["utmos"])
+            scorer.score = lambda ckpt, epoch, work_dir=None: (
+                scored.append(epoch) or self._make_row(epoch, 3.0 + epoch)
+            )
+
+            out = d / "eval"
+            tracker = MetricsTracker(out)
+            selection = SelectionPolicy(metric="utmos_mean")
+            cb = EvalScoreboardCallback(
+                scorer, tracker, selection, out,
+                every_n_epochs=2, checkpoint_dir=ckpt_dir,
+            )
+            trainer = SimpleNamespace(current_epoch=5, should_stop=False,
+                                      checkpoint_callback=None)
+            with mock.patch(
+                "phoonnx_train.evaluation.callbacks.size_stable",
+                return_value=True,
+            ):
+                cb.on_train_epoch_end(trainer, None)
+
+            self.assertEqual(sorted(scored), [1, 3, 5])
+            self.assertEqual(tracker.done_epochs(), {1, 3, 5})
+
+
+# ---------------------------------------------------------------------------
+# #7 mel_basis cache keyed on the full parameter set
+# ---------------------------------------------------------------------------
+class TestMelBasisCacheKeys(unittest.TestCase):
+    def test_vits_same_fmax_different_n_mels(self):
+        from phoonnx_train.vits import mel_processing as mp
+
+        mp.mel_basis.clear()
+        y = torch.zeros(1, 4096)
+        a = mp.mel_spectrogram_torch(y, 1024, 80, 22050, 256, 1024, 0.0, 8000.0)
+        b = mp.mel_spectrogram_torch(y, 1024, 40, 22050, 256, 1024, 0.0, 8000.0)
+        # Same fmax (8000) but different n_mels -> distinct filterbanks and
+        # distinct mel-channel dims, not aliased to one cached bank.
+        self.assertEqual(a.shape[1], 80)
+        self.assertEqual(b.shape[1], 40)
+        self.assertEqual(len(mp.mel_basis), 2)
+
+    def test_matcha_same_fmax_different_n_mels(self):
+        from phoonnx_train.matcha import audio as ma
+
+        ma.mel_basis.clear()
+        ma.hann_window.clear()
+        y = torch.zeros(1, 4096)
+        a = ma.mel_spectrogram(y, 1024, 80, 22050, 256, 1024, 0.0, 8000.0)
+        b = ma.mel_spectrogram(y, 1024, 40, 22050, 256, 1024, 0.0, 8000.0)
+        self.assertEqual(a.shape[1], 80)
+        self.assertEqual(b.shape[1], 40)
+        self.assertEqual(len(ma.mel_basis), 2)
+
+    def test_eps_constants_named(self):
+        from phoonnx_train.vits import mel_processing as mp
+        from phoonnx_train.matcha import audio as ma
+
+        self.assertEqual(mp.VITS_STFT_EPS, 1e-6)
+        self.assertEqual(ma.MEL_STFT_EPS, 1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes triaged from a training-stack audit. Each finding gets a focused commit and a regression test.

## Findings

| # | Finding | Verdict | Fix |
|---|---------|---------|-----|
| — | `on_load_checkpoint` strips `_orig_mod.` so uncompiled consumers load compiled-run checkpoints | Already correct on `dev` — verified, kept | — |
| 1 | Compile × resume reverse direction: a clean/stripped checkpoint fails strict-restore into a `--compile` model that expects `model_g._orig_mod.*` | Real bug | `on_load_checkpoint` normalizes to clean keys then re-inserts the prefix only for submodules compiled on the current model; added `on_save_checkpoint` to always persist clean keys |
| 2 | Unguarded `torch.compile` aborts the run on unsupported python/torch | Real bug | wrap the compile block; on failure warn `torch.compile unavailable: <err> — continuing uncompiled` and continue |
| 3 | `--eval-every` silently no-ops on engines without `eval_synthesize` (fails deep in a swallowed callback after a wasted run) | Real bug | startup `click.UsageError` naming the engine and the supported ones |
| 4 | OptiSpeech in-training eval tokenization | **Confirmed real (H1).** Verification: the scorer tokenizes with the phoonnx `TTSTokenizer`/phoneme_id_map, but the OptiSpeech datamodule feeds ids from its own `TextProcessor` (different phoneme set + blank/BOS-EOS convention). The two id sequences differ, so in-training scores were computed on garbage input and could pick a wrong best checkpoint. | added optional `BaseTrainingEngine.eval_text_to_ids(text, config)` hook (default `None`); implemented for OptiSpeech to mirror training tokenization exactly; scorer prefers the hook when present |
| 5 | `size_stable` always slept 5s on the first iteration, even for fully-written files | Real bug | stat, sleep 0.5s, stat again; equal → stable; longer retry only while the size keeps changing |
| 6 | Eval gate vs on-disk checkpoint filenames diverge with `--checkpoint-epochs > 1`, skipping epochs from scoring | Real bug | score every unscored checkpoint on disk oldest-first per gated firing, deferring only a still-unstable newest one |
| 7 | (a) `mel_basis` caches keyed on `fmax`+device only — configs sharing `fmax` but differing `fmin`/`n_mels`/`n_fft` alias to the wrong filterbank (M1); (b) unnamed magnitude epsilons (S5) | Real bug (a) + cleanup (b) | key both VITS and matcha mel caches (and matcha's hann cache) on the full parameter tuple; name `VITS_STFT_EPS=1e-6` / `MEL_STFT_EPS=1e-9` with the vocos pairing note — no numeric change |
| 8 | base `load_checkpoint` uses `weights_only=True`; scorer speaker id hardcoded `None` while multi-speaker warns | Minor | switch to `trusting_torch_load`; add `--eval-speaker-id` threaded to the scorer |

## Test plan

New `tests/test_training_audit_fixes.py` plus updates to `tests/test_torch_compile_training.py`:

- 4-cell compiled/uncompiled save × load matrix (compile mocked via an `_orig_mod`-exposing wrapper, since torch 2.2 + py3.12 can't dynamo), incl. the reverse case restoring into a compiled model with no missing/unexpected keys
- mocked `torch.compile` raising → run continues uncompiled with the warning
- eval flags on an engine without `eval_synthesize` → `UsageError`
- OptiSpeech hook wiring (scorer prefers hook; falls back without one); the hook-vs-generic tokenization divergence test needs `piper-phonemize` and skips where absent
- `size_stable` on a static file returns stable in < 2s (real sleep)
- fake epoch dir with `--checkpoint-epochs 2` spacing → all unscored epochs scored in one firing
- same `fmax`, different `n_mels` → distinct filterbanks for both VITS and matcha caches; named eps constants

Suite (`pytest tests/`, ovoscope plugin disabled): **1298 passed, 8 skipped, 16 failed** — the 16 failures are pre-existing and unrelated (styletts2 env cluster: missing `ovos_workshop`/aux deps; one yourtts ONNX-export dynamo trace error). Baseline before these changes was the same 16.
