### PR TITLE
feat: on-demand runtime alignment output via load-time graph surgery

### DIFF
--- a/docs/alignment.md
+++ b/docs/alignment.md
@@ -170,6 +170,53 @@ add_phoneme_alignment_output(
 
 ---
 
+## Runtime alignment for models exported without the flag
+
+You don't have to re-export a model to get alignments from it.
+``TTSVoice.synthesize(include_alignments=True)`` (and
+``phoneme_ids_to_audio(include_alignments=True)``) retrofit the duration
+output automatically the first time they are asked for one and the loaded
+session doesn't already have it:
+
+1. Locate the duration tensor in the model's graph (the same ``Ceil``-node
+   autodetection ``--add-phoneme-alignment`` uses, via
+   `phoonnx.onnx_surgery.add_phoneme_alignment_output`).
+2. Write a patched copy next to the original model, `<model>.alignment.onnx`
+   (or under `PHOONNX_ORT_CACHE_DIR` if that env var is set — the model's own
+   directory may be read-only, e.g. a shared voice cache).
+3. Rebuild an ONNX Runtime session from the patched copy, on the same
+   execution providers as the original, and retry inference on it.
+
+This runs **at most once per `TTSVoice` instance** — the outcome (including a
+negative one: no locatable duration tensor, `onnx` not installed, or the
+derived file couldn't be written) is cached on the voice, so later
+`include_alignments=True` calls either reuse the already-open patched session
+or go straight back to `None` without retrying. Across process restarts, the
+`<model>.alignment.onnx` file itself is the cache: if it already exists and is
+newer than the model, it's reused as-is, no surgery repeated.
+
+`include_alignments=False` never touches any of this — it is the exact same
+zero-cost no-op it always was.
+
+```python
+from phoonnx.voice import TTSVoice
+
+# model.onnx was exported without --add-phoneme-alignment
+voice = TTSVoice.load("model.onnx")
+
+for chunk in voice.synthesize("Hello world.", include_alignments=True):
+    # first call: locates the duration tensor, writes model.alignment.onnx
+    # next to model.onnx, and synthesizes from the patched session.
+    print(chunk.phoneme_alignments)
+```
+
+If the model genuinely has no discrete duration predictor (e.g. ZipVoice) or
+the `onnx` package isn't installed, this degrades exactly like any other
+unsupported model: `phoneme_id_samples` / `phoneme_alignments` stay `None`,
+and a single debug/info-level log line explains why.
+
+---
+
 ## Use cases
 
 ### Visemes / lip-sync

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,8 +109,13 @@ for chunk in voice.synthesize("Hello world.", include_alignments=True):
 
 `include_alignments=False` (the default) is a strict no-op on the audio, and
 models without a duration output degrade gracefully — `phoneme_alignments`
-comes back `None`. See [Phoneme alignment](alignment.md) for the full guide,
-the engine support matrix, and how to export a VITS model with alignment.
+comes back `None`. If a model was exported without a duration output but has
+one to find, the first `include_alignments=True` call retrofits it on demand
+via load-time graph surgery (see [Phoneme alignment](alignment.md)'s
+"Runtime alignment for models exported without the flag"), so re-exporting
+is optional, not required. See [Phoneme alignment](alignment.md) for the full
+guide, the engine support matrix, and how to export a VITS model with
+alignment.
 
 ## SynthesisConfig
 

--- a/phoonnx/onnx_surgery.py
+++ b/phoonnx/onnx_surgery.py
@@ -1,0 +1,66 @@
+"""Pure ``onnx``-package graph surgery for the phoneme-alignment output.
+
+This module only ever imports the lightweight ``onnx`` graph-manipulation
+package (never ``onnxruntime`` for inference, never ``torch``), so it is
+safe to import both from the training-side export CLI
+(``phoonnx_train/export_onnx.py``, which depends on this package) and from
+runtime code (``phoonnx.voice``, which must never depend on ``torch`` or
+``phoonnx_train``).
+
+The core operation: promote the per-phoneme duration tensor (found via the
+``Ceil`` node every VITS-family duration predictor ends with, rounding
+predicted log-durations to an integer frame count) to a named ONNX graph
+output. Standard exports don't do this — it is optional and either baked in
+at export time (``--add-phoneme-alignment``) or applied on demand at load
+time when a model without it is asked for alignments (see
+``TTSVoice._ensure_alignment_session`` in ``phoonnx/voice.py``).
+"""
+from typing import Optional, Set
+
+
+def find_duration_tensor(model, tensor_name: str = "autodetect") -> Optional[str]:
+    """Return the name of the tensor to expose as the alignment output.
+
+    ``tensor_name="autodetect"`` looks for a unique ``Ceil`` node output — the
+    rounded per-phoneme duration in every VITS-family export phoonnx has
+    seen. Returns ``None`` (never raises) when no such tensor exists or more
+    than one candidate is found (ambiguous); callers log and degrade to "no
+    alignment available".
+    """
+    if tensor_name != "autodetect":
+        return tensor_name
+
+    ceil_tensor_names: Set[str] = set()
+    for node in model.graph.node:
+        if node.op_type != "Ceil":
+            continue
+        ceil_tensor_names.update(node.output)
+
+    if not ceil_tensor_names or len(ceil_tensor_names) > 1:
+        return None
+    return next(iter(ceil_tensor_names))
+
+
+def add_phoneme_alignment_output(model, tensor_name: str = "autodetect") -> Optional[str]:
+    """Mutate ``model`` (an ``onnx.ModelProto``) in place, promoting the
+    duration tensor to a graph output.
+
+    Returns the promoted tensor's name on success — including when it was
+    already an output, a no-op success — or ``None`` when the tensor could
+    not be located (no/ambiguous ``Ceil`` node). Callers own loading/saving
+    the model and any higher-level logging; this function never raises for
+    the "not found" case and only imports the pure ``onnx`` package.
+    """
+    import onnx
+
+    name = find_duration_tensor(model, tensor_name)
+    if name is None:
+        return None
+
+    if any(output.name == name for output in model.graph.output):
+        return name  # already exposed - nothing to do
+
+    value_info = onnx.helper.ValueInfoProto()
+    value_info.name = name
+    model.graph.output.append(value_info)
+    return name

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -36,6 +36,11 @@ from phoonnx.util import LOG
 
 _PHONEME_BLOCK_PATTERN = re.compile(r"(\[\[.*?\]\])")
 
+# Sentinel distinguishing "on-demand alignment surgery not attempted yet" from
+# a cached negative result (``None`` — tried once, model doesn't expose a
+# locatable duration tensor). See ``TTSVoice._ensure_alignment_session``.
+_UNSET = object()
+
 
 def _phonemic_chunks(text: str, alphabet: Optional[Alphabet]) -> PhonemizedChunks:
     """Split an already-phonemic string into per-sentence symbol lists.
@@ -182,6 +187,19 @@ class TTSVoice:
     phonetic_spellings: Optional[PhoneticSpellings] = None
     phonemizer: Optional[Phonemizer] = None
     adapter: Optional[BaseOnnxAdapter] = None
+    # Path to the ONNX model file backing ``session``, kept so a later
+    # ``include_alignments=True`` call can locate-and-patch a model that was
+    # exported without the alignment output (see ``_ensure_alignment_session``).
+    # ``None`` for voices constructed directly from a session (e.g. tests),
+    # which simply skip the on-demand-surgery path.
+    model_path: Optional[str] = None
+    # Cache for the on-demand alignment-surgery outcome: unset (sentinel
+    # object, distinguishable from a real ``None`` "surgery ran and failed"
+    # result) until the first ``include_alignments=True`` call actually needs
+    # it, so a voice that never asks for alignments never even imports
+    # ``onnx``. Set to an ``onnxruntime.InferenceSession`` on success, or
+    # ``None`` on a cached negative result (tried once, no dice).
+    _alignment_session: Any = field(default=_UNSET, repr=False, compare=False)
 
     def __post_init__(self):
         """
@@ -368,6 +386,7 @@ class TTSVoice:
             config=voice_config,
             session=session,
             adapter=adapter,
+            model_path=str(model_path),
         )
         if warmup:
             voice.warmup()
@@ -689,6 +708,120 @@ class TTSVoice:
                 phoneme_alignments=phoneme_alignments,
             )
 
+    def _alignment_model_path(self) -> Optional[Path]:
+        """Sibling path the on-demand alignment-surgery output is cached at.
+
+        Next to the original model by default (``<model>.alignment.onnx``).
+        When ``PHOONNX_ORT_CACHE_DIR`` is set, that directory is used instead
+        — the same env var :func:`phoonnx.providers.make_session` already
+        uses for its optimized-graph cache, and the sensible choice here too:
+        it signals "phoonnx may write derived ONNX artifacts here" and covers
+        model directories that are read-only (e.g. a shared/system voice
+        cache) without introducing a second env var.
+        """
+        if not self.model_path:
+            return None
+        src = Path(self.model_path)
+        stem = src.name[:-len(".onnx")] if src.name.endswith(".onnx") else src.stem
+        cache_dir = os.environ.get("PHOONNX_ORT_CACHE_DIR")
+        directory = Path(cache_dir) if cache_dir else src.parent
+        return directory / f"{stem}.alignment.onnx"
+
+    def _ensure_alignment_session(self) -> Optional[onnxruntime.InferenceSession]:
+        """At-most-once, best-effort attempt to retrofit a duration output
+        onto this voice's model for a model that doesn't already have one.
+
+        Returns an alternate session with the duration tensor exposed as an
+        extra output (reused across calls once found), or ``None`` when this
+        model has no locatable duration tensor, ``onnx`` isn't installed, or
+        the derived file couldn't be written — every failure mode degrades to
+        "no alignment available" rather than raising, and the outcome
+        (including the negative one) is cached on the instance so surgery is
+        attempted at most once per voice.
+        """
+        if self._alignment_session is not _UNSET:
+            return self._alignment_session
+
+        result = self._attempt_alignment_surgery()
+        self._alignment_session = result
+        return result
+
+    def _attempt_alignment_surgery(self) -> Optional[onnxruntime.InferenceSession]:
+        if not self.model_path:
+            LOG.debug(
+                "no alignment output: this voice's model_path is unknown, "
+                "cannot retrofit one"
+            )
+            return None
+
+        try:
+            providers = self.session.get_providers()
+        except Exception:
+            providers = None
+
+        dest = self._alignment_model_path()
+        try:
+            src_mtime = os.path.getmtime(self.model_path)
+        except OSError:
+            src_mtime = None
+
+        if dest is not None and dest.is_file() and src_mtime is not None:
+            try:
+                if dest.stat().st_mtime >= src_mtime:
+                    return make_session(str(dest), providers=providers)
+            except OSError:
+                pass
+
+        try:
+            import onnx
+        except ImportError:
+            LOG.info(
+                "model has no alignment output and the 'onnx' package isn't "
+                "installed to retrofit one at runtime; install "
+                "'phoonnx[streaming]' (which pulls in 'onnx'), or re-export "
+                "the model with `--add-phoneme-alignment`, to use "
+                "include_alignments=True"
+            )
+            return None
+
+        from phoonnx.onnx_surgery import add_phoneme_alignment_output
+
+        try:
+            model = onnx.load(str(self.model_path))
+        except Exception as e:
+            LOG.info(f"no alignment output: failed to load '{self.model_path}' for surgery ({e})")
+            return None
+
+        tensor_name = add_phoneme_alignment_output(model)
+        if tensor_name is None:
+            LOG.info(
+                f"no alignment output on '{os.path.basename(str(self.model_path))}': "
+                "no unique duration (Ceil-op) tensor found in the graph; "
+                "include_alignments=True will keep returning None for this voice"
+            )
+            return None
+
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            onnx.save(model, str(dest))
+        except OSError as e:
+            LOG.info(
+                f"located duration tensor '{tensor_name}' but could not write "
+                f"the patched model to '{dest}' ({e}); "
+                "include_alignments=True will keep returning None for this voice"
+            )
+            return None
+
+        try:
+            return make_session(str(dest), providers=providers)
+        except Exception as e:
+            LOG.info(
+                f"wrote an alignment-patched model to '{dest}' but failed to "
+                f"load it ({e}); include_alignments=True will keep returning "
+                "None for this voice"
+            )
+            return None
+
     @staticmethod
     def _reconstruct_alignments(
             phoneme_ids: List[int],
@@ -864,14 +997,38 @@ class TTSVoice:
             params=params,
         )
 
+        # Once a prior call already retrofitted a working alignment session
+        # (see ``_ensure_alignment_session``), route straight to it instead
+        # of running inference on the original session first every time.
+        session_to_use = self.session
+        if (
+            include_alignments
+            and self._alignment_session is not _UNSET
+            and self._alignment_session is not None
+        ):
+            session_to_use = self._alignment_session
+
         # Delegate to the adapter (single-graph engines use the default
         # build_feed_dict → run → parse_outputs; iterative engines override).
-        result = self.adapter.synthesize(request, self.session)
+        result = self.adapter.synthesize(request, session_to_use)
 
         if not include_alignments:
             return result.audio
 
         phoneme_id_samples = result.extras.get("phoneme_id_samples")
+        if phoneme_id_samples is None and session_to_use is self.session:
+            # This model's session exposes no duration output. Try (at most
+            # once per voice) retrofitting one via load-time graph surgery —
+            # see ``_ensure_alignment_session`` — and re-run this same
+            # request on the patched session if that worked. Every failure
+            # mode there degrades to ``None`` here exactly like a model that
+            # genuinely has no duration predictor; the outcome (including a
+            # negative one) is cached so this only ever runs once per voice.
+            alignment_session = self._ensure_alignment_session()
+            if alignment_session is not None:
+                result = self.adapter.synthesize(request, alignment_session)
+                phoneme_id_samples = result.extras.get("phoneme_id_samples")
+
         if phoneme_id_samples is None:
             # Alignment is not available from this voice model.
             return result.audio, None

--- a/phoonnx_train/export_onnx.py
+++ b/phoonnx_train/export_onnx.py
@@ -40,6 +40,13 @@ def add_phoneme_alignment_output(
     This may break third-party frameworks (e.g. piper) that expect a single
     output tensor, so keep a separate copy for standard TTS use.
 
+    The actual graph surgery (locating the tensor + promoting it to an
+    output) is pure-``onnx`` and lives in ``phoonnx.onnx_surgery`` so it can
+    also be used at runtime, without a ``torch`` import, by
+    ``phoonnx.voice.TTSVoice`` for models that were exported without this
+    flag (see ``docs/alignment.md``, "runtime alignment for models exported
+    without the flag").
+
     Args:
         model_path: Path to the input ONNX model file.
         output_path: Where to save the modified model (defaults to overwriting).
@@ -47,6 +54,9 @@ def add_phoneme_alignment_output(
             unique ``Ceil`` node output.
     """
     import onnx
+
+    from phoonnx.onnx_surgery import add_phoneme_alignment_output as _surgery
+    from phoonnx.onnx_surgery import find_duration_tensor
 
     output_path = output_path or model_path
 
@@ -56,34 +66,31 @@ def add_phoneme_alignment_output(
         _LOGGER.fatal(f"Failed to load ONNX model from {model_path}: {e}")
         return
 
-    if tensor_name != "autodetect":
-        ceil_tensor_name = tensor_name
-    else:
-        ceil_tensor_names: Set[str] = set()
-        for node in model.graph.node:
-            if node.op_type != "Ceil":
-                continue
-            ceil_tensor_names.update(node.output)
-
+    tensor = find_duration_tensor(model, tensor_name=tensor_name)
+    if tensor is None:
+        if tensor_name != "autodetect":
+            _LOGGER.fatal(f"Tensor '{tensor_name}' not found in {model_path}. Use --tensor-name manually.")
+            return
+        ceil_tensor_names: Set[str] = {
+            o for node in model.graph.node if node.op_type == "Ceil" for o in node.output
+        }
         if not ceil_tensor_names:
             _LOGGER.fatal(f"No ceil tensors detected in {model_path}. Use --tensor-name manually.")
-            return
-        if len(ceil_tensor_names) > 1:
+        else:
             names_str = ', '.join(sorted(ceil_tensor_names))
             _LOGGER.fatal(
                 f"Multiple ceil tensors detected in {model_path}. Use --tensor-name manually: {names_str}"
             )
-            return
-        ceil_tensor_name = next(iter(ceil_tensor_names))
-        _LOGGER.info(f"Detected tensor name: {ceil_tensor_name}")
-
-    if any(output.name == ceil_tensor_name for output in model.graph.output):
-        _LOGGER.fatal(f"Tensor '{ceil_tensor_name}' is already marked as output. Aborting.")
         return
 
-    ceil_value_info = onnx.helper.ValueInfoProto()
-    ceil_value_info.name = ceil_tensor_name
-    model.graph.output.append(ceil_value_info)
+    if tensor_name == "autodetect":
+        _LOGGER.info(f"Detected tensor name: {tensor}")
+
+    if any(output.name == tensor for output in model.graph.output):
+        _LOGGER.fatal(f"Tensor '{tensor}' is already marked as output. Aborting.")
+        return
+
+    _surgery(model, tensor_name=tensor)
 
     try:
         onnx.save(model, output_path)
@@ -91,7 +98,7 @@ def add_phoneme_alignment_output(
         _LOGGER.fatal(f"Failed to save modified ONNX model to {output_path}: {e}")
         return
 
-    _LOGGER.info(f"Successfully wrote modified model with new output '{ceil_tensor_name}' to {output_path}")
+    _LOGGER.info(f"Successfully wrote modified model with new output '{tensor}' to {output_path}")
 
 
 def _validate_engine(ctx, param, value):

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -15,6 +15,7 @@ import shutil
 import tempfile
 import unittest
 from dataclasses import fields, is_dataclass
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -603,6 +604,23 @@ class TestAlignmentIntegration(unittest.TestCase):
         _patch_alignment(src_onnx, ALIGNED_MODEL)
         cls.voice = TTSVoice.load(ALIGNED_MODEL, config_path)
         cls.voice_no_align = TTSVoice.load(src_onnx, config_path)
+        cls._src_onnx = src_onnx
+
+    @classmethod
+    def tearDownClass(cls):
+        # ``voice_no_align``'s model does have a locatable duration tensor
+        # (see test_model_without_alignment_output_triggers_runtime_surgery
+        # below), so an ``include_alignments=True`` call against it writes an
+        # on-demand ``<model>.alignment.onnx`` sibling next to the
+        # downloaded/cached model file. Clean it up rather than leaving a
+        # derived artifact behind in the voice cache.
+        src_onnx = getattr(cls, "_src_onnx", None)
+        if src_onnx:
+            p = Path(src_onnx)
+            stem = p.name[:-len(".onnx")] if p.name.endswith(".onnx") else p.stem
+            derived = p.with_name(f"{stem}.alignment.onnx")
+            if derived.is_file():
+                derived.unlink()
 
     def test_synthesize_produces_audio(self):
         chunks = list(self.voice.synthesize("kaixo"))
@@ -644,11 +662,17 @@ class TestAlignmentIntegration(unittest.TestCase):
             self.assertGreater(a.num_samples, 0,
                                f"phoneme {a.phoneme!r} has zero duration")
 
-    def test_model_without_alignment_output_gives_none(self):
-        """Unpatched model (single output) gives phoneme_alignments=None."""
+    def test_model_without_alignment_output_triggers_runtime_surgery(self):
+        """An unpatched model (single output) that does carry a locatable
+        duration tensor gets one retrofitted on demand — see
+        ``phoonnx.onnx_surgery`` / ``TTSVoice._ensure_alignment_session`` —
+        instead of degrading to ``None``. This is the on-demand-alignment
+        feature working exactly as intended for a real VITS export."""
         chunk = list(self.voice_no_align.synthesize("kaixo", include_alignments=True))[0]
-        self.assertIsNone(chunk.phoneme_id_samples)
-        self.assertIsNone(chunk.phoneme_alignments)
+        self.assertIsNotNone(chunk.phoneme_id_samples)
+        self.assertIsNotNone(chunk.phoneme_alignments)
+        total = sum(a.num_samples for a in chunk.phoneme_alignments)
+        self.assertEqual(total, len(chunk.audio_float_array))
 
     def test_multiple_sentences(self):
         """Multi-sentence input: each chunk is independently aligned."""

--- a/tests/test_runtime_alignment.py
+++ b/tests/test_runtime_alignment.py
@@ -1,0 +1,228 @@
+"""Tests for on-demand runtime alignment output (load-time graph surgery).
+
+A voice model exported *without* ``--add-phoneme-alignment`` has no duration
+output on its ONNX session. ``TTSVoice.phoneme_ids_to_audio(include_alignments
+=True)`` retrofits one on demand: locate the duration (``Ceil``-op) tensor with
+``phoonnx.onnx_surgery``, write a ``<model>.alignment.onnx`` sibling with it
+promoted to a graph output, rebuild the session, and retry -- at most once per
+voice, with the outcome (including a negative one) cached.
+
+These tests build a tiny, real, *runnable* ONNX graph (no torch, no network)
+shaped like a VITS duration predictor: ``input`` (phoneme ids) -> per-id
+duration via ``Ceil`` (not exposed as an output) -> an audio tensor whose
+length is exactly the summed duration. This lets the "sample counts sum to
+audio length" and "byte-identical audio pre/post surgery" properties be
+checked exactly, not approximately.
+"""
+import os
+import shutil
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from onnx import TensorProto, helper, numpy_helper
+from unittest.mock import MagicMock
+
+from phoonnx.config import VoiceConfig
+from phoonnx.engines.vits import VitsAdapter
+from phoonnx.voice import TTSVoice, _UNSET
+
+
+def _tiny_model_without_alignment():
+    """``input`` (int64 [1, T]) -> Ceil-derived per-id durations (hidden,
+    not a graph output) -> ``output`` (float [1, sum(durations)]).
+
+    Durations are ``ceil(id + 1.5)`` -- deterministic, always positive, and
+    with no reliance on any tensor named like a known duration output, so the
+    *only* way to recover them is locating the ``Ceil`` node (exactly what
+    on-demand surgery must do).
+    """
+    inp = helper.make_tensor_value_info("input", TensorProto.INT64, [1, "T"])
+    out = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, None])
+
+    one_const = numpy_helper.from_array(np.array([1], dtype=np.int64), name="one_const")
+    axes_const = numpy_helper.from_array(np.array([1], dtype=np.int64), name="axes_const")
+    add_const = numpy_helper.from_array(np.array(1.5, dtype=np.float32), name="add_const")
+    fill_value = numpy_helper.from_array(np.array([1.0], dtype=np.float32))
+
+    nodes = [
+        helper.make_node("Cast", ["input"], ["input_f"], to=TensorProto.FLOAT),
+        helper.make_node("Add", ["input_f", "add_const"], ["raw_dur"]),
+        helper.make_node("Ceil", ["raw_dur"], ["durations"]),
+        helper.make_node("ReduceSum", ["durations", "axes_const"], ["dur_sum"], keepdims=0),
+        helper.make_node("Cast", ["dur_sum"], ["dur_sum_i"], to=TensorProto.INT64),
+        helper.make_node("Concat", ["one_const", "dur_sum_i"], ["out_shape"], axis=0),
+        helper.make_node("ConstantOfShape", ["out_shape"], ["output"], value=fill_value),
+    ]
+    graph = helper.make_graph(
+        nodes, "tiny_align_no_output", [inp], [out],
+        [one_const, axes_const, add_const],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    return model
+
+
+def _tiny_model_no_ceil():
+    """Same shape, but with no ``Ceil`` node at all -- nothing to locate."""
+    inp = helper.make_tensor_value_info("input", TensorProto.INT64, [1, "T"])
+    out = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, "T"])
+    node = helper.make_node("Cast", ["input"], ["output"], to=TensorProto.FLOAT)
+    graph = helper.make_graph([node], "tiny_no_ceil", [inp], [out])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    return model
+
+
+def _make_voice(model_path):
+    cfg = MagicMock(spec=VoiceConfig)
+    cfg.hop_length = 1  # native frames == samples, so sums check out exactly
+    cfg.noise_scale = None
+    cfg.length_scale = None
+    cfg.noise_w_scale = None
+    cfg.engine_params = {}
+
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    voice.config = cfg
+    voice.adapter = VitsAdapter()
+    voice.model_path = str(model_path)
+    voice._alignment_session = _UNSET
+    return voice
+
+
+class TestRuntimeAlignmentSurgery(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix="phoonnx_runtime_align_")
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.model_path = os.path.join(self.tmpdir, "model.onnx")
+        onnx.save(_tiny_model_without_alignment(), self.model_path)
+
+    def _alignment_path(self):
+        return os.path.join(self.tmpdir, "model.alignment.onnx")
+
+    def test_include_alignments_triggers_surgery_and_populates_alignments(self):
+        voice = _make_voice(self.model_path)
+        ids = [0, 1, 2, 3, 4]
+        audio, samples = voice.phoneme_ids_to_audio(ids, include_alignments=True)
+
+        self.assertTrue(os.path.isfile(self._alignment_path()))
+        self.assertIsNotNone(samples)
+        np.testing.assert_array_equal(samples, [2, 3, 4, 5, 6])
+        self.assertEqual(int(np.sum(samples)), len(audio))
+
+    def test_second_call_reuses_cached_alignment_file(self):
+        voice = _make_voice(self.model_path)
+        ids = [0, 1, 2]
+
+        with patch(
+            "phoonnx.onnx_surgery.add_phoneme_alignment_output",
+            wraps=__import__("phoonnx.onnx_surgery", fromlist=["add_phoneme_alignment_output"]).add_phoneme_alignment_output,
+        ) as mock_surgery:
+            voice.phoneme_ids_to_audio(ids, include_alignments=True)
+            voice.phoneme_ids_to_audio(ids, include_alignments=True)
+            self.assertEqual(mock_surgery.call_count, 1)
+
+    def test_second_voice_reuses_cached_alignment_file_on_disk(self):
+        """A *fresh* voice instance pointed at the same model path reuses the
+        already-written ``.alignment.onnx`` sibling without redoing surgery."""
+        voice1 = _make_voice(self.model_path)
+        voice1.phoneme_ids_to_audio([0, 1], include_alignments=True)
+        self.assertTrue(os.path.isfile(self._alignment_path()))
+
+        voice2 = _make_voice(self.model_path)
+        with patch(
+            "phoonnx.onnx_surgery.add_phoneme_alignment_output"
+        ) as mock_surgery:
+            audio, samples = voice2.phoneme_ids_to_audio([0, 1, 2], include_alignments=True)
+            mock_surgery.assert_not_called()
+        self.assertIsNotNone(samples)
+
+    def test_no_locatable_duration_tensor_gives_none_and_caches_negative(self):
+        no_ceil_path = os.path.join(self.tmpdir, "no_ceil.onnx")
+        onnx.save(_tiny_model_no_ceil(), no_ceil_path)
+        voice = _make_voice(no_ceil_path)
+
+        with patch(
+            "phoonnx.onnx_surgery.find_duration_tensor",
+            wraps=__import__("phoonnx.onnx_surgery", fromlist=["find_duration_tensor"]).find_duration_tensor,
+        ) as mock_locate:
+            audio1, samples1 = voice.phoneme_ids_to_audio([0, 1], include_alignments=True)
+            audio2, samples2 = voice.phoneme_ids_to_audio([0, 1], include_alignments=True)
+
+        self.assertIsNone(samples1)
+        self.assertIsNone(samples2)
+        self.assertGreater(len(audio1), 0)
+        # find_duration_tensor is invoked once inside add_phoneme_alignment_output
+        # during the single surgery attempt; the second call short-circuits on
+        # the cached negative result and never calls it again.
+        self.assertEqual(mock_locate.call_count, 1)
+        self.assertFalse(os.path.isfile(os.path.join(self.tmpdir, "no_ceil.alignment.onnx")))
+
+    def test_include_alignments_false_never_triggers_surgery(self):
+        voice = _make_voice(self.model_path)
+        with patch.object(voice, "_ensure_alignment_session") as mock_ensure:
+            audio = voice.phoneme_ids_to_audio([0, 1, 2], include_alignments=False)
+            mock_ensure.assert_not_called()
+        self.assertGreater(len(audio), 0)
+        self.assertFalse(os.path.isfile(self._alignment_path()))
+
+    def test_audio_byte_identical_before_and_after_surgery(self):
+        ids = [0, 1, 2, 3]
+
+        voice_before = _make_voice(self.model_path)
+        audio_before = voice_before.phoneme_ids_to_audio(ids, include_alignments=False)
+
+        voice_after = _make_voice(self.model_path)
+        audio_after, samples = voice_after.phoneme_ids_to_audio(ids, include_alignments=True)
+        self.assertIsNotNone(samples)
+
+        np.testing.assert_array_equal(audio_before, audio_after)
+
+    def test_ensure_alignment_session_cached_on_instance(self):
+        voice = _make_voice(self.model_path)
+        self.assertIs(voice._alignment_session, _UNSET)
+        voice.phoneme_ids_to_audio([0, 1], include_alignments=True)
+        self.assertIsNotNone(voice._alignment_session)
+        cached = voice._alignment_session
+        # A further request reuses the exact same cached session object.
+        voice.phoneme_ids_to_audio([0, 1], include_alignments=True)
+        self.assertIs(voice._alignment_session, cached)
+
+
+class TestAlignmentModelPath(unittest.TestCase):
+    """``_alignment_model_path`` respects ``PHOONNX_ORT_CACHE_DIR``."""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix="phoonnx_runtime_align_path_")
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.model_path = os.path.join(self.tmpdir, "model.onnx")
+        onnx.save(_tiny_model_without_alignment(), self.model_path)
+
+    def test_default_writes_next_to_model(self):
+        voice = _make_voice(self.model_path)
+        dest = voice._alignment_model_path()
+        self.assertEqual(str(dest), os.path.join(self.tmpdir, "model.alignment.onnx"))
+
+    def test_cache_dir_env_var_redirects_destination(self):
+        cache_dir = os.path.join(self.tmpdir, "ort_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        voice = _make_voice(self.model_path)
+        with patch.dict(os.environ, {"PHOONNX_ORT_CACHE_DIR": cache_dir}):
+            dest = voice._alignment_model_path()
+            self.assertEqual(str(dest), os.path.join(cache_dir, "model.alignment.onnx"))
+
+            audio, samples = voice.phoneme_ids_to_audio([0, 1], include_alignments=True)
+            self.assertIsNotNone(samples)
+            self.assertTrue(os.path.isfile(os.path.join(cache_dir, "model.alignment.onnx")))
+            self.assertFalse(os.path.isfile(os.path.join(self.tmpdir, "model.alignment.onnx")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Factor the duration-tensor location + output-promotion ONNX graph surgery out of `phoonnx_train/export_onnx.py` into a new pure-`onnx` module, `phoonnx/onnx_surgery.py` (no torch import), so both the training-side export CLI and runtime code can use it.
- `TTSVoice.synthesize()` / `phoneme_ids_to_audio(include_alignments=True)` now retrofit a missing duration output on demand when the loaded session doesn't already expose one: locate the tensor, write a `<model>.alignment.onnx` sibling (or under `PHOONNX_ORT_CACHE_DIR` if set), rebuild the session on the same providers, and retry.
- The attempt (and its outcome, including a negative one) is cached on the `TTSVoice` instance, so surgery runs at most once per voice; the on-disk `.alignment.onnx` file itself caches the outcome across process restarts (reused if newer than the model).
- `include_alignments=False` is untouched — exact same zero-cost no-op as before.
- `phoonnx_train/export_onnx.py`'s `add_phoneme_alignment_output()` CLI helper now delegates the actual graph mutation to `phoonnx.onnx_surgery`, preserving its existing CLI behavior/log messages.
- Updated `tests/test_alignment.py::TestAlignmentIntegration`: the real downloaded eu-ES voice's "unpatched" model turns out to have a locatable `Ceil` duration tensor, so it now gets rescued by the new on-demand path instead of degrading to `None` — this is the feature working as intended, not a regression. Added `tearDownClass` cleanup of the derived `.alignment.onnx` sibling it creates in the voice cache.
- Docs: new "Runtime alignment for models exported without the flag" section in `docs/alignment.md`, and a pointer near `include_alignments` in `docs/usage.md`.

## Test plan
- [x] New `tests/test_runtime_alignment.py` (9 tests, unittest, no skips): builds a tiny real runnable ONNX graph (no torch, no network) with a hidden `Ceil`-derived duration tensor and an audio tensor whose length is exactly the summed duration, then covers: surgery triggers and populates alignments; second call on the same voice reuses the cached session (surgery function called once); a second `TTSVoice` pointed at the same model path reuses the on-disk `.alignment.onnx` file without redoing surgery; a graph with no `Ceil` node caches a negative result (locate function called once across two requests); `include_alignments=False` never triggers surgery; audio is byte-identical before/after surgery for the same inputs; `PHOONNX_ORT_CACHE_DIR` redirects the derived file's location.
- [x] Full suite before/after with `-p no:ovoscope`: no new failures beyond known pre-existing ones (styletts2 env cluster, yourtts export trace) after updating the one integration test whose assumption the new feature legitimately overturns.
- [x] Real-model smoke test: copied `~/.cache/phoonnx/voices/piper/en_US-amy-low/model.onnx` to scratch (never touched the cache) and ran the surgery + a full `TTSVoice.synthesize(include_alignments=True)` against it — **the duration tensor (`/Ceil_output_0`) is locatable** in this real Piper export; synthesis produced 52 phoneme alignments summing exactly to the 56064-sample audio length.

pytest summary: `1340 passed, 17 failed (pre-existing), 6 skipped` (full suite, `-p no:ovoscope`).