### PR TITLE
fix: retry transient download failures in network-bound tests

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,6 +68,12 @@ with wave.open("hello.wav", "wb") as wav_file:
     voice.synthesize_wav("Hello world!", wav_file)
 ```
 
+> **Note:** `TTSVoice.load(model_path)` defaults `config_path` to `<model_path>.json`
+> (e.g. `model.onnx.json`), not `model.json`. The voice manager's cache layout ships
+> `model.onnx` + `model.json` side by side, so if you load straight from a cache
+> directory (instead of via `manager.voices[voice_id].load()`, which resolves this
+> for you) pass `config_path` explicitly: `TTSVoice.load(cache_dir / "model.onnx", cache_dir / "model.json")`.
+
 ## 4. Tune the output
 
 `SynthesisConfig` controls speed, expressiveness and more per call:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,12 @@ voice = TTSVoice.load(
 )
 ```
 
+> **Note:** the default (`<model_path>.json`, e.g. `model.onnx.json`) does **not**
+> match the voice manager's cache layout, which ships `model.onnx` + `model.json`
+> side by side. Loading straight out of a cache directory needs `config_path`
+> passed explicitly as above; `manager.voices[voice_id].load()` already does this
+> for you.
+
 ### Loading with Overrides
 
 You can override the phonemizer and language at load time:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared test helpers.
+
+``retry_download`` wraps test-time network calls (model/tokenizer downloads
+from HF Hub or phoonnx's own voice manager) with a small retry-with-backoff
+loop. CI boxes occasionally see the download connection drop mid-transfer
+(``requests.exceptions.ChunkedEncodingError`` / ``IncompleteRead``) on
+multi-hundred-MB model files; these are transient network conditions, not
+test bugs, so we retry a bounded number of times before letting the error
+propagate.
+"""
+import time
+
+import requests
+import urllib3
+
+# Exception classes that indicate a transient, retryable network failure
+# (as opposed to a real bug in the code under test).
+_TRANSIENT_EXCEPTIONS = (
+    requests.exceptions.ChunkedEncodingError,
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    urllib3.exceptions.IncompleteRead,
+    urllib3.exceptions.ProtocolError,
+    ConnectionError,
+)
+
+
+def retry_download(func, *args, attempts=3, base_delay=1.0, **kwargs):
+    """Call ``func(*args, **kwargs)``, retrying on transient network errors.
+
+    Retries up to ``attempts`` times total, with exponential backoff
+    (``base_delay * 2**n`` seconds between attempts). Re-raises the last
+    exception if every attempt fails. Non-transient exceptions propagate
+    immediately without retry.
+    """
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            return func(*args, **kwargs)
+        except _TRANSIENT_EXCEPTIONS as exc:
+            last_exc = exc
+            if attempt == attempts - 1:
+                raise
+            time.sleep(base_delay * (2 ** attempt))
+    raise last_exc  # pragma: no cover - unreachable, satisfies linters

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -24,6 +24,8 @@ from phoonnx.config import VoiceConfig, DEFAULT_HOP_LENGTH, PhonemeType, Alphabe
 from phoonnx.engines.vits import VitsAdapter
 from phoonnx.voice import AudioChunk, PhonemeAlignment, TTSVoice
 
+from tests.conftest import retry_download
+
 
 # ---------------------------------------------------------------------------
 # Test fixtures / helpers
@@ -547,8 +549,8 @@ def _ensure_model():
     v = m.voices.get(VOICE_ID)
     if v is None:
         raise unittest.SkipTest(f"Voice {VOICE_ID} not in registry")
-    v.download_config()
-    v.download_model()
+    retry_download(v.download_config)
+    retry_download(v.download_model)
     import glob
     voice_path = v.voice_path
     onnx_files = glob.glob(os.path.join(voice_path, "*.onnx"))

--- a/tests/test_tokenization_golden.py
+++ b/tests/test_tokenization_golden.py
@@ -12,12 +12,19 @@ right timbre but the wrong words.
 import tempfile
 import pytest
 
+from tests.conftest import retry_download
+
 
 def _manager():
     from phoonnx.model_manager import TTSModelManager
     m = TTSModelManager(cache_path=tempfile.mktemp(suffix=".json"))
     m.merge_default_voices()
     return m
+
+
+def _load_voice(model_info):
+    """Load a voice, retrying on transient network errors from model download."""
+    return retry_download(model_info.load)
 
 
 def _phoonnx_ids(voice, text):
@@ -43,14 +50,14 @@ def _pick(m, pred, why):
 def test_tokenization_transformers_mms():
     transformers = pytest.importorskip("transformers")
     text = "hello world"
-    tok = transformers.VitsTokenizer.from_pretrained("facebook/mms-tts-eng")
+    tok = retry_download(transformers.VitsTokenizer.from_pretrained, "facebook/mms-tts-eng")
     orig = tok(text)["input_ids"]
     if hasattr(orig, "tolist"):
         orig = orig.tolist()
     if orig and isinstance(orig[0], list):
         orig = orig[0]
     m = _manager()
-    voice = m.voices["facebook/mms-tts-eng-English"].load()
+    voice = _load_voice(m.voices["facebook/mms-tts-eng-English"])
     assert _phoonnx_ids(voice, text) == orig
 
 
@@ -63,7 +70,7 @@ def test_tokenization_piper():
     vid = _pick(m, lambda k: "piper" in k.lower() and ("en-us" in k.lower() or "en_us" in k.lower()),
                "no en-US piper voice in index")
     text = "hello world"
-    voice = m.voices[vid].load()
+    voice = _load_voice(m.voices[vid])
     expected = [1, 0, 20, 0, 59, 0, 24, 0, 120, 0, 27, 0, 100, 0, 3, 0,
                 35, 0, 120, 0, 62, 0, 122, 0, 24, 0, 17, 0, 2]
     assert _phoonnx_ids(voice, text) == expected
@@ -125,14 +132,14 @@ def test_tokenization_larynx_gruut_ids():
     m = _manager()
     vid = _pick(m, lambda k: k.startswith("larynx/en-us"), "no en-US Larynx voice in index")
     # diphthong + affricate clusters exercise multi-phoneme tokens
-    _assert_gruut_ids_match(m.voices[vid].load(), "hello my joyful child now", "en-us")
+    _assert_gruut_ids_match(_load_voice(m.voices[vid]), "hello my joyful child now", "en-us")
 
 
 def test_tokenization_mimic3_gruut_ids():
     pytest.importorskip("gruut")
     m = _manager()
     vid = _pick(m, lambda k: k.startswith("mimic3/en_"), "no en mimic3 voice in index")
-    _assert_gruut_ids_match(m.voices[vid].load(), "hello my joyful child now", "en-us")
+    _assert_gruut_ids_match(_load_voice(m.voices[vid]), "hello my joyful child now", "en-us")
 
 
 # --- coqui: coqui-tts won't install in a transformers>=5 env, so we assert the
@@ -172,7 +179,7 @@ def test_tokenization_optispeech():
     vid = "hf_community/mush42/optispeech-lightspeech-en-us-emily"
     if vid not in m.voices:
         pytest.skip("optispeech voice not in index")
-    voice = m.voices[vid].load()
+    voice = _load_voice(m.voices[vid])
     assert _phoonnx_ids(voice, text) == orig
 
 
@@ -197,7 +204,7 @@ def test_tokenization_matcha():
     m = _manager()
     vid = _pick(m, lambda k: "matxa" in k.lower() or (
         m.voices[k].engine and str(m.voices[k].engine).endswith("matcha")), "no matcha voice in index")
-    voice = m.voices[vid].load()
+    voice = _load_voice(m.voices[vid])
     pvocab = voice.config.tokenizer.vocabulary.char2idx
     # identical symbol -> id table
     assert len(pvocab) == len(sid)


### PR DESCRIPTION
## Summary
- `test_tokenization_transformers_mms` flaked in CI with `requests.exceptions.ChunkedEncodingError` (`IncompleteRead`) while downloading the ~114MB `facebook/mms-tts-eng` model mid-test.
- Adds `tests/conftest.py::retry_download`, a shared helper that retries transient connection/incomplete-read/timeout errors up to 3 attempts with exponential backoff, re-raising the last exception on final failure. No skipping, no mocking of the download itself.
- Applies the helper to every test-time model/tokenizer download site found in the repo:
  - `tests/test_tokenization_golden.py`: `transformers.VitsTokenizer.from_pretrained(...)` and every `voice = m.voices[vid].load()` call across the MMS, piper, larynx/gruut, mimic3, optispeech and matcha tests.
  - `tests/test_alignment.py`: `v.download_config()` / `v.download_model()` in the integration fixture (`_ensure_model`).
- Inspected the "flaky matcha test" mentioned in recent CI logs: it goes through the same `m.voices[vid].load()` download path as the other tests here (no separate tmp-collision or ordering issue found), so the same retry helper addresses it. No other flake source was identified.
- Small docs fix: `docs/quickstart.md` and `docs/usage.md` now call out that `TTSVoice.load(model_path)` defaults `config_path` to `<model_path>.json`, while the voice-manager cache directory ships `model.onnx` + `model.json` — loading straight from a cache dir needs `config_path` passed explicitly (the manager's `load()` already does this for you).

## Test plan
- [x] `python -m pytest tests/test_tokenization_golden.py -q -p no:ovoscope` → 6 passed, 2 skipped (piper/optispeech voices not resolvable in this env's index/model set; unrelated to this change)
- [x] `python -m pytest tests/test_alignment.py -q -p no:ovoscope` → 39 passed, including the network-backed integration test