### PR TITLE
Score UTMOS and DNSMOS via speechonnxmetrics

### DIFF
--- a/phoonnx_train/evaluation/scorer.py
+++ b/phoonnx_train/evaluation/scorer.py
@@ -6,7 +6,8 @@ sentences on CPU with **per-utterance deterministic seeding** (``manual_seed``
 is re-applied immediately before each synthesis so a checkpoint scored twice
 produces identical wavs, independent of any RNG drift between epochs), scores
 each clip with a small registry of metric functions that reuse
-``phoonnx_train.quality_filter`` where they fit (UTMOS at least), optionally adds
+``phoonnx_train.quality_filter`` where they fit (UTMOS via speechonnxmetrics),
+optionally adds
 speaker similarity against a reference-speaker centroid, and returns a structured
 :class:`EvalRow`.
 """
@@ -43,7 +44,7 @@ def known_metrics() -> List[str]:
 
 
 def _utmos_metric(wav: np.ndarray, sr: int, text: str) -> float:
-    # Reuse quality_filter's UTMOS scorer (SpeechMOS utmos22_strong).
+    # Reuse quality_filter's UTMOS scorer (via speechonnxmetrics, ONNX).
     duration = float(len(wav)) / float(sr) if sr else 0.0
     return quality_filter.utmos_score(wav, sr, text, duration)
 

--- a/phoonnx_train/quality_filter.py
+++ b/phoonnx_train/quality_filter.py
@@ -15,7 +15,6 @@ model-based) and short-circuit per sample: once a sample fails one filter it
 is dropped without paying for any remaining (possibly expensive) scorers.
 """
 import logging
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -277,62 +276,33 @@ def is_music_like_score(audio: object, sr: int, text: str, duration: float) -> f
     return 1.0 if rhythmicity_score(audio, sr) > IS_MUSIC_LIKE_RHYTHMICITY_THRESHOLD else 0.0
 
 
-_utmos_predictor = None
+def _som_score(audio: object, sr: int, metric: str) -> Dict[str, float]:
+    """Score `audio` (sr Hz) with a single speechonnxmetrics MOS metric,
+    returning its flat result dict (e.g. {'utmos': 4.4} or
+    {'dnsmos.sig': ..., 'dnsmos.bak': ..., 'dnsmos.ovrl': ...}).
 
-
-def _load_utmos():
-    global _utmos_predictor
-    if _utmos_predictor is None:
-        import torch
-        _LOGGER.info("loading UTMOS (SpeechMOS utmos22_strong)...")
-        _utmos_predictor = torch.hub.load(
-            "tarepan/SpeechMOS", "utmos22_strong", trust_repo=True
-        )
-        _utmos_predictor.eval()
-    return _utmos_predictor
+    speechonnxmetrics resamples to each model's native rate internally and
+    downloads its ONNX weights lazily on first use from public HF repos.
+    Per-item failures are surfaced (score() records them under '_errors')
+    and re-raised here so a failing sample is dropped, matching the old
+    behaviour where a scorer exception dropped the sample.
+    """
+    import speechonnxmetrics as som
+    result = som.score(audio, [metric], sr=sr)
+    errors = result.get("_errors")
+    if errors:
+        raise RuntimeError(f"speechonnxmetrics {metric} failed: {errors}")
+    return result
 
 
 def utmos_score(audio: object, sr: int, text: str, duration: float) -> float:
-    """UTMOS1 naturalness MOS via SpeechMOS utmos22_strong. Resamples to
-    16kHz mono, expects roughly peak-normalized audio."""
-    import torch
-    import torchaudio
-
-    predictor = _load_utmos()
-    t = torch.from_numpy(audio).float() if hasattr(audio, "dtype") else torch.tensor(audio).float()
-    if sr != 16000:
-        t = torchaudio.functional.resample(t, sr, 16000)
-    with torch.no_grad():
-        score = predictor(t.unsqueeze(0), 16000)
-    return float(score.squeeze().item())
+    """UTMOS naturalness MOS via speechonnxmetrics (UTMOS22 strong, ONNX).
+    Audio is scored as-is; the library resamples to 16kHz mono internally."""
+    return float(_som_score(audio, sr, "utmos")["utmos"])
 
 
 _dnsmos_cache_audio = None
 _dnsmos_cache_value: Optional[Dict[str, float]] = None
-
-
-_speechmos_run_cache: Dict[str, Callable] = {}
-
-
-def _load_speechmos_run(submodule: str) -> Callable:
-    """Imports the real (pip) speechmos.<submodule>.run and purges
-    `speechmos` from sys.modules afterward.
-
-    torch.hub.load(...) for UTMOS caches a github repo that bundles its own
-    package also named `speechmos` (UTMOS-only). Importing that cached repo
-    after the real pip package has already been imported (or vice versa)
-    lets one shadow the other in sys.modules. Grabbing a bound reference to
-    the real `run` function first and then purging `speechmos*` from
-    sys.modules keeps both usable regardless of import order.
-    """
-    if submodule not in _speechmos_run_cache:
-        import importlib
-        real_module = importlib.import_module(f"speechmos.{submodule}")
-        _speechmos_run_cache[submodule] = real_module.run
-        for mod_name in list(sys.modules):
-            if mod_name == "speechmos" or mod_name.startswith("speechmos."):
-                del sys.modules[mod_name]
-    return _speechmos_run_cache[submodule]
 
 
 def _resample_16k(audio: object, sr: int) -> object:
@@ -344,32 +314,51 @@ def _resample_16k(audio: object, sr: int) -> object:
 
 
 def _dnsmos_all(audio: object, sr: int) -> Dict[str, float]:
+    """All three DNSMOS P.835 heads for a clip, via speechonnxmetrics.
+    Cached on the audio object so the three dnsmos_* scorers share one
+    forward pass per sample."""
     global _dnsmos_cache_audio, _dnsmos_cache_value
     if _dnsmos_cache_audio is not audio or _dnsmos_cache_value is None:
-        run = _load_speechmos_run("dnsmos")
-        resampled = _resample_16k(audio, sr)
-        _dnsmos_cache_value = run(resampled, sr=16000)
+        result = _som_score(audio, sr, "dnsmos")
+        _dnsmos_cache_value = {
+            "sig_mos": float(result["dnsmos.sig"]),
+            "bak_mos": float(result["dnsmos.bak"]),
+            "ovrl_mos": float(result["dnsmos.ovrl"]),
+        }
         _dnsmos_cache_audio = audio
     return _dnsmos_cache_value
 
 
+def _load_speechmos_run(submodule: str) -> Callable:
+    """Bound `run` of the pip `speechmos.<submodule>` (plcmos/aecmos).
+
+    UTMOS no longer comes from torch.hub, so the cached SpeechMOS repo that
+    bundled a shadowing `speechmos` package is never imported and the real
+    pip package can be imported plainly."""
+    import importlib
+    return importlib.import_module(f"speechmos.{submodule}").run
+
+
 def _speechmos_df_value(df, preferred_columns: List[str]) -> float:
-    """Pulls a scalar metric out of a single-row speechmos `return_df=True`
-    result, preferring an exact expected column name but falling back to the
-    last numeric column so a harmless column-naming difference across
-    speechmos versions doesn't hard-crash preprocessing."""
-    row = df.iloc[0]
+    """Pulls a scalar metric out of a speechmos result, preferring an exact
+    expected column name but falling back to the last numeric column so a
+    harmless naming difference across speechmos versions doesn't hard-crash
+    preprocessing. Accepts either a single-row DataFrame (older speechmos
+    `return_df=True`) or a plain dict (newer speechmos returns a dict even
+    with `return_df=True`)."""
+    row = dict(df) if isinstance(df, dict) else df.iloc[0].to_dict()
     for col in preferred_columns:
         if col in row:
             return float(row[col])
-    numeric = [v for v in row if isinstance(v, (int, float))]
+    numeric = [v for v in row.values()
+               if isinstance(v, (int, float)) and not isinstance(v, bool)]
     if not numeric:
-        raise ValueError(f"speechmos result has no numeric columns: {list(row.index)}")
+        raise ValueError(f"speechmos result has no numeric columns: {list(row)}")
     return float(numeric[-1])
 
 
 def dnsmos_sig_score(audio: object, sr: int, text: str, duration: float) -> float:
-    """DNSMOS P.835 signal quality MOS, via the `speechmos` pip package."""
+    """DNSMOS P.835 signal quality MOS, via speechonnxmetrics (ONNX)."""
     return float(_dnsmos_all(audio, sr)["sig_mos"])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ train-resample = [
     "torchaudio",
 ]
 train-eval = [
+    "speechonnxmetrics",
     "speechmos",
     "torchaudio",
     "soundfile",

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -284,6 +284,95 @@ class TestIsMusicLikeScore(unittest.TestCase):
         self.assertEqual(is_music_like_score(np.array([]), 16000, "", 0.0), 0.0)
 
 
+class TestUtmosScore(unittest.TestCase):
+    def test_returns_utmos_from_speechonnxmetrics(self):
+        import numpy as np
+        from unittest.mock import patch
+        from phoonnx_train.quality_filter import utmos_score
+
+        with patch("speechonnxmetrics.score", return_value={"utmos": 4.31}) as m:
+            score = utmos_score(np.zeros(16000, dtype="float32"), 16000, "", 1.0)
+        self.assertAlmostEqual(score, 4.31)
+        args, kwargs = m.call_args
+        self.assertEqual(list(args[1]), ["utmos"])
+        self.assertEqual(kwargs.get("sr"), 16000)
+
+    def test_passes_sr_hint_through(self):
+        import numpy as np
+        from unittest.mock import patch
+        from phoonnx_train.quality_filter import utmos_score
+
+        with patch("speechonnxmetrics.score", return_value={"utmos": 3.0}) as m:
+            utmos_score(np.zeros(48000, dtype="float32"), 48000, "", 1.0)
+        self.assertEqual(m.call_args.kwargs.get("sr"), 48000)
+
+    def test_per_item_error_is_raised_not_silently_zero(self):
+        # score() records a per-item failure under '_errors' rather than
+        # raising; the scorer must surface it so the sample is dropped, not
+        # silently scored as some default.
+        import numpy as np
+        from unittest.mock import patch
+        from phoonnx_train.quality_filter import utmos_score
+
+        with patch("speechonnxmetrics.score",
+                   return_value={"utmos": None, "_errors": {"utmos": "audio too short"}}):
+            with self.assertRaises(RuntimeError):
+                utmos_score(np.zeros(4, dtype="float32"), 16000, "", 1.0)
+
+
+class TestDnsmosScores(unittest.TestCase):
+    def test_three_heads_share_one_forward_pass(self):
+        import numpy as np
+        from unittest.mock import patch
+        from phoonnx_train import quality_filter as qf
+
+        # bust the module-level cache so this test's audio triggers a score
+        qf._dnsmos_cache_audio = None
+        qf._dnsmos_cache_value = None
+        audio = np.zeros(16000, dtype="float32")
+        flat = {"dnsmos.sig": 3.5, "dnsmos.bak": 4.1, "dnsmos.ovrl": 3.2}
+        with patch("speechonnxmetrics.score", return_value=flat) as m:
+            sig = qf.dnsmos_sig_score(audio, 16000, "", 1.0)
+            bak = qf.dnsmos_bak_score(audio, 16000, "", 1.0)
+            ovrl = qf.dnsmos_ovrl_score(audio, 16000, "", 1.0)
+        self.assertAlmostEqual(sig, 3.5)
+        self.assertAlmostEqual(bak, 4.1)
+        self.assertAlmostEqual(ovrl, 3.2)
+        # cached on the audio object: only one underlying score() call
+        self.assertEqual(m.call_count, 1)
+        self.assertEqual(list(m.call_args.args[1]), ["dnsmos"])
+
+    def test_error_is_raised(self):
+        import numpy as np
+        from unittest.mock import patch
+        from phoonnx_train import quality_filter as qf
+
+        qf._dnsmos_cache_audio = None
+        qf._dnsmos_cache_value = None
+        with patch("speechonnxmetrics.score",
+                   return_value={"dnsmos.sig": None, "_errors": {"dnsmos": "boom"}}):
+            with self.assertRaises(RuntimeError):
+                qf.dnsmos_sig_score(np.zeros(4, dtype="float32"), 16000, "", 1.0)
+
+
+class TestSpeechmosDictResult(unittest.TestCase):
+    def test_plain_dict_result_is_supported(self):
+        # newer speechmos returns a dict even with return_df=True
+        from phoonnx_train.quality_filter import _speechmos_df_value
+        result = {"plcmos": 3.71, "model": "plcmos_v2"}
+        self.assertAlmostEqual(_speechmos_df_value(result, ["plcmos"]), 3.71)
+
+    def test_plain_dict_falls_back_to_last_numeric(self):
+        from phoonnx_train.quality_filter import _speechmos_df_value
+        result = {"filename": "clip.wav", "some_mos": 2.5, "model": "x"}
+        self.assertAlmostEqual(_speechmos_df_value(result, ["plcmos"]), 2.5)
+
+    def test_plain_dict_no_numeric_raises(self):
+        from phoonnx_train.quality_filter import _speechmos_df_value
+        with self.assertRaises(ValueError):
+            _speechmos_df_value({"filename": "clip.wav", "model": "x"}, ["plcmos"])
+
+
 class TestPlcmosScore(unittest.TestCase):
     def test_reads_plcmos_column_from_df(self):
         import numpy as np


### PR DESCRIPTION
Routes the training-data quality filter and the checkpoint-eval UTMOS metric through the `speechonnxmetrics` ONNX MOS predictors, replacing the torch.hub SpeechMOS UTMOS model and the `speechmos` DNSMOS runner.

## What changed

- **UTMOS** (`utmos` scorer, and the eval loop's UTMOS metric): now scored by `speechonnxmetrics` (UTMOS22 strong, ONNX) instead of `torch.hub.load("tarepan/SpeechMOS", "utmos22_strong")` + torchaudio resampling. Same scorer name, signature and semantics.
- **DNSMOS** (`dnsmos_sig` / `dnsmos_bak` / `dnsmos_ovrl`): now scored by `speechonnxmetrics` DNSMOS (`dnsmos.sig/bak/ovrl`), sharing one forward pass per clip. Same three scorer names and semantics.
- **Removed** the `sys.modules`-purging import shim. Its sole purpose was to keep the real pip `speechmos` usable alongside the shadowing `speechmos` package bundled inside the torch.hub SpeechMOS cache. With UTMOS no longer loaded from torch.hub that hazard is gone, so `plcmos` / `aecmos` now import `speechmos` plainly. Newer `speechmos` returns a plain dict even with `return_df=True`, so the result reader accepts both a dict and a single-row DataFrame.
- **Deps**: `speechonnxmetrics` added to the `train-eval` extra. `speechmos` stays (plcmos/aecmos). `torch` / `torchaudio` stay — this is a training repo; torchaudio backs the dataloaders and mel frontends, and only the torch-based UTMOS path is dropped, not torch.

The metrics CSV schema and the public quality-filter API (`register_scorer` / `known_scorers` / `FilterSpec` / `parse_filter_spec` / `apply_quality_filters`) are unchanged.

## Parity

Old (torch.hub SpeechMOS / speechmos DNSMOS) vs new (speechonnxmetrics) on three real clips, same 16kHz mono input:

| metric | max abs delta |
|---|---|
| utmos | 4.8e-07 |
| dnsmos.sig / bak / ovrl | <= ~1e-07 (mostly exact) |

The ONNX UTMOS export was independently verified at ~6e-6 vs torch; DNSMOS shares the underlying model, hence the near-exact agreement.

## Tests

`tests/test_quality_filter.py` extended with the new UTMOS/DNSMOS speechonnxmetrics path (including per-item error surfacing so a failing clip is dropped, not silently scored) and dict-result support for plcmos/aecmos. `test_quality_filter.py`, `test_eval_loop.py` and `test_evaluation_package.py` pass. plcmos and utmos/dnsmos verified running live against real audio; `aecmos` fails inside `speechmos`'s own bundled ONNX model on the current onnxruntime (a pre-existing environment issue, unrelated to this change).