### PR TITLE
fix: VITS export dynamo-wrapper regression and OptiSpeech training dataloader wiring

### DIFF
--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -496,10 +496,10 @@ class _JsonlTextWavDataset:
         is_multi_language: bool,
         default_language: str,
     ):
-        import torch
-
-        self._torch = torch
-        feature_extractor.initialize_components()
+        # No module objects on the instance: DataLoader workers pickle the
+        # dataset under spawn/forkserver start methods (the py>=3.14 default).
+        # Feature-extractor components initialize lazily per process.
+        self._fe_initialized = False
         self.text_processor = text_processor
         self.feature_extractor = feature_extractor
         self.is_multi_speaker = is_multi_speaker
@@ -525,10 +525,20 @@ class _JsonlTextWavDataset:
     def __len__(self) -> int:
         return len(self.rows)
 
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        # Initialized extractor components may hold unpicklable runtime state;
+        # each worker re-initializes on first __getitem__.
+        state["_fe_initialized"] = False
+        return state
+
     def __getitem__(self, index: int) -> Dict[str, Any]:
         import numpy as np
+        import torch
 
-        torch = self._torch
+        if not self._fe_initialized:
+            self.feature_extractor.initialize_components()
+            self._fe_initialized = True
         row = self.rows[index]
         lang = self.default_language if self.is_multi_language else None
         phoneme_ids, text = self.text_processor(

--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -475,14 +475,185 @@ def _build_model_kwargs(
     }
 
 
-def build_optispeech(ocfg: "OptiSpeechEngineConfig") -> "pl.LightningModule":
-    """Construct an :class:`OptiSpeech` LightningModule from an explicit config."""
+class _JsonlTextWavDataset:
+    """Adapt phoonnx ``dataset.jsonl`` rows to the per-utterance datapoint dict
+    that :class:`TextWavBatchCollate` (OptiSpeech's collate) consumes.
+
+    OptiSpeech tokenizes with its OWN ``TextProcessor`` (see
+    :meth:`OptiSpeechTrainingEngine.eval_text_to_ids`), NOT the generic phoonnx
+    phoneme ids cached in the manifest — those use a different phoneme set and
+    blank/BOS/EOS convention. So ``x`` is re-derived from each row's ``text``,
+    and mel / pitch / energy are computed on the fly by the vendored feature
+    extractor from the raw ``audio_path`` (matching ``do_preprocess_utterance``).
+    """
+
+    def __init__(
+        self,
+        rows: List[Dict[str, Any]],
+        text_processor,
+        feature_extractor,
+        is_multi_speaker: bool,
+        is_multi_language: bool,
+        default_language: str,
+    ):
+        import torch
+
+        self._torch = torch
+        feature_extractor.initialize_components()
+        self.text_processor = text_processor
+        self.feature_extractor = feature_extractor
+        self.is_multi_speaker = is_multi_speaker
+        self.is_multi_language = is_multi_language
+        self.default_language = default_language
+        # A usable row needs a transcript (OptiSpeech re-tokenizes text) and a
+        # raw audio path (features are extracted on the fly).
+        self.rows = [
+            r for r in rows if r.get("text") and r.get("audio_path")
+        ]
+        dropped = len(rows) - len(self.rows)
+        if dropped:
+            _LOG.warning(
+                "optispeech dataset: skipped %d/%d rows missing text or audio_path",
+                dropped, len(rows),
+            )
+        if not self.rows:
+            raise ValueError(
+                "optispeech training needs dataset.jsonl rows carrying both "
+                "'text' and 'audio_path'; none were found"
+            )
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, index: int) -> Dict[str, Any]:
+        import numpy as np
+
+        torch = self._torch
+        row = self.rows[index]
+        lang = self.default_language if self.is_multi_language else None
+        phoneme_ids, text = self.text_processor(
+            row["text"], lang, split_sentences=False
+        )
+        wav, mel, energy, pitch = self.feature_extractor(row["audio_path"])
+        sid = None
+        if self.is_multi_speaker and row.get("speaker_id") is not None:
+            sid = int(row["speaker_id"])
+        lid = None
+        if self.is_multi_language and row.get("language_id") is not None:
+            lid = int(row["language_id"])
+        return dict(
+            x=torch.LongTensor(phoneme_ids),
+            wav=torch.from_numpy(np.asarray(wav, dtype=np.float32)),
+            mel=torch.from_numpy(np.asarray(mel, dtype=np.float32)),
+            energy=torch.from_numpy(np.asarray(energy, dtype=np.float32)),
+            pitch=torch.from_numpy(np.asarray(pitch, dtype=np.float32)),
+            sid=sid,
+            lid=lid,
+            text=text,
+            filepath=row["audio_path"],
+        )
+
+
+def _optispeech_class():
+    """Return an :class:`OptiSpeech` subclass wired for CLI training.
+
+    The vendored ``OptiSpeech`` has no ``train_dataloader`` (upstream fed it a
+    separate Hydra datamodule), so ``python -m phoonnx_train.train`` raises
+    ``MisconfigurationException: train_dataloader must be implemented``. This
+    subclass adds a dataloader over the phoonnx ``dataset.jsonl`` manifest.
+    Kept as a subclass of the vendored module so checkpoints reload through the
+    base ``OptiSpeech.load_from_checkpoint`` unchanged (export / eval build the
+    plain base class)."""
     from phoonnx_train.optispeech.model.optispeech import OptiSpeech
 
+    class _CliTrainableOptiSpeech(OptiSpeech):
+        def attach_dataset(
+            self,
+            dataset_paths: List[Path],
+            batch_size: int,
+            num_workers: int,
+        ) -> None:
+            from phoonnx_train.matcha.jsonl import load_dataset_lines
+
+            rows: List[Dict[str, Any]] = []
+            for dp in dataset_paths:
+                jsonl_path = Path(dp)
+                if jsonl_path.is_dir():
+                    jsonl_path = jsonl_path / "dataset.jsonl"
+                rows.extend(load_dataset_lines(jsonl_path))
+            if not rows:
+                raise ValueError(
+                    f"no utterances loaded from {list(dataset_paths)}"
+                )
+            self._train_rows = rows
+            self._batch_size = int(batch_size)
+            self._num_workers = int(num_workers)
+
+        def train_dataloader(self):
+            from torch.utils.data import DataLoader
+
+            from phoonnx_train.optispeech.dataset.text_wav_datamodule import (
+                TextWavBatchCollate,
+            )
+
+            tp = self.text_processor
+            fe = self.data_args.feature_extractor
+            dataset = _JsonlTextWavDataset(
+                rows=self._train_rows,
+                text_processor=tp,
+                feature_extractor=fe,
+                is_multi_speaker=self.num_speakers > 1,
+                is_multi_language=getattr(tp, "is_multi_language", False),
+                default_language=getattr(tp, "default_language", "en-us"),
+            )
+            # data_statistics is None (the generator never denormalizes), so the
+            # model is trained in raw mel/pitch/energy space — do_normalize=False
+            # keeps the collate consistent with that.
+            return DataLoader(
+                dataset,
+                batch_size=self._batch_size,
+                shuffle=True,
+                num_workers=self._num_workers,
+                collate_fn=TextWavBatchCollate(
+                    fe.n_feats, None, do_normalize=False
+                ),
+            )
+
+    return _CliTrainableOptiSpeech
+
+
+def build_optispeech(
+    ocfg: "OptiSpeechEngineConfig",
+    dataset_paths: Optional[List[Path]] = None,
+) -> "pl.LightningModule":
+    """Construct an :class:`OptiSpeech` LightningModule from an explicit config.
+
+    When *dataset_paths* are given the returned module also implements
+    ``train_dataloader`` over the phoonnx ``dataset.jsonl`` manifest so it can
+    be driven by ``python -m phoonnx_train.train`` (which calls
+    ``trainer.fit(model)`` without a dataloader)."""
     feature_extractor = _build_feature_extractor(ocfg)
     text_processor = _build_text_processor(ocfg)
+
+    # OptiSpeech re-tokenizes text with its OWN fixed symbol table (the vendored
+    # IPA tokenizer), NOT the phoonnx phoneme map that produced dataset.jsonl's
+    # phoneme_ids. The text-embedding vocab must therefore match that table's
+    # size, or the tokenizer emits ids the embedding cannot index. The shared
+    # config's num_symbols (sized to the phoonnx map) is irrelevant here.
+    input_symbols = getattr(text_processor.tokenizer, "input_symbols", None)
+    if input_symbols:
+        ocfg.num_symbols = len(input_symbols)
+
     kwargs = _build_model_kwargs(ocfg, feature_extractor, text_processor)
-    model = OptiSpeech(**kwargs)
+
+    cls = _optispeech_class()
+    model = cls(**kwargs)
+    if dataset_paths:
+        model.attach_dataset(
+            dataset_paths=dataset_paths,
+            batch_size=ocfg.batch_size,
+            num_workers=ocfg.num_workers,
+        )
     # Keep the flat config around for export/metadata.
     model._engine_config = ocfg
     return model
@@ -507,7 +678,7 @@ class OptiSpeechTrainingEngine(BaseTrainingEngine):
         **kwargs: Any,
     ) -> "pl.LightningModule":
         ocfg = OptiSpeechEngineConfig.from_training_config(config)
-        return build_optispeech(ocfg)
+        return build_optispeech(ocfg, dataset_paths=dataset_paths)
 
     def extra_preprocess(
         self,

--- a/phoonnx_train/norm_audio/trim.py
+++ b/phoonnx_train/norm_audio/trim.py
@@ -21,6 +21,11 @@ def trim_silence(
     last_chunk: Optional[int] = None
     seconds_per_chunk: float = samples_per_chunk / sample_rate
 
+    # Clear any recurrent state left over from a previous utterance so this
+    # trim depends only on this clip — reused detectors would otherwise make
+    # the survivor set order-dependent (and thus run-dependent).
+    detector.reset()
+
     chunk = audio_array[:samples_per_chunk]
     audio_array = audio_array[samples_per_chunk:]
     chunk_idx: int = 0

--- a/phoonnx_train/norm_audio/vad.py
+++ b/phoonnx_train/norm_audio/vad.py
@@ -18,6 +18,19 @@ class SileroVoiceActivityDetector:
         self.session.intra_op_num_threads = 1
         self.session.inter_op_num_threads = 1
 
+        self.reset()
+
+    def reset(self) -> None:
+        """Clear the recurrent hidden state.
+
+        Silero VAD is an RNN: every ``__call__`` feeds ``_h``/``_c`` back in.
+        That state must persist across the chunks of ONE utterance but must be
+        cleared BETWEEN utterances — otherwise a detector reused across a
+        dataset carries the previous clip's state into the next one. Because
+        utterance processing order varies across runs (multiprocessing pool
+        scheduling), the leaked state makes trim boundaries — and thus which
+        clips survive the too-short guard — nondeterministic. Callers reset
+        before each utterance (see ``trim_silence``)."""
         self._h = np.zeros((2, 1, 64)).astype("float32")
         self._c = np.zeros((2, 1, 64)).astype("float32")
 

--- a/phoonnx_train/optispeech/dataset/feature_extractors/__init__.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/__init__.py
@@ -69,7 +69,11 @@ class FeatureExtractor:
             f_max=self.f_max,
             batch_size=self.batch_size,
         )
-        self._silence_detector = make_silence_detector()
+        # The Silero VAD is only needed for silence trimming; building it
+        # unconditionally forces every dataset (trim_silence=False) to ship a
+        # silero_vad.onnx it never uses.
+        if self.trim_silence:
+            self._silence_detector = make_silence_detector()
     
     def __call__(self, audio_path):
         if self.pitch_extractor is None:

--- a/phoonnx_train/optispeech/text/tokenizers.py
+++ b/phoonnx_train/optispeech/text/tokenizers.py
@@ -79,17 +79,25 @@ class IPATokenizer(BaseTokenizer):
                 phoneme_ids.append(phids)
         return phoneme_ids, normalized_text
 
-    def phonemize_text(self, text: str, language: str) -> str:
-        # Route through phoonnx's own espeak layer: the espeak-ng subprocess
-        # wrapper with a pure-Python espyak fallback (no GPL-linked
-        # piper_phonemize / espeak-ng wrapper). EspeakPhonemizer.phonemize
-        # returns the same nested ``list[list[str]]`` (one phoneme list per
-        # sentence) that piper's phonemize_espeak returned, so the tokenizer's
-        # downstream symbol handling and id mapping are unchanged.
-        from phoonnx.phonemizers.mul import EspeakPhonemizer
+    _espeak = None
 
+    @classmethod
+    def _get_espeak(cls):
+        # phoonnx ships its own espeak-ng wrapper (with a pure-Python espyak
+        # fallback), so the IPA tokenizer reuses it instead of piper-phonemize
+        # — which has no wheels for current CPython and is not used anywhere
+        # else in phoonnx.
+        if cls._espeak is None:
+            from phoonnx.phonemizers.mul import EspeakPhonemizer
+
+            cls._espeak = EspeakPhonemizer()
+        return cls._espeak
+
+    def phonemize_text(self, text: str, language: str):
         # Preprocess
         text = self.preprocess_text(text, language)
-        # Phonemize
-        phonemes = EspeakPhonemizer().phonemize(text, language)
+        # Phonemize with phoonnx's espeak wrapper. ``phonemize`` returns one
+        # list of phoneme tokens per sentence — the same nested shape the
+        # tokenizer's downstream flattening/joining expects.
+        phonemes = self._get_espeak().phonemize(text, language)
         return phonemes, text

--- a/phoonnx_train/torch_compat.py
+++ b/phoonnx_train/torch_compat.py
@@ -25,14 +25,44 @@ def trusting_torch_load():
 
 
 def compiler_disable(fn):
-    """torch<2.4 has no torch.compiler.disable. Use this decorator instead
-    so functions that torch.compile cannot trace (e.g. data-dependent
-    control flow in the VITS spline transforms) are excluded from graph
-    capture on new torch, and are a no-op on old torch."""
+    """torch<2.4 has no torch.compiler.disable. Wrap a function so it is
+    excluded from graph capture on new torch, and a no-op on old torch.
+
+    Applied ONLY when torch.compile is actually enabled for a run — see
+    ``disable_compile_on_transforms``. It must never be applied at import
+    time: the wrapper carries dynamo eval-frame hooks that torch.jit.trace
+    (used by ONNX export) rejects with "Detected that you are using FX to
+    torch.jit.trace a dynamo-optimized function". Export paths must always
+    see the raw functions."""
     disable = getattr(getattr(torch, "compiler", None), "disable", None)
     if disable is not None:
         return disable(fn)
     return fn
+
+
+def disable_compile_on_transforms() -> None:
+    """Wrap the VITS spline transforms with ``compiler_disable`` in place, so
+    that a torch.compile'd graph excludes their data-dependent control flow.
+
+    Call this ONLY when a training run has torch.compile enabled and it
+    succeeded — never at import time, or ONNX export's torch.jit.trace of the
+    flow module would hit the wrapped functions and raise."""
+    from phoonnx_train.vits import modules, transforms
+
+    for name in (
+        "piecewise_rational_quadratic_transform",
+        "unconstrained_rational_quadratic_spline",
+        "rational_quadratic_spline",
+    ):
+        setattr(transforms, name, compiler_disable(getattr(transforms, name)))
+
+    # modules.py binds ``piecewise_rational_quadratic_transform`` by value at
+    # import (``from .transforms import ...``); re-bind its copy too so the
+    # call site actually used by the flow forward is disabled under compile.
+    if hasattr(modules, "piecewise_rational_quadratic_transform"):
+        modules.piecewise_rational_quadratic_transform = compiler_disable(
+            modules.piecewise_rational_quadratic_transform
+        )
 
 
 def onnx_export_kwargs() -> Dict[str, Any]:

--- a/phoonnx_train/train.py
+++ b/phoonnx_train/train.py
@@ -305,10 +305,15 @@ def main(
         # A compile failure must never abort a training run that would have
         # been perfectly fine uncompiled: warn and continue.
         try:
+            from phoonnx_train.torch_compat import disable_compile_on_transforms
             if hasattr(model, "model_g") and hasattr(model, "model_d"):
                 _LOGGER.info("Compiling model_g/model_d with torch.compile (mode=%s)", compile_mode)
                 model.model_g = torch.compile(model.model_g, mode=compile_mode)
                 model.model_d = torch.compile(model.model_d, mode=compile_mode)
+                # Exclude the VITS spline transforms from graph capture — their
+                # data-dependent control flow cannot be traced by dynamo. Only
+                # once compile succeeded; export paths never see the wrapper.
+                disable_compile_on_transforms()
             elif hasattr(model, "model") and isinstance(getattr(model, "model"), torch.nn.Module):
                 _LOGGER.info("Compiling model with torch.compile (mode=%s)", compile_mode)
                 model.model = torch.compile(model.model, mode=compile_mode)

--- a/phoonnx_train/vits/transforms.py
+++ b/phoonnx_train/vits/transforms.py
@@ -2,14 +2,12 @@ import numpy as np
 import torch
 from torch.nn import functional as F
 
-from phoonnx_train.torch_compat import compiler_disable
 
 DEFAULT_MIN_BIN_WIDTH = 1e-3
 DEFAULT_MIN_BIN_HEIGHT = 1e-3
 DEFAULT_MIN_DERIVATIVE = 1e-3
 
 
-@compiler_disable
 def piecewise_rational_quadratic_transform(
     inputs,
     unnormalized_widths,
@@ -50,7 +48,6 @@ def searchsorted(bin_locations, inputs, eps=1e-6):
     return torch.sum(inputs[..., None] >= bin_locations, dim=-1) - 1
 
 
-@compiler_disable
 def unconstrained_rational_quadratic_spline(
     inputs,
     unnormalized_widths,
@@ -102,7 +99,6 @@ def unconstrained_rational_quadratic_spline(
     return outputs, logabsdet
 
 
-@compiler_disable
 def rational_quadratic_spline(
     inputs,
     unnormalized_widths,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,8 +153,9 @@ train-mixer = [
 train-optispeech = [
     "pyworld>=0.3.2",
     # pyworld imports pkg_resources at runtime; python>=3.12 environments no
-    # longer ship setuptools implicitly
-    "setuptools",
+    # longer ship setuptools implicitly, and setuptools>=81 removed
+    # pkg_resources entirely
+    "setuptools<81",
     "pyloudnorm",
     "scipy",
     "torchaudio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,9 @@ train-mixer = [
 # and are off by default, so they add no deps here.
 train-optispeech = [
     "pyworld>=0.3.2",
+    # pyworld imports pkg_resources at runtime; python>=3.12 environments no
+    # longer ship setuptools implicitly
+    "setuptools",
     "pyloudnorm",
     "scipy",
     "torchaudio",

--- a/tests/test_optispeech_training.py
+++ b/tests/test_optispeech_training.py
@@ -193,6 +193,80 @@ class TrainingStepTests(unittest.TestCase):
         self.assertGreater(total_delta, 0.0)
 
 
+class DataloaderWiringTests(unittest.TestCase):
+    """create_model(...dataset_paths) must produce a module whose
+    train_dataloader() yields a batch the OptiSpeech training step consumes —
+    the CLI path (``trainer.fit(model)`` with no dataloader) depends on it.
+    """
+
+    @staticmethod
+    def _write_dataset(root: Path, n: int = 3):
+        import json
+        import wave
+
+        wav_dir = root / "wav"
+        wav_dir.mkdir(parents=True, exist_ok=True)
+        rows = []
+        texts = ["hello world", "a small test", "training works now"]
+        for i in range(n):
+            wav_path = wav_dir / f"clip_{i}.wav"
+            samples = (0.4 * np.sin(
+                2 * np.pi * (110 + 20 * i) * np.arange(22050) / 22050
+            ) * 32767).astype("<i2")
+            with wave.open(str(wav_path), "wb") as w:
+                w.setnchannels(1)
+                w.setsampwidth(2)
+                w.setframerate(22050)
+                w.writeframes(samples.tobytes())
+            rows.append({
+                "phoneme_ids": [1, 2, 3, 4],  # ignored by optispeech (re-tokenized)
+                "audio_path": str(wav_path),
+                "audio_norm_path": str(wav_path),
+                "audio_spec_path": str(wav_path),
+                "text": texts[i % len(texts)],
+                "speaker_id": None,
+                "language_id": None,
+            })
+        with open(root / "dataset.jsonl", "w", encoding="utf-8") as fh:
+            for r in rows:
+                fh.write(json.dumps(r) + "\n")
+        return root
+
+    def test_create_model_train_dataloader_yields_usable_batch(self):
+        with tempfile.TemporaryDirectory() as td:
+            ds_dir = self._write_dataset(Path(td))
+            model = get_engine("optispeech").create_model(
+                _tiny_config(), [ds_dir]
+            )
+            # The CLI never passes a dataloader; the module must own one.
+            loader = model.train_dataloader()
+            batch = next(iter(loader))
+            for key in ("x", "x_lengths", "mel", "mel_lengths",
+                        "pitches", "energies", "wav"):
+                self.assertIn(key, batch)
+            self.assertEqual(batch["x"].shape[0], batch["mel"].shape[0])
+            self.assertEqual(batch["mel"].shape[1], NFEATS)
+
+            # And the training step actually runs on it (updates weights).
+            before = {
+                k: v.detach().clone()
+                for k, v in model.generator.named_parameters()
+            }
+            # GAN manual optimization alternates generator/discriminator steps,
+            # so run enough steps to guarantee a generator update.
+            _tiny_trainer(max_steps=6).fit(model)
+            delta = sum(
+                (v.detach() - before[k]).abs().sum().item()
+                for k, v in model.generator.named_parameters()
+            )
+            self.assertGreater(delta, 0.0)
+
+    def test_create_model_without_dataset_has_no_attached_rows(self):
+        # Export/eval build the plain module; no dataset wiring is attached.
+        model = get_engine("optispeech").create_model(_tiny_config(), [])
+        self.assertFalse(hasattr(model, "_train_rows"))
+
+
 class CheckpointTests(unittest.TestCase):
     def test_checkpoint_carries_optimizer_scheduler_epoch(self):
         eng = get_engine("optispeech")

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -382,6 +382,10 @@ class _FakeSilenceDetector:
     trimming, a trivial "always speech" stand-in keeps them fast, safe to
     fork after, and no less meaningful."""
 
+    def reset(self):
+        # Mirrors the real detector's per-utterance state reset (a no-op here).
+        pass
+
     def __call__(self, audio_array, sample_rate=16000):
         return 1.0
 

--- a/tests/test_torch_compile_training.py
+++ b/tests/test_torch_compile_training.py
@@ -73,7 +73,12 @@ class FakeTrainer:
 
 def _invoke_main(tmp_dir, extra_args, engine_instance):
     FakeTrainer.instances = []
-    with mock.patch.object(train_module, "get_engine", return_value=engine_instance), \
+    # Patch the transform-disable helper at its source so the real train path
+    # does not mutate the module-global spline functions (which would leak a
+    # dynamo wrapper into later export tests). Its wiring is covered directly
+    # by TestCompilerDisableShim.
+    with mock.patch("phoonnx_train.torch_compat.disable_compile_on_transforms"), \
+         mock.patch.object(train_module, "get_engine", return_value=engine_instance), \
          mock.patch.object(train_module, "Trainer", FakeTrainer):
         runner = CliRunner()
         result = runner.invoke(
@@ -226,16 +231,46 @@ class TestCompilerDisableShim(unittest.TestCase):
         self.assertTrue(torch.allclose(outputs, outputs2))
         self.assertTrue(torch.allclose(logabsdet, logabsdet2))
 
-    def test_spline_functions_are_wrapped_by_compiler_disable(self):
-        for fn in (
-            transforms.piecewise_rational_quadratic_transform,
-            transforms.unconstrained_rational_quadratic_spline,
-            transforms.rational_quadratic_spline,
+    def test_spline_functions_are_raw_at_import(self):
+        # Regression for the VITS/yourtts export crash: the spline functions
+        # must NOT be wrapped by torch.compiler.disable at import time. The
+        # dynamo eval-frame wrapper carries a ``_torchdynamo_*`` marker and is
+        # rejected by torch.jit.trace during ONNX export ("Detected that you
+        # are using FX to torch.jit.trace a dynamo-optimized function").
+        import importlib
+        mod = importlib.reload(transforms)
+        for name in (
+            "piecewise_rational_quadratic_transform",
+            "unconstrained_rational_quadratic_spline",
+            "rational_quadratic_spline",
         ):
-            # torch.compiler.disable wraps with a distinct callable; simply
-            # asserting the function is still callable and importable
-            # confirms the decorator did not break definition/import.
+            fn = getattr(mod, name)
             self.assertTrue(callable(fn))
+            attrs = [a for a in dir(fn) if "torchdynamo" in a.lower() or "_dynamo" in a.lower()]
+            self.assertEqual(attrs, [], f"{name} is dynamo-wrapped at import: {attrs}")
+
+    def test_disable_compile_on_transforms_applies_wrapper(self):
+        # When a run actually enables torch.compile, the helper wraps the
+        # module-level transforms in place so dynamo excludes them.
+        import importlib
+        from phoonnx_train import torch_compat
+        from phoonnx_train.vits import modules
+        importlib.reload(transforms)
+        importlib.reload(modules)
+
+        sentinel = mock.Mock(name="disabled")
+        with mock.patch.object(torch_compat.torch.compiler, "disable", return_value=sentinel) as mdis:
+            torch_compat.disable_compile_on_transforms()
+
+        self.assertGreaterEqual(mdis.call_count, 3)
+        self.assertIs(transforms.piecewise_rational_quadratic_transform, sentinel)
+        self.assertIs(transforms.unconstrained_rational_quadratic_spline, sentinel)
+        self.assertIs(transforms.rational_quadratic_spline, sentinel)
+        self.assertIs(modules.piecewise_rational_quadratic_transform, sentinel)
+
+        # Restore pristine modules for other tests.
+        importlib.reload(transforms)
+        importlib.reload(modules)
 
 
 class TestDatasetWeightsOnlyLoad(unittest.TestCase):

--- a/tests/test_vad_trim_determinism.py
+++ b/tests/test_vad_trim_determinism.py
@@ -1,0 +1,105 @@
+"""Silero VAD trimming must be deterministic per utterance.
+
+The detector is an RNN whose hidden state (``_h``/``_c``) is fed back on every
+call. A detector reused across a dataset must not let one clip's leftover state
+bleed into the next — otherwise the trim boundaries (and thus which clips
+survive the "audio too short for its text" guard) depend on the order clips
+happen to be processed in, which varies across runs under multiprocessing.
+"""
+import unittest
+import unittest.mock
+from pathlib import Path
+
+import numpy as np
+
+from phoonnx_train.norm_audio import make_silence_detector
+from phoonnx_train.norm_audio.trim import trim_silence
+
+_VAD_MODEL = (
+    Path(__file__).resolve().parent.parent
+    / "phoonnx_train" / "norm_audio" / "models" / "silero_vad.onnx"
+)
+
+SR = 16000
+
+
+def _clip(seconds=1.0, freq=180.0, seed=0):
+    rng = np.random.default_rng(seed)
+    t = np.arange(int(SR * seconds)) / SR
+    # a voiced-ish burst in the middle framed by near-silence
+    speech = 0.6 * np.sin(2 * np.pi * freq * t) * (rng.random(t.shape) * 0.5 + 0.5)
+    env = np.zeros_like(t)
+    a, b = int(0.3 * len(t)), int(0.7 * len(t))
+    env[a:b] = 1.0
+    return (speech * env).astype(np.float32)
+
+
+@unittest.skipUnless(_VAD_MODEL.is_file(), "silero_vad.onnx not present")
+class VadTrimDeterminismTests(unittest.TestCase):
+    def test_trim_is_independent_of_prior_utterances(self):
+        target = _clip(seconds=1.2, freq=200.0, seed=1)
+
+        # Fresh detector trims the target.
+        fresh = make_silence_detector()
+        base = trim_silence(target.copy(), fresh, sample_rate=SR)
+
+        # A detector that already processed OTHER clips (its RNN state is now
+        # non-zero) must trim the same target identically.
+        contaminated = make_silence_detector()
+        for seed in range(3):
+            contaminated(_clip(seconds=0.8, freq=90.0 + 30 * seed, seed=100 + seed),
+                         sample_rate=SR)
+        self.assertFalse(
+            np.allclose(contaminated._h, 0.0) and np.allclose(contaminated._c, 0.0),
+            "test setup failed to contaminate the detector state",
+        )
+
+        after = trim_silence(target.copy(), contaminated, sample_rate=SR)
+        self.assertEqual(base, after)
+
+    def test_repeated_trims_on_same_detector_match(self):
+        det = make_silence_detector()
+        clip = _clip(seconds=1.0, freq=220.0, seed=7)
+        first = trim_silence(clip.copy(), det, sample_rate=SR)
+        # feed unrelated audio, then trim the same clip again
+        det(_clip(seconds=0.5, freq=110.0, seed=8), sample_rate=SR)
+        second = trim_silence(clip.copy(), det, sample_rate=SR)
+        self.assertEqual(first, second)
+
+    def test_trim_resets_state_before_first_chunk(self):
+        # Guaranteed-adversarial: contaminate the detector, then record the
+        # hidden state the FIRST in-trim detector call sees. It must be zero —
+        # i.e. trim_silence reset it. Without the reset this state is non-zero.
+        det = make_silence_detector()
+        for seed in range(3):
+            det(_clip(seconds=0.7, freq=100.0 + 20 * seed, seed=200 + seed),
+                sample_rate=SR)
+
+        from phoonnx_train.norm_audio.vad import SileroVoiceActivityDetector
+
+        states = []
+        real_call = SileroVoiceActivityDetector.__call__
+
+        def _spy(self, audio_array, sample_rate=16000):
+            states.append((self._h.copy(), self._c.copy()))
+            return real_call(self, audio_array, sample_rate=sample_rate)
+
+        with unittest.mock.patch.object(
+            SileroVoiceActivityDetector, "__call__", _spy
+        ):
+            trim_silence(_clip(seconds=1.0, freq=210.0, seed=9), det, sample_rate=SR)
+        self.assertTrue(states, "detector was never called during trim")
+        first_h, first_c = states[0]
+        self.assertTrue(np.allclose(first_h, 0.0))
+        self.assertTrue(np.allclose(first_c, 0.0))
+
+    def test_reset_zeroes_state(self):
+        det = make_silence_detector()
+        det(_clip(seconds=0.6, freq=150.0, seed=3), sample_rate=SR)
+        det.reset()
+        self.assertTrue(np.allclose(det._h, 0.0))
+        self.assertTrue(np.allclose(det._c, 0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes three launch-blocking issues found by end-to-end smoke testing.

## Bug 1 — VITS/yourtts ONNX export broken on torch>=2.1

`phoonnx_train/vits/transforms.py` decorated its three spline functions with `torch.compiler.disable` at import time whenever that API exists (torch>=2.1). The resulting dynamo-wrapped callable is rejected by `torch.jit.trace` during ONNX export:

```
RuntimeError: Detected that you are using FX to torch.jit.trace a dynamo-optimized function. This is not supported at the moment.
```

This failed every VITS-family export path, with or without `--compile`.

**Fix:** the spline functions stay raw at import. The `torch.compiler.disable` wrapper is applied to the module attributes only when a run actually enables `torch.compile` and it succeeds, via `torch_compat.disable_compile_on_transforms()` invoked from `train.py` right after `torch.compile`. Export paths never see the wrapper.

**yourtts export healed:** `tests/test_yourtts_training.py::test_export_onnx_yourtts_loads_and_matches_adapter` failed on `origin/dev` with exactly the RuntimeError above (reproduced before the fix) and passes after. The failure that recent full-suite runs reported as a pre-existing yourtts export trace error IS this bug.

Regression tests (`tests/test_torch_compile_training.py`):
- spline functions carry no `_torchdynamo`/`_dynamo` markers at import;
- with a mocked successful `torch.compile`, `disable_compile_on_transforms()` wraps all three module attributes (and modules.py's imported copy);
- real yourtts export trace succeeds end-to-end.

## Bug 2 — OptiSpeech training dead via CLI

`python -m phoonnx_train.train --engine optispeech` raised `MisconfigurationException: train_dataloader must be implemented` — `create_model` built the module but wired no dataloader.

**Fix:** a `OptiSpeech` subclass implements `train_dataloader` over the phoonnx `dataset.jsonl` manifest. An adapter dataset translates manifest rows into the datapoint dict the vendored `TextWavBatchCollate` expects: text is re-tokenized with OptiSpeech's own `TextProcessor` (consistent with the `eval_text_to_ids` hook from #256) and mel/pitch/energy are computed on the fly by the vendored feature extractor. Supporting fixes uncovered by the end-to-end run:
- the IPA tokenizer used `piper-phonemize`, which has no wheels for CPython 3.12 and is used nowhere else in phoonnx — it now uses phoonnx's own espeak wrapper (`EspeakPhonemizer`);
- `num_symbols` is derived from OptiSpeech's fixed symbol table (159), not the phoonnx phoneme map — otherwise the tokenizer emits ids the text embedding cannot index;
- the feature extractor no longer builds the Silero VAD unless `trim_silence=True` (it was failing on a missing `silero_vad.onnx` every dataset never uses).

### Miniature end-to-end proof (real run, CPU)

8 synthetic clips → preprocess → train 2 epochs → resume 1 epoch → export → onnxruntime load:

```
[preprocess] dataset.jsonl rows = 8
train (max-epochs 2): checkpoints epoch=0-step=8, epoch=1-step=16
resume (max-epochs 3 --resume-from-checkpoint epoch=1-step=16):
  Restoring states from the checkpoint path at .../epoch=1-step=16.ckpt
  Restored all states from the checkpoint at .../epoch=1-step=16.ckpt
  -> epoch=2-step=24.ckpt
[export] onnx = .../model.onnx, exists=True
[onnxruntime] inputs  = ['x', 'x_lengths', 'scales']
[onnxruntime] outputs = ['wav', 'wav_lengths', 'durations']
SMOKE OK
```

Automated coverage (`tests/test_optispeech_training.py::DataloaderWiringTests`): `create_model(..., dataset_paths)` → `train_dataloader()` yields a batch with all required keys and a training step updates generator weights; without dataset paths no dataloader state is attached (export/eval build the plain module).

## Anomaly 3 — nondeterministic preprocess survivor sets (real, fixed)

Root cause found: `SileroVoiceActivityDetector` (`phoonnx_train/norm_audio/vad.py`) is an RNN whose hidden state `_h`/`_c` is fed back on every call and was never reset between utterances. A detector reused across a dataset leaks one clip's leftover state into the first chunk of the next. Because utterance processing order varies across runs (multiprocessing pool scheduling), the leaked state shifts trim boundaries, changing the trimmed spectrogram length and therefore which clips fail the "audio too short for its text" guard — exactly the observed run-to-run difference in the survivor set.

**Fix:** `trim_silence` calls `detector.reset()` before processing each utterance (state still persists across the chunks within one clip). Regression test (`tests/test_vad_trim_determinism.py`) contaminates a detector, then asserts the hidden state seen by the first in-trim call is zero — it passes with the fix and fails without it.

## Tests

`origin/dev` box is disk/CPU-contended, so the full suite was impractical; the affected subsets were run fully with `-p no:ovoscope`:

- optispeech / optispeech_training / torch_compile_training / torch_compat_consistency / vad_trim_determinism / preprocess_pipeline / engine_eval_synthesize / engines: **120 passed** (across runs)
- vits_lightning / vits_streaming / yourtts / yourtts_training / monotonic_align: **88 passed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CLI training can now load JSONL manifests and train directly from dataset paths.
  - Training supports optional speaker and language metadata.
  - Added compatibility handling for compiled VITS training models.

- **Bug Fixes**
  - Silence trimming now resets detector state between audio clips for consistent results.
  - VAD resources are loaded only when silence trimming is enabled.

- **Performance**
  - IPA phonemization reuses its phonemizer for faster repeated processing.

- **Tests**
  - Added coverage for dataset-backed training, deterministic trimming, and compilation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->