### PR TITLE
fix: round-trip all TTSModelInfo fields in voice cache serialization

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -1,7 +1,8 @@
 import onnxruntime
 import json
 import os
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Optional, Dict, List, Any, Sequence
 import requests
@@ -68,6 +69,17 @@ class TTSModelInfo:
     # user-friendly name for UIs/CLIs; may contain "{engine}"/"{phoneme_type}"
     # placeholders that get resolved once those fields are known
     display_name: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize every field to a JSON-safe dict, matching the format used by the
+        bundled voice-index JSON files (enum fields become their plain string value).
+        """
+        d = asdict(self)
+        for k, v in d.items():
+            if isinstance(v, Enum):
+                d[k] = v.value
+        return d
 
     @property
     def config(self) -> VoiceConfig:
@@ -492,7 +504,7 @@ class TTSModelInfo:
                               phonemes_txt=str(tokens_path) if self.tokens_url else None)
         # override phoneme_type, if config.json is wrong
         if self.phoneme_type != voice.config.phoneme_type or self.alphabet != voice.config.alphabet:
-            voice.phoneme_type = self.phoneme_type
+            voice.config.phoneme_type = self.phoneme_type
             voice.config.alphabet = self.alphabet
             voice.phonemizer = get_phonemizer(self.phoneme_type,
                                               alphabet=self.alphabet,
@@ -555,52 +567,27 @@ class TTSModelManager:
     def save(self):
         """
         Persist in-memory voice metadata to the configured cache storage.
-        
-        Writes each managed voice's public metadata to the cache (voice_id, model_url, phoneme_type, lang,
-        tokens_url, tokenizer_config_url, vocab_url, phoneme_map_url, alphabet, engine, config_url)
-        and then persists the cache to disk.
+
+        Writes each managed voice's full metadata (every TTSModelInfo field) to the
+        cache and then persists the cache to disk.
         """
         self.cache.clear()
         for voice_id, voice_info in self.voices.items():
-            self.cache[voice_id] = {"voice_id": voice_info.voice_id,
-                                    "model_url": voice_info.model_url,
-                                    "phoneme_type": voice_info.phoneme_type,
-                                    "lang": voice_info.lang,
-                                    "tokens_url": voice_info.tokens_url,
-                                    "tokenizer_config_url": voice_info.tokenizer_config_url,
-                                    "vocab_url": voice_info.vocab_url,
-                                    "phoneme_map_url": voice_info.phoneme_map_url,
-                                    "alphabet": voice_info.alphabet,
-                                    "engine": voice_info.engine,
-                                    "config_url": voice_info.config_url,
-                                    "display_name": voice_info.display_name}
+            self.cache[voice_id] = voice_info.to_dict()
         self.cache.store()
 
     def add_voice(self, voice_info: TTSModelInfo):
         """
-        Add or update a TTS voice in the manager's in-memory registry and persist its public metadata to the cache.
-        
-        This stores the given TTSModelInfo under its voice_id in memory and writes a curated subset of its fields (voice_id, model_url, tokens_url, phoneme_type, phoneme_map_url, alphabet, lang, config_url) into the persistent cache, overwriting any existing entry for the same voice_id.
-        
+        Add or update a TTS voice in the manager's in-memory registry and persist its full metadata to the cache.
+
+        This stores the given TTSModelInfo under its voice_id in memory and writes every
+        field into the persistent cache, overwriting any existing entry for the same voice_id.
+
         Parameters:
             voice_info (TTSModelInfo): The voice metadata to add or update.
         """
         self.voices[voice_info.voice_id] = voice_info
-        self.cache[voice_info.voice_id] = {"voice_id": voice_info.voice_id,
-                                           "model_url": voice_info.model_url,
-                                           "tokens_url": voice_info.tokens_url,
-                                           "tokenizer_config_url": voice_info.tokenizer_config_url,
-                                           "vocab_url": voice_info.vocab_url,
-                                           "phoneme_type": voice_info.phoneme_type,
-                                           "phoneme_map_url": voice_info.phoneme_map_url,
-                                           "alphabet": voice_info.alphabet,
-                                           "engine": voice_info.engine,
-                                           "lang": voice_info.lang,
-                                           "config_url": voice_info.config_url,
-                                           "vocoder_url": voice_info.vocoder_url,
-                                           "vocoder_config_url": voice_info.vocoder_config_url,
-                                           "vocoder_type": voice_info.vocoder_type,
-                                           "display_name": voice_info.display_name}
+        self.cache[voice_info.voice_id] = voice_info.to_dict()
 
     def get_lang_voices(self, lang: str) -> List[TTSModelInfo]:
         voices = sorted(

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -625,6 +625,130 @@ class TestDownloadVoiceById(ManagerTestCase):
         self.assertFalse(result)
 
 
+class TestFullSerializationRoundTrip(ManagerTestCase):
+    """Adversarial: every optional TTSModelInfo field must survive save/reload
+    and add_voice/reload, including enums, nested dicts, and the aux-graph
+    URLs used by StyleTTS2/Kokoro, YourTTS, F5-TTS and Chatterbox."""
+
+    def _fully_populated_info(self):
+        return TTSModelInfo(
+            voice_id="full/voice",
+            lang="en-US",
+            model_url="https://example.com/model.onnx",
+            config_url="https://example.com/config.json",
+            vocab_url="https://example.com/vocab.json",
+            tokenizer_config_url="https://example.com/tokenizer_config.json",
+            tokens_url="https://example.com/tokens.txt",
+            phoneme_map_url="https://example.com/phoneme_map.json",
+            phoneme_type="espeak",
+            phonemizer_model="modern",
+            alphabet="ipa",
+            engine="piper",
+            vocab_override={"a": 0, "b": 1},
+            vocoder_url="https://example.com/vocoder.onnx",
+            vocoder_config_url="https://example.com/vocoder.json",
+            vocoder_type="hifigan",
+            style_url="https://example.com/style.bin",
+            speaker_encoder_url="https://example.com/enc.onnx",
+            speaker_encoder_type="dvector",
+            aux_model_urls={"preprocess_path": "https://example.com/pre.onnx",
+                             "decode_path": "https://example.com/dec.onnx"},
+            speech_encoder_url="https://example.com/speech_encoder.onnx",
+            embed_tokens_url="https://example.com/embed_tokens.onnx",
+            conditional_decoder_url="https://example.com/conditional_decoder.onnx",
+            lang_tokens={"en-US": "en", "en-GB": "eg"},
+            display_name="full voice",
+        )
+
+    def _assert_full_equality(self, original, reloaded):
+        for f in original.__dataclass_fields__:
+            self.assertEqual(getattr(original, f), getattr(reloaded, f), msg=f"field {f} mismatch")
+
+    def test_save_round_trip_preserves_every_field(self):
+        manager = TTSModelManager(cache_path=self.cache_path)
+        voice = self._fully_populated_info()
+        manager.voices = {voice.voice_id: voice}
+        manager.save()
+
+        reloaded_manager = TTSModelManager(cache_path=self.cache_path)
+        reloaded_manager.load()
+        reloaded = reloaded_manager.voices["full/voice"]
+        self._assert_full_equality(voice, reloaded)
+
+    def test_add_voice_round_trip_preserves_every_field(self):
+        manager = TTSModelManager(cache_path=self.cache_path)
+        voice = self._fully_populated_info()
+        manager.add_voice(voice)
+        manager.cache.store()
+
+        reloaded_manager = TTSModelManager(cache_path=self.cache_path)
+        reloaded_manager.load()
+        reloaded = reloaded_manager.voices["full/voice"]
+        self._assert_full_equality(voice, reloaded)
+
+    def test_bundled_index_style_dict_still_deserializes(self):
+        # Matches the plain-dict-with-None-values format used by voice_index/*.json
+        bundled_dict = {
+            "voice_id": "chatterbox/base/en",
+            "model_url": "https://example.com/language_model.onnx",
+            "speech_encoder_url": "https://example.com/speech_encoder.onnx",
+            "embed_tokens_url": "https://example.com/embed_tokens.onnx",
+            "conditional_decoder_url": "https://example.com/conditional_decoder.onnx",
+            "tokenizer_config_url": "https://example.com/tokenizer.json",
+            "config_url": None,
+            "vocab_url": None,
+            "tokens_url": None,
+            "phoneme_map_url": None,
+            "phoneme_type": "unicode",
+            "alphabet": "unicode",
+            "engine": "chatterbox",
+            "lang": "en-US",
+        }
+        info = TTSModelInfo(**bundled_dict)
+        self.assertEqual(info.speech_encoder_url, bundled_dict["speech_encoder_url"])
+        self.assertEqual(info.embed_tokens_url, bundled_dict["embed_tokens_url"])
+        self.assertEqual(info.conditional_decoder_url, bundled_dict["conditional_decoder_url"])
+        self.assertEqual(info.engine, Engine.CHATTERBOX)
+        self.assertEqual(info.phoneme_type, PhonemeType.UNICODE)
+
+    def test_to_dict_enum_fields_are_plain_strings(self):
+        voice = self._fully_populated_info()
+        d = voice.to_dict()
+        self.assertEqual(d["engine"], "piper")
+        self.assertEqual(d["alphabet"], "ipa")
+        self.assertEqual(d["phoneme_type"], "espeak")
+        # must be JSON serializable without a custom encoder
+        json.dumps(d)
+
+
+class TestLoadPhonemeTypeOverrideAppliesToConfig(VoicePathTestCase):
+    @patch("phoonnx.model_manager.TTSVoice")
+    @patch("phoonnx.model_manager.requests.get")
+    def test_override_sets_config_phoneme_type_not_voice_attribute(self, mock_get, mock_ttsvoice_cls):
+        info = self.make_info(config_url="https://example.com/config.json", phoneme_type="graphemes", alphabet="unicode")
+        resp = _mock_response(200, content=b"data")
+        cm = MagicMock()
+        cm.__enter__.return_value = resp
+        mock_get.return_value = cm
+        info.voice_path.joinpath("model.json").write_text(
+            json.dumps({"phoneme_type": "espeak", "alphabet": "ipa"}), encoding="utf-8"
+        )
+        fake_voice = MagicMock()
+        fake_voice.config.phoneme_type = PhonemeType.ESPEAK
+        fake_voice.config.alphabet = Alphabet.IPA
+        mock_ttsvoice_cls.load.return_value = fake_voice
+
+        with patch("phoonnx.model_manager.get_phonemizer") as mock_get_phonemizer:
+            result = info.load()
+
+        # the override must land on voice.config.phoneme_type, not a dead
+        # voice.phoneme_type attribute
+        self.assertEqual(fake_voice.config.phoneme_type, info.phoneme_type)
+        self.assertEqual(fake_voice.config.alphabet, info.alphabet)
+        mock_get_phonemizer.assert_called_once()
+        self.assertEqual(result, fake_voice)
+
+
 class TestUnwritableCachePath(unittest.TestCase):
     def test_unwritable_cache_dir_raises_clear_error(self):
         tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
`TTSModelManager.save()` and `add_voice()` each hand-maintained a different subset of `TTSModelInfo` fields, silently dropping `style_url`, `speaker_encoder_url`/`_type`, `aux_model_urls`, `lang_tokens`, `phonemizer_model` and the chatterbox graph URLs (and `vocoder_*` in `save`). Any StyleTTS2 / YourTTS / F5 / Chatterbox voice lost required metadata on a cache round-trip.

Both paths now serialize through a single `TTSModelInfo.to_dict()` built on `dataclasses.asdict` with enum→value coercion, matching the bundled voice-index JSON format.

Also fixes `voice.phoneme_type = …` writing a dead attribute where `voice.config.phoneme_type` was intended.

Round-trip test covers a fully-populated info object for every engine-specific field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)