### PR TITLE
fix: unicode punctuation handling, gruut empty-result guard, converter cache poisoning

### DIFF
--- a/phoonnx/lang_preprocess.py
+++ b/phoonnx/lang_preprocess.py
@@ -45,15 +45,23 @@ def hangul_to_jamo(text: str) -> str:
 def japanese_to_hiragana(text: str) -> str:
     """Convert kanji to hiragana (katakana kept) and NFKD-normalise. Needs ``pykakasi``."""
     global _kakasi
-    try:
-        if _kakasi is None:
+    if _kakasi is None:
+        try:
             import pykakasi
             _kakasi = pykakasi.kakasi()
-    except ImportError:
-        LOG.warning("pykakasi not installed — Japanese text left unprocessed")
+        except ImportError:
+            LOG.warning("pykakasi not installed — Japanese text left unprocessed")
+            return text
+        except Exception as e:
+            LOG.warning("Could not initialize pykakasi: %s", e)
+            return text
+    try:
+        converted = _kakasi.convert(text)
+    except Exception as e:
+        LOG.warning("Japanese conversion failed: %s", e)
         return text
     out = []
-    for r in _kakasi.convert(text):
+    for r in converted:
         inp, hira = r["orig"], r["hira"]
         if any(is_kanji(c) for c in inp):
             if hira and hira[0] in ("は", "へ"):   # は / へ
@@ -138,8 +146,16 @@ def chinese_to_cangjie(text: str) -> str:
     """Convert Chinese text to Cangjie tokens, reusing a single converter instance."""
     global _cangjie
     if _cangjie is None:
-        _cangjie = ChineseCangjieConverter()
-    return _cangjie(text)
+        try:
+            _cangjie = ChineseCangjieConverter()
+        except Exception as e:
+            LOG.warning("Could not initialize Cangjie converter: %s", e)
+            return text
+    try:
+        return _cangjie(text)
+    except Exception as e:
+        LOG.warning("Cangjie conversion failed: %s", e)
+        return text
 
 
 # language code -> transform; languages absent here need no script transform.

--- a/phoonnx/phonemizers/base.py
+++ b/phoonnx/phonemizers/base.py
@@ -142,12 +142,24 @@ class BasePhonemizer(metaclass=abc.ABCMeta):
     @staticmethod
     def remove_punctuation(text):
         """
-        Removes all punctuation characters from a string.
-        Punctuation characters are defined by string.punctuation.
+        Removes punctuation characters from a string, based on unicode punctuation
+        categories (P*) rather than ASCII-only ``string.punctuation``. This also strips
+        non-ASCII punctuation such as Arabic ``،``/``؟`` and curly quotes.
+
+        Apostrophes and hyphens sandwiched between letters (e.g. "don't", "well-known")
+        are preserved so contractions and compounds aren't broken apart.
         """
-        # Create a regex pattern that matches any character in string.punctuation
-        punctuation_pattern = r"[" + re.escape(string.punctuation) + r"]"
-        return re.sub(punctuation_pattern, '', text).strip()
+        out = []
+        chars = list(text)
+        for i, c in enumerate(chars):
+            if c in ("'", "’", "-") and 0 < i < len(chars) - 1 \
+                    and chars[i - 1].isalpha() and chars[i + 1].isalpha():
+                out.append(c)
+                continue
+            if unicodedata.category(c).startswith("P"):
+                continue
+            out.append(c)
+        return "".join(out).strip()
 
     @staticmethod
     def chunk_text(text: str, delimiters: Optional[List[str]] = None) -> TextChunks:

--- a/phoonnx/phonemizers/mul.py
+++ b/phoonnx/phonemizers/mul.py
@@ -459,6 +459,8 @@ class GruutPhonemizer(BasePhonemizer):
             sent_phonemes = [w.phonemes for w in sentence if w.phonemes]
             if sentence and not sent_phonemes:
                 raise RuntimeError(f"did you install gruut[{lang}] ?")
+            if not sent_phonemes:
+                continue
             if sentence.text.endswith("?"):
                 sent_phonemes[-1] = ["?"]
             elif sentence.text.endswith("!"):

--- a/phoonnx/thirdparty/mantoq/pyarabic/trans.py
+++ b/phoonnx/thirdparty/mantoq/pyarabic/trans.py
@@ -292,7 +292,7 @@ def segment_language(text):
                 resultlist.append(("latin", actual_text))
                 arabic = True
                 actual_text = k
-        elif re.search("[\s\d\?, :\!\(\)]", k):
+        elif re.search(r"[\s\d\?, :\!\(\)]", k):
             actual_text += k
         else:
             if arabic:
@@ -511,7 +511,7 @@ n~aAsi""".split(
     # test detect language
     text = """السلام عليكم how are you, لم اسمع أخبارك منذ مدة, where are you going"""
     print(arepr(segment_language(text)))
-    text_out = delimite_language(text, start="\RL{", end="}")
+    text_out = delimite_language(text, start=r"\RL{", end="}")
     print(text_out.encode("utf8"))
     text_out = delimite_language(text, start="<arabic>", end="</arabic>")
     print(text_out.encode("utf8"))

--- a/phoonnx/util.py
+++ b/phoonnx/util.py
@@ -725,6 +725,7 @@ def _normalize_word(word: str, full_lang: str, rbnf_engine) -> str:
     Helper function to normalize a single word.
     """
     lang_code = full_lang.split("-")[0]
+    word = word.replace("’", "'")
 
     if word in CONTRACTIONS.get(lang_code, {}):
         return CONTRACTIONS[lang_code][word]

--- a/tests/test_misc_hardening.py
+++ b/tests/test_misc_hardening.py
@@ -1,0 +1,144 @@
+import subprocess
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from phoonnx.phonemizers.base import BasePhonemizer
+from phoonnx.util import _normalize_word
+
+
+class TestRemovePunctuation(unittest.TestCase):
+    """Adversarial tests for BasePhonemizer.remove_punctuation."""
+
+    def test_arabic_punctuation_removed(self):
+        text = "مرحبا، كيف حالك؟"
+        result = BasePhonemizer.remove_punctuation(text)
+        self.assertNotIn("،", result)
+        self.assertNotIn("؟", result)
+
+    def test_curly_quotes_removed(self):
+        text = "she said “hello” to me"
+        result = BasePhonemizer.remove_punctuation(text)
+        self.assertNotIn("“", result)
+        self.assertNotIn("”", result)
+
+    def test_intraword_apostrophe_preserved(self):
+        text = "don't stop"
+        result = BasePhonemizer.remove_punctuation(text)
+        self.assertIn("don't", result)
+
+    def test_intraword_curly_apostrophe_preserved(self):
+        text = "don’t stop"
+        result = BasePhonemizer.remove_punctuation(text)
+        self.assertIn("don’t", result)
+
+    def test_intraword_hyphen_preserved(self):
+        text = "a well-known fact."
+        result = BasePhonemizer.remove_punctuation(text)
+        self.assertIn("well-known", result)
+        self.assertNotIn(".", result)
+
+    def test_leading_trailing_hyphen_stripped(self):
+        # a hyphen not sandwiched between letters is still punctuation
+        text = "- dash at start"
+        result = BasePhonemizer.remove_punctuation(text)
+        self.assertFalse(result.startswith("-"))
+
+    def test_ascii_punctuation_still_removed(self):
+        text = "hello, world!"
+        result = BasePhonemizer.remove_punctuation(text)
+        self.assertNotIn(",", result)
+        self.assertNotIn("!", result)
+
+
+class TestContractionCurlyApostrophe(unittest.TestCase):
+    """The CONTRACTIONS lookup keys use straight apostrophes; curly variants must
+    be normalized before the lookup or they silently miss."""
+
+    def test_curly_apostrophe_contraction_expands(self):
+        rbnf_engine = MagicMock()
+        result = _normalize_word("don’t", "en-US", rbnf_engine)
+        self.assertEqual(result, "do not")
+
+    def test_straight_apostrophe_contraction_still_expands(self):
+        rbnf_engine = MagicMock()
+        result = _normalize_word("don't", "en-US", rbnf_engine)
+        self.assertEqual(result, "do not")
+
+
+class TestGruutEmptySentence(unittest.TestCase):
+    """An empty gruut sentence result must not IndexError on sent_phonemes[-1]."""
+
+    def test_empty_sentence_phonemes_skipped(self):
+        from phoonnx.phonemizers.mul import GruutPhonemizer
+
+        fake_sentence = MagicMock()
+        fake_sentence.__iter__ = lambda self: iter([])
+        fake_sentence.__bool__ = lambda self: False  # empty sentence -> empty sent_phonemes
+        fake_sentence.text = ""
+
+        phonemizer = GruutPhonemizer.__new__(GruutPhonemizer)
+        phonemizer.get_lang = lambda lang: lang
+
+        with patch("gruut.sentences", return_value=[fake_sentence]):
+            # must not raise IndexError; empty result is simply skipped
+            result = list(phonemizer._text_to_phonemes("...", "en"))
+        self.assertEqual(result, [])
+
+
+class TestConverterCachePoisoning(unittest.TestCase):
+    """A transient converter-construction failure must not poison the module-level
+    cache, and a runtime failure during conversion must degrade gracefully."""
+
+    def test_kakasi_construction_failure_not_cached(self):
+        import phoonnx.lang_preprocess as lp
+
+        lp._kakasi = None
+        fake_pykakasi = MagicMock()
+        fake_pykakasi.kakasi.side_effect = RuntimeError("boom")
+        with patch.dict("sys.modules", {"pykakasi": fake_pykakasi}):
+            result = lp.japanese_to_hiragana("こんにちは")
+        self.assertEqual(result, "こんにちは")
+        self.assertIsNone(lp._kakasi)  # not poisoned, retry allowed next call
+
+    def test_kakasi_convert_runtime_error_degrades_gracefully(self):
+        import phoonnx.lang_preprocess as lp
+
+        fake_kakasi = MagicMock()
+        fake_kakasi.convert.side_effect = RuntimeError("boom")
+        lp._kakasi = fake_kakasi
+        result = lp.japanese_to_hiragana("こんにちは")
+        self.assertEqual(result, "こんにちは")
+        lp._kakasi = None  # reset global for other tests
+
+    def test_cangjie_construction_failure_not_cached(self):
+        import phoonnx.lang_preprocess as lp
+
+        lp._cangjie = None
+        with patch.object(lp, "ChineseCangjieConverter", side_effect=RuntimeError("boom")):
+            result = lp.chinese_to_cangjie("你好")
+        self.assertEqual(result, "你好")
+        self.assertIsNone(lp._cangjie)
+
+    def test_cangjie_call_runtime_error_degrades_gracefully(self):
+        import phoonnx.lang_preprocess as lp
+
+        fake_converter = MagicMock(side_effect=RuntimeError("boom"))
+        lp._cangjie = fake_converter
+        result = lp.chinese_to_cangjie("你好")
+        self.assertEqual(result, "你好")
+        lp._cangjie = None  # reset global for other tests
+
+
+class TestPyarabicNoSyntaxWarning(unittest.TestCase):
+    def test_import_raises_no_syntax_warning(self):
+        proc = subprocess.run(
+            [sys.executable, "-W", "error::SyntaxWarning", "-c",
+             "import phoonnx.thirdparty.mantoq.pyarabic.trans"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `remove_punctuation` now strips punctuation by unicode category (P*) instead of ASCII-only `string.punctuation`, removing Arabic `،`/`؟` and curly quotes while preserving intra-word apostrophes and hyphens ("don't", "well-known").
- `_normalize_word` normalizes curly apostrophes (`'`) to straight ones before the `CONTRACTIONS` lookup, so contractions typed with smart quotes still expand.
- `GruutPhonemizer._text_to_phonemes` no longer raises `IndexError` when a sentence yields no phonemes; the empty result is skipped instead.
- `japanese_to_hiragana` and `chinese_to_cangjie` no longer cache a failed converter construction — a transient failure is retried on the next call instead of being permanently poisoned — and both now catch runtime errors from the converter call itself, degrading gracefully back to the original text with a `LOG.warning`.
- Fixed two invalid escape sequences in `pyarabic/trans.py` that emitted `SyntaxWarning` on import.

## Test plan
- [x] `tests/test_misc_hardening.py` (new): Arabic/curly punctuation removal, intra-word apostrophe/hyphen preservation, curly-apostrophe contraction expansion, empty gruut sentence handling, converter cache-poisoning and runtime-degradation paths, pyarabic import under `-W error::SyntaxWarning`
- [x] `pytest tests/ -k "punct or contraction or preprocess or mul or misc_hardening"` — 125 passed
- [x] `pytest tests/test_util.py tests/test_lang_preprocess.py tests/test_chatterbox.py tests/test_misc_hardening.py` — 94 passed
- [x] `pytest tests/test_mixertts.py tests/test_scriptconv_integration.py tests/test_ar.py` — 87 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)