### PR TITLE
fix: config detection crashes on missing lang_code and tokenizer_config, register missing engine adapters

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -386,7 +386,7 @@ class VoiceConfig:
 
             lang_code = lang_code or (config.get("language", {}).get("code") or
                          config.get("espeak", {}).get("voice"))
-            diacritics = lang_code.startswith("ar")
+            diacritics = (lang_code or "").startswith("ar")
             phoneme_type = phoneme_type or config.get("phoneme_type", PhonemeType.ESPEAK)
             if phoneme_type == "text":
                 phoneme_type = PhonemeType.UNICODE
@@ -446,12 +446,12 @@ class VoiceConfig:
         elif vocab:
             add_blank = True
             if tokenizer_config:
-                add_blank = tokenizer_config["add_blank"]
-                lang_code = tokenizer_config["language"]
-                config["blank"] = tokenizer_config["pad_token"]
+                add_blank = tokenizer_config.get("add_blank", add_blank)
+                lang_code = tokenizer_config.get("language", lang_code)
+                config["blank"] = tokenizer_config.get("pad_token", config.get("blank", DEFAULT_BLANK_TOKEN))
 
             tokenizer = TTSTokenizer(
-                Vocabulary(char2idx=vocab, blank=config["blank"]),
+                Vocabulary(char2idx=vocab, blank=config.get("blank", DEFAULT_BLANK_TOKEN)),
                 add_blank_char=add_blank,
                 add_blank_word=False,
                 use_eos_bos=False,

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -228,10 +228,13 @@ class TTSVoice:
             engine_name = self.config.engine.value if self.config.engine else None
             try:
                 # Try by engine name first
-                if engine_name and engine_name not in ("piper", "mimic3", "coqui"):
+                if engine_name and engine_name not in (
+                    "piper", "mimic3", "coqui", "phoonnx", "transformers",
+                ):
                     self.adapter = get_adapter(engine_name)
                 else:
-                    # For piper/mimic3/coqui all use the vits adapter
+                    # piper/mimic3/coqui/phoonnx/transformers are all VITS-style
+                    # architectures (tokens in, waveform out) and share the vits adapter.
                     self.adapter = get_adapter("vits")
             except KeyError:
                 # Fall back to auto-detection

--- a/tests/test_config_detection_edges.py
+++ b/tests/test_config_detection_edges.py
@@ -1,0 +1,109 @@
+import unittest
+
+from phoonnx.config import Alphabet, Engine, PhonemeType, VoiceConfig
+from phoonnx.engines.vits import VitsAdapter
+from phoonnx.phonemizers import GraphemePhonemizer
+from phoonnx.voice import TTSVoice
+
+
+class TestPiperLangCodeMayBeAbsent(unittest.TestCase):
+    """config.py ~L387-389: piper's Arabic-diacritics check must not crash
+    when neither the config nor the caller supplies a language code."""
+
+    def _piper_cfg(self, **extra):
+        cfg = {"piper_version": "1.0.0", "phoneme_type": "espeak",
+               "phoneme_id_map": {"a": [0], "b": [1]}}
+        cfg.update(extra)
+        return cfg
+
+    def test_missing_language_and_espeak_keys_does_not_raise(self):
+        # no config.language, no config.espeak.voice, no explicit lang_code kwarg
+        vc = VoiceConfig.from_dict(self._piper_cfg())
+        self.assertFalse(vc.add_diacritics)
+
+    def test_explicit_none_lang_code_does_not_raise(self):
+        vc = VoiceConfig.from_dict(self._piper_cfg(), lang_code=None)
+        self.assertFalse(vc.add_diacritics)
+
+    def test_empty_language_dict_does_not_raise(self):
+        cfg = self._piper_cfg(language={})
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertFalse(vc.add_diacritics)
+
+    def test_empty_espeak_dict_does_not_raise(self):
+        cfg = self._piper_cfg(espeak={})
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertFalse(vc.add_diacritics)
+
+    def test_arabic_still_detected_when_lang_code_present(self):
+        cfg = self._piper_cfg(espeak={"voice": "ar"})
+        vc = VoiceConfig.from_dict(cfg)
+        self.assertTrue(vc.add_diacritics)
+
+
+class TestTransformersVocabBranchMissingTokenizerConfigKeys(unittest.TestCase):
+    """config.py ~L446-454: the transformers/vocab branch must not KeyError
+    when tokenizer_config is present but missing individual keys, or absent
+    entirely with no "blank" key anywhere in config."""
+
+    def test_no_tokenizer_config_and_no_blank_key_does_not_raise(self):
+        vocab = {"_": 0, "a": 1, "b": 2}
+        vc = VoiceConfig.from_dict({}, vocab=vocab, phoneme_type="graphemes",
+                                    alphabet="unicode", lang_code="en")
+        self.assertIsNotNone(vc.tokenizer)
+
+    def test_tokenizer_config_missing_pad_token_key_does_not_raise(self):
+        vocab = {"_": 0, "a": 1, "b": 2}
+        tok_cfg = {"add_blank": False, "language": "pt"}  # no pad_token
+        vc = VoiceConfig.from_dict({}, vocab=vocab, tokenizer_config=tok_cfg,
+                                    phoneme_type="graphemes", alphabet="unicode")
+        self.assertIsNotNone(vc.tokenizer)
+        self.assertEqual(vc.lang_code, "pt")
+
+    def test_tokenizer_config_missing_add_blank_key_does_not_raise(self):
+        vocab = {"_": 0, "a": 1, "b": 2}
+        tok_cfg = {"language": "de", "pad_token": "_"}  # no add_blank
+        vc = VoiceConfig.from_dict({}, vocab=vocab, tokenizer_config=tok_cfg,
+                                    phoneme_type="graphemes", alphabet="unicode")
+        self.assertIsNotNone(vc.tokenizer)
+
+    def test_empty_tokenizer_config_does_not_raise(self):
+        vocab = {"_": 0, "a": 1, "b": 2}
+        vc = VoiceConfig.from_dict({}, vocab=vocab, tokenizer_config={},
+                                    phoneme_type="graphemes", alphabet="unicode",
+                                    lang_code="en")
+        self.assertIsNotNone(vc.tokenizer)
+
+
+class TestVoiceAdapterResolutionForMissingEngines(unittest.TestCase):
+    """voice.py ~L227-238: Engine.PHOONNX and Engine.TRANSFORMERS have no
+    dedicated entry in the adapter registry. Resolution must not silently
+    fall through to session-only auto-detection (which loses the already
+    loaded config) — it must land on the shared VITS-family adapter, same
+    as piper/mimic3/coqui."""
+
+    def _config(self, engine):
+        return VoiceConfig(num_symbols=4, num_speakers=1, num_langs=1, sample_rate=16000,
+                            lang_code="en", phoneme_type=PhonemeType.GRAPHEMES,
+                            alphabet=Alphabet.UNICODE, phonemizer_model=None, engine=engine)
+
+    def test_phoonnx_engine_resolves_to_vits_adapter(self):
+        voice = TTSVoice(session=None, config=self._config(Engine.PHOONNX),
+                          phonemizer=GraphemePhonemizer())
+        self.assertIsInstance(voice.adapter, VitsAdapter)
+
+    def test_transformers_engine_resolves_to_vits_adapter(self):
+        voice = TTSVoice(session=None, config=self._config(Engine.TRANSFORMERS),
+                          phonemizer=GraphemePhonemizer())
+        self.assertIsInstance(voice.adapter, VitsAdapter)
+
+    def test_piper_engine_still_resolves_to_vits_adapter(self):
+        # regression guard: the existing piper/mimic3/coqui aliasing must
+        # keep working after adding phoonnx/transformers to the same branch
+        voice = TTSVoice(session=None, config=self._config(Engine.PIPER),
+                          phonemizer=GraphemePhonemizer())
+        self.assertIsInstance(voice.adapter, VitsAdapter)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three crash paths in engine/config detection:

- `VoiceConfig.from_dict`'s piper branch called `lang_code.startswith("ar")` unconditionally; when neither `config["language"]["code"]` nor `config["espeak"]["voice"]` is set and no explicit `lang_code` is passed, `lang_code` is `None` and this raises `AttributeError`. Now guarded with `(lang_code or "").startswith("ar")`.
- The transformers/vocab branch indexed `tokenizer_config["add_blank"]`, `["language"]`, `["pad_token"]`, and `config["blank"]` directly, raising `KeyError` whenever a tokenizer_config is missing any of those keys (or `config` has no `blank` key at all). Now reads via `.get(...)` with the existing `DEFAULT_BLANK_TOKEN`/prior values as fallback.
- `TTSVoice.__post_init__`'s adapter lookup only aliased `piper`/`mimic3`/`coqui` to the shared VITS adapter; `Engine.PHOONNX` and `Engine.TRANSFORMERS` fell through `get_adapter()`'s `KeyError` into session-only auto-detection, discarding the already-loaded config. Both are now aliased alongside piper/mimic3/coqui, since they are VITS-family (tokens in, waveform out) architectures handled by the same adapter.

## Test plan

- [x] `tests/test_config_detection_edges.py` (new): adversarial cases for a null/absent piper `lang_code`, a transformers config missing `tokenizer_config` entirely and missing individual keys within it, and adapter resolution for `Engine.PHOONNX`/`Engine.TRANSFORMERS`/`Engine.PIPER`.
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_config*.py tests/test_config_detection_edges.py tests/test_engines.py tests/test_matcha_adapter.py tests/test_native_config.py -q` — all pass.
- [x] Full suite: 1365 passed, 15 pre-existing failures unrelated to this change (styletts2 training `ImportError`/`RuntimeError`), 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)