### PR TITLE
fix: track and warn on OOV phonemes instead of dropping them silently

### DIFF
--- a/phoonnx/tokenizer.py
+++ b/phoonnx/tokenizer.py
@@ -465,6 +465,7 @@ class TTSTokenizer:
     use_eos_bos: bool
     blank_at_end: bool
     blank_at_start: bool
+    not_found_characters: Set[str] = field(default_factory=set)
 
     @property
     def pad_id(self) -> Optional[int]:
@@ -533,6 +534,12 @@ class TTSTokenizer:
                         idx = self.vocabulary.char2idx[compound]
                         compound_idxs += [i for i in range(i, i+n)]
                         break
+
+                if idx is None and char not in self.not_found_characters:
+                    self.not_found_characters.add(char)
+                    LOG.warning(f"Out-of-vocabulary phoneme {char!r} "
+                                f"(codepoints: {[hex(ord(c)) for c in char]}) "
+                                f"not found in vocabulary, dropping it")
 
             token_ids.append(idx)
 

--- a/tests/test_tokenizer_vocab.py
+++ b/tests/test_tokenizer_vocab.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from phoonnx.tokenizer import (
     BlankBetween,
@@ -437,6 +438,63 @@ class TestBPETokenizerDelegates(unittest.TestCase):
         self.assertIsNone(tok.pad_id)
         self.assertIsNone(tok.blank_id)
         self.assertIsNone(tok.blank_word_id)
+
+
+class TestOutOfVocabularyTracking(unittest.TestCase):
+    """OOV phonemes must be dropped from the output but recorded and warned
+    about, instead of vanishing silently."""
+
+    def test_oov_char_is_recorded_and_warns(self):
+        voc = Vocabulary(char2idx={"a": 0}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        with mock.patch("phoonnx.tokenizer.LOG.warning") as warn:
+            result = tok.encode("azb")
+        self.assertEqual(result, [0])
+        self.assertEqual(tok.not_found_characters, {"z", "b"})
+        warned_messages = [call.args[0] for call in warn.call_args_list]
+        self.assertTrue(any("'z'" in msg for msg in warned_messages))
+        self.assertTrue(any("'b'" in msg for msg in warned_messages))
+
+    def test_same_oov_char_warns_only_once(self):
+        voc = Vocabulary(char2idx={"a": 0}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        with mock.patch("phoonnx.tokenizer.LOG.warning") as warn:
+            tok.encode("azzzaz")
+        self.assertEqual(tok.not_found_characters, {"z"})
+        warned_messages = [call.args[0] for call in warn.call_args_list]
+        self.assertEqual(sum("'z'" in msg for msg in warned_messages), 1)
+
+    def test_empty_string_encodes_to_empty_list(self):
+        voc = Vocabulary(char2idx={"a": 0}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode(""), [])
+        self.assertEqual(tok.not_found_characters, set())
+
+
+class TestVocabularyFormPreserved(unittest.TestCase):
+    """The vocabulary is correct by construction (it comes from the model's own
+    config), so its keys are used exactly as declared -- no unicode
+    normalization of keys or input."""
+
+    def test_combining_char_keys_kept_verbatim(self):
+        # NFD-keyed map: 'a' + COMBINING TILDE as a single two-codepoint key
+        key = "a\u0303"
+        voc = Vocabulary(char2idx={key: 0, "b": 1}, blank=None)
+        self.assertIn(key, voc.char2idx)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode([key, "b"]), [0, 1])
+        self.assertEqual(tok.not_found_characters, set())
+
+    def test_compound_phonemes_match(self):
+        voc = Vocabulary(char2idx={"a": 0, "i": 1, "ai": 2}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("ai"), [2])
+        self.assertEqual(tok.not_found_characters, set())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`TTSTokenizer.encode` silently dropped out-of-vocabulary phonemes: characters not found in the vocabulary's `char2idx` map were skipped without recording or warning, even though the class documents a `not_found_characters` field for tracking them. Vocabulary gaps were invisible until inference quality degraded, with no signal pointing at the missing phoneme.

## Fix

Unresolved characters are now added to `not_found_characters` and logged via `LOG.warning` (with their codepoints) exactly once per distinct character. Lookup semantics are otherwise untouched: the vocabulary comes from the model's own config and is correct by construction, so keys and input are compared exactly as declared, with no unicode normalization on either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)