### PR TITLE
refactor: delegate Japanese, Cangjie and jamo script conversion to scriptconv

### DIFF
--- a/phoonnx/alphabet_convert.py
+++ b/phoonnx/alphabet_convert.py
@@ -245,47 +245,36 @@ def _graphemes_to_hangul(text: str, lang: str, _pt=None) -> str:
 
 
 def _graphemes_to_hiragana(text: str, lang: str, _pt=None) -> str:
-    """Japanese: convert kanji/katakana → hiragana via pykakasi."""
+    """Japanese: kanji/katakana → hiragana via scriptconv's reading dictionary."""
     try:
-        import pykakasi
-        kks = pykakasi.kakasi()
-        result = kks.convert(text)
-        return "".join(item["hira"] for item in result)
+        from scriptconv.readings import to_hiragana
+        return to_hiragana(text)
     except ImportError:
-        LOG.debug("pykakasi not available; returning text unchanged")
+        LOG.debug("scriptconv[ja] not available; returning text unchanged")
         return text
     except Exception as e:
-        LOG.debug("pykakasi conversion failed: %s", e)
+        LOG.debug("hiragana conversion failed: %s", e)
         return text
 
 
 def _graphemes_to_kana(text: str, lang: str, _pt=None) -> str:
-    """Japanese: convert to katakana via pykakasi."""
+    """Japanese: convert to katakana via scriptconv's reading dictionary."""
     try:
-        import pykakasi
-        kks = pykakasi.kakasi()
-        result = kks.convert(text)
-        return "".join(item["kana"] for item in result)
+        from scriptconv.readings import to_katakana
+        return to_katakana(text)
     except ImportError:
-        LOG.debug("pykakasi not available; returning text unchanged")
+        LOG.debug("scriptconv[ja] not available; returning text unchanged")
         return text
     except Exception as e:
-        LOG.debug("pykakasi conversion failed: %s", e)
+        LOG.debug("katakana conversion failed: %s", e)
         return text
 
 
 def _graphemes_to_cangjie(text: str, lang: str, _pt=None) -> str:
-    """Chinese: convert to Cangjie codes via spacy-pkuseg (best-effort)."""
+    """Chinese: hanzi → Cangjie5 codes via scriptconv's vendored table."""
     try:
-        import pkuseg
-        seg = pkuseg.pkuseg()
-        words = seg.cut(text)
-        # Cangjie encoding is not directly provided by pkuseg; return segmented.
-        # A full Cangjie lookup table would be needed for complete conversion.
-        return " ".join(words)
-    except ImportError:
-        LOG.debug("spacy-pkuseg not available; returning text unchanged")
-        return text
+        from scriptconv.cangjie import to_cangjie
+        return to_cangjie(text)
     except Exception as e:
         LOG.debug("Cangjie conversion failed: %s", e)
         return text

--- a/phoonnx/lang_preprocess.py
+++ b/phoonnx/lang_preprocess.py
@@ -30,16 +30,9 @@ def is_katakana(c: str) -> bool:
 
 
 def hangul_to_jamo(text: str) -> str:
-    """Decompose Korean syllables into initial/medial/final Jamo. Pure Python."""
-    def decompose(ch: str) -> str:
-        if not ("가" <= ch <= "힯"):
-            return ch
-        base = ord(ch) - 0xAC00
-        initial = chr(0x1100 + base // (21 * 28))
-        medial = chr(0x1161 + (base % (21 * 28)) // 28)
-        final = chr(0x11A7 + base % 28) if base % 28 else ""
-        return initial + medial + final
-    return "".join(decompose(c) for c in text).strip()
+    """Decompose Korean syllables into conjoining Jamo (scriptconv)."""
+    from scriptconv import decompose_hangul
+    return decompose_hangul(text, form="conjoining").strip()
 
 
 def japanese_to_hiragana(text: str) -> str:

--- a/phoonnx/lang_preprocess.py
+++ b/phoonnx/lang_preprocess.py
@@ -2,7 +2,7 @@
 
 Some scripts are ambiguous about pronunciation, so the model is trained on a transformed
 form of the text that must be reproduced at inference. Korean (Hangul → Jamo) is pure
-Python and always available; Japanese (pykakasi) and Chinese (spacy-pkuseg) need an
+Python and always available; Japanese (scriptconv[ja]) and Chinese (spacy-pkuseg) need an
 optional dependency; Russian stress comes from ``stressonnx`` (pure onnxruntime). Each
 degrades to the raw text (with a warning) when its backend is missing. Hebrew/Arabic
 vocalization is the universal ``add_diacritics`` flag, not here.
@@ -16,7 +16,6 @@ from unicodedata import category, normalize
 from phoonnx.util import LOG
 
 # lazy singletons for the optional backends (created on first use)
-_kakasi = None
 _russian_stresser = None
 _cangjie = None
 
@@ -36,34 +35,31 @@ def hangul_to_jamo(text: str) -> str:
 
 
 def japanese_to_hiragana(text: str) -> str:
-    """Convert kanji to hiragana (katakana kept) and NFKD-normalise. Needs ``pykakasi``."""
-    global _kakasi
-    if _kakasi is None:
-        try:
-            import pykakasi
-            _kakasi = pykakasi.kakasi()
-        except ImportError:
-            LOG.warning("pykakasi not installed — Japanese text left unprocessed")
-            return text
-        except Exception as e:
-            LOG.warning("Could not initialize pykakasi: %s", e)
-            return text
+    """Convert kanji to hiragana (katakana kept) and NFKD-normalise.
+
+    Readings come from scriptconv's token API; this function only applies
+    phoonnx policy on top: a space is inserted before kanji readings starting
+    は/へ so the phonemizer sees them word-initially (pronounced ha/he) instead
+    of mistaking them for the topic/direction particles (wa/e).
+    """
     try:
-        converted = _kakasi.convert(text)
+        from scriptconv.readings import tokens
+        converted = list(tokens(text))
+    except ImportError:
+        LOG.warning("scriptconv[ja] not installed — Japanese text left unprocessed")
+        return text
     except Exception as e:
         LOG.warning("Japanese conversion failed: %s", e)
         return text
     out = []
-    for r in converted:
-        inp, hira = r["orig"], r["hira"]
-        if any(is_kanji(c) for c in inp):
+    for tok in converted:
+        if any(is_kanji(c) for c in tok.orig):
+            hira = tok.hira
             if hira and hira[0] in ("は", "へ"):   # は / へ
                 hira = " " + hira
             out.append(hira)
-        elif inp and all(is_katakana(c) for c in inp):
-            out.append(inp)
         else:
-            out.append(inp)
+            out.append(tok.orig)
     return normalize("NFKD", "".join(out))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "langcodes",
     "ovos-number-parser>=0.4.0",
     "ovos-date-parser>=0.6.4a1",
-    "scriptconv>=0.0.3a5",
+    "scriptconv>=0.0.3a6",
     "unicode_rbnf",
     "click",
     "requests",
@@ -185,7 +185,7 @@ sv = ["epitran"]
 sw = ["epitran"]
 vi = ["epitran", "gruut[vi]>=2.3.0,<3.0", "misaki[vi]", "spacy>=3.7"]
 zh = ["epitran", "gruut[zh]>=2.3.0,<3.0", "misaki[zh]", "spacy>=3.7"]
-cjk = ["scriptconv[ja]>=0.0.3a5", "pykakasi==2.3.0", "spacy-pkuseg"]
+cjk = ["scriptconv[ja]>=0.0.3a6", "pykakasi==2.3.0", "spacy-pkuseg"]
 
 # multilingual data-driven IPA backend (hundreds of language specs)
 o2i = ["orthography2ipa"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "langcodes",
     "ovos-number-parser>=0.4.0",
     "ovos-date-parser>=0.6.4a1",
-    "scriptconv>=0.0.2",
+    "scriptconv>=0.0.3a5",
     "unicode_rbnf",
     "click",
     "requests",
@@ -185,7 +185,7 @@ sv = ["epitran"]
 sw = ["epitran"]
 vi = ["epitran", "gruut[vi]>=2.3.0,<3.0", "misaki[vi]", "spacy>=3.7"]
 zh = ["epitran", "gruut[zh]>=2.3.0,<3.0", "misaki[zh]", "spacy>=3.7"]
-cjk = ["pykakasi==2.3.0", "spacy-pkuseg"]
+cjk = ["scriptconv[ja]>=0.0.3a5", "pykakasi==2.3.0", "spacy-pkuseg"]
 
 # multilingual data-driven IPA backend (hundreds of language specs)
 o2i = ["orthography2ipa"]

--- a/tests/test_alphabet_convert.py
+++ b/tests/test_alphabet_convert.py
@@ -124,31 +124,18 @@ class TestNoPathIdentity(unittest.TestCase):
 
 
 class TestScriptConversion(unittest.TestCase):
-    def test_graphemes_to_hira_with_pykakasi(self):
-        """GRAPHEMES→HIRA edge calls pykakasi when available."""
-        mock_kks = MagicMock()
-        mock_kks.convert.return_value = [{"hira": "と"}, {"hira": "き"}]
+    def test_graphemes_to_hira_real_conversion(self):
+        """GRAPHEMES→HIRA edge resolves kanji readings via scriptconv."""
+        result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.HIRA)
+        self.assertEqual(result, "とうきょう")
 
-        mock_kakasi_module = MagicMock()
-        mock_kakasi_module.kakasi.return_value = mock_kks
-
-        with patch.dict("sys.modules", {"pykakasi": mock_kakasi_module}):
+    def test_graphemes_to_hira_no_dictionary(self):
+        """GRAPHEMES→HIRA falls back gracefully when scriptconv[ja] is missing."""
+        import scriptconv.readings as _readings
+        with patch.object(_readings, "_kakasi", None), \
+                patch.dict("sys.modules", {"pykakasi": None}):
             result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.HIRA)
-
-        self.assertEqual(result, "とき")
-
-    def test_graphemes_to_hira_no_pykakasi(self):
-        """GRAPHEMES→HIRA falls back gracefully when pykakasi missing."""
-        import sys
-        old = sys.modules.pop("pykakasi", None)
-        try:
-            with patch.dict("sys.modules", {"pykakasi": None}):
-                result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.HIRA)
-            # Should return input unchanged
-            self.assertEqual(result, "東京")
-        finally:
-            if old is not None:
-                sys.modules["pykakasi"] = old
+        self.assertEqual(result, "東京")
 
 
 class TestPhonemizationEdge(unittest.TestCase):

--- a/tests/test_alphabet_convert_edges.py
+++ b/tests/test_alphabet_convert_edges.py
@@ -146,62 +146,37 @@ class TestConvertNoOpSameAlphabet(unittest.TestCase):
         self.assertEqual(result, "")
 
 
-class TestCangjiePassthrough(unittest.TestCase):
-    def test_pkuseg_import_error_falls_back_to_passthrough(self):
-        import sys as _sys
-        old = _sys.modules.pop("pkuseg", None)
-        try:
-            with patch.dict("sys.modules", {"pkuseg": None}):
-                result = convert("你好世界", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
-            self.assertEqual(result, "你好世界")
-        finally:
-            if old is not None:
-                _sys.modules["pkuseg"] = old
+class TestCangjieEdge(unittest.TestCase):
+    def test_hanzi_become_real_cangjie_codes(self):
+        result = convert("你好", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
+        self.assertEqual(result, "onf vnd")
 
-    def test_pkuseg_generic_exception_falls_back_to_passthrough(self):
-        mock_pkuseg_module = MagicMock()
-        mock_pkuseg_module.pkuseg.side_effect = RuntimeError("model not downloaded")
-        with patch.dict("sys.modules", {"pkuseg": mock_pkuseg_module}):
+    def test_unmapped_runs_pass_through(self):
+        result = convert("你好 ABC 123", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
+        self.assertEqual(result, "onf vnd  ABC 123")
+
+    def test_conversion_error_falls_back_to_passthrough(self):
+        with patch("scriptconv.cangjie.to_cangjie", side_effect=RuntimeError("boom")):
             result = convert("你好", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
         self.assertEqual(result, "你好")
 
-    def test_pkuseg_success_path_segments_words(self):
-        mock_seg = MagicMock()
-        mock_seg.cut.return_value = ["你好", "世界"]
-        mock_pkuseg_module = MagicMock()
-        mock_pkuseg_module.pkuseg.return_value = mock_seg
-        with patch.dict("sys.modules", {"pkuseg": mock_pkuseg_module}):
-            result = convert("你好世界", "zh", Alphabet.GRAPHEMES, Alphabet.CANGJIE)
-        self.assertEqual(result, "你好 世界")
 
+class TestKanaEdge(unittest.TestCase):
+    def test_kanji_to_katakana(self):
+        result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.KANA)
+        self.assertEqual(result, "トウキョウ")
 
-class TestKanaPassthrough(unittest.TestCase):
-    def test_pykakasi_import_error_falls_back_to_passthrough_for_kana(self):
-        import sys as _sys
-        old = _sys.modules.pop("pykakasi", None)
-        try:
-            with patch.dict("sys.modules", {"pykakasi": None}):
-                result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.KANA)
-            self.assertEqual(result, "東京")
-        finally:
-            if old is not None:
-                _sys.modules["pykakasi"] = old
-
-    def test_pykakasi_generic_exception_falls_back_to_passthrough(self):
-        mock_kakasi_module = MagicMock()
-        mock_kakasi_module.kakasi.side_effect = RuntimeError("dict load failed")
-        with patch.dict("sys.modules", {"pykakasi": mock_kakasi_module}):
+    def test_scriptconv_ja_missing_falls_back_to_passthrough(self):
+        import scriptconv.readings as _r
+        with patch.object(_r, "_kakasi", None), \
+                patch.dict("sys.modules", {"pykakasi": None}):
             result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.KANA)
         self.assertEqual(result, "東京")
 
-    def test_pykakasi_success_path_for_kana(self):
-        mock_kks = MagicMock()
-        mock_kks.convert.return_value = [{"kana": "トウ"}, {"kana": "キョウ"}]
-        mock_kakasi_module = MagicMock()
-        mock_kakasi_module.kakasi.return_value = mock_kks
-        with patch.dict("sys.modules", {"pykakasi": mock_kakasi_module}):
+    def test_conversion_error_falls_back_to_passthrough(self):
+        with patch("scriptconv.readings.to_katakana", side_effect=RuntimeError("dict load failed")):
             result = convert("東京", "ja", Alphabet.GRAPHEMES, Alphabet.KANA)
-        self.assertEqual(result, "トウキョウ")
+        self.assertEqual(result, "東京")
 
 
 class TestNoHangulToHiraEdge(unittest.TestCase):
@@ -235,14 +210,9 @@ class TestHangulIdentityEdge(unittest.TestCase):
 
 
 class TestMixedScriptScriptConversion(unittest.TestCase):
-    def test_mixed_script_input_through_pykakasi_mock(self):
+    def test_mixed_script_input_hiragana_edge(self):
         """Latin+Kanji mixed input must not crash the hiragana edge."""
-        mock_kks = MagicMock()
-        mock_kks.convert.return_value = [{"hira": "abc"}, {"hira": "とうきょう"}]
-        mock_kakasi_module = MagicMock()
-        mock_kakasi_module.kakasi.return_value = mock_kks
-        with patch.dict("sys.modules", {"pykakasi": mock_kakasi_module}):
-            result = convert("abc東京", "ja", Alphabet.GRAPHEMES, Alphabet.HIRA)
+        result = convert("abc東京", "ja", Alphabet.GRAPHEMES, Alphabet.HIRA)
         self.assertEqual(result, "abcとうきょう")
 
 


### PR DESCRIPTION
Script-level conversions that scriptconv now provides are delegated to it, making it the single source of truth the alphabet graph already declares:

- `GRAPHEMES→HIRA` / `GRAPHEMES→KANA` edges use `scriptconv.readings` (dictionary-backed kanji→kana behind the `scriptconv[ja]` extra) instead of inlining pykakasi; the kakasi dictionary now loads once per process instead of once per call.
- `GRAPHEMES→CANGJIE` becomes a real conversion: the edge previously returned word-segmented graphemes with a comment noting a lookup table would be needed — it now emits actual Cangjie5 codes via `scriptconv.cangjie`'s vendored table, with no runtime download.
- `lang_preprocess.hangul_to_jamo` delegates to `scriptconv.decompose_hangul(form="conjoining")`, removing a byte-for-byte duplicate implementation.
- `lang_preprocess.japanese_to_hiragana` iterates `scriptconv.readings.tokens()` instead of calling pykakasi directly, keeping only phoonnx policy: the space inserted before kanji readings starting は/へ (so the phonemizer reads them word-initially as ha/he rather than as the topic/direction particles wa/e) and the NFKD normalization pass. Behavior is unchanged; the module no longer imports pykakasi.

Deliberately unchanged: `ChineseCangjieConverter` keeps loading the chatterbox `Cangjie5_TC.json` — that file carries collision-disambiguation indices baked into chatterbox model vocabularies, so it is model data, correct by construction. The pypinyin/kakasi phonemizer backends in `phonemizers/` are phonemizer dependencies, not script conversion, and stay. Edge failure behavior is unchanged: conversion errors degrade to passthrough with a debug log.

scriptconv floor moves to `0.0.3a6`; the `cjk` extra pulls `scriptconv[ja]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)