### PR TITLE
test: make provider-fallback warning test independent of local CUDA state

### DIFF
--- a/tests/test_coldstart_warmup_cache.py
+++ b/tests/test_coldstart_warmup_cache.py
@@ -164,10 +164,17 @@ class TestProviderFallbackWarning(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             model_path = Path(tmp) / "model.onnx"
             _build_tiny_onnx_model(model_path)
+            # Force the CPU fallback regardless of whether this machine can
+            # actually initialize the CUDA provider: build every session
+            # CPU-only no matter which providers were requested.
+            real_session = providers.onnxruntime.InferenceSession
+            cpu_only = lambda path, *a, **kw: real_session(path, providers=[CPU_PROVIDER])
             with patch.object(providers, "resolve_providers",
                                return_value=["CUDAExecutionProvider", CPU_PROVIDER]):
-                with patch.object(providers.LOG, "warning") as warn:
-                    make_session(model_path, providers=["CUDAExecutionProvider"])
+                with patch.object(providers.onnxruntime, "InferenceSession",
+                                   side_effect=cpu_only):
+                    with patch.object(providers.LOG, "warning") as warn:
+                        make_session(model_path, providers=["CUDAExecutionProvider"])
             self.assertTrue(warn.called)
             warned = " ".join(str(c) for c in warn.call_args_list)
             self.assertIn("CUDAExecutionProvider", warned)


### PR DESCRIPTION
The end-to-end provider-fallback test asserted that requesting CUDAExecutionProvider always ends in a CPU fallback warning. That assumption is environmental: on a machine where the CUDA provider can initialize (for example when another library already loaded a compatible CUDA runtime into the process), no fallback happens and the assertion fails.

The test now patches session construction to build CPU-only sessions regardless of the requested providers, so the fallback warning path is exercised deterministically on any machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for scenarios where GPU acceleration is unavailable and the system falls back to CPU processing.
  * Added deterministic verification that the fallback warning is surfaced during session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->