### PR TITLE
feat: replace pyworld F0 extraction with in-repo pyin implementation

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,6 +11,6 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.11", "3.12", "3.13", "3.14"]'
-      install_extras: 'test,train,train-styletts2,train-eval,train-data,train-optispeech'
+      install_extras: 'test,train,train-styletts2,train-eval,train-data,train-optispeech,train-pyworld'
       test_path: 'tests'
       system_deps: 'espeak-ng'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,6 @@ jobs:
       python_version: '3.11'
       coverage_source: 'phoonnx'
       test_path: 'tests/'
-      install_extras: '-e .[test,train,train-styletts2,train-eval,train-data,train-optispeech]'
+      install_extras: '-e .[test,train,train-styletts2,train-eval,train-data,train-optispeech,train-pyworld]'
       min_coverage: 43
       system_deps: 'espeak-ng'

--- a/phoonnx_train/engines/base.py
+++ b/phoonnx_train/engines/base.py
@@ -113,7 +113,7 @@ class BaseTrainingEngine(ABC):
         phonemization + audio normalization.
 
         For example, OptiSpeech needs F0 (pitch) and energy extraction
-        via pyworld, while VITS does not.
+        via ``librosa.pyin``, while VITS does not.
 
         Returns a dict of extra fields to merge into the utterance
         record in dataset.jsonl.  Default returns empty.

--- a/phoonnx_train/engines/fastpitch.py
+++ b/phoonnx_train/engines/fastpitch.py
@@ -268,26 +268,25 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         hop_length: int = 256,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """Extract F0 (pitch) via pyworld; cached alongside the mel cache.
+        """Extract F0 (pitch) via ``librosa.pyin``; cached alongside the mel cache.
 
-        pyworld DIO + StoneMask, run at a frame period matched to the mel
-        hop (``1000 * hop_length / sample_rate`` ms) so the f0 track is
-        frame-aligned with the mel target, and computed on the same
-        trimmed/normalized audio the mels come from (the ``<sha>.pt``
-        cache written by ``cache_norm_audio``). The sidecar is named
-        ``<sha>.f0.npy`` next to the ``<sha>.spec.pt`` cache so the
-        training dataset finds it. SpeedySpeech does not use pitch, but
-        the cache is harmless and lets the same preprocessed dataset be
-        reused for either variant.
+        Run at a frame period matched to the mel hop (``1000 * hop_length /
+        sample_rate`` ms) so the f0 track is frame-aligned with the mel
+        target, and computed on the same trimmed/normalized audio the mels
+        come from (the ``<sha>.pt`` cache written by ``cache_norm_audio``).
+        The sidecar is named ``<sha>.f0.npy`` next to the ``<sha>.spec.pt``
+        cache so the training dataset finds it. SpeedySpeech does not use
+        pitch, but the cache is harmless and lets the same preprocessed
+        dataset be reused for either variant.
         """
         import numpy as np
 
         try:
-            import librosa  # noqa: F401 — fallback loader below
-            import pyworld as pw
+            import librosa
+            from phoonnx_train.vendor.f0 import extract_f0
         except ImportError:
             _LOG.warning(
-                "pyworld/librosa not installed — skipping F0 extraction "
+                "librosa not installed — skipping F0 extraction "
                 "(FastPitch pitch predictor will train without a target; "
                 "install phoonnx[train,train-fastpitch] for real pitch)."
             )
@@ -315,9 +314,7 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
             wav, _sr = librosa.load(str(utterance_audio_path), sr=sample_rate, mono=True)
 
         wav_double = wav.astype(np.float64)
-        frame_period = 1000.0 * hop_length / sample_rate  # ms, = mel hop
-        f0, timeaxis = pw.dio(wav_double, sample_rate, frame_period=frame_period)
-        f0 = pw.stonemask(wav_double, f0, timeaxis, sample_rate).astype(np.float32)
+        f0 = extract_f0(wav_double, sample_rate, hop_length).astype(np.float32)
 
         if spec_path.exists():
             import torch

--- a/phoonnx_train/engines/fastpitch.py
+++ b/phoonnx_train/engines/fastpitch.py
@@ -274,7 +274,9 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         sample_rate`` ms) so the f0 track is frame-aligned with the mel
         target, and computed on the same trimmed/normalized audio the mels
         come from (the ``<sha>.pt`` cache written by ``cache_norm_audio``).
-        The sidecar is named ``<sha>.f0.npy`` next to the ``<sha>.spec.pt``
+        The sidecar is named ``<sha>.f0-<method>.npy`` (see
+        ``phoonnx_train.fastpitch.pitch_stats.f0_cache_path``) next to the
+        ``<sha>.spec.pt``
         cache so the training dataset finds it. SpeedySpeech does not use
         pitch, but the cache is harmless and lets the same preprocessed
         dataset be reused for either variant.
@@ -333,8 +335,10 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
             elif diff < 0:
                 f0 = np.pad(f0, (0, -diff))
 
+        from phoonnx_train.fastpitch.pitch_stats import f0_cache_path
+
         cache_dir.mkdir(parents=True, exist_ok=True)
-        f0_path = cache_dir / f"{audio_cache_id}.f0.npy"
+        f0_path = f0_cache_path(spec_path)
         np.save(f0_path, f0)
 
         return {"f0_path": str(f0_path)}

--- a/phoonnx_train/engines/fastpitch.py
+++ b/phoonnx_train/engines/fastpitch.py
@@ -266,9 +266,15 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         cache_dir: Path,
         sample_rate: int,
         hop_length: int = 256,
+        f0_method: str = "pyin",
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """Extract F0 (pitch) via ``librosa.pyin``; cached alongside the mel cache.
+        """Extract F0 (pitch); cached alongside the mel cache.
+
+        ``f0_method`` selects the extractor: ``"pyin"`` (default,
+        ``librosa.pyin``, no extra native dependency) or ``"dio"``/
+        ``"harvest"`` (WORLD via ``pyworld``, opt-in through the
+        ``train-pyworld`` extra — ~50x faster at preprocessing time).
 
         Run at a frame period matched to the mel hop (``1000 * hop_length /
         sample_rate`` ms) so the f0 track is frame-aligned with the mel
@@ -285,7 +291,7 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
 
         try:
             import librosa
-            from phoonnx_train.vendor.f0 import extract_f0
+            from phoonnx_train.vendor.f0 import extract_f0, extract_f0_world, get_extractor_tag
         except ImportError:
             _LOG.warning(
                 "librosa not installed — skipping F0 extraction "
@@ -293,6 +299,18 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
                 "install phoonnx[train,train-fastpitch] for real pitch)."
             )
             return {}
+
+        get_extractor_tag(f0_method)  # fail fast on an unknown method
+
+        if f0_method != "pyin":
+            try:
+                import pyworld  # noqa: F401 — presence check, extract_f0_world imports it
+            except ImportError:
+                _LOG.warning(
+                    "pyworld not installed — skipping F0 extraction "
+                    "(f0_method=%r needs the 'train-pyworld' extra).", f0_method,
+                )
+                return {}
 
         from hashlib import sha256
 
@@ -316,7 +334,10 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
             wav, _sr = librosa.load(str(utterance_audio_path), sr=sample_rate, mono=True)
 
         wav_double = wav.astype(np.float64)
-        f0 = extract_f0(wav_double, sample_rate, hop_length).astype(np.float32)
+        if f0_method == "pyin":
+            f0 = extract_f0(wav_double, sample_rate, hop_length).astype(np.float32)
+        else:
+            f0 = extract_f0_world(wav_double, sample_rate, hop_length, method=f0_method).astype(np.float32)
 
         if spec_path.exists():
             import torch
@@ -338,7 +359,7 @@ class ForwardTTSTrainingEngine(BaseTrainingEngine):
         from phoonnx_train.fastpitch.pitch_stats import f0_cache_path
 
         cache_dir.mkdir(parents=True, exist_ok=True)
-        f0_path = f0_cache_path(spec_path)
+        f0_path = f0_cache_path(spec_path, method=f0_method)
         np.save(f0_path, f0)
 
         return {"f0_path": str(f0_path)}

--- a/phoonnx_train/engines/mixer.py
+++ b/phoonnx_train/engines/mixer.py
@@ -17,9 +17,9 @@ dataset / collate live in ``phoonnx_train.mixertts.lightning``; heavy
 torch imports are deferred until a model is actually built so the engine
 registry stays importable in torch-free environments.
 
-Pitch (F0) preprocessing is shared with the FastPitch engine (pyworld
-DIO+StoneMask at ``frame_period = 1000 * hop / sample_rate`` ms on the
-same trimmed/normalized cached audio the mels come from, length-reconciled
+Pitch (F0) preprocessing is shared with the FastPitch engine (``librosa.pyin``
+at a hop matched to ``hop / sample_rate`` seconds on the same
+trimmed/normalized cached audio the mels come from, length-reconciled
 to the mel frame count) — the ``<utterance>.f0.npy`` sidecars and
 ``pitch_stats.json`` are engine-compatible.
 
@@ -84,7 +84,7 @@ class MixerTTSTrainingEngine(ForwardTTSTrainingEngine):
     """Training engine adapter for Mixer-TTS.
 
     Subclasses the FastPitch engine only to reuse its shared plumbing —
-    the pyworld F0 ``extra_preprocess`` sidecar cache and the tolerant
+    the pyin-based F0 ``extra_preprocess`` sidecar cache and the tolerant
     ``load_checkpoint`` — the model/ONNX contract is Mixer-TTS's own.
     """
 

--- a/phoonnx_train/engines/mixer.py
+++ b/phoonnx_train/engines/mixer.py
@@ -20,7 +20,7 @@ registry stays importable in torch-free environments.
 Pitch (F0) preprocessing is shared with the FastPitch engine (``librosa.pyin``
 at a hop matched to ``hop / sample_rate`` seconds on the same
 trimmed/normalized cached audio the mels come from, length-reconciled
-to the mel frame count) — the ``<utterance>.f0.npy`` sidecars and
+to the mel frame count) — the ``<utterance>.f0-<method>.npy`` sidecars and
 ``pitch_stats.json`` are engine-compatible.
 
 ONNX export follows the contract consumed by

--- a/phoonnx_train/engines/optispeech.py
+++ b/phoonnx_train/engines/optispeech.py
@@ -200,6 +200,11 @@ class OptiSpeechEngineConfig:
     f_min: int = 0
     f_max: int = 8000
 
+    # F0 extraction method: "pyin" (default, librosa, no extra native
+    # dependency) or "dio"/"harvest" (WORLD via pyworld, train-pyworld
+    # extra, ~50x faster at preprocessing time).
+    f0_method: str = "pyin"
+
     # Text processing
     tokenizer: str = "ipa"
     add_blank: bool = False
@@ -306,7 +311,18 @@ def _build_feature_extractor(ocfg: "OptiSpeechEngineConfig"):
     from phoonnx_train.optispeech.dataset.feature_extractors import CommonFeatureExtractor
     from phoonnx_train.optispeech.dataset.feature_extractors.pitch_extractors import (
         DIOPitchExtractor,
+        HarvestPitchExtractor,
+        PyinPitchExtractor,
     )
+
+    pitch_extractor_classes = {
+        "pyin": PyinPitchExtractor,
+        "dio": DIOPitchExtractor,
+        "harvest": HarvestPitchExtractor,
+    }
+    if ocfg.f0_method not in pitch_extractor_classes:
+        _LOG.warning("unknown f0_method %r — falling back to 'pyin'", ocfg.f0_method)
+    pitch_extractor_cls = pitch_extractor_classes.get(ocfg.f0_method, PyinPitchExtractor)
 
     return CommonFeatureExtractor(
         sample_rate=ocfg.sample_rate,
@@ -317,7 +333,7 @@ def _build_feature_extractor(ocfg: "OptiSpeechEngineConfig"):
         f_min=ocfg.f_min,
         f_max=ocfg.f_max,
         center=True,
-        pitch_extractor=functools.partial(DIOPitchExtractor, interpolate=True),
+        pitch_extractor=functools.partial(pitch_extractor_cls, interpolate=True),
     )
 
 

--- a/phoonnx_train/engines/styletts2_pitch.py
+++ b/phoonnx_train/engines/styletts2_pitch.py
@@ -48,6 +48,11 @@ class PitchConfig:
     save_dir: Optional[str] = None
     pretrained_path: Optional[str] = None  # warm-start (e.g. English bst.t7)
 
+    # F0 extraction method: "pyin" (default, librosa) or "dio"/"harvest"
+    # (WORLD via pyworld, train-pyworld extra) — selects which
+    # ``<wav>.f0-<sr>-<method>.npy`` sidecar cache is read/written.
+    f0_method: str = "pyin"
+
     @classmethod
     def from_training_config(cls, cfg: TrainingEngineConfig) -> "PitchConfig":
         extra = dict(cfg.extra)

--- a/phoonnx_train/engines/styletts2_pitch.py
+++ b/phoonnx_train/engines/styletts2_pitch.py
@@ -7,8 +7,8 @@ usually transfers and training one is optional; ``pretrained_path``
 warm-starts a fine-tune.
 
 Losses per upstream: ``lambda_f0 * SmoothL1(f0)`` + ``BCEWithLogits`` on the
-voicing/silence labels, with pyworld harvest (dio fallback) ground-truth F0
-cached next to the audio. Dataset: same ``train_list.txt``/``wavs/`` layout
+voicing/silence labels, with ``librosa.pyin`` ground-truth F0 cached next to
+the audio. Dataset: same ``train_list.txt``/``wavs/`` layout
 as the other StyleTTS2 engines (the text field is unused).
 
 Output (``save_f0_checkpoint``): a ``.t7`` with ``{"net": state_dict}`` —

--- a/phoonnx_train/fastpitch/lightning.py
+++ b/phoonnx_train/fastpitch/lightning.py
@@ -76,7 +76,8 @@ class ForwardTTSDataset(Dataset):
     def __init__(self, dataset_paths: List[Path], mel_channels: int,
                  filter_length: int, sample_rate: int,
                  mel_fmin: float, mel_fmax: Optional[float],
-                 max_phoneme_ids: Optional[int] = None):
+                 max_phoneme_ids: Optional[int] = None,
+                 f0_method: str = "pyin"):
         # accept either a preprocessed dataset dir or the dataset.jsonl itself
         jsonl_paths = [
             (Path(p) / "dataset.jsonl") if Path(p).is_dir() else Path(p)
@@ -88,9 +89,11 @@ class ForwardTTSDataset(Dataset):
         self.sample_rate = sample_rate
         self.mel_fmin = mel_fmin
         self.mel_fmax = mel_fmax
+        self.f0_method = f0_method
         self.pitch_mean, self.pitch_std = load_or_compute_pitch_stats(
             dataset_paths,
-            [f0_cache_path(utt.audio_spec_path) for utt in self._inner.utterances],
+            [f0_cache_path(utt.audio_spec_path, method=f0_method) for utt in self._inner.utterances],
+            method=f0_method,
         )
 
     def __len__(self) -> int:
@@ -106,7 +109,7 @@ class ForwardTTSDataset(Dataset):
 
         pitch = None
         # optional sidecar cache written by extra_preprocess: "<stem>.f0-<method>.npy"
-        f0_candidate = f0_cache_path(utt.audio_spec_path)
+        f0_candidate = f0_cache_path(utt.audio_spec_path, method=self.f0_method)
         if f0_candidate.exists():
             import numpy as np
 
@@ -193,6 +196,11 @@ class ForwardTTSModule(pl.LightningModule):
         # epoch 0 risks locking in a still-random soft alignment
         binary_loss_start_epoch: int = 10,
         binary_loss_warmup_epochs: int = 10,
+        # F0 extraction method used at preprocessing time — "pyin" (default)
+        # or "dio"/"harvest" (WORLD via pyworld, train-pyworld extra). Must
+        # match whatever ``--f0-method`` extra_preprocess ran with, since it
+        # selects which ``<utterance>.f0-<method>.npy`` sidecar to read.
+        f0_method: str = "pyin",
         **kwargs: Any,
     ):
         super().__init__()
@@ -238,6 +246,7 @@ class ForwardTTSModule(pl.LightningModule):
             mel_fmin=self.hparams.mel_fmin,
             mel_fmax=self.hparams.mel_fmax,
             max_phoneme_ids=max_phoneme_ids,
+            f0_method=self.hparams.f0_method,
         )
         valid_size = max(0, int(len(full_dataset) * validation_split))
         test_size = min(num_test_examples, max(0, len(full_dataset) - valid_size))

--- a/phoonnx_train/fastpitch/lightning.py
+++ b/phoonnx_train/fastpitch/lightning.py
@@ -5,7 +5,7 @@ Reuses the shared VITS preprocessing pipeline: ``audio_norm_path`` /
 ``phoonnx_train.preprocess``; the mel target is derived from the linear
 spectrogram at load time via ``phoonnx_train.vits.mel_processing`` (no
 separate mel cache needed). Pitch (F0) is read from the optional
-``<utterance>.f0.npy`` sidecar caches written by
+``<utterance>.f0-<method>.npy`` sidecar caches written by
 ``ForwardTTSTrainingEngine.extra_preprocess``.
 """
 import logging
@@ -105,7 +105,7 @@ class ForwardTTSDataset(Dataset):
         ).squeeze(0)  # [mel_channels, T]
 
         pitch = None
-        # optional sidecar cache written by extra_preprocess: "<stem>.f0.npy"
+        # optional sidecar cache written by extra_preprocess: "<stem>.f0-<method>.npy"
         f0_candidate = f0_cache_path(utt.audio_spec_path)
         if f0_candidate.exists():
             import numpy as np

--- a/phoonnx_train/fastpitch/pitch_stats.py
+++ b/phoonnx_train/fastpitch/pitch_stats.py
@@ -11,14 +11,19 @@ import logging
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
+from phoonnx_train.vendor.f0 import EXTRACTOR_TAG
+
 _LOG = logging.getLogger(__name__)
 
 STATS_FILENAME = "pitch_stats.json"
 
 
 def f0_cache_path(audio_spec_path: Path) -> Path:
-    """``<utterance>.spec.pt`` -> sidecar ``<utterance>.f0.npy`` cache."""
-    return Path(str(audio_spec_path)).with_suffix("").with_suffix(".f0.npy")
+    """``<utterance>.spec.pt`` -> sidecar ``<utterance>.f0-<method>.npy``
+    cache. The extraction-method tag is folded into the filename so a
+    cache written by a previous F0 extractor is a clean miss instead of
+    being silently reused."""
+    return Path(str(audio_spec_path)).with_suffix("").with_suffix(f".f0-{EXTRACTOR_TAG}.npy")
 
 
 def load_or_compute_pitch_stats(
@@ -29,7 +34,7 @@ def load_or_compute_pitch_stats(
 
     Stats are cached as ``pitch_stats.json`` in the first dataset
     directory; a missing or malformed cache is recomputed from the
-    ``.f0.npy`` sidecar files. With no pitch caches at all, identity
+    ``f0_cache_path`` sidecar files. With no pitch caches at all, identity
     normalization ``(0.0, 1.0)`` is returned.
     """
     import numpy as np

--- a/phoonnx_train/fastpitch/pitch_stats.py
+++ b/phoonnx_train/fastpitch/pitch_stats.py
@@ -15,7 +15,9 @@ from phoonnx_train.vendor.f0 import EXTRACTOR_TAG
 
 _LOG = logging.getLogger(__name__)
 
-STATS_FILENAME = "pitch_stats.json"
+# Keyed by extraction method for the same reason as f0_cache_path: corpus
+# mean/std computed from one extractor's tracks must not normalize another's.
+STATS_FILENAME = f"pitch_stats-{EXTRACTOR_TAG}.json"
 
 
 def f0_cache_path(audio_spec_path: Path) -> Path:
@@ -32,7 +34,7 @@ def load_or_compute_pitch_stats(
 ) -> Tuple[float, float]:
     """Return corpus (mean, std) over voiced F0 frames.
 
-    Stats are cached as ``pitch_stats.json`` in the first dataset
+    Stats are cached as ``pitch_stats-<method>.json`` (see ``STATS_FILENAME``) in the first dataset
     directory; a missing or malformed cache is recomputed from the
     ``f0_cache_path`` sidecar files. With no pitch caches at all, identity
     normalization ``(0.0, 1.0)`` is returned.

--- a/phoonnx_train/fastpitch/pitch_stats.py
+++ b/phoonnx_train/fastpitch/pitch_stats.py
@@ -11,33 +11,44 @@ import logging
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
-from phoonnx_train.vendor.f0 import EXTRACTOR_TAG
+from phoonnx_train.vendor.f0 import get_extractor_tag
 
 _LOG = logging.getLogger(__name__)
 
 # Keyed by extraction method for the same reason as f0_cache_path: corpus
 # mean/std computed from one extractor's tracks must not normalize another's.
-STATS_FILENAME = f"pitch_stats-{EXTRACTOR_TAG}.json"
+# Kept as a plain constant (the default/pyin case) for call sites that don't
+# need to be method-aware; method-aware callers should use ``stats_filename``.
+STATS_FILENAME = f"pitch_stats-{get_extractor_tag()}.json"
 
 
-def f0_cache_path(audio_spec_path: Path) -> Path:
+def stats_filename(method: str = "pyin") -> str:
+    """``pitch_stats-<method>.json`` — the corpus pitch-stats cache name for
+    a given F0 extraction method."""
+    return f"pitch_stats-{get_extractor_tag(method)}.json"
+
+
+def f0_cache_path(audio_spec_path: Path, method: str = "pyin") -> Path:
     """``<utterance>.spec.pt`` -> sidecar ``<utterance>.f0-<method>.npy``
     cache. The extraction-method tag is folded into the filename so a
     cache written by a previous F0 extractor is a clean miss instead of
     being silently reused."""
-    return Path(str(audio_spec_path)).with_suffix("").with_suffix(f".f0-{EXTRACTOR_TAG}.npy")
+    tag = get_extractor_tag(method)
+    return Path(str(audio_spec_path)).with_suffix("").with_suffix(f".f0-{tag}.npy")
 
 
 def load_or_compute_pitch_stats(
     dataset_paths: Iterable[Path],
     f0_paths: List[Path],
+    method: str = "pyin",
 ) -> Tuple[float, float]:
     """Return corpus (mean, std) over voiced F0 frames.
 
-    Stats are cached as ``pitch_stats-<method>.json`` (see ``STATS_FILENAME``) in the first dataset
-    directory; a missing or malformed cache is recomputed from the
-    ``f0_cache_path`` sidecar files. With no pitch caches at all, identity
-    normalization ``(0.0, 1.0)`` is returned.
+    Stats are cached as ``pitch_stats-<method>.json`` (see
+    ``stats_filename``) in the first dataset directory; a missing or
+    malformed cache is recomputed from the ``f0_cache_path`` sidecar files.
+    With no pitch caches at all, identity normalization ``(0.0, 1.0)`` is
+    returned.
     """
     import numpy as np
 
@@ -45,7 +56,7 @@ def load_or_compute_pitch_stats(
     for p in dataset_paths:
         p = Path(p)
         if p.is_dir():
-            stats_path = p / STATS_FILENAME
+            stats_path = p / stats_filename(method)
             break
     if stats_path and stats_path.is_file():
         try:

--- a/phoonnx_train/mixertts/lightning.py
+++ b/phoonnx_train/mixertts/lightning.py
@@ -13,7 +13,7 @@ FastPitch engine): phoneme ids + linear-spectrogram caches come from
 from the linear spectrogram at load time via
 ``phoonnx_train.vits.mel_processing`` (fmin/fmax pinned to the shared
 0/8000 Hz convention), and the frame-aligned F0 target is read from the
-``<utterance>.f0.npy`` sidecars written by the engine's
+``<utterance>.f0-<method>.npy`` sidecars written by the engine's
 ``extra_preprocess`` (``librosa.pyin`` at the mel hop, on the same
 trimmed/normalized cached audio the mels come from).
 

--- a/phoonnx_train/mixertts/lightning.py
+++ b/phoonnx_train/mixertts/lightning.py
@@ -106,7 +106,8 @@ class MixerTTSDataset(Dataset):
     def __init__(self, dataset_paths: List[Path], mel_channels: int,
                  filter_length: int, sample_rate: int,
                  mel_fmin: float, mel_fmax: Optional[float],
-                 max_phoneme_ids: Optional[int] = None):
+                 max_phoneme_ids: Optional[int] = None,
+                 f0_method: str = "pyin"):
         jsonl_paths = [
             (Path(p) / "dataset.jsonl") if Path(p).is_dir() else Path(p)
             for p in dataset_paths
@@ -117,10 +118,12 @@ class MixerTTSDataset(Dataset):
         self.sample_rate = sample_rate
         self.mel_fmin = mel_fmin
         self.mel_fmax = mel_fmax
+        self.f0_method = f0_method
         self.prior = BetaBinomialPrior()
         self.pitch_mean, self.pitch_std = load_or_compute_pitch_stats(
             dataset_paths,
-            [f0_cache_path(utt.audio_spec_path) for utt in self._inner.utterances],
+            [f0_cache_path(utt.audio_spec_path, method=f0_method) for utt in self._inner.utterances],
+            method=f0_method,
         )
 
     def __len__(self) -> int:
@@ -136,7 +139,7 @@ class MixerTTSDataset(Dataset):
         t_mel = mel.size(1)
 
         pitch = torch.zeros(t_mel)
-        f0_candidate = f0_cache_path(utt.audio_spec_path)
+        f0_candidate = f0_cache_path(utt.audio_spec_path, method=self.f0_method)
         if f0_candidate.exists():
             f0 = np.load(f0_candidate).astype("float32")
             # length-reconcile to T_mel (extra_preprocess already keeps the
@@ -237,6 +240,11 @@ class MixerTTSModule(pl.LightningModule):
         # inference know the pitch-normalization domain
         pitch_mean: float = 0.0,
         pitch_std: float = 1.0,
+        # F0 extraction method used at preprocessing time — "pyin" (default)
+        # or "dio"/"harvest" (WORLD via pyworld, train-pyworld extra). Must
+        # match whatever ``--f0-method`` extra_preprocess ran with, since it
+        # selects which ``<utterance>.f0-<method>.npy`` sidecar to read.
+        f0_method: str = "pyin",
         **kwargs: Any,
     ):
         super().__init__()
@@ -283,6 +291,7 @@ class MixerTTSModule(pl.LightningModule):
             mel_fmin=self.hparams.mel_fmin,
             mel_fmax=self.hparams.mel_fmax,
             max_phoneme_ids=max_phoneme_ids,
+            f0_method=self.hparams.f0_method,
         )
         # persist the corpus pitch stats (checkpointed via hparams) so
         # inference-time pitch controls know the normalization domain

--- a/phoonnx_train/mixertts/lightning.py
+++ b/phoonnx_train/mixertts/lightning.py
@@ -14,7 +14,7 @@ from the linear spectrogram at load time via
 ``phoonnx_train.vits.mel_processing`` (fmin/fmax pinned to the shared
 0/8000 Hz convention), and the frame-aligned F0 target is read from the
 ``<utterance>.f0.npy`` sidecars written by the engine's
-``extra_preprocess`` (pyworld DIO+StoneMask at the mel hop, on the same
+``extra_preprocess`` (``librosa.pyin`` at the mel hop, on the same
 trimmed/normalized cached audio the mels come from).
 
 Loss/optimizer fidelity vs upstream NeMo:

--- a/phoonnx_train/optispeech/dataset/feature_extractors/pitch_extractors.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/pitch_extractors.py
@@ -1,4 +1,5 @@
 import dataclasses
+import typing
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -10,7 +11,7 @@ import torchaudio
 from scipy.interpolate import interp1d
 
 from phoonnx_train.optispeech.utils import pylogger, trim_or_pad_to_target_length
-from phoonnx_train.vendor.f0 import extract_f0
+from phoonnx_train.vendor.f0 import extract_f0, extract_f0_world
 
 log = pylogger.get_pylogger(__name__)
 
@@ -88,8 +89,9 @@ class BasePitchExtractor(ABC):
 
 
 @dataclass
-class DIOPitchExtractor(BasePitchExtractor):
-    """Frame-level F0 extraction via ``librosa.pyin`` (probabilistic YIN)."""
+class PyinPitchExtractor(BasePitchExtractor):
+    """Frame-level F0 extraction via ``librosa.pyin`` (probabilistic YIN).
+    No extra native dependency; the default pitch extractor."""
 
     def __call__(self, wav, mel_length):
         wav = wav.astype(np.double)
@@ -101,9 +103,31 @@ class DIOPitchExtractor(BasePitchExtractor):
         return pitch
 
 
+@dataclass
+class DIOPitchExtractor(BasePitchExtractor):
+    """Frame-level F0 extraction via WORLD ``dio`` + ``stonemask``
+    (``pyworld``, opt-in through the ``train-pyworld`` extra) — ~50x faster
+    than :class:`PyinPitchExtractor` at preprocessing time."""
+
+    _METHOD: typing.ClassVar[str] = "dio"
+
+    def __call__(self, wav, mel_length):
+        wav = wav.astype(np.double)
+        pitch = extract_f0_world(wav, self.sample_rate, self.hop_length,
+                                  f_min=self.f_min, f_max=self.f_max,
+                                  method=self._METHOD)
+        pitch = trim_or_pad_to_target_length(pitch, mel_length)
+        if self.interpolate:
+            pitch = self.perform_interpolation(pitch)
+        return pitch
+
+
 class HarvestPitchExtractor(DIOPitchExtractor):
-    """Same ``librosa.pyin``-backed F0 extraction as :class:`DIOPitchExtractor`;
-    kept as a distinct class for config/registry backward compatibility."""
+    """Same WORLD-backed extraction as :class:`DIOPitchExtractor`, using
+    ``pyworld.harvest`` instead of ``pyworld.dio`` (slower, generally more
+    robust)."""
+
+    _METHOD: typing.ClassVar[str] = "harvest"
 
 
 @dataclass
@@ -239,9 +263,11 @@ class CrepePitchExtractor(BasePitchExtractor):
 
 @dataclass
 class EnsemblePitchExtractor(BasePitchExtractor):
-    # cls -> voiced-reliability score
+    # cls -> voiced-reliability score. Uses PyinPitchExtractor (not the
+    # WORLD-backed DIOPitchExtractor) so the ensemble has no hard pyworld
+    # dependency.
     extractor_classes = {
-        DIOPitchExtractor: 0.75,
+        PyinPitchExtractor: 0.75,
         PENNPitchExtractor: 0.08,
         JDCPitchExtractor: 0.15,
         CrepePitchExtractor: 0.02,

--- a/phoonnx_train/optispeech/dataset/feature_extractors/pitch_extractors.py
+++ b/phoonnx_train/optispeech/dataset/feature_extractors/pitch_extractors.py
@@ -1,5 +1,4 @@
 import dataclasses
-import typing
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -11,20 +10,13 @@ import torchaudio
 from scipy.interpolate import interp1d
 
 from phoonnx_train.optispeech.utils import pylogger, trim_or_pad_to_target_length
+from phoonnx_train.vendor.f0 import extract_f0
 
 log = pylogger.get_pylogger(__name__)
 
 # Optional pitch extraction backends — each extractor imports its own
 # library lazily so missing deps don't break the whole module.
-_torchcrepe = _penn = _pyworld = _jdc = None
-
-
-def _get_pyworld():
-    global _pyworld
-    if _pyworld is None:
-        import pyworld as _pyworld_mod
-        _pyworld = _pyworld_mod
-    return _pyworld
+_torchcrepe = _penn = _jdc = None
 
 
 def _get_torchcrepe():
@@ -97,17 +89,12 @@ class BasePitchExtractor(ABC):
 
 @dataclass
 class DIOPitchExtractor(BasePitchExtractor):
-    _METHOD: typing.ClassVar[str] = "dio"
-
-    def __post_init__(self):
-        self.extraction_func = getattr(_get_pyworld(), self._METHOD)
+    """Frame-level F0 extraction via ``librosa.pyin`` (probabilistic YIN)."""
 
     def __call__(self, wav, mel_length):
         wav = wav.astype(np.double)
-        pitch, t = self.extraction_func(
-            wav, self.sample_rate, frame_period=self.hop_length / self.sample_rate * 1000
-        )
-        pitch = _get_pyworld().stonemask(wav, pitch, t, self.sample_rate)
+        pitch = extract_f0(wav, self.sample_rate, self.hop_length,
+                            f_min=self.f_min, f_max=self.f_max)
         pitch = trim_or_pad_to_target_length(pitch, mel_length)
         if self.interpolate:
             pitch = self.perform_interpolation(pitch)
@@ -115,7 +102,8 @@ class DIOPitchExtractor(BasePitchExtractor):
 
 
 class HarvestPitchExtractor(DIOPitchExtractor):
-    _METHOD: str = "harvest"
+    """Same ``librosa.pyin``-backed F0 extraction as :class:`DIOPitchExtractor`;
+    kept as a distinct class for config/registry backward compatibility."""
 
 
 @dataclass

--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -354,6 +354,19 @@ def phonemize_worker(
          "(multilingual training)",
 )
 @click.option(
+    "--f0-method",
+    "f0_method",
+    default="pyin",
+    type=click.Choice(["pyin", "dio", "harvest"]),
+    show_default=True,
+    help="[--engine fastpitch/speedyspeech/mixer] ground-truth F0 (pitch) "
+         "extractor: 'pyin' (librosa, default, no extra native dependency) "
+         "or 'dio'/'harvest' (WORLD via pyworld, ~50x faster at "
+         "preprocessing time, requires the 'train-pyworld' extra). Must "
+         "match the f0_method the training engine config uses, since it "
+         "selects which F0 sidecar cache filename is read at train time.",
+)
+@click.option(
     "--filter",
     "quality_filters",
     multiple=True,
@@ -443,6 +456,7 @@ def cli(
     engine: Optional[str],
     speaker_encoder_path: Optional[str],
     language_id: Optional[int],
+    f0_method: str,
     quality_filters: Tuple[str, ...],
     vad_model: str,
     speaker_model: str,
@@ -826,6 +840,8 @@ def cli(
                 engine_kwargs["speaker_encoder_path"] = speaker_encoder_path
             if language_id is not None:
                 engine_kwargs["language_id"] = language_id
+            if f0_method:
+                engine_kwargs["f0_method"] = f0_method
 
         for utt in processed_utterances:
             if is_multispeaker and utt.speaker is not None:

--- a/phoonnx_train/styletts2/aligner_dataset.py
+++ b/phoonnx_train/styletts2/aligner_dataset.py
@@ -25,7 +25,7 @@ import torchaudio
 from torch.utils.data import Sampler
 
 from phoonnx_train.styletts2.meldataset import MEL_PARAMS, SPECT_PARAMS, TextCleaner
-from phoonnx_train.vendor.f0 import EXTRACTOR_TAG, extract_f0
+from phoonnx_train.vendor.f0 import extract_f0, extract_f0_world, get_extractor_tag
 
 LOG = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ def parse_list_lines(lines: List[str], root_path: str) -> List[Tuple[str, str, i
 
 class AuxMelDataset(torch.utils.data.Dataset):
     """Mel + phoneme-id dataset for the aligner; optionally F0 for the pitch
-    extractor (``with_f0=True`` computes ``librosa.pyin`` F0, cached)."""
+    extractor (``with_f0=True`` computes F0 via ``f0_method``, cached)."""
 
     def __init__(self,
                  data_list: List[str],
@@ -59,12 +59,14 @@ class AuxMelDataset(torch.utils.data.Dataset):
                  sr: int = 24000,
                  n_mels: int = MEL_PARAMS["n_mels"],
                  with_f0: bool = False,
-                 cache_features: bool = True):
+                 cache_features: bool = True,
+                 f0_method: str = "pyin"):
         self.data = parse_list_lines(data_list, root_path)
         self.sr = sr
         self.n_mels = n_mels
         self.with_f0 = with_f0
         self.cache_features = cache_features
+        self.f0_method = f0_method
         self.text_cleaner = TextCleaner()
         self.to_melspec = torchaudio.transforms.MelSpectrogram(
             n_mels=n_mels, **SPECT_PARAMS)
@@ -102,12 +104,16 @@ class AuxMelDataset(torch.utils.data.Dataset):
         # extraction-method tag is folded into the filename so a cache
         # written by a previous F0 extractor is a clean miss, not silently
         # reused
-        cache = Path(wav_path).with_suffix(f".f0-{self.sr}-{EXTRACTOR_TAG}.npy")
+        tag = get_extractor_tag(self.f0_method)
+        cache = Path(wav_path).with_suffix(f".f0-{self.sr}-{tag}.npy")
         if self.cache_features and cache.is_file():
             f0 = np.load(cache)
         else:
             x = self._load_wave(wav_path).numpy().astype(np.float64)
-            f0 = extract_f0(x, self.sr, SPECT_PARAMS["hop_length"])
+            if self.f0_method == "pyin":
+                f0 = extract_f0(x, self.sr, SPECT_PARAMS["hop_length"])
+            else:
+                f0 = extract_f0_world(x, self.sr, SPECT_PARAMS["hop_length"], method=self.f0_method)
             if self.cache_features:
                 try:
                     np.save(cache, f0)

--- a/phoonnx_train/styletts2/aligner_dataset.py
+++ b/phoonnx_train/styletts2/aligner_dataset.py
@@ -25,7 +25,7 @@ import torchaudio
 from torch.utils.data import Sampler
 
 from phoonnx_train.styletts2.meldataset import MEL_PARAMS, SPECT_PARAMS, TextCleaner
-from phoonnx_train.vendor.f0 import extract_f0
+from phoonnx_train.vendor.f0 import EXTRACTOR_TAG, extract_f0
 
 LOG = logging.getLogger(__name__)
 
@@ -99,7 +99,10 @@ class AuxMelDataset(torch.utils.data.Dataset):
         return mel
 
     def _f0(self, wav_path: str, n_frames: int) -> torch.Tensor:
-        cache = Path(wav_path).with_suffix(f".f0-{self.sr}.npy")
+        # extraction-method tag is folded into the filename so a cache
+        # written by a previous F0 extractor is a clean miss, not silently
+        # reused
+        cache = Path(wav_path).with_suffix(f".f0-{self.sr}-{EXTRACTOR_TAG}.npy")
         if self.cache_features and cache.is_file():
             f0 = np.load(cache)
         else:

--- a/phoonnx_train/styletts2/aligner_dataset.py
+++ b/phoonnx_train/styletts2/aligner_dataset.py
@@ -25,30 +25,11 @@ import torchaudio
 from torch.utils.data import Sampler
 
 from phoonnx_train.styletts2.meldataset import MEL_PARAMS, SPECT_PARAMS, TextCleaner
+from phoonnx_train.vendor.f0 import extract_f0
 
 LOG = logging.getLogger(__name__)
 
 MEL_MEAN, MEL_STD = -4, 4
-
-
-def _import_pyworld():
-    """Import ``pyworld``, shimming ``pkg_resources`` if setuptools no longer
-    ships it (removed in setuptools >= 81). pyworld's package ``__init__`` only
-    touches ``pkg_resources`` to read its own version string, so a minimal
-    stand-in keeps it importable on Python 3.12+ / modern-setuptools venvs
-    without pinning setuptools back."""
-    import sys
-    if "pkg_resources" not in sys.modules:
-        try:
-            import pkg_resources  # noqa: F401
-        except ImportError:
-            import types
-            shim = types.ModuleType("pkg_resources")
-            shim.get_distribution = lambda name: types.SimpleNamespace(
-                version="0.0.0")
-            sys.modules["pkg_resources"] = shim
-    import pyworld
-    return pyworld
 
 
 def parse_list_lines(lines: List[str], root_path: str) -> List[Tuple[str, str, int]]:
@@ -70,7 +51,7 @@ def parse_list_lines(lines: List[str], root_path: str) -> List[Tuple[str, str, i
 
 class AuxMelDataset(torch.utils.data.Dataset):
     """Mel + phoneme-id dataset for the aligner; optionally F0 for the pitch
-    extractor (``with_f0=True`` computes pyworld harvest F0, cached)."""
+    extractor (``with_f0=True`` computes ``librosa.pyin`` F0, cached)."""
 
     def __init__(self,
                  data_list: List[str],
@@ -122,13 +103,8 @@ class AuxMelDataset(torch.utils.data.Dataset):
         if self.cache_features and cache.is_file():
             f0 = np.load(cache)
         else:
-            pyworld = _import_pyworld()
             x = self._load_wave(wav_path).numpy().astype(np.float64)
-            frame_period = SPECT_PARAMS["hop_length"] / self.sr * 1000
-            f0, t = pyworld.harvest(x, self.sr, frame_period=frame_period)
-            if np.count_nonzero(f0) < 5:  # harvest failed — retry with dio
-                f0, t = pyworld.dio(x, self.sr, frame_period=frame_period)
-            f0 = pyworld.stonemask(x, f0, t, self.sr)
+            f0 = extract_f0(x, self.sr, SPECT_PARAMS["hop_length"])
             if self.cache_features:
                 try:
                     np.save(cache, f0)

--- a/phoonnx_train/styletts2/pitch_module.py
+++ b/phoonnx_train/styletts2/pitch_module.py
@@ -25,10 +25,10 @@ class PitchSegmentDataset(torch.utils.data.Dataset):
     per upstream MelDataset (features cached via AuxMelDataset)."""
 
     def __init__(self, data_list: List[str], root_path: str, sr: int,
-                 seq_len: int):
+                 seq_len: int, f0_method: str = "pyin"):
         from phoonnx_train.styletts2.aligner_dataset import AuxMelDataset
         self.inner = AuxMelDataset(data_list, root_path=root_path, sr=sr,
-                                   with_f0=True)
+                                   with_f0=True, f0_method=f0_method)
         self.seq_len = seq_len
 
     def __len__(self) -> int:
@@ -152,7 +152,8 @@ class PitchModule(pl.LightningModule):
     def _dataloader(self, data_list, validation: bool):
         ds = PitchSegmentDataset(data_list, root_path=self.config.root_path,
                                  sr=self.config.sample_rate,
-                                 seq_len=self.config.seq_len)
+                                 seq_len=self.config.seq_len,
+                                 f0_method=self.config.f0_method)
         kwargs: Dict[str, Any] = dict(
             batch_size=self.config.batch_size, shuffle=not validation,
             drop_last=not validation, num_workers=self.config.num_workers,

--- a/phoonnx_train/styletts2/pitch_module.py
+++ b/phoonnx_train/styletts2/pitch_module.py
@@ -21,7 +21,7 @@ LOG = logging.getLogger(__name__)
 
 
 class PitchSegmentDataset(torch.utils.data.Dataset):
-    """Fixed-length (seq_len) mel segments + pyworld F0 + silence labels,
+    """Fixed-length (seq_len) mel segments + pyin F0 + silence labels,
     per upstream MelDataset (features cached via AuxMelDataset)."""
 
     def __init__(self, data_list: List[str], root_path: str, sr: int,

--- a/phoonnx_train/vendor/f0.py
+++ b/phoonnx_train/vendor/f0.py
@@ -2,27 +2,46 @@
 training engine that needs a ground-truth pitch target (FastPitch, Mixer-TTS,
 the StyleTTS2 aligner/pitch-extractor auxiliaries, OptiSpeech).
 
-Built on ``librosa.pyin`` (probabilistic YIN) so no extra native dependency
-is required beyond ``librosa``, which the ``train`` extras already pull in.
+Two backends:
 
-``EXTRACTOR_TAG`` identifies the extraction method for cache-key purposes:
-every module that persists an F0 sidecar (``.npy`` cache keyed by audio
-content hash / mel-cache path) must fold this tag into the cache filename,
-so a change of extraction method here naturally invalidates every
-previously-cached F0 track instead of silently mixing tracks computed by
-different methods. Import it rather than hardcoding the string.
+- ``extract_f0`` (default): ``librosa.pyin`` (probabilistic YIN). No extra
+  native dependency beyond ``librosa``, which the ``train`` extras already
+  pull in.
+- ``extract_f0_world`` (opt-in): WORLD ``dio``/``harvest`` + ``stonemask``
+  via ``pyworld``. ~50x faster than pyin at dataset-preprocessing time, at
+  the cost of an extra native dependency (the ``train-pyworld`` extra).
+
+``get_extractor_tag(method)`` identifies the extraction method for
+cache-key purposes: every module that persists an F0 sidecar (``.npy``
+cache keyed by audio content hash / mel-cache path) must fold this tag
+into the cache filename, so a change of extraction method naturally
+invalidates every previously-cached F0 track instead of silently mixing
+tracks computed by different methods. Derive the tag from this function
+rather than hardcoding the string.
 """
 import typing
 
 if typing.TYPE_CHECKING:
     import numpy as np
 
-# Bump whenever the extraction method or its numeric behavior changes —
-# this is the single source of truth every F0 cache-key site derives from.
-EXTRACTOR_TAG = "pyin"
+_METHODS = ("pyin", "dio", "harvest")
 
 _DEFAULT_FMIN = 65.0
 _DEFAULT_FMAX = 2093.0
+
+
+def get_extractor_tag(method: str = "pyin") -> str:
+    """Cache-key tag for an F0 extraction method (``"pyin"``, ``"dio"`` or
+    ``"harvest"``). The single source of truth every F0 cache-key site
+    derives from — bump/extend ``_METHODS`` here, not at each call site."""
+    if method not in _METHODS:
+        raise ValueError(f"unknown F0 extraction method {method!r} — expected one of {_METHODS}")
+    return method
+
+
+# Default-method tag, kept for call sites/tests that don't need to be
+# method-aware — equivalent to ``get_extractor_tag()``.
+EXTRACTOR_TAG = get_extractor_tag()
 
 
 def extract_f0(wav: "np.ndarray", sample_rate: int, hop_length: int,
@@ -30,8 +49,8 @@ def extract_f0(wav: "np.ndarray", sample_rate: int, hop_length: int,
     """Frame-level fundamental frequency via probabilistic YIN.
 
     Returns a float64 array of F0 in Hz, one value per hop, 0.0 for
-    unvoiced frames — the same shape/convention the previous WORLD
-    (dio/harvest + stonemask) path produced.
+    unvoiced frames — the same shape/convention the WORLD (dio/harvest +
+    stonemask) path produces.
     """
     import numpy as np
     import librosa
@@ -51,3 +70,43 @@ def extract_f0(wav: "np.ndarray", sample_rate: int, hop_length: int,
     )
     f0 = np.nan_to_num(f0, nan=0.0).astype(np.float64)
     return f0
+
+
+def extract_f0_world(wav: "np.ndarray", sample_rate: int, hop_length: int,
+                      f_min: "typing.Optional[float]" = None,
+                      f_max: "typing.Optional[float]" = None,
+                      method: str = "dio") -> "np.ndarray":
+    """Frame-level fundamental frequency via WORLD (``pyworld``) — opt-in,
+    ~50x faster than :func:`extract_f0` at dataset-preprocessing time.
+
+    ``method`` selects ``pyworld.dio`` (fast) or ``pyworld.harvest`` (slower,
+    generally more robust); either way the raw estimate is refined with
+    ``pyworld.stonemask``, at ``frame_period = hop_length / sample_rate *
+    1000`` ms (matched to the mel hop), exactly as the previous pyworld-based
+    pipeline did. ``f_min``/``f_max`` are accepted for call-site symmetry
+    with :func:`extract_f0` but are not passed to WORLD, which the original
+    pipeline never bounded by frequency.
+
+    Requires the ``train-pyworld`` extra; raises ``ImportError`` naming it
+    when ``pyworld`` isn't installed.
+    """
+    if method not in ("dio", "harvest"):
+        raise ValueError(f"extract_f0_world method must be 'dio' or 'harvest', got {method!r}")
+
+    try:
+        import pyworld as pw
+    except ImportError as e:
+        raise ImportError(
+            "pyworld is required for WORLD F0 extraction (f0_method="
+            f"{method!r}) — install it via the 'train-pyworld' extra "
+            "(pip install phoonnx[train-pyworld])."
+        ) from e
+
+    import numpy as np
+
+    wav = np.asarray(wav, dtype=np.float64)
+    frame_period = hop_length / sample_rate * 1000.0
+    extraction_func = getattr(pw, method)
+    f0, timeaxis = extraction_func(wav, sample_rate, frame_period=frame_period)
+    f0 = pw.stonemask(wav, f0, timeaxis, sample_rate)
+    return f0.astype(np.float64)

--- a/phoonnx_train/vendor/f0.py
+++ b/phoonnx_train/vendor/f0.py
@@ -4,22 +4,38 @@ the StyleTTS2 aligner/pitch-extractor auxiliaries, OptiSpeech).
 
 Built on ``librosa.pyin`` (probabilistic YIN) so no extra native dependency
 is required beyond ``librosa``, which the ``train`` extras already pull in.
+
+``EXTRACTOR_TAG`` identifies the extraction method for cache-key purposes:
+every module that persists an F0 sidecar (``.npy`` cache keyed by audio
+content hash / mel-cache path) must fold this tag into the cache filename,
+so a change of extraction method here naturally invalidates every
+previously-cached F0 track instead of silently mixing tracks computed by
+different methods. Import it rather than hardcoding the string.
 """
-import numpy as np
-import librosa
+import typing
+
+if typing.TYPE_CHECKING:
+    import numpy as np
+
+# Bump whenever the extraction method or its numeric behavior changes —
+# this is the single source of truth every F0 cache-key site derives from.
+EXTRACTOR_TAG = "pyin"
 
 _DEFAULT_FMIN = 65.0
 _DEFAULT_FMAX = 2093.0
 
 
-def extract_f0(wav: np.ndarray, sample_rate: int, hop_length: int,
-                f_min: float = _DEFAULT_FMIN, f_max: float = _DEFAULT_FMAX) -> np.ndarray:
+def extract_f0(wav: "np.ndarray", sample_rate: int, hop_length: int,
+                f_min: float = _DEFAULT_FMIN, f_max: float = _DEFAULT_FMAX) -> "np.ndarray":
     """Frame-level fundamental frequency via probabilistic YIN.
 
     Returns a float64 array of F0 in Hz, one value per hop, 0.0 for
     unvoiced frames — the same shape/convention the previous WORLD
     (dio/harvest + stonemask) path produced.
     """
+    import numpy as np
+    import librosa
+
     if not f_min:
         f_min = _DEFAULT_FMIN
     if not f_max:

--- a/phoonnx_train/vendor/f0.py
+++ b/phoonnx_train/vendor/f0.py
@@ -1,0 +1,37 @@
+"""Frame-level fundamental-frequency (F0/pitch) extraction shared by every
+training engine that needs a ground-truth pitch target (FastPitch, Mixer-TTS,
+the StyleTTS2 aligner/pitch-extractor auxiliaries, OptiSpeech).
+
+Built on ``librosa.pyin`` (probabilistic YIN) so no extra native dependency
+is required beyond ``librosa``, which the ``train`` extras already pull in.
+"""
+import numpy as np
+import librosa
+
+_DEFAULT_FMIN = 65.0
+_DEFAULT_FMAX = 2093.0
+
+
+def extract_f0(wav: np.ndarray, sample_rate: int, hop_length: int,
+                f_min: float = _DEFAULT_FMIN, f_max: float = _DEFAULT_FMAX) -> np.ndarray:
+    """Frame-level fundamental frequency via probabilistic YIN.
+
+    Returns a float64 array of F0 in Hz, one value per hop, 0.0 for
+    unvoiced frames — the same shape/convention the previous WORLD
+    (dio/harvest + stonemask) path produced.
+    """
+    if not f_min:
+        f_min = _DEFAULT_FMIN
+    if not f_max:
+        f_max = _DEFAULT_FMAX
+    wav = np.asarray(wav, dtype=np.float64)
+    f0, _voiced_flag, _voiced_prob = librosa.pyin(
+        wav,
+        fmin=f_min,
+        fmax=f_max,
+        sr=sample_rate,
+        hop_length=hop_length,
+        fill_na=0.0,
+    )
+    f0 = np.nan_to_num(f0, nan=0.0).astype(np.float64)
+    return f0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,14 @@ train-optispeech = [
     "onnx",
     "opt_einsum",
 ]
+# opt-in WORLD F0 backend (f0_method="dio"/"harvest") for FastPitch,
+# Mixer-TTS, StyleTTS2-pitch and OptiSpeech: ~50x faster than the default
+# librosa.pyin backend at dataset-preprocessing time. setuptools<81 is
+# needed because pyworld imports pkg_resources at runtime.
+train-pyworld = [
+    "pyworld>=0.3.2",
+    "setuptools<81",
+]
 ar = ["epitran", "arbtok", "text2tashkeel"]
 ca = ["epitran"]
 gl = ["pycotovia>=0.1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ train-styletts2 = [
     "transformers>=4.48",  # PL-BERT backbones (albert / modernbert)
     "torchaudio",
     "soundfile",
-    "pyworld>=0.3.2",  # ground-truth F0 for styletts2-pitch
     "pandas",
     "PyYAML",
 ]
@@ -133,31 +132,23 @@ train-data = [
     "soundfile",
 ]
 # extra deps for the FastPitch / SpeedySpeech training engine
-# (phoonnx_train/engines/fastpitch.py) on top of [train]: pyworld for F0
-# (pitch) extraction in extra_preprocess. librosa is already in [train].
-train-fastpitch = [
-    "pyworld>=0.3.2",
-]
+# (phoonnx_train/engines/fastpitch.py) on top of [train]: F0 (pitch)
+# extraction in extra_preprocess uses librosa.pyin, already in [train].
+train-fastpitch = []
 # extra deps for the Mixer-TTS training engine (phoonnx_train/engines/mixer.py)
-# on top of [train]: pyworld for the shared F0 (pitch) sidecar cache. einops
-# (Mixer blocks / aligner) and numba (monotonic alignment search) are already
-# pulled in via [train] (numba transitively through librosa on <3.13).
-train-mixer = [
-    "pyworld>=0.3.2",
-]
+# on top of [train]: the shared F0 (pitch) sidecar cache uses librosa.pyin,
+# already in [train]. einops (Mixer blocks / aligner) and numba (monotonic
+# alignment search) are also already pulled in via [train] (numba
+# transitively through librosa on <3.13).
+train-mixer = []
 # extra deps for the OptiSpeech training engine
 # (phoonnx_train/optispeech/ + phoonnx_train/engines/optispeech.py) on top of
-# [train]: pyworld for the DIO/Harvest F0 pitch extractor, scipy for pitch
-# interpolation, torchaudio for the vocoder-discriminator resampling / STFT
-# losses, and onnx to embed the inference metadata into the exported model.
-# The perceptual validation metrics (UTMOS / PESQ / periodicity) stay optional
-# and are off by default, so they add no deps here.
+# [train]: scipy for pitch interpolation (the pitch extractor itself uses
+# librosa.pyin, already in [train]), torchaudio for the vocoder-discriminator
+# resampling / STFT losses, and onnx to embed the inference metadata into the
+# exported model. The perceptual validation metrics (UTMOS / PESQ /
+# periodicity) stay optional and are off by default, so they add no deps here.
 train-optispeech = [
-    "pyworld>=0.3.2",
-    # pyworld imports pkg_resources at runtime; python>=3.12 environments no
-    # longer ship setuptools implicitly, and setuptools>=81 removed
-    # pkg_resources entirely
-    "setuptools<81",
     "pyloudnorm",
     "scipy",
     "torchaudio",

--- a/tests/test_fastpitch_training.py
+++ b/tests/test_fastpitch_training.py
@@ -178,7 +178,7 @@ def test_pitch_stats_computed_and_cached(tmp_path):
     f0_path = _write_f0(tmp_path / "utt0.f0.npy")
     mean, std = pitch_stats.load_or_compute_pitch_stats([tmp_path], [f0_path])
     assert 190 < mean < 210 and 0 < std < 30
-    cached = json.loads((tmp_path / "pitch_stats.json").read_text())
+    cached = json.loads((tmp_path / pitch_stats.STATS_FILENAME).read_text())
     assert cached["mean"] == mean and cached["std"] == std
     # cached value is reused even if the f0 files disappear
     f0_path.unlink()
@@ -208,7 +208,7 @@ def test_pitch_stats_all_unvoiced_is_identity(tmp_path):
     json.dumps({"mean": 100.0, "std": 0.0}),     # zero std divisor
 ])
 def test_pitch_stats_malformed_cache_recomputed(tmp_path, payload):
-    (tmp_path / "pitch_stats.json").write_text(payload)
+    (tmp_path / pitch_stats.STATS_FILENAME).write_text(payload)
     f0_path = _write_f0(tmp_path / "utt0.f0.npy")
     mean, std = pitch_stats.load_or_compute_pitch_stats([tmp_path], [f0_path])
     assert 190 < mean < 210 and std > 0
@@ -219,4 +219,4 @@ def test_pitch_stats_no_dataset_dir_still_computes(tmp_path):
     mean, std = pitch_stats.load_or_compute_pitch_stats(
         [tmp_path / "dataset.jsonl"], [f0_path])  # file, not dir — no cache
     assert 190 < mean < 210
-    assert not (tmp_path / "pitch_stats.json").exists()
+    assert not (tmp_path / pitch_stats.STATS_FILENAME).exists()

--- a/tests/test_fastpitch_training.py
+++ b/tests/test_fastpitch_training.py
@@ -142,8 +142,36 @@ def _write_f0(path: Path, voiced_value=200.0, n=50, voiced=slice(10, 40)):
 
 
 def test_f0_cache_path_strips_double_suffix(tmp_path):
+    from phoonnx_train.vendor.f0 import EXTRACTOR_TAG
+
     spec_path = tmp_path / "utt0.spec.pt"
-    assert pitch_stats.f0_cache_path(spec_path) == tmp_path / "utt0.f0.npy"
+    assert (pitch_stats.f0_cache_path(spec_path)
+            == tmp_path / f"utt0.f0-{EXTRACTOR_TAG}.npy")
+
+
+def test_f0_cache_path_keys_by_extraction_method(tmp_path):
+    """A cache written under the pre-pyin (pyworld-era) naming scheme is a
+    clean miss under the current key — it must not be silently reused with
+    the new extractor — while a cache written under the current key round-
+    trips (write, then read hits the same path)."""
+    from phoonnx_train.vendor.f0 import EXTRACTOR_TAG
+
+    spec_path = tmp_path / "utt0.spec.pt"
+    legacy_path = tmp_path / "utt0.f0.npy"  # pre-tag (pyworld-era) filename
+    current_path = pitch_stats.f0_cache_path(spec_path)
+
+    assert current_path != legacy_path
+    assert current_path.name == f"utt0.f0-{EXTRACTOR_TAG}.npy"
+
+    # a stale pyworld-era cache sitting next to the spec is never picked up
+    _write_f0(legacy_path)
+    assert not current_path.exists()
+
+    # writing under the current key makes it discoverable by the same
+    # derivation used at read time
+    _write_f0(current_path)
+    assert pitch_stats.f0_cache_path(spec_path) == current_path
+    assert current_path.exists()
 
 
 def test_pitch_stats_computed_and_cached(tmp_path):

--- a/tests/test_fastpitch_training.py
+++ b/tests/test_fastpitch_training.py
@@ -116,13 +116,13 @@ def test_kwargs_config_wins_over_extra_symbol_count():
 
 # --------------------------------------------------------- extra_preprocess
 def test_extra_preprocess_missing_deps_returns_empty(monkeypatch, tmp_path):
-    """When pyworld/librosa aren't importable, extra_preprocess degrades to {}."""
+    """When librosa isn't importable, extra_preprocess degrades to {}."""
     engine = ForwardTTSTrainingEngine()
     import builtins
     real_import = builtins.__import__
 
     def fake_import(name, *a, **k):
-        if name in ("pyworld", "librosa"):
+        if name in ("librosa", "phoonnx_train.vendor.f0"):
             raise ImportError(name)
         return real_import(name, *a, **k)
 

--- a/tests/test_fastpitch_training.py
+++ b/tests/test_fastpitch_training.py
@@ -132,6 +132,44 @@ def test_extra_preprocess_missing_deps_returns_empty(monkeypatch, tmp_path):
     assert not (tmp_path / "cache").exists()  # nothing written
 
 
+def _write_sine_wav(path: Path, freq_hz: float = 220.0, seconds: float = 0.5,
+                    sr: int = 22050) -> None:
+    import wave as wave_mod
+
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False)
+    samples = (0.3 * np.sin(2 * np.pi * freq_hz * t) * 32767).astype(np.int16)
+    with wave_mod.open(str(path), "wb") as fh:
+        fh.setnchannels(1)
+        fh.setsampwidth(2)
+        fh.setframerate(sr)
+        fh.writeframes(samples.tobytes())
+
+
+def test_extra_preprocess_f0_method_selects_cache_filename(tmp_path):
+    """pyin (default) and dio (WORLD, opt-in) must write to distinct cache
+    filenames for the same utterance — no silent cross-method reuse."""
+    engine = ForwardTTSTrainingEngine()
+    wav_path = tmp_path / "a.wav"
+    _write_sine_wav(wav_path)
+    cache_dir = tmp_path / "cache"
+
+    pyin_result = engine.extra_preprocess(wav_path, cache_dir, 22050, f0_method="pyin")
+    dio_result = engine.extra_preprocess(wav_path, cache_dir, 22050, f0_method="dio")
+
+    assert pyin_result and dio_result
+    pyin_path = Path(pyin_result["f0_path"])
+    dio_path = Path(dio_result["f0_path"])
+    assert pyin_path != dio_path
+    assert pyin_path.name.endswith("f0-pyin.npy")
+    assert dio_path.name.endswith("f0-dio.npy")
+    assert pyin_path.is_file() and dio_path.is_file()
+
+    pyin_f0 = np.load(pyin_path)
+    dio_f0 = np.load(dio_path)
+    assert np.any(pyin_f0 > 0)
+    assert np.any(dio_f0 > 0)
+
+
 # ------------------------------------------------------------- pitch stats
 def _write_f0(path: Path, voiced_value=200.0, n=50, voiced=slice(10, 40)):
     f0 = np.zeros(n, dtype=np.float32)
@@ -172,6 +210,46 @@ def test_f0_cache_path_keys_by_extraction_method(tmp_path):
     _write_f0(current_path)
     assert pitch_stats.f0_cache_path(spec_path) == current_path
     assert current_path.exists()
+
+
+def test_f0_cache_path_separates_pyin_and_world_methods(tmp_path):
+    """dio/harvest are opt-in WORLD backends and must get their own cache
+    filenames — never silently share a pyin-era (or each other's) cache."""
+    spec_path = tmp_path / "utt0.spec.pt"
+    pyin_path = pitch_stats.f0_cache_path(spec_path, method="pyin")
+    dio_path = pitch_stats.f0_cache_path(spec_path, method="dio")
+    harvest_path = pitch_stats.f0_cache_path(spec_path, method="harvest")
+
+    assert len({pyin_path, dio_path, harvest_path}) == 3
+    assert pyin_path.name == "utt0.f0-pyin.npy"
+    assert dio_path.name == "utt0.f0-dio.npy"
+    assert harvest_path.name == "utt0.f0-harvest.npy"
+
+
+def test_stats_filename_separates_methods(tmp_path):
+    assert pitch_stats.stats_filename("pyin") == "pitch_stats-pyin.json"
+    assert pitch_stats.stats_filename("dio") == "pitch_stats-dio.json"
+    assert pitch_stats.stats_filename("harvest") == "pitch_stats-harvest.json"
+    assert len({
+        pitch_stats.stats_filename("pyin"),
+        pitch_stats.stats_filename("dio"),
+        pitch_stats.stats_filename("harvest"),
+    }) == 3
+
+
+def test_load_or_compute_pitch_stats_keyed_by_method(tmp_path):
+    """Stats computed under one method's cache file must not be read back
+    (or overwritten) under a different method's stats filename."""
+    pyin_f0 = _write_f0(tmp_path / "utt0.f0-pyin.npy", voiced_value=200.0)
+    dio_f0 = _write_f0(tmp_path / "utt0.f0-dio.npy", voiced_value=300.0)
+
+    pyin_mean, _ = pitch_stats.load_or_compute_pitch_stats([tmp_path], [pyin_f0], method="pyin")
+    dio_mean, _ = pitch_stats.load_or_compute_pitch_stats([tmp_path], [dio_f0], method="dio")
+
+    assert 190 < pyin_mean < 210
+    assert 290 < dio_mean < 310
+    assert (tmp_path / "pitch_stats-pyin.json").is_file()
+    assert (tmp_path / "pitch_stats-dio.json").is_file()
 
 
 def test_pitch_stats_computed_and_cached(tmp_path):

--- a/tests/test_mixertts_training.py
+++ b/tests/test_mixertts_training.py
@@ -100,14 +100,14 @@ def test_kwargs_gan_flag_passes_through():
 
 # --------------------------------------------------------- extra_preprocess
 def test_extra_preprocess_missing_deps_returns_empty(monkeypatch, tmp_path):
-    """Shared with the FastPitch engine: without pyworld/librosa it
+    """Shared with the FastPitch engine: without librosa it
     degrades to {} instead of crashing preprocessing."""
     engine = MixerTTSTrainingEngine()
     import builtins
     real_import = builtins.__import__
 
     def fake_import(name, *a, **k):
-        if name in ("pyworld", "librosa"):
+        if name in ("librosa", "phoonnx_train.vendor.f0"):
             raise ImportError(name)
         return real_import(name, *a, **k)
 

--- a/tests/test_optispeech_training.py
+++ b/tests/test_optispeech_training.py
@@ -21,6 +21,7 @@ from phoonnx_train.engines.base import TrainingEngineConfig
 from phoonnx_train.engines.optispeech import (
     OptiSpeechEngineConfig,
     OptiSpeechTrainingEngine,
+    _build_feature_extractor,
     _QUALITY_PRESETS,
 )
 from phoonnx_train.torch_compat import trusting_torch_load
@@ -154,6 +155,29 @@ class ConfigTests(unittest.TestCase):
             TrainingEngineConfig(num_symbols=40, extra={"quality": "x-low", "dim": 999})
         )
         self.assertEqual(before, _QUALITY_PRESETS)
+
+    def test_f0_method_selects_pitch_extractor_class(self):
+        from phoonnx_train.optispeech.dataset.feature_extractors.pitch_extractors import (
+            DIOPitchExtractor,
+            HarvestPitchExtractor,
+            PyinPitchExtractor,
+        )
+
+        cases = {"pyin": PyinPitchExtractor, "dio": DIOPitchExtractor,
+                 "harvest": HarvestPitchExtractor}
+        for method, expected_cls in cases.items():
+            cfg = OptiSpeechEngineConfig.from_training_config(
+                TrainingEngineConfig(num_symbols=40, extra={"f0_method": method, **_min()})
+            )
+            self.assertEqual(cfg.f0_method, method)
+            extractor = _build_feature_extractor(cfg)
+            self.assertIs(extractor.pitch_extractor_initializer.func, expected_cls)
+
+    def test_f0_method_defaults_to_pyin(self):
+        cfg = OptiSpeechEngineConfig.from_training_config(
+            TrainingEngineConfig(num_symbols=40, extra=_min())
+        )
+        self.assertEqual(cfg.f0_method, "pyin")
 
 
 class ConstructionTests(unittest.TestCase):

--- a/tests/test_styletts2_aux_training.py
+++ b/tests/test_styletts2_aux_training.py
@@ -150,6 +150,29 @@ def test_f0_cache_keyed_by_extraction_method(dataset_dir):
     assert np.allclose(f0_2.numpy()[:n], cached_value[:n])
 
 
+def test_f0_method_dio_uses_distinct_cache_from_pyin(dataset_dir):
+    """f0_method='dio' (WORLD, opt-in via train-pyworld) must cache under
+    its own filename, separate from the default pyin cache — real pyworld
+    extraction, not mocked."""
+    from phoonnx_train.styletts2.aligner_dataset import AuxMelDataset
+
+    lines = ["utt0.wav|mɐɲˈɐ|0"]
+    root = str(dataset_dir / "wavs")
+    wav_path = dataset_dir / "wavs" / "utt0.wav"
+    sr = 24000
+    pyin_cache = wav_path.with_suffix(f".f0-{sr}-pyin.npy")
+    dio_cache = wav_path.with_suffix(f".f0-{sr}-dio.npy")
+
+    ds_pyin = AuxMelDataset(lines, root_path=root, sr=sr, with_f0=True, f0_method="pyin")
+    ds_pyin[0]
+    ds_dio = AuxMelDataset(lines, root_path=root, sr=sr, with_f0=True, f0_method="dio")
+    ds_dio[0]
+
+    assert pyin_cache.is_file()
+    assert dio_cache.is_file()
+    assert pyin_cache != dio_cache
+
+
 def test_aligner_training_step_runs():
     module = AlignerModule(AlignerConfig(**TINY_ALIGNER))
     loss = module.training_step(_aligner_batch(), 0)

--- a/tests/test_styletts2_aux_training.py
+++ b/tests/test_styletts2_aux_training.py
@@ -114,6 +114,42 @@ def test_pitch_dataset_never_stretches_mel(dataset_dir):
     assert f0.size(0) == pitch_mel.size(1)  # F0 aligned to unstretched mel
 
 
+def test_f0_cache_keyed_by_extraction_method(dataset_dir):
+    """A pre-tag (pyworld-era) F0 cache sitting next to the wav is a clean
+    miss — fresh extraction runs and writes under the current key — while a
+    cache already written under the current key round-trips without
+    recomputation."""
+    import numpy as np
+    from phoonnx_train.styletts2.aligner_dataset import AuxMelDataset
+    from phoonnx_train.vendor.f0 import EXTRACTOR_TAG
+
+    lines = ["utt0.wav|mɐɲˈɐ|0"]
+    root = str(dataset_dir / "wavs")
+    wav_path = dataset_dir / "wavs" / "utt0.wav"
+    sr = 24000
+    current_cache = wav_path.with_suffix(f".f0-{sr}-{EXTRACTOR_TAG}.npy")
+    legacy_cache = wav_path.with_suffix(f".f0-{sr}.npy")  # pre-tag filename
+
+    assert current_cache != legacy_cache
+
+    # a stale pyworld-era cache is ignored; a real extraction still runs and
+    # writes under the current (tagged) key
+    legacy_sentinel = np.full(5, 999.0, dtype=np.float64)
+    np.save(legacy_cache, legacy_sentinel)
+    ds = AuxMelDataset(lines, root_path=root, sr=sr, with_f0=True)
+    _mel, _text, f0 = ds[0]
+    assert not np.array_equal(f0.numpy()[:5], legacy_sentinel)
+    assert current_cache.is_file()
+
+    # a cache under the current key round-trips: writing then reading hits
+    # the same path without needing a fresh extraction
+    cached_value = np.load(current_cache)
+    ds2 = AuxMelDataset(lines, root_path=root, sr=sr, with_f0=True)
+    _mel2, _text2, f0_2 = ds2[0]
+    n = min(len(cached_value), f0_2.numel())
+    assert np.allclose(f0_2.numpy()[:n], cached_value[:n])
+
+
 def test_aligner_training_step_runs():
     module = AlignerModule(AlignerConfig(**TINY_ALIGNER))
     loss = module.training_step(_aligner_batch(), 0)

--- a/tests/test_vendor_f0.py
+++ b/tests/test_vendor_f0.py
@@ -102,6 +102,30 @@ def test_extract_f0_world_harvest_matches_frequency():
     assert abs(np.median(voiced) - 220.0) <= 10.0
 
 
+@pytest.mark.parametrize("freq", [110.0, 220.0, 440.0])
+def test_pyin_and_world_agree_on_known_frequency(freq):
+    """The default pyin backend and the WORLD (dio + stonemask) backend must
+    track the same pitch on a tone of known frequency — a silently wrong F0
+    target would corrupt every model trained with it."""
+    sample_rate = 22050
+    hop_length = 256
+    wav = _sine(freq, sample_rate=sample_rate, duration_s=1.0)
+
+    pyin = extract_f0(wav, sample_rate, hop_length)
+    world = extract_f0_world(wav, sample_rate, hop_length, method="dio")
+
+    pyin_median = np.median(pyin[pyin > 0])
+    world_median = np.median(world[world > 0])
+
+    # each backend is within 1% of the true frequency ...
+    assert abs(pyin_median - freq) / freq < 0.01
+    assert abs(world_median - freq) / freq < 0.01
+    # ... and within 1% of each other
+    assert abs(pyin_median - world_median) / freq < 0.01
+    # both produce one value per hop, so the F0 track lines up with the mel
+    assert abs(len(pyin) - len(world)) <= 1
+
+
 def test_extract_f0_world_silence_is_all_zero():
     sample_rate = 22050
     hop_length = 256

--- a/tests/test_vendor_f0.py
+++ b/tests/test_vendor_f0.py
@@ -1,15 +1,35 @@
-"""Tests for the shared pyin-based F0 extractor
-(phoonnx_train.vendor.f0.extract_f0), the in-repo ground-truth pitch path
-used by the FastPitch/Mixer-TTS/StyleTTS2/OptiSpeech training engines.
+"""Tests for the shared F0 extractors (phoonnx_train.vendor.f0), the
+in-repo ground-truth pitch path used by the FastPitch/Mixer-TTS/StyleTTS2/
+OptiSpeech training engines: ``extract_f0`` (librosa.pyin, default) and
+``extract_f0_world`` (pyworld dio/harvest, opt-in via the train-pyworld
+extra).
 """
 import numpy as np
+import pytest
 
-from phoonnx_train.vendor.f0 import extract_f0
+from phoonnx_train.vendor.f0 import (
+    EXTRACTOR_TAG,
+    extract_f0,
+    extract_f0_world,
+    get_extractor_tag,
+)
 
 
 def _sine(freq_hz, sample_rate=22050, duration_s=1.0):
     t = np.arange(int(sample_rate * duration_s)) / sample_rate
     return np.sin(2 * np.pi * freq_hz * t).astype(np.float64)
+
+
+def _noisy_sine(freq_hz, sample_rate=22050, duration_s=1.0, seed=0):
+    """WORLD's harvest returns all-unvoiced on a pure synthetic sine (its
+    aperiodicity estimator reads a perfectly clean tone as unnatural); a
+    lightly amplitude/noise-modulated tone is tracked normally, so this is
+    used for harvest-specific tests."""
+    rng = np.random.RandomState(seed)
+    n = int(sample_rate * duration_s)
+    t = np.arange(n) / sample_rate
+    sine = np.sin(2 * np.pi * freq_hz * t)
+    return (sine * (1.0 + 0.05 * rng.randn(n)) + 0.01 * rng.randn(n)).astype(np.float64)
 
 
 def test_extract_f0_sine_wave_matches_frequency():
@@ -41,3 +61,73 @@ def test_extract_f0_frame_count_matches_hop_grid():
     # librosa frame-level features (STFT-equivalent frame count)
     expected_frames = 1 + len(wav) // hop_length
     assert abs(len(f0) - expected_frames) <= 1
+
+
+# --------------------------------------------------------- get_extractor_tag
+def test_get_extractor_tag_default_is_pyin():
+    assert get_extractor_tag() == "pyin" == EXTRACTOR_TAG
+
+
+@pytest.mark.parametrize("method", ["pyin", "dio", "harvest"])
+def test_get_extractor_tag_known_methods(method):
+    assert get_extractor_tag(method) == method
+
+
+def test_get_extractor_tag_unknown_method_raises():
+    with pytest.raises(ValueError):
+        get_extractor_tag("crepe")
+
+
+# -------------------------------------------------------- extract_f0_world
+def test_extract_f0_world_dio_matches_frequency():
+    sample_rate = 22050
+    hop_length = 256
+    wav = _sine(220.0, sample_rate=sample_rate, duration_s=1.0)
+    f0 = extract_f0_world(wav, sample_rate, hop_length, method="dio")
+    assert f0.dtype == np.float64
+    voiced = f0[f0 > 0]
+    assert voiced.size > 0
+    assert abs(np.median(voiced) - 220.0) <= 10.0
+
+
+def test_extract_f0_world_harvest_matches_frequency():
+    # harvest reads a perfectly clean synthetic sine as unnatural and
+    # returns all-unvoiced; a lightly modulated tone is tracked normally
+    sample_rate = 22050
+    hop_length = 256
+    wav = _noisy_sine(220.0, sample_rate=sample_rate, duration_s=1.0)
+    f0 = extract_f0_world(wav, sample_rate, hop_length, method="harvest")
+    voiced = f0[f0 > 0]
+    assert voiced.size > 0
+    assert abs(np.median(voiced) - 220.0) <= 10.0
+
+
+def test_extract_f0_world_silence_is_all_zero():
+    sample_rate = 22050
+    hop_length = 256
+    wav = np.zeros(sample_rate, dtype=np.float64)
+    f0 = extract_f0_world(wav, sample_rate, hop_length, method="dio")
+    assert np.all(f0 == 0.0)
+
+
+def test_extract_f0_world_invalid_method_raises():
+    wav = _sine(220.0)
+    with pytest.raises(ValueError):
+        extract_f0_world(wav, 22050, 256, method="pyin")
+
+
+def test_extract_f0_world_missing_pyworld_raises_named_import_error(monkeypatch):
+    """When pyworld isn't importable, the error message names the
+    train-pyworld extra instead of a bare ModuleNotFoundError."""
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "pyworld":
+            raise ImportError(name)
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    wav = _sine(220.0)
+    with pytest.raises(ImportError, match="train-pyworld"):
+        extract_f0_world(wav, 22050, 256, method="dio")

--- a/tests/test_vendor_f0.py
+++ b/tests/test_vendor_f0.py
@@ -1,0 +1,43 @@
+"""Tests for the shared pyin-based F0 extractor
+(phoonnx_train.vendor.f0.extract_f0), the in-repo ground-truth pitch path
+used by the FastPitch/Mixer-TTS/StyleTTS2/OptiSpeech training engines.
+"""
+import numpy as np
+
+from phoonnx_train.vendor.f0 import extract_f0
+
+
+def _sine(freq_hz, sample_rate=22050, duration_s=1.0):
+    t = np.arange(int(sample_rate * duration_s)) / sample_rate
+    return np.sin(2 * np.pi * freq_hz * t).astype(np.float64)
+
+
+def test_extract_f0_sine_wave_matches_frequency():
+    sample_rate = 22050
+    hop_length = 256
+    wav = _sine(220.0, sample_rate=sample_rate, duration_s=1.0)
+    f0 = extract_f0(wav, sample_rate, hop_length)
+    assert f0.dtype == np.float64
+    voiced = f0[f0 > 0]
+    assert voiced.size > 0
+    assert abs(np.median(voiced) - 220.0) <= 10.0
+
+
+def test_extract_f0_silence_is_all_zero():
+    sample_rate = 22050
+    hop_length = 256
+    wav = np.zeros(sample_rate, dtype=np.float64)
+    f0 = extract_f0(wav, sample_rate, hop_length)
+    assert np.all(f0 == 0.0)
+    assert not np.any(np.isnan(f0))
+
+
+def test_extract_f0_frame_count_matches_hop_grid():
+    sample_rate = 22050
+    hop_length = 256
+    wav = _sine(220.0, sample_rate=sample_rate, duration_s=1.0)
+    f0 = extract_f0(wav, sample_rate, hop_length)
+    # librosa.pyin frames the signal on the same hop grid as other
+    # librosa frame-level features (STFT-equivalent frame count)
+    expected_frames = 1 + len(wav) // hop_length
+    assert abs(len(f0) - expected_frames) <= 1


### PR DESCRIPTION
Removes `pyworld` from every default install path. Ground-truth F0 (pitch) extraction for FastPitch, Mixer-TTS, the StyleTTS2 pitch/aligner auxiliaries and OptiSpeech goes through a single in-repo module, `phoonnx_train/vendor/f0.py`:

- **Default**: `extract_f0` — `librosa.pyin` (probabilistic YIN), pure Python, no native dependency beyond librosa (already in the train extras). No WORLD build, no `setuptools<81`/`pkg_resources` workaround.
- **Opt-in**: `extract_f0_world` — WORLD `dio`/`harvest` + `stonemask` via the `train-pyworld` extra, ~50x faster at dataset preprocessing (measured: 0.09 s vs 4.2 s per 10 s of audio for dio vs pyin). Selected with the uniform `f0_method` config knob (`pyin` | `dio` | `harvest`) available on every pitch-consuming engine and as `--f0-method` on the preprocess CLI.

Cache coherence: per-utterance F0 sidecars **and** the corpus `pitch_stats` mean/std file are keyed by extraction method, so tracks and stats from different extractors are never silently mixed — switching methods is a clean cache miss and regenerate.

Behavioral notes:
- pyin voicing decisions and Hz values differ frame-by-frame from WORLD; frame-length, interpolation and trim/pad handling is unchanged at every call site.
- In optispeech, `dio`/`harvest` extractor keys mean genuine WORLD again (requiring the extra); `pyin` is the default extractor and the ensemble extractor no longer hard-depends on pyworld.
- Resuming a pre-existing run with the default settings regenerates targets with pyin; pass `f0_method: dio` (or `harvest`) with the `train-pyworld` extra for exact continuity with previous caches' extraction method.

Tests cover `extract_f0` (220 Hz sine ±10 Hz, silence → zeros), real WORLD extraction for both methods, cache/stats key separation across methods, the ImportError message when pyworld is absent, and per-engine `f0_method` plumbing.

Implementation by a Sonnet subagent, reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)