### PR TITLE
feat: add SuperTonic training pipeline

### DIFF
--- a/docs/training/engines/supertonic.md
+++ b/docs/training/engines/supertonic.md
@@ -1,0 +1,204 @@
+# SuperTonic Engine (training)
+
+This page teaches, from zero, how to train a **SuperTonic** text-to-speech model
+in phoonnx: what each of its three stages is, how to prepare data, how to train
+and resume each stage, how to fine-tune from the released weights, and how to
+export the four ONNX graphs the phoonnx `supertonic` runtime consumes.
+
+> Related: [training reference](../training.md) ·
+> [adapter architecture](../../engines.md) · [export](../export.md)
+
+## What SuperTonic is
+
+**SuperTonic** (Kim et al., Supertone Inc., *SupertonicTTS*,
+[arXiv:2503.23108](https://arxiv.org/abs/2503.23108)) is a fast, multilingual
+text-to-speech system. Unlike a single end-to-end model, it is built from **three
+networks that are trained one after another**, each solving one piece of the
+problem:
+
+1. **Speech autoencoder** — learns to compress a waveform into a compact
+   *latent* sequence and reconstruct the waveform from it. A *latent* here is
+   just a short numeric summary of a slice of audio: instead of ~22050 numbers
+   per second of sound, the autoencoder keeps a few dozen channels at a much
+   lower frame rate. It is trained like a vocoder GAN — a *generator* (the
+   autoencoder) versus *discriminators* that try to tell real audio from
+   reconstructed audio, which pushes the reconstruction to sound natural.
+2. **Text-to-latent** — learns to turn text into one of those latent sequences,
+   in a chosen voice. It uses **flow matching**: think of it as learning the
+   direction to "flow" a cloud of random noise, step by step, until it becomes a
+   valid speech latent for the given text. At synthesis time you start from noise
+   and take a handful of small steps along the learned directions.
+3. **Duration predictor** — learns how *long* the spoken sentence should be (in
+   seconds) from the text and the target voice, so the flow-matching stage knows
+   how many latent frames to generate.
+
+The text side is **grapheme-level and G2P-free**: SuperTonic reads raw
+characters (wrapped in a `<lang>…</lang>` tag), so no phonemizer is involved. The
+voice ("style") is supplied at inference as a small per-speaker JSON, so the two
+text stages consume a pre-computed style vector rather than a speaker encoder.
+
+## When to pick it
+
+Pick SuperTonic for a fast, compact, multilingual model where you can train all
+three stages, and where reading raw text (no phoneme dictionary) is an advantage.
+It is an **iterative** engine like ZipVoice (a short sampling loop), but with a
+separate learned duration model instead of in-context infilling.
+
+## Install
+
+```bash
+pip install phoonnx[train]        # torch, pytorch-lightning, torchaudio
+pip install phoonnx[train-resample]  # only if your audio is not already at the model sample rate
+```
+
+## Prepare data
+
+SuperTonic is grapheme-level, so it trains directly from **raw text**, not from
+phoneme ids. It therefore uses a simple filelist rather than the phoneme-oriented
+`dataset.jsonl` other engines use. One utterance per line:
+
+```
+audio/utt0001.wav|Hello there, this is a test.|en
+audio/utt0002.wav|Another line of speech.|en
+```
+
+- Column 1: path to an audio file, relative to a `root_dir` you pass in.
+- Column 2: the transcript, exactly as it should be read.
+- Column 3 (optional): a language code (`en`, `ko`, `ja`, `ar`, `pt`, … — the 31
+  SuperTonic languages, defaulting to `en`).
+
+Any `soundfile`-readable format works; audio at a different sample rate is
+resampled on load.
+
+## Train the three stages
+
+Each stage is a separate LightningModule (`phoonnx_train/supertonic/lightning.py`)
+and is trained in order, because stages 2 and 3 need the frozen stage-1
+autoencoder to produce their target latents.
+
+```python
+import pytorch_lightning as pl
+from phoonnx_train.supertonic.config import SuperTonicConfig
+from phoonnx_train.supertonic.text import CharTokenizer
+from phoonnx_train.supertonic.lightning import (
+    AutoencoderModule, TextToLatentModule, DurationPredictorModule,
+)
+
+cfg = SuperTonicConfig(vocab_size=512)          # or config.tiny_config(...) for a smoke run
+tok = CharTokenizer.build_from_texts(open_transcripts, langs)  # build the char->id map
+files = ["train.filelist"]
+root = "/path/to/audio_root"
+
+# Stage 1 — speech autoencoder (GAN)
+ae = AutoencoderModule(config=cfg, dataset=files, root_dir=root, batch_size=8)
+pl.Trainer(accelerator="gpu", devices=1, max_steps=400_000).fit(ae)
+ae_ckpt = "ae.ckpt"; ae.trainer.save_checkpoint(ae_ckpt)
+
+# Stage 2 — text-to-latent (flow matching), targets from the frozen autoencoder
+ttl = TextToLatentModule(config=cfg, tokenizer=tok, dataset=files, root_dir=root,
+                         ae_checkpoint=ae_ckpt, batch_size=8)
+pl.Trainer(accelerator="gpu", devices=1, max_steps=600_000).fit(ttl)
+
+# Stage 3 — duration predictor
+dp = DurationPredictorModule(config=cfg, tokenizer=tok, dataset=files, root_dir=root,
+                             ae_checkpoint=ae_ckpt, batch_size=8)
+pl.Trainer(accelerator="gpu", devices=1, max_steps=100_000).fit(dp)
+```
+
+Stage 1 measures the per-channel statistics of its own latent space at the end of
+every epoch and stores them in the checkpoint. Stages 2 and 3 normalize their
+targets with those statistics, so they refuse an autoencoder checkpoint that does
+not carry them — train stage 1 at least to the end of one epoch before starting
+either.
+
+Via the shared CLI/registry the engine name is `supertonic` and the stage is
+chosen with `stage=` in the engine's `extra` bag; `--quality low` selects a tiny
+architecture for a smoke run, `--quality base` the full size.
+
+### Resuming
+
+Every stage writes standard Lightning checkpoints, which carry the model,
+optimizer, LR-scheduler and step — plus the SuperTonic config and tokenizer, so a
+checkpoint fully rebuilds the model. Resume with Lightning's `ckpt_path`:
+
+```python
+pl.Trainer(...).fit(module, ckpt_path="last.ckpt")   # continues optimizer + step
+```
+
+For standalone (non-Lightning) loops, `phoonnx_train/supertonic/checkpointing.py`
+provides **atomic** full-checkpoint saves (`save_checkpoint`) and `resume_into`,
+which restore model + every optimizer + scheduler + step. A truncated or corrupt
+file raises a clear `CheckpointError` rather than loading half a model.
+
+### Fine-tuning from the released `supertonic-3` weights
+
+`phoonnx_train/supertonic/import_onnx.py` reads the initializers out of the
+released ONNX graphs (`vocoder.onnx`, `text_encoder.onnx`,
+`vector_estimator.onnx`, `duration_predictor.onnx`) and copies them into the
+PyTorch modules by an explicit name map, tolerating the conv-1×1↔linear and
+linear-transpose conventions of the export. A `PortReport` records what loaded,
+what was missing, and any shape mismatch — nothing is copied under a wrong shape.
+The encoder-side networks (speech encoder and the two style encoders) are absent
+from the public graphs, so they always start from a fresh initialization and must
+be trained.
+
+To fine-tune onto a new language whose script is missing from a pretrained
+tokenizer, grow the vocab **without disturbing existing rows** so the pretrained
+embedding stays aligned:
+
+```python
+tok2 = tok.extend_with_texts(new_texts, new_langs)   # appends ids for new chars only
+# then load the pretrained weights with checkpointing.load_state_dict_grow_vocab(...)
+```
+
+## Export
+
+Export produces exactly the four graphs the `supertonic` inference engine
+consumes, with the official input names, plus `tts.json` (runtime config) and
+`unicode_indexer.json` (the code-point → id table):
+
+```python
+from phoonnx_train.supertonic.export_onnx import export_from_checkpoints
+export_from_checkpoints(
+    "exported/",
+    autoencoder_ckpt="ae.ckpt",
+    text_to_latent_ckpt="ttl.ckpt",
+    duration_predictor_ckpt="dp.ckpt",
+)
+```
+
+| Graph | Inputs | Output |
+|---|---|---|
+| `duration_predictor.onnx` | `text_ids`, `style_dp`, `text_mask` | `duration` |
+| `text_encoder.onnx` | `text_ids`, `style_ttl`, `text_mask` | `text_emb` |
+| `vector_estimator.onnx` | `noisy_latent`, `text_emb`, `style_ttl`, `text_mask`, `latent_mask`, `current_step`, `total_step` | `latent` |
+| `vocoder.onnx` | `latent` | `wav` |
+
+The two text graphs take the **pre-pooled** style tokens directly (`style_dp` /
+`style_ttl`), matching the released model: the style encoders are not part of any
+graph, and the runtime supplies per-voice style JSONs. The vector-estimator graph
+folds one Euler integration step so the runtime loop feeds its output straight
+back in as `noisy_latent`; the vocoder graph decompresses and denormalizes the
+latent internally before decoding to a waveform.
+
+## Loading the result in phoonnx
+
+Once the four graphs plus `tts.json` and `unicode_indexer.json` are in a voice
+directory, they are loaded by the phoonnx `supertonic` inference engine (added
+separately). See the runtime engine's own guide for `SynthesisConfig`/voice
+wiring.
+
+## Licensing
+
+The training code in `phoonnx_train/supertonic/` is written from scratch against
+the SuperTonic paper and the public `Supertone/supertonic-3` ONNX graphs. The
+released **weights** are OpenRAIL-M licensed; fine-tuning from them inherits that
+license.
+
+## Upstream
+
+| | |
+|---|---|
+| Paper | *SupertonicTTS* — [arXiv:2503.23108](https://arxiv.org/abs/2503.23108) |
+| Weights | [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3) (OpenRAIL-M) |
+| Languages | 31 (`en`, `ko`, `ja`, `ar`, `bg`, `cs`, `da`, `de`, `el`, `es`, `et`, `fi`, `fr`, `hi`, `hr`, `hu`, `id`, `it`, `lt`, `lv`, `nl`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sv`, `tr`, `uk`, `vi`) |

--- a/docs/training/training.md
+++ b/docs/training/training.md
@@ -60,6 +60,7 @@ tensorboard --logdir <default-root-dir>/lightning_logs
 | `speedyspeech` | ForwardTTS / SpeedySpeech | Same engine as `fastpitch`, no pitch |
 | `mixer` / `mixertts` | Mixer-TTS | Two-stage; [guide](engines/mixertts.md) |
 | `zipvoice` | ZipVoice (flow-matching, in-context cloning) | [guide](engines/zipvoice.md) |
+| `supertonic` | SuperTonic (three-stage: autoencoder + flow-matching + duration) | [guide](engines/supertonic.md) |
 | `optispeech` | OptiSpeech (lightweight end-to-end, S4D attention) | Install `phoonnx[train,train-optispeech]` |
 | `yourtts` | YourTTS (VITS + d-vector cloning) | See [Cloning](../cloning.md) |
 | `styletts2` | StyleTTS2 / Kokoro | See [StyleTTS2](#styletts2-engine---engine-styletts2) below |

--- a/phoonnx_train/engines/__init__.py
+++ b/phoonnx_train/engines/__init__.py
@@ -106,6 +106,7 @@ def _register_builtins() -> None:
     from phoonnx_train.engines.styletts2_plbert import PLBertTrainingEngine
     from phoonnx_train.engines.styletts2_pitch import PitchTrainingEngine
     from phoonnx_train.engines.yourtts import YourttsTrainingEngine
+    from phoonnx_train.engines.supertonic import SuperTonicTrainingEngine
 
     register_engine("vits", VitsTrainingEngine)
     register_engine("glowtts", GlowTTSTrainingEngine)
@@ -121,6 +122,7 @@ def _register_builtins() -> None:
     register_engine("styletts2-plbert", PLBertTrainingEngine)
     register_engine("styletts2-pitch", PitchTrainingEngine)
     register_engine("yourtts", YourttsTrainingEngine)
+    register_engine("supertonic", SuperTonicTrainingEngine)
 
 
 _register_builtins()

--- a/phoonnx_train/engines/supertonic.py
+++ b/phoonnx_train/engines/supertonic.py
@@ -1,0 +1,82 @@
+"""SuperTonic training engine (``--engine supertonic``).
+
+SuperTonic (Kim et al., Supertone Inc., "SupertonicTTS", arXiv:2503.23108) is a
+three-stage TTS: a GAN speech autoencoder, a flow-matching text-to-latent module,
+and an utterance-level duration predictor. Each stage trains independently, so
+this engine selects a stage through ``extra["stage"]`` (``autoencoder`` /
+``text_to_latent`` / ``duration_predictor``) and builds the matching
+LightningModule from :mod:`phoonnx_train.supertonic.lightning`.
+
+The model, losses and export live in the vendored ``phoonnx_train/supertonic/``
+package. ``export_onnx`` produces the four-graph contract the phoonnx
+``supertonic`` inference engine consumes (``duration_predictor.onnx``,
+``text_encoder.onnx``, ``vector_estimator.onnx``, ``vocoder.onnx`` plus
+``tts.json`` and ``unicode_indexer.json``); it needs all three stage checkpoints,
+passed as ``extra["autoencoder_ckpt"] / ["text_to_latent_ckpt"] /
+["duration_predictor_ckpt"]``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from phoonnx_train.engines.base import BaseTrainingEngine, TrainingEngineConfig
+
+if TYPE_CHECKING:
+    import pytorch_lightning as pl
+
+LOG = logging.getLogger(__name__)
+
+_STAGES = {
+    "autoencoder": "AutoencoderModule",
+    "text_to_latent": "TextToLatentModule",
+    "duration_predictor": "DurationPredictorModule",
+}
+
+# model-size tiers; "base" keeps the package defaults, "low" is a tiny CI tier
+_QUALITY_PRESETS: Dict[str, Dict[str, Any]] = {
+    "base": {},
+    "low": {"quality_low": True},
+}
+
+
+class SuperTonicTrainingEngine(BaseTrainingEngine):
+    """Three-stage SuperTonic training engine."""
+
+    def _config_for(self, config: TrainingEngineConfig):
+        from phoonnx_train.supertonic.config import tiny_config, SuperTonicConfig
+        if config.extra.get("quality") == "low" or config.extra.get("quality_low"):
+            cfg = tiny_config(vocab_size=config.num_symbols)
+        else:
+            cfg = SuperTonicConfig(vocab_size=config.num_symbols)
+        cfg.ae.sample_rate = config.sample_rate
+        return cfg
+
+    def create_model(self, config: TrainingEngineConfig, dataset_paths: List[Path],
+                     **kwargs: Any) -> "pl.LightningModule":
+        import phoonnx_train.supertonic.lightning as lm
+
+        extra = dict(config.extra)
+        stage = extra.pop("stage", "autoencoder")
+        if stage not in _STAGES:
+            raise KeyError(f"unknown supertonic stage {stage!r}; expected {list(_STAGES)}")
+        extra.pop("quality", None)
+        extra.pop("quality_low", None)
+        cfg = self._config_for(config)
+        module_cls = getattr(lm, _STAGES[stage])
+        return module_cls(config=cfg, dataset=[str(p) for p in dataset_paths], **extra, **kwargs)
+
+    def export_onnx(self, checkpoint_path: Path, config_path: Path,
+                    output_dir: Path, **kwargs: Any) -> Path:
+        from phoonnx_train.supertonic.export_onnx import export_from_checkpoints
+
+        paths = export_from_checkpoints(
+            str(output_dir),
+            autoencoder_ckpt=kwargs.get("autoencoder_ckpt", str(checkpoint_path)),
+            text_to_latent_ckpt=kwargs["text_to_latent_ckpt"],
+            duration_predictor_ckpt=kwargs["duration_predictor_ckpt"])
+        return paths["vector_estimator"]
+
+    def quality_presets(self) -> Dict[str, Dict[str, Any]]:
+        return _QUALITY_PRESETS

--- a/phoonnx_train/supertonic/__init__.py
+++ b/phoonnx_train/supertonic/__init__.py
@@ -1,0 +1,28 @@
+"""SuperTonic TTS training (Kim et al., Supertone Inc., "SupertonicTTS",
+arXiv:2503.23108).
+
+SuperTonic is a three-stage system, each stage trained independently:
+
+1. a GAN-trained **speech autoencoder** (:mod:`.autoencoder`,
+   :mod:`.discriminators`, :mod:`.losses`) that maps a waveform to a
+   low-dimensional continuous latent and back;
+2. a **text-to-latent** module (:mod:`.text_to_latent`) that maps character-level
+   text plus a reference voice style to that latent by conditional flow matching;
+3. a **duration predictor** (:mod:`.duration_predictor`) that estimates the total
+   utterance length.
+
+Supporting modules: :mod:`.config` (per-stage dataclasses + released-``tts.json``
+loading), :mod:`.layers` (shared ConvNeXt / attention / pooling blocks),
+:mod:`.latent_utils` (temporal compression + reference crops), :mod:`.text`
+(character tokenizer), :mod:`.dataset` (filelist datasets), :mod:`.lightning`
+(one LightningModule per stage), :mod:`.checkpointing` (atomic full checkpoints +
+resume + grow-vocab load), :mod:`.import_onnx` (fine-tune from the released ONNX
+weights) and :mod:`.export_onnx` (the four-graph inference contract).
+
+Modules are written from scratch against the SuperTonic paper and the public
+Supertone/supertonic-3 ONNX graphs; nothing here is copied from the unlicensed
+community training repository.
+
+Nothing is imported at package load time so the training-engine registry stays
+importable without torch; each submodule pulls torch in on its own.
+"""

--- a/phoonnx_train/supertonic/autoencoder.py
+++ b/phoonnx_train/supertonic/autoencoder.py
@@ -1,0 +1,127 @@
+"""Speech autoencoder: waveform -> log-spectrogram -> continuous latent ->
+waveform. A Vocos-style ConvNeXt encoder compresses the spectrogram to a
+low-dimensional latent; a causal ConvNeXt decoder with a WaveNeXt-style head
+projects each latent frame straight into ``hop_length`` waveform samples (no
+transposed convolutions or ISTFT).
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchaudio
+
+from phoonnx_train.supertonic.config import AutoencoderConfig
+from phoonnx_train.supertonic.layers import ConvNeXtBlock
+
+
+class SpecFront(nn.Module):
+    """Log mel-spectrogram, optionally concatenated with the log linear spectrum."""
+
+    def __init__(self, cfg: AutoencoderConfig):
+        super().__init__()
+        self.cfg = cfg
+        self.mel = torchaudio.transforms.MelSpectrogram(
+            sample_rate=cfg.sample_rate, n_fft=cfg.n_fft, win_length=cfg.win_length,
+            hop_length=cfg.hop_length, n_mels=cfg.n_mels, power=1.0, center=True,
+        )
+        self.lin = torchaudio.transforms.Spectrogram(
+            n_fft=cfg.n_fft, win_length=cfg.win_length, hop_length=cfg.hop_length,
+            power=1.0, center=True,
+        )
+
+    def forward(self, wav: torch.Tensor) -> torch.Tensor:
+        mel = torch.log(self.mel(wav).clamp_min(1e-5))
+        if not self.cfg.concat_linear_spec:
+            return mel
+        lin = torch.log(self.lin(wav).clamp_min(1e-5))
+        return torch.cat([mel, lin], dim=1)
+
+
+class LatentEncoder(nn.Module):
+    def __init__(self, cfg: AutoencoderConfig):
+        super().__init__()
+        self.spec = SpecFront(cfg)
+        self.pad = cfg.encoder_kernel // 2
+        self.proj_in = nn.Conv1d(cfg.input_dim, cfg.hidden_dim, cfg.encoder_kernel)
+        self.bn = nn.BatchNorm1d(cfg.hidden_dim)
+        self.blocks = nn.ModuleList(
+            [ConvNeXtBlock(cfg.hidden_dim, cfg.ffn_dim, cfg.encoder_kernel) for _ in range(cfg.encoder_layers)]
+        )
+        self.norm = nn.LayerNorm(cfg.hidden_dim)
+        self.proj_out = nn.Linear(cfg.hidden_dim, cfg.latent_dim)
+
+    def forward(self, wav: torch.Tensor) -> torch.Tensor:
+        x = F.pad(self.spec(wav), (self.pad, self.pad), mode="replicate")
+        x = self.bn(self.proj_in(x))
+        for block in self.blocks:
+            x = block(x)
+        x = self.proj_out(self.norm(x.transpose(1, 2)))
+        return x.transpose(1, 2)  # (B, latent_dim, T)
+
+
+class LatentDecoder(nn.Module):
+    def __init__(self, cfg: AutoencoderConfig):
+        super().__init__()
+        self.cfg = cfg
+        self.k = cfg.decoder_kernel
+        self.proj_in = nn.Conv1d(cfg.latent_dim, cfg.hidden_dim, cfg.decoder_kernel)
+        self.blocks = nn.ModuleList(
+            [ConvNeXtBlock(cfg.hidden_dim, cfg.ffn_dim, cfg.decoder_kernel, dilation=d, causal=True)
+             for d in cfg.decoder_dilations]
+        )
+        self.bn = nn.BatchNorm1d(cfg.hidden_dim)
+        self.head_conv = nn.Conv1d(cfg.hidden_dim, cfg.head_dim, 3)
+        self.head_act = nn.PReLU()
+        self.head_proj = nn.Linear(cfg.head_dim, cfg.hop_length, bias=False)
+
+    def forward(self, latent: torch.Tensor) -> torch.Tensor:
+        x = F.pad(latent, (self.k - 1, 0), mode="replicate")
+        x = self.proj_in(x)
+        for block in self.blocks:
+            x = block(x)
+        x = self.bn(x)
+        x = F.pad(x, (2, 0), mode="replicate")
+        x = self.head_act(self.head_conv(x))
+        x = self.head_proj(x.transpose(1, 2))  # (B, T, hop)
+        return x.reshape(x.shape[0], -1)
+
+
+class SpeechAutoencoder(nn.Module):
+    """Owns per-channel latent statistics shared with the two downstream stages."""
+
+    def __init__(self, cfg: AutoencoderConfig):
+        super().__init__()
+        self.cfg = cfg
+        self.encoder = LatentEncoder(cfg)
+        self.decoder = LatentDecoder(cfg)
+        self.register_buffer("latent_mean", torch.zeros(1, cfg.latent_dim, 1))
+        self.register_buffer("latent_std", torch.ones(1, cfg.latent_dim, 1))
+        self.register_buffer("stats_fitted", torch.tensor(False))
+
+    def forward(self, wav: torch.Tensor):
+        latent = self.encoder(wav)
+        recon = self.decoder(latent)
+        n = min(wav.shape[-1], recon.shape[-1])
+        return recon[..., :n], latent
+
+    @torch.no_grad()
+    def encode(self, wav: torch.Tensor) -> torch.Tensor:
+        return self.encoder(wav)
+
+    @torch.no_grad()
+    def decode(self, latent: torch.Tensor) -> torch.Tensor:
+        return self.decoder(latent)
+
+    @torch.no_grad()
+    def fit_latent_stats(self, latents) -> None:
+        flat = torch.cat([lat.transpose(0, 1).reshape(lat.shape[1], -1) for lat in latents], dim=1)
+        self.latent_mean.copy_(flat.mean(dim=1).view(1, -1, 1))
+        self.latent_std.copy_(flat.std(dim=1).clamp_min(1e-5).view(1, -1, 1))
+        self.stats_fitted.fill_(True)
+
+    def normalize(self, latent: torch.Tensor) -> torch.Tensor:
+        return (latent - self.latent_mean) / self.latent_std
+
+    def denormalize(self, latent: torch.Tensor) -> torch.Tensor:
+        return latent * self.latent_std + self.latent_mean

--- a/phoonnx_train/supertonic/checkpointing.py
+++ b/phoonnx_train/supertonic/checkpointing.py
@@ -1,0 +1,108 @@
+"""Full-state checkpointing for the SuperTonic training stages.
+
+A checkpoint carries everything needed to resume bit-for-bit: model weights,
+optimizer state(s), LR-scheduler state(s), the global step, and the config +
+tokenizer needed to rebuild the model. Writes are atomic (write to a temp file
+in the same directory, then ``os.replace``) so an interrupted save never
+corrupts the previous good checkpoint. Loading a truncated or corrupt file
+raises a clear :class:`CheckpointError`.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import torch
+
+
+class CheckpointError(RuntimeError):
+    """Raised when a checkpoint cannot be read or is missing required fields."""
+
+
+def save_checkpoint(path: str, *, step: int, models: Dict[str, torch.nn.Module],
+                    optimizers: Optional[Dict[str, torch.optim.Optimizer]] = None,
+                    schedulers: Optional[Dict[str, Any]] = None,
+                    extra: Optional[Dict[str, Any]] = None) -> None:
+    """Atomically write a full checkpoint.
+
+    ``models``/``optimizers``/``schedulers`` are name->object maps so a
+    multi-network stage (e.g. the autoencoder generator + discriminators) can
+    round-trip every optimizer.
+    """
+    payload: Dict[str, Any] = {
+        "format": "supertonic-checkpoint-v1",
+        "step": int(step),
+        "models": {k: m.state_dict() for k, m in models.items()},
+        "optimizers": {k: o.state_dict() for k, o in (optimizers or {}).items()},
+        "schedulers": {k: s.state_dict() for k, s in (schedulers or {}).items()
+                       if hasattr(s, "state_dict")},
+        "extra": dict(extra or {}),
+    }
+    path = str(path)
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".ckpt-", dir=str(Path(path).parent))
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            torch.save(payload, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
+
+
+def load_checkpoint(path: str, map_location: str = "cpu") -> Dict[str, Any]:
+    path = str(path)
+    if not os.path.exists(path):
+        raise CheckpointError(f"checkpoint not found: {path}")
+    try:
+        ckpt = torch.load(path, map_location=map_location, weights_only=False)
+    except Exception as exc:  # truncated / corrupt / non-torch file
+        raise CheckpointError(f"failed to read checkpoint {path}: {exc}") from exc
+    if not isinstance(ckpt, dict) or "models" not in ckpt or "step" not in ckpt:
+        raise CheckpointError(f"checkpoint {path} is missing required fields (models/step)")
+    return ckpt
+
+
+def resume_into(path: str, *, models: Dict[str, torch.nn.Module],
+                optimizers: Optional[Dict[str, torch.optim.Optimizer]] = None,
+                schedulers: Optional[Dict[str, Any]] = None,
+                map_location: str = "cpu") -> int:
+    """Restore model/optimizer/scheduler state in place and return the step."""
+    ckpt = load_checkpoint(path, map_location=map_location)
+    for name, model in models.items():
+        if name not in ckpt["models"]:
+            raise CheckpointError(f"checkpoint {path} has no state for model {name!r}")
+        model.load_state_dict(ckpt["models"][name])
+    for name, opt in (optimizers or {}).items():
+        if name in ckpt.get("optimizers", {}):
+            opt.load_state_dict(ckpt["optimizers"][name])
+    for name, sched in (schedulers or {}).items():
+        if name in ckpt.get("schedulers", {}) and hasattr(sched, "load_state_dict"):
+            sched.load_state_dict(ckpt["schedulers"][name])
+    return int(ckpt["step"])
+
+
+def load_state_dict_grow_vocab(model: torch.nn.Module, state_dict: Dict[str, torch.Tensor]) -> None:
+    """Load ``state_dict`` into ``model``, tolerating a larger dim-0 (e.g. an
+    embedding grown for a fine-tuning tokenizer with extra characters). Every
+    other dimension must match exactly; extra rows keep the model's fresh init.
+    """
+    target = model.state_dict()
+    missing = state_dict.keys() - target.keys()
+    unexpected = target.keys() - state_dict.keys()
+    if missing or unexpected:
+        raise CheckpointError(f"key mismatch: missing={sorted(missing)} unexpected={sorted(unexpected)}")
+    with torch.no_grad():
+        for key, src in state_dict.items():
+            dst = target[key]
+            if src.shape == dst.shape:
+                dst.copy_(src)
+            elif src.dim() == dst.dim() and src.shape[1:] == dst.shape[1:] and src.shape[0] <= dst.shape[0]:
+                dst[:src.shape[0]].copy_(src)
+            else:
+                raise CheckpointError(f"incompatible shape for {key}: ckpt={tuple(src.shape)} model={tuple(dst.shape)}")

--- a/phoonnx_train/supertonic/config.py
+++ b/phoonnx_train/supertonic/config.py
@@ -1,0 +1,238 @@
+"""Architecture and hyper-parameter configuration for the SuperTonic TTS stack.
+
+SuperTonic (Kim et al., Supertone Inc., "SupertonicTTS", arXiv:2503.23108) is a
+three-stage system:
+
+* a GAN-trained **speech autoencoder** that turns a waveform into a low
+  dimensional continuous latent sequence and back,
+* a **text-to-latent** module that maps character-level text plus a reference
+  voice style to that latent via conditional flow matching, and
+* a **duration predictor** that estimates the total utterance length.
+
+The dataclasses below carry the shape/size knobs for each stage. The defaults are
+small enough to build and forward on CPU in a test; the values published for the
+released ``Supertone/supertonic-3`` model are read from its ``tts.json`` by
+:func:`load_model_config` when that file is supplied, so training at the released
+scale never requires editing this module.
+
+All sequence tensors use the ``(batch, channels, time)`` layout at module
+boundaries, matching the ONNX graphs of the released model.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _dig(raw: dict, dotted: str, fallback: Any) -> Any:
+    """Fetch ``raw["a"]["b"]["c"]`` for ``dotted="a.b.c"``, or ``fallback``."""
+    cur: Any = raw
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return fallback
+        cur = cur[part]
+    return cur
+
+
+@dataclass
+class AutoencoderConfig:
+    """Speech autoencoder (spectrogram -> latent -> waveform)."""
+
+    sample_rate: int = 22050
+    n_fft: int = 1024
+    win_length: int = 1024
+    hop_length: int = 256
+    n_mels: int = 80
+    concat_linear_spec: bool = True
+    hidden_dim: int = 64
+    ffn_dim: int = 128
+    latent_dim: int = 24
+    encoder_layers: int = 3
+    encoder_kernel: int = 7
+    decoder_layers: int = 4
+    decoder_kernel: int = 7
+    decoder_dilations: tuple = (1, 2, 4, 1)
+    head_dim: int = 128
+
+    @property
+    def input_dim(self) -> int:
+        linear_bins = (self.n_fft // 2 + 1) if self.concat_linear_spec else 0
+        return self.n_mels + linear_bins
+
+
+@dataclass
+class TextToLatentConfig:
+    """Conditional-flow-matching text-to-latent module."""
+
+    latent_dim: int = 24
+    compress_factor: int = 6
+    normalizer_scale: float = 0.25
+    batch_expand: int = 2
+    prob_text_uncond: float = 0.05
+    prob_both_uncond: float = 0.04
+    sigma_min: float = 1e-8
+
+    char_dim: int = 64
+    convnext_ffn: int = 128
+    convnext_layers: int = 2
+    convnext_kernel: int = 5
+    self_attn_layers: int = 2
+    self_attn_heads: int = 2
+    self_attn_ffn: int = 128
+    self_attn_window: int = 4
+
+    style_dim: int = 64
+    style_convnext_layers: int = 2
+    style_convnext_ffn: int = 128
+    style_convnext_kernel: int = 5
+    n_style: int = 8
+    style_heads: int = 2
+    prompt_heads: int = 2
+
+    vf_dim: int = 64
+    vf_ffn: int = 128
+    vf_kernel: int = 5
+    vf_blocks: int = 2
+    vf_dilations: tuple = (1, 2)
+    vf_final_layers: int = 2
+    vf_text_heads: int = 2
+    vf_style_heads: int = 2
+    rotary_base: float = 10000.0
+    rotary_scale: float = 10.0
+    time_dim: int = 32
+    time_hidden: int = 128
+
+    @property
+    def compressed_dim(self) -> int:
+        return self.latent_dim * self.compress_factor
+
+
+@dataclass
+class DurationPredictorConfig:
+    """Utterance-level duration predictor."""
+
+    latent_dim: int = 24
+    compress_factor: int = 6
+    normalizer_scale: float = 1.0
+
+    char_dim: int = 32
+    convnext_ffn: int = 64
+    convnext_layers: int = 2
+    convnext_kernel: int = 5
+    self_attn_layers: int = 1
+    self_attn_heads: int = 2
+    self_attn_ffn: int = 64
+    self_attn_window: int = 4
+
+    style_dim: int = 32
+    style_convnext_layers: int = 2
+    style_convnext_ffn: int = 64
+    n_style: int = 4
+    style_value_dim: int = 16
+    style_heads: int = 2
+
+    predictor_hidden: int = 64
+
+    @property
+    def compressed_dim(self) -> int:
+        return self.latent_dim * self.compress_factor
+
+
+@dataclass
+class SuperTonicConfig:
+    ae: AutoencoderConfig = field(default_factory=AutoencoderConfig)
+    ttl: TextToLatentConfig = field(default_factory=TextToLatentConfig)
+    dp: DurationPredictorConfig = field(default_factory=DurationPredictorConfig)
+    vocab_size: int = 256
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+    def save(self, path: str) -> None:
+        Path(path).write_text(self.to_json())
+
+
+def load_model_config(path: Optional[str]) -> SuperTonicConfig:
+    """Build a config, overlaying values from a released ``tts.json`` if given.
+
+    Unknown/absent keys keep the dataclass defaults, so a partial or a
+    differently-shaped file still yields a usable config.
+    """
+    cfg = SuperTonicConfig()
+    if not path:
+        return cfg
+    raw = json.loads(Path(path).read_text())
+
+    ae = cfg.ae
+    ae.sample_rate = _dig(raw, "ae.sample_rate", ae.sample_rate)
+    ae.n_fft = _dig(raw, "ae.encoder.spec_processor.n_fft", ae.n_fft)
+    ae.hop_length = _dig(raw, "ae.encoder.spec_processor.hop_length", ae.hop_length)
+    ae.win_length = _dig(raw, "ae.encoder.spec_processor.win_length", ae.win_length)
+    ae.n_mels = _dig(raw, "ae.encoder.spec_processor.n_mels", ae.n_mels)
+    ae.hidden_dim = _dig(raw, "ae.encoder.hdim", ae.hidden_dim)
+    ae.ffn_dim = _dig(raw, "ae.encoder.intermediate_dim", ae.ffn_dim)
+    ae.latent_dim = _dig(raw, "ae.ldim", ae.latent_dim)
+    ae.encoder_layers = _dig(raw, "ae.encoder.num_layers", ae.encoder_layers)
+    ae.encoder_kernel = _dig(raw, "ae.encoder.ksz", ae.encoder_kernel)
+    ae.decoder_layers = _dig(raw, "ae.decoder.num_layers", ae.decoder_layers)
+    ae.decoder_kernel = _dig(raw, "ae.decoder.ksz", ae.decoder_kernel)
+    dils = _dig(raw, "ae.decoder.dilation_lst", None)
+    if dils is not None:
+        ae.decoder_dilations = tuple(dils)
+    ae.head_dim = _dig(raw, "ae.decoder.head.hdim", ae.head_dim)
+    measured = _dig(raw, "ae.encoder.idim", None)
+    if measured is not None:
+        ae.concat_linear_spec = measured != ae.n_mels
+
+    ttl = cfg.ttl
+    ttl.latent_dim = _dig(raw, "ttl.latent_dim", ttl.latent_dim)
+    ttl.compress_factor = _dig(raw, "ttl.chunk_compress_factor", ttl.compress_factor)
+    ttl.normalizer_scale = _dig(raw, "ttl.normalizer.scale", ttl.normalizer_scale)
+    ttl.prob_text_uncond = _dig(raw, "ttl.uncond_masker.prob_text_uncond", ttl.prob_text_uncond)
+    ttl.sigma_min = _dig(raw, "ttl.flow_matching.sig_min", ttl.sigma_min)
+    ttl.char_dim = _dig(raw, "ttl.text_encoder.text_embedder.char_emb_dim", ttl.char_dim)
+    ttl.self_attn_heads = _dig(raw, "ttl.text_encoder.attn_encoder.n_heads", ttl.self_attn_heads)
+    ttl.n_style = _dig(raw, "ttl.style_encoder.style_token_layer.n_style", ttl.n_style)
+    ttl.style_dim = _dig(raw, "ttl.style_encoder.convnext.idim", ttl.style_dim)
+    ttl.vf_dim = _dig(raw, "ttl.vector_field.proj_in.odim", ttl.vf_dim)
+    ttl.vf_blocks = _dig(raw, "ttl.vector_field.main_blocks.n_blocks", ttl.vf_blocks)
+    ttl.rotary_base = _dig(raw, "ttl.vector_field.main_blocks.text_cond_layer.rotary_base", ttl.rotary_base)
+    ttl.rotary_scale = _dig(raw, "ttl.vector_field.main_blocks.text_cond_layer.rotary_scale", ttl.rotary_scale)
+    ttl.time_dim = _dig(raw, "ttl.vector_field.time_encoder.time_dim", ttl.time_dim)
+
+    dp = cfg.dp
+    dp.latent_dim = _dig(raw, "dp.latent_dim", dp.latent_dim)
+    dp.compress_factor = _dig(raw, "dp.chunk_compress_factor", dp.compress_factor)
+    dp.normalizer_scale = _dig(raw, "dp.normalizer.scale", dp.normalizer_scale)
+    dp.char_dim = _dig(raw, "dp.sentence_encoder.char_emb_dim", dp.char_dim)
+    dp.n_style = _dig(raw, "dp.style_encoder.style_token_layer.n_style", dp.n_style)
+    dp.style_value_dim = _dig(raw, "dp.style_encoder.style_token_layer.style_value_dim", dp.style_value_dim)
+    dp.style_dim = _dig(raw, "dp.style_encoder.convnext.idim", dp.style_dim)
+    dp.predictor_hidden = _dig(raw, "dp.predictor.hdim", dp.predictor_hidden)
+
+    return cfg
+
+
+def tiny_config(vocab_size: int = 64) -> SuperTonicConfig:
+    """A minimal config sized for fast CPU forward/backward smoke tests."""
+    cfg = SuperTonicConfig(vocab_size=vocab_size)
+    cfg.ae = AutoencoderConfig(
+        sample_rate=16000, n_fft=256, win_length=256, hop_length=64, n_mels=32,
+        hidden_dim=16, ffn_dim=32, latent_dim=8, encoder_layers=2, decoder_layers=2,
+        decoder_dilations=(1, 2), head_dim=32,
+    )
+    cfg.ttl = TextToLatentConfig(
+        latent_dim=8, compress_factor=2, char_dim=16, convnext_ffn=32, convnext_layers=1,
+        self_attn_layers=1, self_attn_heads=2, self_attn_ffn=32, style_dim=16, n_style=4,
+        style_convnext_layers=1, style_convnext_ffn=32, vf_dim=16, vf_ffn=32, vf_blocks=1,
+        vf_dilations=(1,), vf_final_layers=1, vf_text_heads=2, vf_style_heads=2,
+        time_dim=16, time_hidden=32, batch_expand=1,
+    )
+    cfg.dp = DurationPredictorConfig(
+        latent_dim=8, compress_factor=2, char_dim=16, convnext_ffn=32, convnext_layers=1,
+        self_attn_layers=1, self_attn_heads=2, self_attn_ffn=32, style_dim=16, n_style=4,
+        style_value_dim=8, style_convnext_layers=1, style_convnext_ffn=32, predictor_hidden=32,
+    )
+    return cfg

--- a/phoonnx_train/supertonic/dataset.py
+++ b/phoonnx_train/supertonic/dataset.py
@@ -1,0 +1,109 @@
+"""Filelist datasets for the three SuperTonic stages.
+
+SuperTonic is grapheme-level and G2P-free, so it consumes raw text rather than
+the phoneme ids in phoonnx's shared ``dataset.jsonl``. The filelist is one
+utterance per line::
+
+    relative/path/to/audio.wav|transcript text|lang_code
+
+``lang_code`` is optional and defaults to ``en``. Paths resolve against
+``root_dir`` and any ``soundfile``-readable audio format works.
+
+* :class:`WaveformDataset` (stage 1) returns fixed-length random audio crops for
+  the GAN-trained autoencoder.
+* :class:`TextAudioDataset` (stages 2 and 3) returns ``(waveform, text_ids)``;
+  target latents are produced on the fly by a frozen autoencoder in the training
+  loop, so this dataset only loads audio and tokenizes text.
+"""
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import List, Tuple
+
+import soundfile as sf
+import torch
+import torchaudio
+from torch.utils.data import Dataset
+
+from phoonnx_train.supertonic.text import CharTokenizer
+
+
+def load_audio(path: str) -> Tuple[torch.Tensor, int]:
+    wav, sr = sf.read(path, dtype="float32", always_2d=True)
+    return torch.from_numpy(wav).mean(dim=1), sr
+
+
+def load_filelist(path: str) -> List[Tuple[str, str, str]]:
+    entries = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("|")
+        if len(parts) < 2 or not parts[0] or not parts[1].strip():
+            continue
+        lang = parts[2].strip() if len(parts) > 2 and parts[2].strip() else "en"
+        entries.append((parts[0], parts[1], lang))
+    return entries
+
+
+class WaveformDataset(Dataset):
+    def __init__(self, filelist: str, root_dir: str, sample_rate: int, segment_samples: int):
+        self.entries = load_filelist(filelist)
+        self.root = Path(root_dir)
+        self.sample_rate = sample_rate
+        self.segment = segment_samples
+
+    def __len__(self):
+        return len(self.entries)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        wav, sr = load_audio(str(self.root / self.entries[idx][0]))
+        if sr != self.sample_rate:
+            wav = torchaudio.functional.resample(wav, sr, self.sample_rate)
+        n = self.segment
+        if wav.shape[0] < n:
+            return torch.nn.functional.pad(wav, (0, n - wav.shape[0]))
+        start = random.randint(0, wav.shape[0] - n)
+        return wav[start:start + n]
+
+
+def waveform_collate(batch: List[torch.Tensor]) -> torch.Tensor:
+    return torch.stack(batch, dim=0)
+
+
+class TextAudioDataset(Dataset):
+    def __init__(self, filelist: str, root_dir: str, tokenizer: CharTokenizer,
+                 sample_rate: int, max_seconds: float = 10.0):
+        self.entries = load_filelist(filelist)
+        self.root = Path(root_dir)
+        self.tokenizer = tokenizer
+        self.sample_rate = sample_rate
+        self.max_samples = int(max_seconds * sample_rate)
+
+    def __len__(self):
+        return len(self.entries)
+
+    def __getitem__(self, idx: int):
+        wav_path, text, lang = self.entries[idx]
+        wav, sr = load_audio(str(self.root / wav_path))
+        if sr != self.sample_rate:
+            wav = torchaudio.functional.resample(wav, sr, self.sample_rate)
+        if wav.shape[0] > self.max_samples:
+            wav = wav[:self.max_samples]
+        ids = torch.tensor(self.tokenizer.encode(text, lang), dtype=torch.long)
+        return wav, ids
+
+
+def text_audio_collate(batch):
+    wavs, ids = zip(*batch)
+    wav_lens = torch.tensor([w.shape[0] for w in wavs], dtype=torch.long)
+    text_lens = torch.tensor([t.shape[0] for t in ids], dtype=torch.long)
+    wav_pad = torch.zeros(len(wavs), int(wav_lens.max()))
+    for i, w in enumerate(wavs):
+        wav_pad[i, :w.shape[0]] = w
+    text_pad = torch.zeros(len(ids), int(text_lens.max().clamp_min(1)), dtype=torch.long)
+    for i, t in enumerate(ids):
+        text_pad[i, :t.shape[0]] = t
+    return wav_pad, wav_lens, text_pad, text_lens

--- a/phoonnx_train/supertonic/discriminators.py
+++ b/phoonnx_train/supertonic/discriminators.py
@@ -1,0 +1,97 @@
+"""GAN discriminators for the speech autoencoder: a HiFi-GAN-style multi-period
+discriminator over the raw waveform and a multi-resolution discriminator over
+log-magnitude spectrograms. Each returns per-sub-discriminator scores plus the
+intermediate feature maps used by the feature-matching loss.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.utils.parametrizations import weight_norm
+
+PERIODS = (2, 3, 5, 7, 11)
+PERIOD_CHANNELS = (16, 64, 128, 256, 256)
+FFT_SIZES = (512, 1024, 2048)
+
+
+class _PeriodDisc(nn.Module):
+    def __init__(self, period: int):
+        super().__init__()
+        self.period = period
+        chans = (1,) + PERIOD_CHANNELS
+        self.convs = nn.ModuleList([
+            weight_norm(nn.Conv2d(chans[i], chans[i + 1], (5, 1),
+                                  (3, 1) if i < len(chans) - 2 else (1, 1), padding=(2, 0)))
+            for i in range(len(chans) - 1)
+        ])
+        self.out = weight_norm(nn.Conv2d(PERIOD_CHANNELS[-1], 1, (3, 1), 1, padding=(1, 0)))
+
+    def forward(self, x: torch.Tensor):
+        b, t = x.shape
+        if t % self.period:
+            x = F.pad(x, (0, self.period - t % self.period), mode="reflect")
+        x = x.view(b, 1, -1, self.period)
+        feats = []
+        for conv in self.convs:
+            x = F.leaky_relu(conv(x), 0.1)
+            feats.append(x)
+        x = self.out(x)
+        feats.append(x)
+        return x.flatten(1), feats
+
+
+class MultiPeriodDiscriminator(nn.Module):
+    def __init__(self, periods=PERIODS):
+        super().__init__()
+        self.discs = nn.ModuleList([_PeriodDisc(p) for p in periods])
+
+    def forward(self, x: torch.Tensor):
+        outs, feats = [], []
+        for disc in self.discs:
+            o, f = disc(x)
+            outs.append(o)
+            feats.append(f)
+        return outs, feats
+
+
+class _ResolutionDisc(nn.Module):
+    def __init__(self, n_fft: int):
+        super().__init__()
+        self.n_fft = n_fft
+        self.hop = n_fft // 4
+        self.win = n_fft
+        specs = [(1, 16, (2, 1)), (16, 16, (2, 1)), (16, 16, (2, 1)), (16, 16, (1, 1))]
+        self.convs = nn.ModuleList(
+            [weight_norm(nn.Conv2d(ci, co, (5, 5), stride=s, padding=(2, 2))) for ci, co, s in specs]
+        )
+        self.out = weight_norm(nn.Conv2d(16, 1, (3, 3), 1, padding=(1, 1)))
+
+    def _spec(self, x: torch.Tensor) -> torch.Tensor:
+        window = torch.hann_window(self.win, device=x.device)
+        spec = torch.stft(x, self.n_fft, self.hop, self.win, window=window, center=True, return_complex=True)
+        return torch.log(spec.abs().clamp_min(1e-5))
+
+    def forward(self, x: torch.Tensor):
+        x = self._spec(x).unsqueeze(1)
+        feats = []
+        for conv in self.convs:
+            x = F.leaky_relu(conv(x), 0.1)
+            feats.append(x)
+        x = self.out(x)
+        feats.append(x)
+        return x.flatten(1), feats
+
+
+class MultiResolutionDiscriminator(nn.Module):
+    def __init__(self, fft_sizes=FFT_SIZES):
+        super().__init__()
+        self.discs = nn.ModuleList([_ResolutionDisc(n) for n in fft_sizes])
+
+    def forward(self, x: torch.Tensor):
+        outs, feats = [], []
+        for disc in self.discs:
+            o, f = disc(x)
+            outs.append(o)
+            feats.append(f)
+        return outs, feats

--- a/phoonnx_train/supertonic/duration_predictor.py
+++ b/phoonnx_train/supertonic/duration_predictor.py
@@ -1,0 +1,74 @@
+"""Utterance-level duration predictor: estimates the total duration of the
+synthesized speech directly from the text plus a reference voice style, avoiding
+any phoneme-level alignment. A learnable "sentence token" prepended to the
+character sequence gathers a fixed-size text embedding; a flattened reference
+embedding is concatenated, and a small MLP predicts log-duration (exponentiated
+to seconds).
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from phoonnx_train.supertonic.config import DurationPredictorConfig
+from phoonnx_train.supertonic.layers import ConvNeXtStack, FlattenStylePool, RelPositionEncoder
+
+
+class SentenceEncoder(nn.Module):
+    def __init__(self, cfg: DurationPredictorConfig, vocab_size: int):
+        super().__init__()
+        dim = cfg.char_dim
+        self.embed = nn.Embedding(vocab_size, dim)
+        self.sentence_token = nn.Parameter(torch.randn(1, dim, 1) * 0.02)
+        self.convnext = ConvNeXtStack(dim, cfg.convnext_ffn, cfg.convnext_kernel, (1,) * cfg.convnext_layers)
+        self.self_attn = RelPositionEncoder(dim, cfg.self_attn_ffn, cfg.self_attn_heads,
+                                            cfg.self_attn_layers, cfg.self_attn_window)
+        self.proj = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, text_ids, text_mask) -> torch.Tensor:
+        b = text_ids.shape[0]
+        x = self.embed(text_ids).transpose(1, 2)
+        token = self.sentence_token.expand(b, -1, -1)
+        x = torch.cat([token, x], dim=2)
+        mask = torch.cat([torch.ones(b, 1, 1, device=text_mask.device), text_mask], dim=2)
+        conv = self.convnext(x, mask)
+        attn = self.self_attn(conv, mask)
+        return self.proj((attn + conv)[:, :, 0])
+
+
+class ReferenceEncoder(nn.Module):
+    def __init__(self, cfg: DurationPredictorConfig):
+        super().__init__()
+        self.proj_in = nn.Linear(cfg.compressed_dim, cfg.style_dim)
+        self.convnext = ConvNeXtStack(cfg.style_dim, cfg.style_convnext_ffn, 5, (1,) * cfg.style_convnext_layers)
+        self.pool = FlattenStylePool(cfg.style_dim, cfg.n_style, cfg.style_dim,
+                                     cfg.n_style * cfg.style_value_dim, cfg.style_heads)
+
+    def forward(self, ref, ref_mask=None) -> torch.Tensor:
+        x = self.proj_in(ref.transpose(1, 2)).transpose(1, 2)
+        x = self.convnext(x, ref_mask)
+        return self.pool(x, ref_mask)  # (B, n_style * style_value_dim)
+
+
+class DurationPredictor(nn.Module):
+    def __init__(self, cfg: DurationPredictorConfig, vocab_size: int):
+        super().__init__()
+        self.cfg = cfg
+        self.text_encoder = SentenceEncoder(cfg, vocab_size)
+        self.style_encoder = ReferenceEncoder(cfg)
+        in_dim = cfg.char_dim + cfg.n_style * cfg.style_value_dim
+        self.estimator = nn.Sequential(
+            nn.Linear(in_dim, cfg.predictor_hidden), nn.PReLU(), nn.Linear(cfg.predictor_hidden, 1)
+        )
+
+    def log_duration_from_embeddings(self, text_emb, style_flat) -> torch.Tensor:
+        return self.estimator(torch.cat([text_emb, style_flat], dim=-1)).squeeze(-1)
+
+    def forward(self, text_ids, text_mask, ref, ref_mask=None) -> torch.Tensor:
+        text_emb = self.text_encoder(text_ids, text_mask)
+        style_flat = self.style_encoder(ref, ref_mask)
+        return self.log_duration_from_embeddings(text_emb, style_flat).exp()
+
+
+def duration_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return (pred - target).abs().mean()

--- a/phoonnx_train/supertonic/export_onnx.py
+++ b/phoonnx_train/supertonic/export_onnx.py
@@ -1,0 +1,206 @@
+"""Export trained SuperTonic modules to the four-graph ONNX contract the phoonnx
+``supertonic`` inference engine consumes.
+
+The four graphs and their exact input names (matching the official ``helper.py``):
+
+* ``duration_predictor.onnx`` : ``text_ids``, ``style_dp``, ``text_mask`` -> ``duration``
+* ``text_encoder.onnx``       : ``text_ids``, ``style_ttl``, ``text_mask`` -> ``text_emb``
+* ``vector_estimator.onnx``   : ``noisy_latent``, ``text_emb``, ``style_ttl``,
+  ``text_mask``, ``latent_mask``, ``current_step``, ``total_step`` -> ``latent``
+* ``vocoder.onnx``            : ``latent`` -> ``wav``
+
+The exported duration-predictor and text-encoder graphs take the *pre-pooled*
+style tokens directly (``style_dp`` / ``style_ttl``), so the style encoders are
+not part of any graph — the inference engine supplies per-voice style JSONs. The
+vector-estimator graph folds one Euler integration step (``current_step`` ->
+``current_step+1``) so the engine's loop can feed the output straight back in.
+The vocoder graph decompresses + denormalises the latent internally before the
+waveform decoder.
+
+Alongside the graphs it writes ``tts.json`` (the runtime config the engine
+reads) and ``unicode_indexer.json`` (the code-point -> id table).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import torch
+
+from phoonnx_train.supertonic.config import SuperTonicConfig
+from phoonnx_train.supertonic.text import CharTokenizer
+
+_OPSET = 17
+
+
+def _export_kwargs() -> Dict[str, Any]:
+    import inspect
+    if "dynamo" in inspect.signature(torch.onnx.export).parameters:
+        return {"dynamo": False}
+    return {}
+
+
+class _DurationOnnx(torch.nn.Module):
+    def __init__(self, dp):
+        super().__init__()
+        self.dp = dp
+
+    def forward(self, text_ids, style_dp, text_mask):
+        text_emb = self.dp.text_encoder(text_ids, text_mask)
+        style_flat = style_dp.reshape(style_dp.shape[0], -1)
+        return self.dp.log_duration_from_embeddings(text_emb, style_flat).exp()
+
+
+class _TextEncoderOnnx(torch.nn.Module):
+    def __init__(self, ttl):
+        super().__init__()
+        self.text_encoder = ttl.text_encoder
+
+    def forward(self, text_ids, style_ttl, text_mask):
+        return self.text_encoder(text_ids, text_mask, style_ttl)
+
+
+class _VectorEstimatorOnnx(torch.nn.Module):
+    def __init__(self, ttl):
+        super().__init__()
+        self.vf = ttl.vector_field
+
+    def forward(self, noisy_latent, text_emb, style_ttl, text_mask, latent_mask,
+                current_step, total_step):
+        t = current_step / total_step
+        v = self.vf(noisy_latent, t, text_emb, style_ttl, latent_mask, text_mask)
+        dt = (1.0 / total_step).view(-1, 1, 1)
+        return (noisy_latent + v * dt) * latent_mask
+
+
+class _VocoderOnnx(torch.nn.Module):
+    def __init__(self, ae, compress_factor, latent_dim, scale):
+        super().__init__()
+        self.ae = ae
+        self.k = compress_factor
+        self.ld = latent_dim
+        self.scale = scale
+
+    def forward(self, latent):
+        from phoonnx_train.supertonic.latent_utils import decompress_and_denormalize
+        raw = decompress_and_denormalize(self.ae, latent, self.k, self.ld, self.scale)
+        return self.ae.decoder(raw)
+
+
+def _write(module, args, path, input_names, output_names, dynamic_axes):
+    torch.onnx.export(
+        module, args, str(path), opset_version=_OPSET, input_names=input_names,
+        output_names=output_names, dynamic_axes=dynamic_axes, **_export_kwargs())
+
+
+def export_all(output_dir: str, *, config: SuperTonicConfig, tokenizer: CharTokenizer,
+               autoencoder, text_to_latent, duration_predictor) -> Dict[str, Path]:
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    autoencoder.eval(); text_to_latent.eval(); duration_predictor.eval()
+
+    ttl, dp, ae = config.ttl, config.dp, config.ae
+    if not ae.latent_dim == ttl.latent_dim == dp.latent_dim:
+        raise ValueError("latent_dim disagrees across the stages "
+                         f"(ae={ae.latent_dim}, ttl={ttl.latent_dim}, dp={dp.latent_dim}); "
+                         "the exported graphs would reshape the latent inconsistently")
+    b, t_text, t_lat = 1, 6, 4
+    n_ttl, n_dp = ttl.n_style, dp.n_style
+    text_ids = torch.randint(1, max(2, config.vocab_size), (b, t_text), dtype=torch.long)
+    text_mask = torch.ones(b, 1, t_text)
+    latent_mask = torch.ones(b, 1, t_lat)
+    style_ttl = torch.randn(b, n_ttl, ttl.style_dim)
+    style_dp = torch.randn(b, n_dp, dp.style_value_dim)
+    noisy = torch.randn(b, ttl.compressed_dim, t_lat)
+    text_emb = torch.randn(b, ttl.char_dim, t_text)
+
+    with torch.no_grad():
+        dp_path = out / "duration_predictor.onnx"
+        _write(_DurationOnnx(duration_predictor), (text_ids, style_dp, text_mask), dp_path,
+               ["text_ids", "style_dp", "text_mask"], ["duration"],
+               {"text_ids": {0: "B", 1: "T"}, "style_dp": {0: "B"}, "text_mask": {0: "B", 2: "T"}})
+
+        te_path = out / "text_encoder.onnx"
+        _write(_TextEncoderOnnx(text_to_latent), (text_ids, style_ttl, text_mask), te_path,
+               ["text_ids", "style_ttl", "text_mask"], ["text_emb"],
+               {"text_ids": {0: "B", 1: "T"}, "style_ttl": {0: "B"},
+                "text_mask": {0: "B", 2: "T"}, "text_emb": {0: "B", 2: "T"}})
+
+        current_step = torch.tensor([1.0])
+        total_step = torch.tensor([8.0])
+        ve_path = out / "vector_estimator.onnx"
+        _write(_VectorEstimatorOnnx(text_to_latent),
+               (noisy, text_emb, style_ttl, text_mask, latent_mask, current_step, total_step),
+               ve_path,
+               ["noisy_latent", "text_emb", "style_ttl", "text_mask", "latent_mask",
+                "current_step", "total_step"], ["latent"],
+               {"noisy_latent": {0: "B", 2: "L"}, "text_emb": {0: "B", 2: "T"},
+                "style_ttl": {0: "B"}, "text_mask": {0: "B", 2: "T"},
+                "latent_mask": {0: "B", 2: "L"}, "current_step": {0: "B"},
+                "total_step": {0: "B"}, "latent": {0: "B", 2: "L"}})
+
+        voc_path = out / "vocoder.onnx"
+        _write(_VocoderOnnx(autoencoder, ttl.compress_factor, ae.latent_dim, ttl.normalizer_scale),
+               (noisy,), voc_path, ["latent"], ["wav"],
+               {"latent": {0: "B", 2: "L"}, "wav": {0: "B", 1: "T"}})
+
+    (out / "tts.json").write_text(json.dumps({
+        "ae": {"sample_rate": ae.sample_rate, "base_chunk_size": ae.hop_length},
+        "ttl": {"chunk_compress_factor": ttl.compress_factor, "latent_dim": ae.latent_dim,
+                "normalizer": {"scale": ttl.normalizer_scale}},
+        "dp": {"chunk_compress_factor": dp.compress_factor, "latent_dim": ae.latent_dim,
+               "normalizer": {"scale": dp.normalizer_scale}},
+        "engine": "supertonic",
+    }, indent=2))
+    (out / "unicode_indexer.json").write_text(json.dumps(tokenizer.to_indexer_list()))
+
+    return {"duration_predictor": dp_path, "text_encoder": te_path,
+            "vector_estimator": ve_path, "vocoder": voc_path,
+            "tts": out / "tts.json", "unicode_indexer": out / "unicode_indexer.json"}
+
+
+def _load_stage(checkpoint: Optional[str], stage: str):
+    if checkpoint is None:
+        return None, None, None
+    ckpt = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    found = ckpt.get("supertonic_stage")
+    if found is not None and found != stage:
+        raise ValueError(f"{checkpoint} is a {found!r} checkpoint but was passed as the {stage!r} one")
+    from phoonnx_train.supertonic.lightning import _build_config
+    cfg = _build_config(ckpt.get("supertonic_config"))
+    tok = CharTokenizer.from_dict(ckpt.get("supertonic_tokenizer") or {})
+    return ckpt, cfg, tok
+
+
+def export_from_checkpoints(output_dir: str, *, autoencoder_ckpt: str,
+                            text_to_latent_ckpt: str, duration_predictor_ckpt: str) -> Dict[str, Path]:
+    """Rebuild all three modules from their Lightning checkpoints and export."""
+    from phoonnx_train.supertonic.autoencoder import SpeechAutoencoder
+    from phoonnx_train.supertonic.duration_predictor import DurationPredictor
+    from phoonnx_train.supertonic.text_to_latent import TextToLatentModel
+
+    ae_ckpt, ae_cfg, _ = _load_stage(autoencoder_ckpt, "autoencoder")
+    ttl_ckpt, ttl_cfg, tok = _load_stage(text_to_latent_ckpt, "text_to_latent")
+    dp_ckpt, dp_cfg, _ = _load_stage(duration_predictor_ckpt, "duration_predictor")
+    cfg = ttl_cfg or dp_cfg or ae_cfg
+
+    ae = SpeechAutoencoder(cfg.ae)
+    _load_prefixed(ae, ae_ckpt["state_dict"], "generator.", autoencoder_ckpt)
+    ttl = TextToLatentModel(cfg.ttl, cfg.vocab_size)
+    _load_prefixed(ttl, ttl_ckpt["state_dict"], "model.", text_to_latent_ckpt)
+    dp = DurationPredictor(cfg.dp, cfg.vocab_size)
+    _load_prefixed(dp, dp_ckpt["state_dict"], "model.", duration_predictor_ckpt)
+
+    return export_all(output_dir, config=cfg, tokenizer=tok,
+                      autoencoder=ae, text_to_latent=ttl, duration_predictor=dp)
+
+
+def _load_prefixed(module, state_dict, prefix, source):
+    picked = {k[len(prefix):]: v for k, v in state_dict.items() if k.startswith(prefix)}
+    missing = set(module.state_dict()) - set(picked)
+    if missing:
+        raise ValueError(
+            f"{source} does not contain weights for {type(module).__name__} under {prefix!r}: "
+            f"{len(missing)} missing key(s), e.g. {sorted(missing)[:3]}")
+    module.load_state_dict(picked, strict=False)

--- a/phoonnx_train/supertonic/import_onnx.py
+++ b/phoonnx_train/supertonic/import_onnx.py
@@ -1,0 +1,134 @@
+"""Import weights from the released ONNX graphs into the PyTorch modules.
+
+This is the fine-tune-from-``supertonic-3`` path. It reads every initializer
+(constant tensor) out of an ONNX file, resolving the anonymous initializers that
+``torch.onnx.export`` emits for some linear layers by tracing which node
+consumes them (the node name keeps the original module path). Tensors are then
+copied into a target module's ``state_dict`` by an explicit
+released-name -> local-name map, tolerating the usual conv-1x1<->linear squeeze
+and linear-weight transpose. A :class:`PortReport` records what loaded, what was
+missing, and any shape mismatches; nothing is copied silently under a wrong shape.
+
+Because the released graphs do not contain the encoder-side networks (speech
+encoder, the two style encoders), those always stay at their fresh init and must
+be trained; the report lists them as expected-missing.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+
+
+def load_onnx_initializers(path: str) -> Dict[str, np.ndarray]:
+    """Return ``{qualified_name: array}`` for every initializer in ``path``.
+
+    Named initializers are used as-is. Anonymous ones (``onnx::...`` / ``/...``)
+    are attributed to the consuming node's module path, with the input index
+    disambiguating weight (``.weight``) from bias (the 3rd input of Conv/Gemm).
+    """
+    import onnx
+    from onnx import numpy_helper
+
+    model = onnx.load(path)
+    inits = {i.name: i for i in model.graph.initializer}
+    consumer: Dict[str, Tuple[str, int]] = {}
+    for node in model.graph.node:
+        for idx, inp in enumerate(node.input):
+            if inp in inits and (inp.startswith("onnx::") or inp.startswith("/")):
+                consumer.setdefault(inp, (node.name, idx))
+
+    out: Dict[str, np.ndarray] = {}
+    for name, init in inits.items():
+        arr = numpy_helper.to_array(init)
+        if name.startswith("onnx::") or name.startswith("/"):
+            entry = consumer.get(name)
+            if entry is None:
+                continue
+            node_name, idx = entry
+            suffix = "bias" if idx >= 2 else "weight"
+            qualified = node_name.strip("/").rsplit("/", 1)[0].replace("/", ".") + f".{suffix}"
+        else:
+            qualified = name
+        out[qualified] = arr
+    return out
+
+
+@dataclass
+class PortReport:
+    loaded: List[str] = field(default_factory=list)
+    missing: List[str] = field(default_factory=list)
+    mismatched: List[Tuple[str, tuple, tuple]] = field(default_factory=list)
+
+    def summary(self) -> str:
+        return f"loaded={len(self.loaded)} missing={len(self.missing)} mismatched={len(self.mismatched)}"
+
+
+def _shape_aware_copy(dst: torch.Tensor, src_np: np.ndarray) -> bool:
+    src = torch.from_numpy(np.ascontiguousarray(src_np)).float()
+    if src.dim() == dst.dim() + 1 and src.shape[-1] == 1:  # conv-1x1 -> linear
+        src = src.squeeze(-1)
+    with torch.no_grad():
+        if src.shape == dst.shape:
+            dst.copy_(src)
+        elif src.dim() == 2 and src.t().shape == dst.shape:
+            dst.copy_(src.t())
+        elif src.numel() == dst.numel():
+            dst.copy_(src.reshape(dst.shape))
+        else:
+            return False
+    return True
+
+
+def assign_by_map(module: torch.nn.Module, arrays: Dict[str, np.ndarray],
+                  mapping: Dict[str, str], report: PortReport) -> PortReport:
+    """Copy ``arrays[onnx_name]`` into ``module``'s parameter ``local_name`` for
+    every ``local_name -> onnx_name`` in ``mapping``."""
+    params = dict(module.named_parameters())
+    params.update(module.named_buffers())
+    for local_name, onnx_name in mapping.items():
+        if local_name not in params:
+            report.missing.append(f"{local_name} (no such parameter)")
+            continue
+        if onnx_name not in arrays:
+            report.missing.append(f"{local_name} <- {onnx_name}")
+            continue
+        if _shape_aware_copy(params[local_name], arrays[onnx_name]):
+            report.loaded.append(local_name)
+        else:
+            report.mismatched.append((local_name, tuple(arrays[onnx_name].shape),
+                                      tuple(params[local_name].shape)))
+    return report
+
+
+def import_onnx_weights(onnx_dir: str, *, autoencoder=None, text_to_latent=None,
+                        duration_predictor=None,
+                        mappings: Dict[str, Dict[str, str]] | None = None) -> Dict[str, PortReport]:
+    """Best-effort port from ``<onnx_dir>/{vocoder,text_encoder,vector_estimator,
+    duration_predictor}.onnx`` into whichever modules are supplied.
+
+    ``mappings`` provides, per graph, a ``local_name -> onnx_name`` dict. When a
+    mapping is omitted the graph is loaded but nothing is assigned (the report
+    lists it as fully missing), so a caller can inspect the available names first.
+    """
+    import os
+
+    mappings = mappings or {}
+    reports: Dict[str, PortReport] = {}
+    graphs = {
+        "vocoder": autoencoder,
+        "text_encoder": text_to_latent,
+        "vector_estimator": text_to_latent,
+        "duration_predictor": duration_predictor,
+    }
+    for graph, module in graphs.items():
+        path = os.path.join(onnx_dir, f"{graph}.onnx")
+        if module is None or not os.path.exists(path):
+            continue
+        arrays = load_onnx_initializers(path)
+        report = PortReport()
+        assign_by_map(module, arrays, mappings.get(graph, {}), report)
+        reports[graph] = report
+    return reports

--- a/phoonnx_train/supertonic/latent_utils.py
+++ b/phoonnx_train/supertonic/latent_utils.py
@@ -1,0 +1,69 @@
+"""Temporal latent compression and reference-crop helpers shared by the
+text-to-latent module and the duration predictor.
+
+The autoencoder produces a ``latent_dim``-channel latent at the spectrogram
+frame rate. Both downstream stages operate on a *compressed* latent: groups of
+``k`` consecutive frames are folded into the channel dimension, shrinking the
+time axis ``k``-fold. Normalisation order matches the released model: normalise
+the raw latent with the autoencoder's per-channel stats, then compress, then
+apply the stage's own scalar multiplier.
+"""
+from __future__ import annotations
+
+import torch
+
+from phoonnx_train.supertonic.layers import make_mask
+
+
+def compress(latent: torch.Tensor, k: int) -> torch.Tensor:
+    """``(B, C, T)`` -> ``(B, C*k, T//k)``; trims T to a multiple of ``k``."""
+    b, c, t = latent.shape
+    t = (t // k) * k
+    latent = latent[..., :t].view(b, c, t // k, k)
+    return latent.permute(0, 1, 3, 2).reshape(b, c * k, t // k)
+
+
+def decompress(latent: torch.Tensor, k: int, latent_dim: int) -> torch.Tensor:
+    """Inverse of :func:`compress`: ``(B, C*k, T)`` -> ``(B, C, T*k)``."""
+    b, ck, t = latent.shape
+    latent = latent.view(b, latent_dim, k, t)
+    return latent.permute(0, 1, 3, 2).reshape(b, latent_dim, t * k)
+
+
+def normalize_and_compress(ae, raw: torch.Tensor, k: int, scale: float) -> torch.Tensor:
+    return compress(ae.normalize(raw), k) * scale
+
+
+def decompress_and_denormalize(ae, compressed: torch.Tensor, k: int, latent_dim: int, scale: float) -> torch.Tensor:
+    return ae.denormalize(decompress(compressed / scale, k, latent_dim))
+
+
+def sample_reference_crop(z1: torch.Tensor, lengths: torch.Tensor, frame_rate: float,
+                          min_dur: float = 0.2, max_dur: float = 9.0):
+    """Crop a random reference segment from each utterance's own compressed latent.
+
+    Returns ``(ref_latent, ref_mask, ref_time_mask)`` where ``ref_time_mask``
+    marks the positions of ``z1`` used as the reference (excluded from the flow
+    matching loss to avoid leakage).
+    """
+    b, c, t = z1.shape
+    dev = z1.device
+    min_frames = max(1, round(min_dur * frame_rate))
+    starts = torch.zeros(b, dtype=torch.long, device=dev)
+    lens = torch.zeros(b, dtype=torch.long, device=dev)
+    for i in range(b):
+        li = int(lengths[i].item())
+        top = max(min_frames, min(round(max_dur * frame_rate), li // 2))
+        crop = min_frames if top <= min_frames else int(torch.randint(min_frames, top + 1, (1,)).item())
+        crop = min(crop, max(li, 1))
+        start = 0 if li - crop <= 0 else int(torch.randint(0, li - crop + 1, (1,)).item())
+        starts[i], lens[i] = start, crop
+
+    t_ref = int(lens.max().item())
+    ref = z1.new_zeros(b, c, t_ref)
+    ref_time_mask = z1.new_zeros(b, 1, t)
+    for i in range(b):
+        s, l = int(starts[i]), int(lens[i])
+        ref[i, :, :l] = z1[i, :, s:s + l]
+        ref_time_mask[i, :, s:s + l] = 1.0
+    return ref, make_mask(lens, t_ref), ref_time_mask

--- a/phoonnx_train/supertonic/layers.py
+++ b/phoonnx_train/supertonic/layers.py
@@ -1,0 +1,348 @@
+"""Reusable neural building blocks for the SuperTonic stack.
+
+Every module here works on ``(batch, channels, time)`` tensors and, where a
+``mask`` is accepted, expects it shaped ``(batch, 1, time)`` with ``1`` marking
+valid positions and ``0`` marking padding. Masking padded frames repeatedly
+inside each block keeps padded batches numerically identical to single-utterance
+batches, which matters as soon as real (ragged) data is used.
+
+These are original implementations of standard components — Vocos-style ConvNeXt
+blocks, rotary multi-head attention, the VITS/Glow-TTS windowed
+relative-position self-attention, a fixed-context cross-attention pooler, and a
+sinusoidal timestep embedding.
+"""
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def make_mask(lengths: torch.Tensor, max_len: int | None = None) -> torch.Tensor:
+    """``(B,)`` valid-lengths -> ``(B, 1, max_len)`` float mask."""
+    if max_len is None:
+        max_len = int(lengths.max().item())
+    steps = torch.arange(max_len, device=lengths.device)
+    valid = steps.unsqueeze(0) < lengths.unsqueeze(1)
+    return valid.float().unsqueeze(1)
+
+
+class ConvNeXtBlock(nn.Module):
+    """Depthwise-conv ConvNeXt block (Vocos flavour) over ``(B, C, T)``.
+
+    ``causal=True`` pads only on the left so no future frame leaks into the
+    present one — used by the streaming waveform decoder. Padding uses replicate
+    mode, matching the released graphs' edge-padding.
+    """
+
+    def __init__(self, dim: int, ffn_dim: int, kernel: int = 7, dilation: int = 1,
+                 causal: bool = False, scale_init: float = 1e-6):
+        super().__init__()
+        span = (kernel - 1) * dilation
+        self.left = span if causal else span // 2
+        self.right = 0 if causal else span - span // 2
+        self.depthwise = nn.Conv1d(dim, dim, kernel, groups=dim, dilation=dilation)
+        self.norm = nn.LayerNorm(dim)
+        self.up = nn.Linear(dim, ffn_dim)
+        self.down = nn.Linear(ffn_dim, dim)
+        self.scale = nn.Parameter(scale_init * torch.ones(dim))
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if mask is not None:
+            x = x * mask
+        skip = x
+        x = F.pad(x, (self.left, self.right), mode="replicate")
+        x = self.depthwise(x)
+        if mask is not None:
+            x = x * mask
+        x = x.transpose(1, 2)
+        x = self.down(F.gelu(self.up(self.norm(x))))
+        x = (self.scale * x).transpose(1, 2)
+        out = skip + x
+        return out * mask if mask is not None else out
+
+
+class ConvNeXtStack(nn.Module):
+    def __init__(self, dim: int, ffn_dim: int, kernel: int, dilations, causal: bool = False):
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [ConvNeXtBlock(dim, ffn_dim, kernel, d, causal=causal) for d in dilations]
+        )
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(x, mask)
+        return x
+
+
+class ChannelNorm(nn.Module):
+    """LayerNorm across the channel axis of a ``(B, C, T)`` tensor."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.norm(x.transpose(1, 2)).transpose(1, 2)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    a, b = x.chunk(2, dim=-1)
+    return torch.cat([-b, a], dim=-1)
+
+
+class RotaryAttention(nn.Module):
+    """Multi-head attention over ``(B, C, T)`` supporting cross-attention with
+    length-normalised rotary positions on the query and key axes independently.
+
+    ``length_aware`` divides each sample's positions by its own true (unpadded)
+    length so text->latent cross-attention keeps a monotonic diagonal even when
+    the two sequences differ in length.
+    """
+
+    def __init__(self, q_dim: int, kv_dim: int, n_heads: int, units: int | None = None,
+                 rotary_base: float | None = None):
+        super().__init__()
+        units = units or q_dim
+        assert units % n_heads == 0
+        self.n_heads = n_heads
+        self.head_dim = units // n_heads
+        self.q = nn.Linear(q_dim, units)
+        self.k = nn.Linear(kv_dim, units)
+        self.v = nn.Linear(kv_dim, units)
+        self.o = nn.Linear(units, q_dim)
+        if rotary_base:
+            inv = 1.0 / (rotary_base ** (torch.arange(0, self.head_dim, 2).float() / self.head_dim))
+            self.register_buffer("inv_freq", inv, persistent=False)
+        else:
+            self.inv_freq = None
+
+    def _heads(self, x: torch.Tensor) -> torch.Tensor:
+        b, t, _ = x.shape
+        return x.view(b, t, self.n_heads, self.head_dim).transpose(1, 2)
+
+    def _cos_sin(self, positions: torch.Tensor, dtype):
+        freqs = positions.unsqueeze(-1) * self.inv_freq.to(positions.device)
+        emb = torch.cat([freqs, freqs], dim=-1)
+        return emb.cos().to(dtype), emb.sin().to(dtype)
+
+    def forward(self, x_q, x_kv, mask=None, length_aware=False, gamma=1.0,
+                q_len=None, k_len=None):
+        q = self._heads(self.q(x_q.transpose(1, 2)))
+        k = self._heads(self.k(x_kv.transpose(1, 2)))
+        v = self._heads(self.v(x_kv.transpose(1, 2)))
+
+        if self.inv_freq is not None:
+            tq, tk = q.shape[2], k.shape[2]
+            dev = q.device
+            if length_aware:
+                ql = (q_len if q_len is not None else torch.full((q.shape[0],), tq, device=dev)).clamp(min=1).float()
+                kl = (k_len if k_len is not None else torch.full((k.shape[0],), tk, device=dev)).clamp(min=1).float()
+                pos_q = gamma * torch.arange(tq, device=dev).float().unsqueeze(0) / ql.unsqueeze(1)
+                pos_k = gamma * torch.arange(tk, device=dev).float().unsqueeze(0) / kl.unsqueeze(1)
+                cos_q, sin_q = self._cos_sin(pos_q, q.dtype)
+                cos_k, sin_k = self._cos_sin(pos_k, q.dtype)
+                cos_q, sin_q, cos_k, sin_k = (t.unsqueeze(1) for t in (cos_q, sin_q, cos_k, sin_k))
+            else:
+                pos_q = torch.arange(tq, device=dev).float()
+                pos_k = torch.arange(tk, device=dev).float()
+                cos_q, sin_q = self._cos_sin(pos_q, q.dtype)
+                cos_k, sin_k = self._cos_sin(pos_k, q.dtype)
+                cos_q, sin_q, cos_k, sin_k = (t.unsqueeze(0).unsqueeze(0) for t in (cos_q, sin_q, cos_k, sin_k))
+            q = q * cos_q + _rotate_half(q) * sin_q
+            k = k * cos_k + _rotate_half(k) * sin_k
+
+        bias = None
+        if mask is not None:
+            bias = torch.zeros_like(mask, dtype=q.dtype).masked_fill(mask < 0.5, float("-inf")).unsqueeze(1)
+        out = F.scaled_dot_product_attention(q, k, v, attn_mask=bias)
+        out = out.transpose(1, 2).reshape(x_q.shape[0], -1, self.n_heads * self.head_dim)
+        return self.o(out).transpose(1, 2)
+
+
+class FixedContextCrossAttention(nn.Module):
+    """Cross-attention from a ``(B, C_x, T)`` stream onto a fixed-length context
+    ``(B, T_ctx, C_ctx)`` (e.g. the style token bank). The context is re-projected
+    into keys and values here. ``tanh_key`` bounds the key with tanh before the
+    score (used for style conditioning). The score is scaled by ``sqrt(hidden)``.
+    """
+
+    def __init__(self, x_dim: int, ctx_dim: int, n_heads: int, hidden: int | None = None,
+                 tanh_key: bool = True):
+        super().__init__()
+        hidden = hidden or ctx_dim
+        assert hidden % n_heads == 0
+        self.n_heads = n_heads
+        self.head_dim = hidden // n_heads
+        self.hidden = hidden
+        self.tanh_key = tanh_key
+        self.q = nn.Linear(x_dim, hidden)
+        self.k = nn.Linear(ctx_dim, hidden)
+        self.v = nn.Linear(ctx_dim, hidden)
+        self.o = nn.Linear(hidden, x_dim)
+
+    def _heads(self, x: torch.Tensor) -> torch.Tensor:
+        b, t, _ = x.shape
+        return x.view(b, t, self.n_heads, self.head_dim).transpose(1, 2)
+
+    def forward(self, x: torch.Tensor, ctx: torch.Tensor, ctx_mask: torch.Tensor | None = None) -> torch.Tensor:
+        q = self._heads(self.q(x.transpose(1, 2)))
+        k = self._heads(self.k(ctx))
+        v = self._heads(self.v(ctx))
+        key = torch.tanh(k) if self.tanh_key else k
+        scores = torch.matmul(q, key.transpose(-2, -1)) / math.sqrt(self.hidden)
+        if ctx_mask is not None:
+            scores = scores.masked_fill(ctx_mask.view(x.shape[0], 1, 1, -1) < 0.5, float("-inf"))
+        attn = F.softmax(scores, dim=-1)
+        out = torch.matmul(attn, v).transpose(1, 2).reshape(x.shape[0], -1, self.n_heads * self.head_dim)
+        return self.o(out).transpose(1, 2)
+
+
+def _flatten_pad(shape):
+    return [v for pair in reversed(shape) for v in pair]
+
+
+class RelPositionSelfAttention(nn.Module):
+    """Windowed relative-position multi-head self-attention (Shaw et al. 2018),
+    as used in VITS/Glow-TTS. Learns a pair of relative-position embedding banks
+    of width ``2*window+1`` and adds a relative-position score term to the
+    standard dot-product attention.
+    """
+
+    def __init__(self, dim: int, n_heads: int, window: int = 4):
+        super().__init__()
+        assert dim % n_heads == 0
+        self.n_heads = n_heads
+        self.dk = dim // n_heads
+        self.window = window
+        self.q = nn.Conv1d(dim, dim, 1)
+        self.k = nn.Conv1d(dim, dim, 1)
+        self.v = nn.Conv1d(dim, dim, 1)
+        self.out = nn.Conv1d(dim, dim, 1)
+        std = self.dk ** -0.5
+        self.rel_k = nn.Parameter(torch.randn(1, 2 * window + 1, self.dk) * std)
+        self.rel_v = nn.Parameter(torch.randn(1, 2 * window + 1, self.dk) * std)
+
+    def _slice_rel(self, emb: torch.Tensor, length: int) -> torch.Tensor:
+        pad = max(length - (self.window + 1), 0)
+        start = max((self.window + 1) - length, 0)
+        end = start + 2 * length - 1
+        if pad > 0:
+            emb = F.pad(emb, _flatten_pad([[0, 0], [pad, pad], [0, 0]]))
+        return emb[:, start:end]
+
+    def _rel_to_abs(self, x: torch.Tensor) -> torch.Tensor:
+        b, h, length, _ = x.shape
+        x = F.pad(x, _flatten_pad([[0, 0], [0, 0], [0, 0], [0, 1]]))
+        flat = x.view(b, h, length * 2 * length)
+        flat = F.pad(flat, _flatten_pad([[0, 0], [0, 0], [0, length - 1]]))
+        return flat.view(b, h, length + 1, 2 * length - 1)[:, :, :length, length - 1:]
+
+    def _abs_to_rel(self, x: torch.Tensor) -> torch.Tensor:
+        b, h, length, _ = x.shape
+        x = F.pad(x, _flatten_pad([[0, 0], [0, 0], [0, 0], [0, length - 1]]))
+        flat = x.view(b, h, length ** 2 + length * (length - 1))
+        flat = F.pad(flat, _flatten_pad([[0, 0], [0, 0], [length, 0]]))
+        return flat.view(b, h, length, 2 * length)[:, :, :, 1:]
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        b, c, t = x.shape
+        q = self.q(x).view(b, self.n_heads, self.dk, t).transpose(2, 3)
+        k = self.k(x).view(b, self.n_heads, self.dk, t).transpose(2, 3)
+        v = self.v(x).view(b, self.n_heads, self.dk, t).transpose(2, 3)
+
+        qs = q / math.sqrt(self.dk)
+        scores = torch.matmul(qs, k.transpose(-2, -1))
+        rel_k = self._slice_rel(self.rel_k, t)
+        rel_scores = torch.matmul(qs, rel_k.unsqueeze(0).transpose(-2, -1))
+        scores = scores + self._rel_to_abs(rel_scores)
+
+        if mask is not None:
+            scores = scores.masked_fill(mask.unsqueeze(1) < 0.5, float("-inf"))
+        attn = F.softmax(scores, dim=-1)
+        rel_v = self._slice_rel(self.rel_v, t)
+        out = torch.matmul(attn, v) + torch.matmul(self._abs_to_rel(attn), rel_v.unsqueeze(0))
+        out = out.transpose(2, 3).reshape(b, c, t)
+        return self.out(out)
+
+
+class RelPositionEncoder(nn.Module):
+    """Stack of relative-position self-attention + conv-FFN layers, each with a
+    residual post-norm (VITS/Glow-TTS encoder layout)."""
+
+    def __init__(self, dim: int, ffn_dim: int, n_heads: int, n_layers: int, window: int = 4):
+        super().__init__()
+        self.attn = nn.ModuleList([RelPositionSelfAttention(dim, n_heads, window) for _ in range(n_layers)])
+        self.norm1 = nn.ModuleList([ChannelNorm(dim) for _ in range(n_layers)])
+        self.ffn = nn.ModuleList(
+            [nn.ModuleDict({"c1": nn.Conv1d(dim, ffn_dim, 1), "c2": nn.Conv1d(ffn_dim, dim, 1)})
+             for _ in range(n_layers)]
+        )
+        self.norm2 = nn.ModuleList([ChannelNorm(dim) for _ in range(n_layers)])
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        for attn, n1, ffn, n2 in zip(self.attn, self.norm1, self.ffn, self.norm2):
+            x = n1(x + attn(x, mask))
+            h = x * mask if mask is not None else x
+            h = F.relu(ffn["c1"](h))
+            h = h * mask if mask is not None else h
+            h = ffn["c2"](h)
+            x = n2(x + h)
+            if mask is not None:
+                x = x * mask
+        return x
+
+
+class StylePool(nn.Module):
+    """Pools a variable-length reference sequence into ``n_style`` fixed tokens
+    with a learnable query bank, via one cross-attention pass."""
+
+    def __init__(self, input_dim: int, n_style: int, dim: int, n_heads: int):
+        super().__init__()
+        self.query = nn.Parameter(torch.randn(1, n_style, dim) * 0.02)
+        self.pool = FixedContextCrossAttention(dim, input_dim, n_heads, hidden=dim, tanh_key=False)
+
+    def forward(self, ref: torch.Tensor, ref_mask: torch.Tensor | None = None) -> torch.Tensor:
+        b = ref.shape[0]
+        q = self.query.expand(b, -1, -1).transpose(1, 2)
+        ctx_mask = ref_mask.squeeze(1) if ref_mask is not None else None
+        out = self.pool(q, ref.transpose(1, 2), ctx_mask=ctx_mask)
+        return out.transpose(1, 2)  # (B, n_style, dim)
+
+
+class FlattenStylePool(nn.Module):
+    """Pools a reference sequence into a single flat vector by concatenating
+    ``n_style`` pooled tokens along the channel axis (duration predictor)."""
+
+    def __init__(self, input_dim: int, n_style: int, dim: int, value_dim: int, n_heads: int):
+        super().__init__()
+        self.n_style = n_style
+        self.query = nn.Parameter(torch.randn(1, n_style, dim) * 0.02)
+        self.attn = RotaryAttention(dim, input_dim, n_heads, units=dim)
+        self.proj = nn.Linear(dim, value_dim // n_style)
+
+    def forward(self, ref: torch.Tensor, ref_mask: torch.Tensor | None = None) -> torch.Tensor:
+        b = ref.shape[0]
+        q = self.query.expand(b, -1, -1).transpose(1, 2)
+        pooled = self.attn(q, ref, mask=ref_mask).transpose(1, 2)
+        pooled = self.proj(pooled)
+        return pooled.reshape(b, -1)
+
+
+class TimestepEmbedding(nn.Module):
+    """Sinusoidal timestep features expanded to ``hidden`` and projected back to
+    ``dim`` (Grad-TTS style)."""
+
+    def __init__(self, dim: int, hidden: int):
+        super().__init__()
+        self.dim = dim
+        self.mlp = nn.Sequential(nn.Linear(dim, hidden), nn.SiLU(), nn.Linear(hidden, dim))
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        half = self.dim // 2
+        freqs = torch.exp(-math.log(10000.0) * torch.arange(half, device=t.device).float() / half)
+        args = t.float().unsqueeze(-1) * freqs.unsqueeze(0)
+        emb = torch.cat([args.sin(), args.cos()], dim=-1)
+        return self.mlp(emb)

--- a/phoonnx_train/supertonic/lightning.py
+++ b/phoonnx_train/supertonic/lightning.py
@@ -1,0 +1,354 @@
+"""pytorch_lightning training loops for the three SuperTonic stages.
+
+Each stage is a separate :class:`~pytorch_lightning.LightningModule`:
+
+* :class:`AutoencoderModule` — GAN training of the speech autoencoder (manual
+  optimization: a generator step and a discriminator step per batch). At the end
+  of every epoch it measures the per-channel latent statistics over up to
+  ``stats_batches`` batches and stores them in the autoencoder's buffers, so the
+  checkpoint carries the normalisation the later stages depend on.
+* :class:`TextToLatentModule` — conditional flow matching, with target latents
+  produced on the fly by a frozen autoencoder.
+* :class:`DurationPredictorModule` — regress the utterance duration (in seconds)
+  from text plus a reference crop of the utterance's own latent.
+
+All three take a :class:`SuperTonicConfig` and a :class:`CharTokenizer` (or the
+data needed to build one) so a checkpoint fully reconstructs the model. Datasets
+are the filelist form in :mod:`phoonnx_train.supertonic.dataset`. Lightning
+already round-trips model/optimizer/scheduler/step in its checkpoints; the
+config and tokenizer are embedded via :meth:`on_save_checkpoint` so ONNX export
+and fine-tuning can rebuild the exact model.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Any, Dict, List, Optional
+
+import pytorch_lightning as pl
+import torch
+
+from phoonnx_train.supertonic.config import SuperTonicConfig
+from phoonnx_train.supertonic.text import CharTokenizer
+
+LOG = logging.getLogger(__name__)
+
+
+def _build_config(config: Any) -> SuperTonicConfig:
+    if isinstance(config, SuperTonicConfig):
+        return config
+    if isinstance(config, dict):
+        cfg = SuperTonicConfig()
+        for stage in ("ae", "ttl", "dp"):
+            for k, v in (config.get(stage) or {}).items():
+                if hasattr(getattr(cfg, stage), k):
+                    setattr(getattr(cfg, stage), k, tuple(v) if isinstance(v, list) else v)
+        cfg.vocab_size = config.get("vocab_size", cfg.vocab_size)
+        return cfg
+    return SuperTonicConfig()
+
+
+class _StageBase(pl.LightningModule):
+    stage_name = "base"
+
+    def _stash(self, config: SuperTonicConfig, tokenizer: Optional[CharTokenizer]):
+        self._config = config
+        self._tokenizer = tokenizer or CharTokenizer()
+
+    def on_save_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
+        checkpoint["supertonic_config"] = asdict(self._config)
+        checkpoint["supertonic_tokenizer"] = self._tokenizer.to_dict()
+        checkpoint["supertonic_stage"] = self.stage_name
+
+    def _load_into(self, module, state_dict, prefix, source):
+        picked = {k[len(prefix):]: v for k, v in state_dict.items() if k.startswith(prefix)}
+        if not picked:
+            picked = state_dict
+        missing = set(module.state_dict()) - set(picked)
+        if missing:
+            raise ValueError(
+                f"{source} does not contain weights for {type(module).__name__}: "
+                f"{len(missing)} missing key(s), e.g. {sorted(missing)[:3]}")
+        module.load_state_dict(picked, strict=False)
+
+    def _make_loader(self, ds, batch_size, shuffle, collate, num_workers):
+        return torch.utils.data.DataLoader(
+            ds, batch_size=batch_size, shuffle=shuffle, drop_last=shuffle,
+            collate_fn=collate, num_workers=num_workers,
+            pin_memory=torch.cuda.is_available())
+
+
+# ----------------------------------------------------------------------
+# Stage 1 — speech autoencoder (GAN)
+# ----------------------------------------------------------------------
+
+class AutoencoderModule(_StageBase):
+    stage_name = "autoencoder"
+
+    def __init__(self, config: Any = None, dataset: Optional[List[str]] = None,
+                 root_dir: str = ".", batch_size: int = 4, num_workers: int = 0,
+                 segment_seconds: float = 0.5, base_lr: float = 2e-4,
+                 lambda_mel: float = 45.0, lambda_fm: float = 2.0,
+                 stats_batches: int = 200, **_ignored: Any):
+        super().__init__()
+        from phoonnx_train.supertonic.autoencoder import SpeechAutoencoder
+        from phoonnx_train.supertonic.discriminators import (
+            MultiPeriodDiscriminator,
+            MultiResolutionDiscriminator,
+        )
+        from phoonnx_train.supertonic.losses import MultiResolutionMelLoss
+
+        cfg = _build_config(config)
+        self._stash(cfg, None)
+        self.save_hyperparameters(ignore=["config"])
+        self.automatic_optimization = False
+
+        self.generator = SpeechAutoencoder(cfg.ae)
+        self.mpd = MultiPeriodDiscriminator()
+        self.mrd = MultiResolutionDiscriminator()
+        self.mel_loss = MultiResolutionMelLoss(cfg.ae.sample_rate)
+        self._dataset = dataset
+        self._root = root_dir
+        self._train_set = None
+
+    def setup(self, stage: Optional[str] = None):
+        from phoonnx_train.supertonic.dataset import WaveformDataset
+        if self._train_set is not None or not self._dataset:
+            return
+        seg = int(self.hparams.segment_seconds * self._config.ae.sample_rate)
+        self._train_set = torch.utils.data.ConcatDataset(
+            [WaveformDataset(p, self._root, self._config.ae.sample_rate, seg) for p in self._dataset])
+
+    def train_dataloader(self):
+        from phoonnx_train.supertonic.dataset import waveform_collate
+        return self._make_loader(self._train_set, self.hparams.batch_size, True,
+                                 waveform_collate, self.hparams.num_workers)
+
+    def _disc_outputs(self, wav):
+        mpd_out, mpd_feat = self.mpd(wav)
+        mrd_out, mrd_feat = self.mrd(wav)
+        return mpd_out + mrd_out, mpd_feat + mrd_feat
+
+    def training_step(self, batch, batch_idx):
+        from phoonnx_train.supertonic.losses import (
+            discriminator_loss,
+            feature_matching_loss,
+            generator_adv_loss,
+        )
+        opt_g, opt_d = self.optimizers()
+        wav = batch
+        recon, _ = self.generator(wav)
+        n = min(wav.shape[-1], recon.shape[-1])
+        wav, recon = wav[..., :n], recon[..., :n]
+
+        # discriminator step
+        real_out, _ = self._disc_outputs(wav)
+        fake_out, _ = self._disc_outputs(recon.detach())
+        d_loss = discriminator_loss(real_out, fake_out)
+        opt_d.zero_grad()
+        self.manual_backward(d_loss)
+        opt_d.step()
+
+        # generator step
+        real_out, real_feat = self._disc_outputs(wav)
+        fake_out, fake_feat = self._disc_outputs(recon)
+        g_adv = generator_adv_loss(fake_out)
+        g_fm = feature_matching_loss(real_feat, fake_feat)
+        g_mel = self.mel_loss(recon, wav)
+        g_loss = g_adv + self.hparams.lambda_fm * g_fm + self.hparams.lambda_mel * g_mel
+        opt_g.zero_grad()
+        self.manual_backward(g_loss)
+        opt_g.step()
+
+        self.log_dict({"train/g_loss": g_loss, "train/d_loss": d_loss, "train/mel": g_mel},
+                      prog_bar=True, batch_size=wav.shape[0])
+        return g_loss
+
+    def on_train_epoch_end(self):
+        """Refit the per-channel latent statistics the downstream stages normalise with.
+
+        They must describe the encoder as it stands in the checkpoint about to be
+        written, so they are measured in a separate encode-only pass rather than
+        accumulated across an epoch of changing weights.
+        """
+        loader = self.trainer.train_dataloader if self.trainer else None
+        if loader is None:
+            return
+        was_training = self.generator.training
+        self.generator.eval()
+        latents = []
+        with torch.no_grad():
+            for i, wav in enumerate(loader):
+                if i >= self.hparams.stats_batches:
+                    break
+                latents.append(self.generator.encode(wav.to(self.device)).cpu())
+        self.generator.train(was_training)
+        if latents:
+            self.generator.fit_latent_stats(latents)
+
+    def configure_optimizers(self):
+        opt_g = torch.optim.AdamW(self.generator.parameters(), lr=self.hparams.base_lr, betas=(0.8, 0.99))
+        opt_d = torch.optim.AdamW(
+            list(self.mpd.parameters()) + list(self.mrd.parameters()),
+            lr=self.hparams.base_lr, betas=(0.8, 0.99))
+        return [opt_g, opt_d]
+
+
+# ----------------------------------------------------------------------
+# frozen-AE helper for stages 2 and 3
+# ----------------------------------------------------------------------
+
+class _NeedsFrozenAE(_StageBase):
+    def _init_ae(self, cfg, ae_checkpoint):
+        from phoonnx_train.supertonic.autoencoder import SpeechAutoencoder
+        ae = SpeechAutoencoder(cfg.ae)
+        if not ae_checkpoint:
+            raise ValueError(f"stage {self.stage_name!r} needs a trained autoencoder checkpoint "
+                             "(ae_checkpoint) to produce latent targets")
+        ckpt = torch.load(ae_checkpoint, map_location="cpu", weights_only=False)
+        found = ckpt.get("supertonic_stage")
+        if found is not None and found != AutoencoderModule.stage_name:
+            raise ValueError(f"{ae_checkpoint} is a {found!r} checkpoint, not an autoencoder one")
+        self._load_into(ae, ckpt.get("state_dict", ckpt), "generator.", ae_checkpoint)
+        if not bool(ae.stats_fitted):
+            raise ValueError(
+                f"{ae_checkpoint} carries no fitted latent statistics; stage {self.stage_name!r} "
+                "would train against unnormalised latents. Train the autoencoder to the end of an "
+                "epoch so its statistics are fitted and saved.")
+        ae.eval()
+        for p in ae.parameters():
+            p.requires_grad_(False)
+        self.frozen_ae = ae
+
+    @torch.no_grad()
+    def _targets(self, wav, wav_lens, stage_cfg):
+        from phoonnx_train.supertonic.latent_utils import normalize_and_compress
+        from phoonnx_train.supertonic.layers import make_mask
+        raw = self.frozen_ae.encode(wav)  # (B, ld, T)
+        z1 = normalize_and_compress(self.frozen_ae, raw, stage_cfg.compress_factor, stage_cfg.normalizer_scale)
+        # per-sample compressed-frame lengths
+        # centred STFT emits one frame per hop plus one
+        frames = torch.div(wav_lens, self._config.ae.hop_length, rounding_mode="floor") + 1
+        latent_lens = torch.div(frames, stage_cfg.compress_factor, rounding_mode="floor").clamp(min=1, max=z1.shape[-1])
+        return z1, make_mask(latent_lens, z1.shape[-1]), latent_lens
+
+
+# ----------------------------------------------------------------------
+# Stage 2 — text to latent (flow matching)
+# ----------------------------------------------------------------------
+
+class TextToLatentModule(_NeedsFrozenAE):
+    stage_name = "text_to_latent"
+
+    def __init__(self, config: Any = None, tokenizer: Any = None,
+                 dataset: Optional[List[str]] = None, root_dir: str = ".",
+                 ae_checkpoint: Optional[str] = None, batch_size: int = 4,
+                 num_workers: int = 0, base_lr: float = 1e-4, **_ignored: Any):
+        super().__init__()
+        from phoonnx_train.supertonic.text_to_latent import TextToLatentModel
+
+        cfg = _build_config(config)
+        tok = tokenizer if isinstance(tokenizer, CharTokenizer) else (
+            CharTokenizer.from_dict(tokenizer) if isinstance(tokenizer, dict) else CharTokenizer())
+        self._stash(cfg, tok)
+        self.save_hyperparameters(ignore=["config", "tokenizer"])
+
+        self.model = TextToLatentModel(cfg.ttl, cfg.vocab_size)
+        self._init_ae(cfg, ae_checkpoint)
+        self._dataset, self._root, self._ae_ckpt = dataset, root_dir, ae_checkpoint
+        self._train_set = None
+
+    def setup(self, stage: Optional[str] = None):
+        from phoonnx_train.supertonic.dataset import TextAudioDataset
+        if self._train_set is not None or not self._dataset:
+            return
+        self._train_set = torch.utils.data.ConcatDataset([
+            TextAudioDataset(p, self._root, self._tokenizer, self._config.ae.sample_rate)
+            for p in self._dataset])
+
+    def train_dataloader(self):
+        from phoonnx_train.supertonic.dataset import text_audio_collate
+        return self._make_loader(self._train_set, self.hparams.batch_size, True,
+                                 text_audio_collate, self.hparams.num_workers)
+
+    def _loss(self, batch):
+        from phoonnx_train.supertonic.latent_utils import sample_reference_crop
+        from phoonnx_train.supertonic.layers import make_mask
+        from phoonnx_train.supertonic.text_to_latent import flow_matching_loss
+        wav, wav_lens, text_ids, text_lens = batch
+        cfg = self._config.ttl
+        z1, latent_mask, latent_lens = self._targets(wav, wav_lens, cfg)
+        frame_rate = self._config.ae.sample_rate / self._config.ae.hop_length / cfg.compress_factor
+        ref, ref_mask, ref_time_mask = sample_reference_crop(z1, latent_lens, frame_rate)
+        text_mask = make_mask(text_lens.clamp(min=1), text_ids.shape[-1])
+        return flow_matching_loss(self.model, z1, latent_mask, text_ids, text_mask,
+                                  ref, ref_mask, ref_time_mask, n_expand=cfg.batch_expand)
+
+    def training_step(self, batch, batch_idx):
+        loss = self._loss(batch)
+        self.log("train/fm_loss", loss, prog_bar=True, batch_size=batch[0].shape[0])
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.AdamW(self.model.parameters(), lr=self.hparams.base_lr, betas=(0.9, 0.98))
+
+
+# ----------------------------------------------------------------------
+# Stage 3 — duration predictor
+# ----------------------------------------------------------------------
+
+class DurationPredictorModule(_NeedsFrozenAE):
+    stage_name = "duration_predictor"
+
+    def __init__(self, config: Any = None, tokenizer: Any = None,
+                 dataset: Optional[List[str]] = None, root_dir: str = ".",
+                 ae_checkpoint: Optional[str] = None, batch_size: int = 4,
+                 num_workers: int = 0, base_lr: float = 1e-4, **_ignored: Any):
+        super().__init__()
+        from phoonnx_train.supertonic.duration_predictor import DurationPredictor
+
+        cfg = _build_config(config)
+        tok = tokenizer if isinstance(tokenizer, CharTokenizer) else (
+            CharTokenizer.from_dict(tokenizer) if isinstance(tokenizer, dict) else CharTokenizer())
+        self._stash(cfg, tok)
+        self.save_hyperparameters(ignore=["config", "tokenizer"])
+
+        self.model = DurationPredictor(cfg.dp, cfg.vocab_size)
+        self._init_ae(cfg, ae_checkpoint)
+        self._dataset, self._root = dataset, root_dir
+        self._train_set = None
+
+    def setup(self, stage: Optional[str] = None):
+        from phoonnx_train.supertonic.dataset import TextAudioDataset
+        if self._train_set is not None or not self._dataset:
+            return
+        self._train_set = torch.utils.data.ConcatDataset([
+            TextAudioDataset(p, self._root, self._tokenizer, self._config.ae.sample_rate)
+            for p in self._dataset])
+
+    def train_dataloader(self):
+        from phoonnx_train.supertonic.dataset import text_audio_collate
+        return self._make_loader(self._train_set, self.hparams.batch_size, True,
+                                 text_audio_collate, self.hparams.num_workers)
+
+    def _loss(self, batch):
+        from phoonnx_train.supertonic.duration_predictor import duration_loss
+        from phoonnx_train.supertonic.latent_utils import sample_reference_crop
+        from phoonnx_train.supertonic.layers import make_mask
+        wav, wav_lens, text_ids, text_lens = batch
+        cfg = self._config.dp
+        z1, _, latent_lens = self._targets(wav, wav_lens, cfg)
+        frame_rate = self._config.ae.sample_rate / self._config.ae.hop_length / cfg.compress_factor
+        ref, ref_mask, _ = sample_reference_crop(z1, latent_lens, frame_rate)
+        text_mask = make_mask(text_lens.clamp(min=1), text_ids.shape[-1])
+        pred = self.model(text_ids, text_mask, ref, ref_mask)
+        target = wav_lens.float() / self._config.ae.sample_rate
+        return duration_loss(pred, target)
+
+    def training_step(self, batch, batch_idx):
+        loss = self._loss(batch)
+        self.log("train/dur_loss", loss, prog_bar=True, batch_size=batch[0].shape[0])
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.AdamW(self.model.parameters(), lr=self.hparams.base_lr, betas=(0.9, 0.98))

--- a/phoonnx_train/supertonic/losses.py
+++ b/phoonnx_train/supertonic/losses.py
@@ -1,0 +1,50 @@
+"""Loss functions for the speech-autoencoder GAN stage: multi-resolution mel
+reconstruction, least-squares adversarial losses, and discriminator
+feature-matching.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+import torchaudio
+
+MEL_RESOLUTIONS = ((256, 32), (512, 64), (1024, 80))  # (n_fft, n_mels); hop = n_fft // 4
+
+
+class MultiResolutionMelLoss(torch.nn.Module):
+    def __init__(self, sample_rate: int, resolutions=MEL_RESOLUTIONS):
+        super().__init__()
+        self.transforms = torch.nn.ModuleList([
+            torchaudio.transforms.MelSpectrogram(
+                sample_rate=sample_rate, n_fft=n_fft, win_length=n_fft,
+                hop_length=n_fft // 4, n_mels=n_mels, power=1.0, center=True)
+            for n_fft, n_mels in resolutions
+        ])
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        total = x.new_zeros(())
+        for tf in self.transforms:
+            mx = torch.log(tf(x).clamp_min(1e-5))
+            my = torch.log(tf(y).clamp_min(1e-5))
+            total = total + F.l1_loss(mx, my)
+        return total / len(self.transforms)
+
+
+def discriminator_loss(real_outs, fake_outs) -> torch.Tensor:
+    total = 0.0
+    for real, fake in zip(real_outs, fake_outs):
+        total = total + ((real - 1) ** 2).mean() + ((fake + 1) ** 2).mean()
+    return total / len(real_outs)
+
+
+def generator_adv_loss(fake_outs) -> torch.Tensor:
+    return sum(((fake - 1) ** 2).mean() for fake in fake_outs) / len(fake_outs)
+
+
+def feature_matching_loss(real_feats, fake_feats) -> torch.Tensor:
+    total, n = 0.0, 0
+    for real_layers, fake_layers in zip(real_feats, fake_feats):
+        for r, f in zip(real_layers, fake_layers):
+            total = total + F.l1_loss(f, r.detach())
+            n += 1
+    return total / max(n, 1)

--- a/phoonnx_train/supertonic/text.py
+++ b/phoonnx_train/supertonic/text.py
@@ -1,0 +1,96 @@
+"""Character-level tokenizer for SuperTonic.
+
+The released model treats text as a sequence of Unicode characters: input is
+NFKD-normalised, wrapped in a ``<lang>...</lang>`` tag, and each character is
+looked up in an indexer that maps its Unicode code point to a small integer id.
+Training only needs a bijection from the characters that actually occur in the
+corpus to contiguous ids, so the indexer is built lazily from the data rather
+than shipping the full 65536-entry table; :meth:`CharTokenizer.to_indexer_list`
+expands it back to that table shape at export time for the inference engine.
+
+Tokenizer keys are code points and are used verbatim — NFKD applies to input
+*text*, never to the stored key set.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+AVAILABLE_LANGS = [
+    "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr",
+    "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk",
+    "sl", "sv", "tr", "uk", "vi", "na",
+]
+
+CODEPOINT_RANGE = 65536  # uint16 space, matching the released unicode_indexer.json
+
+_TERMINAL = re.compile(r"[.!?;:,'\"')\]}…。」』】〉》›»]$")
+
+
+def normalize_text(text: str, lang: str) -> str:
+    """NFKD-normalise, collapse whitespace, ensure a terminal punctuation mark,
+    and wrap the result in a ``<lang>...</lang>`` tag."""
+    if lang not in AVAILABLE_LANGS:
+        raise ValueError(f"unsupported language {lang!r}; expected one of {AVAILABLE_LANGS}")
+    text = unicodedata.normalize("NFKD", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if text and not _TERMINAL.search(text):
+        text += "."
+    return f"<{lang}>{text}</{lang}>"
+
+
+@dataclass
+class CharTokenizer:
+    """Maps characters to contiguous ids. Id ``0`` is reserved for padding /
+    unknown characters."""
+
+    char2id: Dict[str, int] = field(default_factory=dict)
+    PAD_ID: int = 0
+
+    @classmethod
+    def build_from_texts(cls, texts: List[str], langs: List[str]) -> "CharTokenizer":
+        chars = set()
+        for text, lang in zip(texts, langs):
+            chars.update(normalize_text(text, lang))
+        return cls(char2id={c: i + 1 for i, c in enumerate(sorted(chars))})
+
+    def extend_with_texts(self, texts: List[str], langs: List[str]) -> "CharTokenizer":
+        """New tokenizer keeping every existing id (so a pretrained embedding
+        stays row-aligned) and appending ids for previously unseen characters."""
+        chars = set()
+        for text, lang in zip(texts, langs):
+            chars.update(normalize_text(text, lang))
+        new = sorted(chars - self.char2id.keys())
+        nxt = max(self.char2id.values(), default=0) + 1
+        merged = dict(self.char2id)
+        for c in new:
+            merged[c] = nxt
+            nxt += 1
+        return CharTokenizer(char2id=merged)
+
+    def encode(self, text: str, lang: str) -> List[int]:
+        return [self.char2id.get(c, self.PAD_ID) for c in normalize_text(text, lang)]
+
+    @property
+    def vocab_size(self) -> int:
+        return (max(self.char2id.values(), default=0)) + 1
+
+    def to_dict(self) -> Dict[str, int]:
+        return dict(self.char2id)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, int]) -> "CharTokenizer":
+        return cls(char2id=dict(d))
+
+    def to_indexer_list(self, size: int = CODEPOINT_RANGE) -> List[int]:
+        """Expand to a ``size``-long list mapping ``codepoint -> id`` (the shape
+        the inference engine's ``unicode_indexer.json`` uses). Code points not in
+        the vocab map to :attr:`PAD_ID`."""
+        table = [self.PAD_ID] * size
+        for char, idx in self.char2id.items():
+            cp = ord(char)
+            if cp < size:
+                table[cp] = idx
+        return table

--- a/phoonnx_train/supertonic/text_to_latent.py
+++ b/phoonnx_train/supertonic/text_to_latent.py
@@ -1,0 +1,185 @@
+"""Text-to-latent module (conditional flow matching).
+
+Flow matching learns a velocity field that transports Gaussian noise to the data
+distribution along a straight path. Here the "data" is the compressed speech
+latent, and the field is conditioned on a text embedding and a reference voice
+style. At inference the field is integrated with a few Euler steps to turn noise
+into a latent; at training we regress the known straight-line target velocity.
+
+The style tokens (``style_ttl``) and text embedding are computed once and reused
+across ``batch_expand`` independent noise/timestep draws per utterance.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from phoonnx_train.supertonic.config import TextToLatentConfig
+from phoonnx_train.supertonic.layers import (
+    ChannelNorm,
+    ConvNeXtStack,
+    FixedContextCrossAttention,
+    RelPositionEncoder,
+    RotaryAttention,
+    StylePool,
+    TimestepEmbedding,
+)
+
+
+class StyleEncoder(nn.Module):
+    """Reference compressed latent -> ``n_style`` style tokens ``(B, n_style, style_dim)``."""
+
+    def __init__(self, cfg: TextToLatentConfig):
+        super().__init__()
+        self.proj_in = nn.Linear(cfg.compressed_dim, cfg.style_dim)
+        self.convnext = ConvNeXtStack(cfg.style_dim, cfg.style_convnext_ffn,
+                                      cfg.style_convnext_kernel, (1,) * cfg.style_convnext_layers)
+        self.pool = StylePool(cfg.style_dim, cfg.n_style, cfg.style_dim, cfg.style_heads)
+
+    def forward(self, ref: torch.Tensor, ref_mask=None) -> torch.Tensor:
+        x = self.proj_in(ref.transpose(1, 2)).transpose(1, 2)
+        x = self.convnext(x, ref_mask)
+        return self.pool(x, ref_mask)
+
+
+class TextEncoder(nn.Module):
+    """Char ids -> style-conditioned text embedding ``(B, char_dim, T)``."""
+
+    def __init__(self, cfg: TextToLatentConfig, vocab_size: int):
+        super().__init__()
+        dim = cfg.char_dim
+        self.embed = nn.Embedding(vocab_size, dim)
+        self.convnext = ConvNeXtStack(dim, cfg.convnext_ffn, cfg.convnext_kernel, cfg.vf_dilations)
+        self.self_attn = RelPositionEncoder(dim, cfg.self_attn_ffn, cfg.self_attn_heads,
+                                            cfg.self_attn_layers, cfg.self_attn_window)
+        self.style_attn1 = FixedContextCrossAttention(dim, cfg.style_dim, cfg.prompt_heads, hidden=dim)
+        self.style_attn2 = FixedContextCrossAttention(dim, cfg.style_dim, cfg.prompt_heads, hidden=dim)
+        self.norm = ChannelNorm(dim)
+
+    def forward(self, text_ids, text_mask, style_ttl) -> torch.Tensor:
+        x = self.embed(text_ids).transpose(1, 2)
+        conv = self.convnext(x, text_mask)
+        x = (self.self_attn(conv, text_mask) + conv) * text_mask
+        x = x + self.style_attn1(x, style_ttl)
+        x = x + self.style_attn2(x, style_ttl)
+        return self.norm(x) * text_mask
+
+
+class UncondMasker(nn.Module):
+    """Classifier-free-guidance dropout: replace text and/or style conditioning
+    with learnable null tokens during training only."""
+
+    def __init__(self, cfg: TextToLatentConfig):
+        super().__init__()
+        self.p_text = cfg.prob_text_uncond
+        self.p_both = cfg.prob_both_uncond
+        self.null_text = nn.Parameter(torch.randn(1, cfg.char_dim, 1) * 0.1)
+        self.null_style = nn.Parameter(torch.randn(1, cfg.n_style, cfg.style_dim) * 0.1)
+
+    def forward(self, text_emb, style_ttl):
+        if not self.training:
+            return text_emb, style_ttl
+        b = text_emb.shape[0]
+        r = torch.rand(b, device=text_emb.device)
+        both = (r < self.p_both).view(b, 1, 1)
+        text_only = ((r >= self.p_both) & (r < self.p_both + self.p_text)).view(b, 1, 1)
+        text_emb = torch.where(both | text_only, self.null_text.expand(b, -1, text_emb.shape[-1]), text_emb)
+        style_ttl = torch.where(both, self.null_style.expand(b, -1, -1), style_ttl)
+        return text_emb, style_ttl
+
+
+class VFBlock(nn.Module):
+    """One repeated block of the velocity-field estimator: dilated ConvNeXt, time
+    conditioning, text cross-attention (length-aware rotary), ConvNeXt, style
+    cross-attention (tanh-bounded)."""
+
+    def __init__(self, cfg: TextToLatentConfig):
+        super().__init__()
+        dim = cfg.vf_dim
+        self.dilated = ConvNeXtStack(dim, cfg.vf_ffn, cfg.vf_kernel, cfg.vf_dilations)
+        self.time_proj = nn.Linear(cfg.time_dim, dim)
+        self.mid = ConvNeXtStack(dim, cfg.vf_ffn, cfg.vf_kernel, (1,))
+        self.text_attn = RotaryAttention(dim, cfg.char_dim, cfg.vf_text_heads, units=dim, rotary_base=cfg.rotary_base)
+        self.text_norm = ChannelNorm(dim)
+        self.post = ConvNeXtStack(dim, cfg.vf_ffn, cfg.vf_kernel, (1,))
+        self.style_attn = FixedContextCrossAttention(dim, cfg.style_dim, cfg.vf_style_heads, hidden=cfg.style_dim)
+        self.style_norm = ChannelNorm(dim)
+        self.gamma = cfg.rotary_scale
+
+    def forward(self, x, t_emb, text_emb, style_ttl, latent_mask, text_mask):
+        x = self.dilated(x, latent_mask)
+        x = (x + self.time_proj(t_emb).unsqueeze(-1)) * latent_mask
+        x = self.mid(x, latent_mask)
+        q_len = latent_mask.sum(dim=(1, 2))
+        k_len = text_mask.sum(dim=(1, 2))
+        y = self.text_attn(x, text_emb, mask=text_mask, length_aware=True, gamma=self.gamma, q_len=q_len, k_len=k_len)
+        x = self.text_norm(x + y) * latent_mask
+        x = self.post(x, latent_mask)
+        x = self.style_norm(x + self.style_attn(x, style_ttl))
+        return x * latent_mask
+
+
+class VFEstimator(nn.Module):
+    def __init__(self, cfg: TextToLatentConfig):
+        super().__init__()
+        self.proj_in = nn.Linear(cfg.compressed_dim, cfg.vf_dim)
+        self.time = TimestepEmbedding(cfg.time_dim, cfg.time_hidden)
+        self.blocks = nn.ModuleList([VFBlock(cfg) for _ in range(cfg.vf_blocks)])
+        self.final = ConvNeXtStack(cfg.vf_dim, cfg.vf_ffn, cfg.vf_kernel, (1,) * cfg.vf_final_layers)
+        self.proj_out = nn.Linear(cfg.vf_dim, cfg.compressed_dim)
+
+    def forward(self, noisy_latent, t, text_emb, style_ttl, latent_mask, text_mask):
+        x = self.proj_in(noisy_latent.transpose(1, 2)).transpose(1, 2) * latent_mask
+        t_emb = self.time(t)
+        for block in self.blocks:
+            x = block(x, t_emb, text_emb, style_ttl, latent_mask, text_mask)
+        x = self.final(x, latent_mask)
+        x = self.proj_out(x.transpose(1, 2)).transpose(1, 2)
+        return x * latent_mask
+
+
+class TextToLatentModel(nn.Module):
+    def __init__(self, cfg: TextToLatentConfig, vocab_size: int):
+        super().__init__()
+        self.cfg = cfg
+        self.style_encoder = StyleEncoder(cfg)
+        self.text_encoder = TextEncoder(cfg, vocab_size)
+        self.uncond = UncondMasker(cfg)
+        self.vector_field = VFEstimator(cfg)
+
+    def conditions(self, text_ids, text_mask, ref, ref_mask):
+        style_ttl = self.style_encoder(ref, ref_mask)
+        text_emb = self.text_encoder(text_ids, text_mask, style_ttl)
+        return self.uncond(text_emb, style_ttl)
+
+    def forward(self, noisy_latent, t, text_ids, text_mask, ref, ref_mask, latent_mask):
+        text_emb, style_ttl = self.conditions(text_ids, text_mask, ref, ref_mask)
+        return self.vector_field(noisy_latent, t, text_emb, style_ttl, latent_mask, text_mask)
+
+
+def flow_matching_loss(model, z1, latent_mask, text_ids, text_mask, ref, ref_mask,
+                       ref_time_mask, n_expand=1):
+    """Optimal-transport conditional flow matching loss with context-sharing
+    batch expansion. The reference-crop region is excluded from the loss."""
+    cfg = model.cfg
+    text_emb, style_ttl = model.conditions(text_ids, text_mask, ref, ref_mask)
+    b, c, _ = z1.shape
+
+    z1_e = z1.repeat_interleave(n_expand, dim=0)
+    mask_e = latent_mask.repeat_interleave(n_expand, dim=0)
+    rt_e = ref_time_mask.repeat_interleave(n_expand, dim=0)
+    text_emb_e = text_emb.repeat_interleave(n_expand, dim=0)
+    text_mask_e = text_mask.repeat_interleave(n_expand, dim=0)
+    style_e = style_ttl.repeat_interleave(n_expand, dim=0)
+
+    z0 = torch.randn_like(z1_e)
+    t = torch.rand(b * n_expand, device=z1.device)
+    tb = t.view(-1, 1, 1)
+    sig = cfg.sigma_min
+    zt = (1 - (1 - sig) * tb) * z0 + tb * z1_e
+    target = z1_e - (1 - sig) * z0
+
+    pred = model.vector_field(zt, t, text_emb_e, style_e, mask_e, text_mask_e)
+    loss_mask = mask_e * (1 - rt_e)
+    diff = (pred - target).abs() * loss_mask
+    return diff.sum() / (loss_mask.sum().clamp_min(1.0) * c)

--- a/tests/test_supertonic_training.py
+++ b/tests/test_supertonic_training.py
@@ -1,0 +1,640 @@
+"""Tests for the SuperTonic training package (phoonnx_train.supertonic).
+
+Everything runs on CPU at a tiny config in a second or two: module forward
+shapes, loss and mask math, full-checkpoint save/resume round-trips (including
+corrupt-file and grow-vocab handling), the four-graph ONNX export IO signature
+run through onnxruntime, and the training-engine registry wiring. Adversarial
+cases cover zero-length text, a resampled sample-rate mismatch, an empty indexer
+and a truncated checkpoint.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from phoonnx_train.supertonic.autoencoder import SpeechAutoencoder
+from phoonnx_train.supertonic.checkpointing import (
+    CheckpointError,
+    load_state_dict_grow_vocab,
+    resume_into,
+    save_checkpoint,
+)
+from phoonnx_train.supertonic.config import SuperTonicConfig, load_model_config, tiny_config
+from phoonnx_train.supertonic.duration_predictor import DurationPredictor, duration_loss
+from phoonnx_train.supertonic.latent_utils import (
+    compress,
+    decompress,
+    normalize_and_compress,
+    sample_reference_crop,
+)
+from phoonnx_train.supertonic.layers import make_mask
+from phoonnx_train.supertonic.text import AVAILABLE_LANGS, CharTokenizer, normalize_text
+from phoonnx_train.supertonic.text_to_latent import TextToLatentModel, flow_matching_loss
+
+
+@pytest.fixture()
+def cfg():
+    return tiny_config(vocab_size=64)
+
+
+@pytest.fixture()
+def ae(cfg):
+    torch.manual_seed(0)
+    return SpeechAutoencoder(cfg.ae)
+
+
+# ----------------------------------------------------------------------
+# config
+# ----------------------------------------------------------------------
+
+def test_compressed_dim_relation(cfg):
+    assert cfg.ttl.compressed_dim == cfg.ttl.latent_dim * cfg.ttl.compress_factor
+
+
+def test_load_model_config_overlays_ttsjson(tmp_path):
+    p = tmp_path / "tts.json"
+    p.write_text(json.dumps({"ae": {"sample_rate": 44100, "ldim": 32}}))
+    cfg = load_model_config(str(p))
+    assert cfg.ae.sample_rate == 44100 and cfg.ae.latent_dim == 32
+
+
+def test_load_model_config_none_is_defaults():
+    assert load_model_config(None) == SuperTonicConfig()
+
+
+# ----------------------------------------------------------------------
+# module forward shapes
+# ----------------------------------------------------------------------
+
+def test_autoencoder_roundtrip_shapes(ae):
+    wav = torch.randn(2, 16000)
+    recon, latent = ae(wav)
+    assert recon.shape[0] == 2 and recon.dim() == 2
+    assert latent.shape[:2] == (2, ae.cfg.latent_dim)
+
+
+def test_text_to_latent_loss_backward(cfg, ae):
+    torch.manual_seed(1)
+    _, latent = ae(torch.randn(2, 16000))
+    z1 = normalize_and_compress(ae, latent.detach(), cfg.ttl.compress_factor, cfg.ttl.normalizer_scale)
+    lens = torch.tensor([z1.shape[-1], z1.shape[-1] - 1])
+    lat_mask = make_mask(lens, z1.shape[-1])
+    ref, ref_mask, rtm = sample_reference_crop(z1, lens, 10.0)
+    text_ids = torch.randint(1, 64, (2, 7))
+    text_mask = make_mask(torch.tensor([7, 5]), 7)
+    ttl = TextToLatentModel(cfg.ttl, cfg.vocab_size)
+    loss = flow_matching_loss(ttl, z1, lat_mask, text_ids, text_mask, ref, ref_mask, rtm,
+                              n_expand=cfg.ttl.batch_expand)
+    assert loss.ndim == 0 and torch.isfinite(loss)
+    loss.backward()
+    assert any(p.grad is not None for p in ttl.parameters())
+
+
+def test_duration_predictor_positive(cfg, ae):
+    _, latent = ae(torch.randn(2, 16000))
+    z1 = normalize_and_compress(ae, latent.detach(), cfg.dp.compress_factor, cfg.dp.normalizer_scale)
+    lens = torch.tensor([z1.shape[-1], z1.shape[-1]])
+    ref, ref_mask, _ = sample_reference_crop(z1, lens, 10.0)
+    text_ids = torch.randint(1, 64, (2, 7))
+    text_mask = make_mask(torch.tensor([7, 6]), 7)
+    dp = DurationPredictor(cfg.dp, cfg.vocab_size)
+    dur = dp(text_ids, text_mask, ref, ref_mask)
+    assert dur.shape == (2,) and (dur > 0).all()  # exp() output is strictly positive
+    assert torch.isfinite(duration_loss(dur, torch.tensor([1.0, 1.2])))
+
+
+# ----------------------------------------------------------------------
+# mask / compression math
+# ----------------------------------------------------------------------
+
+def test_make_mask_values():
+    m = make_mask(torch.tensor([2, 4]), 4)
+    assert m.shape == (2, 1, 4)
+    assert m[0, 0].tolist() == [1, 1, 0, 0]
+    assert m[1, 0].tolist() == [1, 1, 1, 1]
+
+
+def test_compress_decompress_roundtrip():
+    x = torch.arange(2 * 3 * 12).float().reshape(2, 3, 12)
+    c = compress(x, 4)
+    assert c.shape == (2, 12, 3)
+    back = decompress(c, 4, 3)
+    assert torch.equal(back, x)
+
+
+def test_compress_trims_to_multiple():
+    x = torch.randn(1, 3, 13)
+    assert compress(x, 4).shape == (1, 12, 3)  # 13 -> 12
+
+
+def test_reference_crop_masks_align():
+    z1 = torch.randn(3, 5, 40)
+    lens = torch.tensor([40, 20, 10])
+    ref, ref_mask, rtm = sample_reference_crop(z1, lens, frame_rate=10.0)
+    assert ref.shape[0] == 3 and ref_mask.shape[1] == 1
+    # the reference-time mask marks at least one frame per sample
+    assert (rtm.sum(dim=(1, 2)) >= 1).all()
+
+
+# ----------------------------------------------------------------------
+# tokenizer
+# ----------------------------------------------------------------------
+
+def test_tokenizer_wraps_lang_tag():
+    assert normalize_text("hello", "en").startswith("<en>") and normalize_text("hi", "en").endswith("</en>")
+
+
+def test_tokenizer_adds_terminal_punctuation():
+    assert normalize_text("hello", "en") == "<en>hello.</en>"
+    assert normalize_text("hi!", "en") == "<en>hi!</en>"
+
+
+def test_tokenizer_unknown_lang_raises():
+    with pytest.raises(ValueError):
+        normalize_text("hello", "xx")
+
+
+def test_tokenizer_encode_and_indexer():
+    tok = CharTokenizer.build_from_texts(["hello world"], ["en"])
+    ids = tok.encode("hello", "en")
+    assert all(i > 0 for i in ids)  # every char is known
+    table = tok.to_indexer_list()
+    assert len(table) == 65536
+    assert table[ord("h")] == tok.char2id["h"]
+
+
+def test_tokenizer_extend_keeps_existing_ids():
+    tok = CharTokenizer.build_from_texts(["abc"], ["en"])
+    grown = tok.extend_with_texts(["abcñ"], ["es"])
+    for c, i in tok.char2id.items():
+        assert grown.char2id[c] == i  # row-aligned
+    assert grown.vocab_size >= tok.vocab_size
+
+
+def test_all_langs_present():
+    for lang in ("en", "ko", "ja", "ar", "pt"):
+        assert lang in AVAILABLE_LANGS
+
+
+# ----------------------------------------------------------------------
+# adversarial: zero-length text, sample-rate mismatch
+# ----------------------------------------------------------------------
+
+def test_zero_length_text_batch(cfg):
+    # a batch where one utterance tokenizes to a single (padded) id must not crash
+    text_ids = torch.zeros(2, 1, dtype=torch.long)
+    text_mask = make_mask(torch.tensor([1, 1]), 1)
+    ttl = TextToLatentModel(cfg.ttl, cfg.vocab_size)
+    style = ttl.style_encoder(torch.randn(2, cfg.ttl.compressed_dim, 6))
+    out = ttl.text_encoder(text_ids, text_mask, style)
+    assert out.shape == (2, cfg.ttl.char_dim, 1)
+
+
+def test_dataset_resamples_mismatched_sample_rate(tmp_path):
+    import soundfile as sf
+    from phoonnx_train.supertonic.dataset import TextAudioDataset
+    wav = np.random.randn(8000).astype(np.float32)
+    sf.write(str(tmp_path / "a.wav"), wav, 8000)  # 8 kHz source
+    (tmp_path / "list.txt").write_text("a.wav|hello there|en\n")
+    tok = CharTokenizer.build_from_texts(["hello there"], ["en"])
+    ds = TextAudioDataset(str(tmp_path / "list.txt"), str(tmp_path), tok, sample_rate=16000)
+    audio, ids = ds[0]
+    assert audio.shape[0] == pytest.approx(16000, abs=64)  # resampled 8k -> 16k
+    assert ids.numel() > 0
+
+
+# ----------------------------------------------------------------------
+# checkpointing
+# ----------------------------------------------------------------------
+
+def test_checkpoint_save_resume_roundtrip(tmp_path, ae):
+    opt = torch.optim.Adam(ae.parameters(), lr=1e-3)
+    ae(torch.randn(1, 16000))[0].sum().backward()
+    opt.step()
+    before = {k: v.clone() for k, v in ae.state_dict().items()}
+    path = tmp_path / "ckpt.pt"
+    save_checkpoint(str(path), step=42, models={"ae": ae}, optimizers={"ae": opt})
+
+    fresh = SpeechAutoencoder(ae.cfg)
+    fresh_opt = torch.optim.Adam(fresh.parameters(), lr=1e-3)
+    step = resume_into(str(path), models={"ae": fresh}, optimizers={"ae": fresh_opt})
+    assert step == 42
+    for k, v in fresh.state_dict().items():
+        assert torch.equal(v, before[k])
+
+
+def test_checkpoint_atomic_no_partial_on_replace(tmp_path, ae):
+    path = tmp_path / "ckpt.pt"
+    save_checkpoint(str(path), step=1, models={"ae": ae})
+    # no leftover temp files in the directory
+    assert [p.name for p in tmp_path.iterdir()] == ["ckpt.pt"]
+
+
+def test_resume_missing_file_raises(tmp_path, ae):
+    with pytest.raises(CheckpointError):
+        resume_into(str(tmp_path / "nope.pt"), models={"ae": ae})
+
+
+def test_resume_corrupt_checkpoint_raises(tmp_path, ae):
+    path = tmp_path / "ckpt.pt"
+    save_checkpoint(str(path), step=1, models={"ae": ae})
+    with open(path, "r+b") as fh:  # truncate to half its bytes
+        size = os.fstat(fh.fileno()).st_size
+        fh.truncate(size // 2)
+    with pytest.raises(CheckpointError):
+        resume_into(str(path), models={"ae": SpeechAutoencoder(ae.cfg)})
+
+
+def test_grow_vocab_load(cfg):
+    small = TextToLatentModel(cfg.ttl, vocab_size=20)
+    big = TextToLatentModel(cfg.ttl, vocab_size=30)
+    load_state_dict_grow_vocab(big, small.state_dict())
+    # the first 20 embedding rows come from the small model, the rest keep init
+    assert torch.equal(big.text_encoder.embed.weight[:20], small.text_encoder.embed.weight)
+
+
+def test_grow_vocab_rejects_shrink(cfg):
+    big = TextToLatentModel(cfg.ttl, vocab_size=30)
+    small = TextToLatentModel(cfg.ttl, vocab_size=20)
+    with pytest.raises(CheckpointError):
+        load_state_dict_grow_vocab(small, big.state_dict())
+
+
+# ----------------------------------------------------------------------
+# ONNX export IO signature
+# ----------------------------------------------------------------------
+
+def _build_all(cfg):
+    from phoonnx_train.supertonic.text_to_latent import TextToLatentModel as TTL
+    torch.manual_seed(0)
+    return (SpeechAutoencoder(cfg.ae), TTL(cfg.ttl, cfg.vocab_size),
+            DurationPredictor(cfg.dp, cfg.vocab_size))
+
+
+def test_onnx_export_io_signature(tmp_path, cfg):
+    pytest.importorskip("onnx")
+    ort = pytest.importorskip("onnxruntime")
+    from phoonnx_train.supertonic.export_onnx import export_all
+    ae, ttl, dp = _build_all(cfg)
+    tok = CharTokenizer.build_from_texts(["hello world"], ["en"])
+    paths = export_all(str(tmp_path), config=cfg, tokenizer=tok,
+                       autoencoder=ae, text_to_latent=ttl, duration_predictor=dp)
+    for key in ("duration_predictor", "text_encoder", "vector_estimator", "vocoder"):
+        assert paths[key].is_file()
+
+    def run(path, feed):
+        return ort.InferenceSession(str(path), providers=["CPUExecutionProvider"]).run(None, feed)
+
+    text_ids = np.random.randint(1, 64, (1, 6)).astype(np.int64)
+    text_mask = np.ones((1, 1, 6), np.float32)
+    style_dp = np.random.randn(1, cfg.dp.n_style, cfg.dp.style_value_dim).astype(np.float32)
+    style_ttl = np.random.randn(1, cfg.ttl.n_style, cfg.ttl.style_dim).astype(np.float32)
+
+    dur = run(paths["duration_predictor"], {"text_ids": text_ids, "style_dp": style_dp, "text_mask": text_mask})[0]
+    assert dur.shape == (1,) and dur.dtype == np.float32
+    te = run(paths["text_encoder"], {"text_ids": text_ids, "style_ttl": style_ttl, "text_mask": text_mask})[0]
+    assert te.shape == (1, cfg.ttl.char_dim, 6)
+    L = 4
+    noisy = np.random.randn(1, cfg.ttl.compressed_dim, L).astype(np.float32)
+    ve = run(paths["vector_estimator"], {
+        "noisy_latent": noisy, "text_emb": te, "style_ttl": style_ttl, "text_mask": text_mask,
+        "latent_mask": np.ones((1, 1, L), np.float32),
+        "current_step": np.array([1.0], np.float32), "total_step": np.array([8.0], np.float32)})[0]
+    assert ve.shape == noisy.shape
+    wav = run(paths["vocoder"], {"latent": noisy})[0]
+    assert wav.shape[0] == 1 and wav.ndim == 2
+
+
+def test_exported_config_and_indexer(tmp_path, cfg):
+    pytest.importorskip("onnx")
+    from phoonnx_train.supertonic.export_onnx import export_all
+    ae, ttl, dp = _build_all(cfg)
+    tok = CharTokenizer.build_from_texts(["hello"], ["en"])
+    paths = export_all(str(tmp_path), config=cfg, tokenizer=tok,
+                       autoencoder=ae, text_to_latent=ttl, duration_predictor=dp)
+    tts = json.loads(paths["tts"].read_text())
+    assert tts["ae"]["sample_rate"] == cfg.ae.sample_rate
+    assert tts["ttl"]["chunk_compress_factor"] == cfg.ttl.compress_factor
+    idx = json.loads(paths["unicode_indexer"].read_text())
+    assert len(idx) == 65536 and idx[ord("h")] == tok.char2id["h"]
+
+
+def test_empty_indexer_is_all_pad():
+    tok = CharTokenizer()  # nothing built
+    table = tok.to_indexer_list(size=128)
+    assert set(table) == {0}
+
+
+# ----------------------------------------------------------------------
+# import-onnx utility
+# ----------------------------------------------------------------------
+
+def test_import_onnx_reads_initializers(tmp_path, cfg):
+    pytest.importorskip("onnx")
+    from phoonnx_train.supertonic.export_onnx import export_all
+    from phoonnx_train.supertonic.import_onnx import load_onnx_initializers
+    ae, ttl, dp = _build_all(cfg)
+    tok = CharTokenizer.build_from_texts(["hello"], ["en"])
+    paths = export_all(str(tmp_path), config=cfg, tokenizer=tok,
+                       autoencoder=ae, text_to_latent=ttl, duration_predictor=dp)
+    arrays = load_onnx_initializers(str(paths["vocoder"]))
+    assert arrays  # at least the decoder weights are present
+    assert all(hasattr(v, "shape") for v in arrays.values())
+
+
+# ----------------------------------------------------------------------
+# engine registry
+# ----------------------------------------------------------------------
+
+def test_engine_registered():
+    from phoonnx_train.engines import get_engine, list_engines
+    from phoonnx_train.engines.supertonic import SuperTonicTrainingEngine
+    assert "supertonic" in list_engines()
+    assert isinstance(get_engine("supertonic"), SuperTonicTrainingEngine)
+
+
+def test_engine_presets():
+    from phoonnx_train.engines import get_engine
+    presets = get_engine("supertonic").quality_presets()
+    assert "base" in presets and "low" in presets
+
+
+def test_engine_unknown_stage_raises(tmp_path):
+    from phoonnx_train.engines import get_engine
+    from phoonnx_train.engines.base import TrainingEngineConfig
+    eng = get_engine("supertonic")
+    cfg = TrainingEngineConfig(num_symbols=64, sample_rate=16000,
+                               extra={"quality": "low", "stage": "nonsense"})
+    with pytest.raises(KeyError):
+        eng.create_model(cfg, [])
+
+
+# ----------------------------------------------------------------------
+# Lightning training loops (short CPU fit + resume)
+# ----------------------------------------------------------------------
+
+def _write_corpus(tmp_path, n=4, seconds=0.6, sr=16000):
+    import soundfile as sf
+    lines = []
+    for i in range(n):
+        sf.write(str(tmp_path / f"u{i}.wav"), np.random.randn(int(seconds * sr)).astype(np.float32), sr)
+        lines.append(f"u{i}.wav|hello world number {i}|en")
+    (tmp_path / "list.txt").write_text("\n".join(lines) + "\n")
+    return str(tmp_path / "list.txt")
+
+
+def _trainer(tmp_path, **kw):
+    import pytorch_lightning as pl
+    return pl.Trainer(accelerator="cpu", devices=1, logger=False,
+                      enable_checkpointing=False, enable_progress_bar=False,
+                      enable_model_summary=False, **kw)
+
+
+def _fitted_ae_checkpoint(tmp_path, cfg, flist, name="ae.pt"):
+    """Train the autoencoder for one step and save it with its latent statistics."""
+    from phoonnx_train.supertonic.lightning import AutoencoderModule
+    mod = AutoencoderModule(config=cfg, dataset=[flist], root_dir=str(tmp_path),
+                            batch_size=2, num_workers=0, segment_seconds=0.4)
+    _trainer(tmp_path, max_steps=1).fit(mod)
+    path = tmp_path / name
+    torch.save({"state_dict": mod.state_dict()}, path)
+    return str(path)
+
+
+def test_autoencoder_lightning_fit(tmp_path):
+    pl = pytest.importorskip("pytorch_lightning")
+    from phoonnx_train.supertonic.lightning import AutoencoderModule
+    flist = _write_corpus(tmp_path)
+    mod = AutoencoderModule(config=tiny_config(64), dataset=[flist], root_dir=str(tmp_path),
+                            batch_size=2, num_workers=0, segment_seconds=0.4)
+    _trainer(tmp_path, max_steps=2).fit(mod)
+    # a config + tokenizer ride along in every checkpoint
+    ck = {}
+    mod.on_save_checkpoint(ck)
+    assert ck["supertonic_stage"] == "autoencoder" and "supertonic_config" in ck
+
+
+def test_ttl_and_dp_lightning_fit_with_frozen_ae(tmp_path):
+    pl = pytest.importorskip("pytorch_lightning")
+    from phoonnx_train.supertonic.lightning import (
+        DurationPredictorModule,
+        TextToLatentModule,
+    )
+    flist = _write_corpus(tmp_path)
+    cfg = tiny_config(64)
+    tok = CharTokenizer.build_from_texts(["hello world number 0"], ["en"])
+
+    ae_ckpt = _fitted_ae_checkpoint(tmp_path, cfg, flist)
+
+    ttl = TextToLatentModule(config=cfg, tokenizer=tok, dataset=[flist], root_dir=str(tmp_path),
+                             ae_checkpoint=ae_ckpt, batch_size=2, num_workers=0)
+    _trainer(tmp_path, max_steps=2).fit(ttl)
+    assert all(not p.requires_grad for p in ttl.frozen_ae.parameters())
+
+    dp = DurationPredictorModule(config=cfg, tokenizer=tok, dataset=[flist], root_dir=str(tmp_path),
+                                 ae_checkpoint=ae_ckpt, batch_size=2, num_workers=0)
+    _trainer(tmp_path, max_steps=2).fit(dp)
+
+
+def test_lightning_resume_from_checkpoint(tmp_path):
+    pl = pytest.importorskip("pytorch_lightning")
+    from phoonnx_train.supertonic.lightning import DurationPredictorModule
+    flist = _write_corpus(tmp_path)
+    cfg = tiny_config(64)
+    tok = CharTokenizer.build_from_texts(["hello world number 0"], ["en"])
+    ck_path = tmp_path / "dp.ckpt"
+    ae_ckpt = _fitted_ae_checkpoint(tmp_path, cfg, flist)
+
+    dp = DurationPredictorModule(config=cfg, tokenizer=tok, dataset=[flist], root_dir=str(tmp_path),
+                                 ae_checkpoint=ae_ckpt, batch_size=2, num_workers=0)
+    tr = _trainer(tmp_path, max_steps=2)
+    tr.fit(dp)
+    tr.save_checkpoint(str(ck_path))
+
+    dp2 = DurationPredictorModule(config=cfg, tokenizer=tok, dataset=[flist], root_dir=str(tmp_path),
+                                  ae_checkpoint=ae_ckpt, batch_size=2, num_workers=0)
+    _trainer(tmp_path, max_steps=4).fit(dp2, ckpt_path=str(ck_path))
+    assert dp2.global_step >= 2  # continued past the resumed step
+
+
+def test_export_from_lightning_checkpoints(tmp_path):
+    pl = pytest.importorskip("pytorch_lightning")
+    pytest.importorskip("onnx")
+    from phoonnx_train.supertonic.export_onnx import export_from_checkpoints
+    from phoonnx_train.supertonic.lightning import (
+        AutoencoderModule,
+        DurationPredictorModule,
+        TextToLatentModule,
+    )
+    flist = _write_corpus(tmp_path)
+    cfg = tiny_config(64)
+    tok = CharTokenizer.build_from_texts(["hello world number 0"], ["en"])
+
+    def fit_and_save(mod, name):
+        tr = _trainer(tmp_path, max_steps=1)
+        tr.fit(mod)
+        p = tmp_path / name
+        tr.save_checkpoint(str(p))
+        return str(p)
+
+    ae_ck = fit_and_save(AutoencoderModule(config=cfg, dataset=[flist], root_dir=str(tmp_path),
+                                           batch_size=2, num_workers=0, segment_seconds=0.4), "ae.ckpt")
+    ttl_ck = fit_and_save(TextToLatentModule(config=cfg, tokenizer=tok, dataset=[flist],
+                                             root_dir=str(tmp_path), ae_checkpoint=ae_ck,
+                                             batch_size=2, num_workers=0), "ttl.ckpt")
+    dp_ck = fit_and_save(DurationPredictorModule(config=cfg, tokenizer=tok, dataset=[flist],
+                                                 root_dir=str(tmp_path), ae_checkpoint=ae_ck,
+                                                 batch_size=2, num_workers=0), "dp.ckpt")
+
+    paths = export_from_checkpoints(str(tmp_path / "out"), autoencoder_ckpt=ae_ck,
+                                    text_to_latent_ckpt=ttl_ck, duration_predictor_ckpt=dp_ck)
+    for key in ("duration_predictor", "text_encoder", "vector_estimator", "vocoder"):
+        assert paths[key].is_file()
+
+
+# ----------------------------------------------------------------------
+# semantics: masking, flow-matching target, reference-crop exclusion
+# ----------------------------------------------------------------------
+
+def test_style_pool_ignores_batch_padding(cfg):
+    from phoonnx_train.supertonic.layers import StylePool
+    torch.manual_seed(3)
+    pool = StylePool(cfg.ttl.compressed_dim, cfg.ttl.n_style, cfg.ttl.style_dim, cfg.ttl.style_heads)
+    ref = torch.randn(1, cfg.ttl.compressed_dim, 7)
+    base = pool(ref, make_mask(torch.tensor([7]), 7))
+    for pad in (1, 5, 20):
+        padded = torch.cat([ref, torch.zeros(1, cfg.ttl.compressed_dim, pad)], dim=-1)
+        out = pool(padded, make_mask(torch.tensor([7]), 7 + pad))
+        assert (out - base).abs().max() < 1e-5, f"padding by {pad} moved the style tokens"
+
+
+class _OracleVectorField:
+    """Reproduces the optimal-transport target from ``zt`` and ``t`` alone."""
+
+    def __init__(self, cfg, z1, sign=1.0):
+        self.cfg, self.z1, self.sign = cfg, z1, sign
+
+    def __call__(self, zt, t, *args):
+        sig = self.cfg.sigma_min
+        tb = t.view(-1, 1, 1)
+        z0 = (zt - tb * self.z1) / (1 - (1 - sig) * tb)
+        return self.sign * (self.z1 - (1 - sig) * z0)
+
+
+class _OracleModel:
+    def __init__(self, cfg, z1, sign=1.0):
+        self.cfg = cfg
+        self.vector_field = _OracleVectorField(cfg, z1, sign)
+
+    def conditions(self, text_ids, text_mask, ref, ref_mask):
+        return torch.zeros(text_ids.shape[0], self.cfg.char_dim, text_ids.shape[-1]), \
+            torch.zeros(text_ids.shape[0], self.cfg.n_style, self.cfg.style_dim)
+
+
+def test_flow_matching_target_is_the_ot_velocity(cfg):
+    torch.manual_seed(4)
+    z1 = torch.randn(2, cfg.ttl.compressed_dim, 9)
+    lat_mask = make_mask(torch.tensor([9, 7]), 9)
+    text_ids = torch.randint(1, 64, (2, 5))
+    text_mask = make_mask(torch.tensor([5, 4]), 5)
+    ref, ref_mask, rtm = sample_reference_crop(z1, torch.tensor([9, 7]), 10.0)
+
+    args = (z1, lat_mask, text_ids, text_mask, ref, ref_mask, rtm)
+    right = flow_matching_loss(_OracleModel(cfg.ttl, z1), *args, n_expand=1)
+    wrong = flow_matching_loss(_OracleModel(cfg.ttl, z1, sign=-1.0), *args, n_expand=1)
+    assert right.item() < 1e-4, f"the exact OT velocity should cost nothing, got {right.item()}"
+    assert wrong.item() > 0.5, f"the sign-flipped velocity should cost a lot, got {wrong.item()}"
+
+
+def test_flow_matching_loss_excludes_the_reference_region(cfg):
+    torch.manual_seed(5)
+    z1 = torch.randn(2, cfg.ttl.compressed_dim, 12)
+    lens = torch.tensor([12, 12])
+    lat_mask = make_mask(lens, 12)
+    text_ids = torch.randint(1, 64, (2, 5))
+    text_mask = make_mask(torch.tensor([5, 5]), 5)
+    ref, ref_mask, rtm = sample_reference_crop(z1, lens, 10.0)
+    ttl = TextToLatentModel(cfg.ttl, cfg.vocab_size).eval()
+
+    def loss_of(target_latent):
+        torch.manual_seed(6)  # same noise draw and timestep for both calls
+        return flow_matching_loss(ttl, target_latent, lat_mask, text_ids, text_mask,
+                                  ref, ref_mask, rtm, n_expand=1).item()
+
+    garbled = z1.clone()
+    garbled[rtm.expand_as(z1) > 0.5] = 1000.0  # only the excluded positions
+    assert loss_of(garbled) == pytest.approx(loss_of(z1), rel=1e-5)
+
+
+# ----------------------------------------------------------------------
+# latent statistics and checkpoint identity
+# ----------------------------------------------------------------------
+
+def test_stage_one_fits_latent_statistics(tmp_path):
+    pytest.importorskip("pytorch_lightning")
+    from phoonnx_train.supertonic.autoencoder import SpeechAutoencoder
+    cfg = tiny_config(64)
+    flist = _write_corpus(tmp_path)
+    ae = SpeechAutoencoder(cfg.ae).eval()
+    state = torch.load(_fitted_ae_checkpoint(tmp_path, cfg, flist), weights_only=False)["state_dict"]
+    ae.load_state_dict({k[len("generator."):]: v for k, v in state.items()
+                        if k.startswith("generator.")})
+    assert bool(ae.stats_fitted)
+
+    # the stage-2 flow target must match the unit-variance prior it is transported from
+    wav, _ = torch.randn(2, 16000), None
+    z1 = normalize_and_compress(ae, ae.encode(wav), cfg.ttl.compress_factor, 1.0)
+    assert 0.5 < z1.std().item() < 2.0, f"flow target std {z1.std().item()} is far from the prior"
+
+
+def test_stage_two_refuses_an_unfitted_autoencoder(tmp_path):
+    pytest.importorskip("pytorch_lightning")
+    from phoonnx_train.supertonic.autoencoder import SpeechAutoencoder
+    from phoonnx_train.supertonic.lightning import TextToLatentModule
+    cfg = tiny_config(64)
+    path = tmp_path / "raw_ae.pt"
+    torch.save({"state_dict": {f"generator.{k}": v
+                               for k, v in SpeechAutoencoder(cfg.ae).state_dict().items()}}, path)
+    with pytest.raises(ValueError, match="latent statistics"):
+        TextToLatentModule(config=cfg, dataset=[], root_dir=str(tmp_path), ae_checkpoint=str(path))
+
+
+def test_export_rejects_swapped_stage_checkpoints(tmp_path):
+    pytest.importorskip("pytorch_lightning")
+    from phoonnx_train.supertonic.export_onnx import export_from_checkpoints
+    from phoonnx_train.supertonic.lightning import DurationPredictorModule, TextToLatentModule
+    cfg = tiny_config(64)
+    flist = _write_corpus(tmp_path)
+    tok = CharTokenizer.build_from_texts(["hello world number 0"], ["en"])
+    ae_ck = _fitted_ae_checkpoint(tmp_path, cfg, flist)
+
+    def fit_and_save(mod, name):
+        tr = _trainer(tmp_path, max_steps=1)
+        tr.fit(mod)
+        tr.save_checkpoint(str(tmp_path / name))
+        return str(tmp_path / name)
+
+    ttl_ck = fit_and_save(TextToLatentModule(config=cfg, tokenizer=tok, dataset=[flist],
+                                             root_dir=str(tmp_path), ae_checkpoint=ae_ck,
+                                             batch_size=2, num_workers=0), "ttl.ckpt")
+    dp_ck = fit_and_save(DurationPredictorModule(config=cfg, tokenizer=tok, dataset=[flist],
+                                                 root_dir=str(tmp_path), ae_checkpoint=ae_ck,
+                                                 batch_size=2, num_workers=0), "dp.ckpt")
+    with pytest.raises(ValueError, match="text_to_latent"):
+        export_from_checkpoints(str(tmp_path / "out"), autoencoder_ckpt=ae_ck,
+                                text_to_latent_ckpt=dp_ck, duration_predictor_ckpt=ttl_ck)
+
+
+def test_exported_config_records_normalizer_scales(tmp_path, cfg):
+    pytest.importorskip("onnx")
+    from phoonnx_train.supertonic.export_onnx import export_all
+    ae, ttl, dp = _build_all(cfg)
+    paths = export_all(str(tmp_path), config=cfg, tokenizer=CharTokenizer.build_from_texts(["hi"], ["en"]),
+                       autoencoder=ae, text_to_latent=ttl, duration_predictor=dp)
+    tts = json.loads(paths["tts"].read_text())
+    assert tts["ttl"]["normalizer"]["scale"] == cfg.ttl.normalizer_scale
+    assert tts["dp"]["normalizer"]["scale"] == cfg.dp.normalizer_scale
+    assert load_model_config(str(paths["tts"])).ttl.normalizer_scale == cfg.ttl.normalizer_scale


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Adds a training pipeline for SuperTonic (Kim et al., arXiv:2503.23108) under `phoonnx_train/supertonic/`, wired into the engine registry as `supertonic`. The three stages train independently: a GAN speech autoencoder, a flow-matching text-to-latent module, and an utterance-level duration predictor. Export produces the four-graph ONNX contract the phoonnx `supertonic` inference engine already consumes, plus `tts.json` and `unicode_indexer.json`.

The autoencoder measures the per-channel statistics of its own latent space at the end of each epoch and stores them in its checkpoint. Stages 2 and 3 normalize their targets with those statistics and refuse an autoencoder checkpoint that does not carry them, because unnormalized latents give the flow matching a target whose scale does not match the unit-variance prior it is transported from.

Style cross-attention applies its context mask to the scores before the softmax rather than zeroing probabilities afterwards. Masking after the softmax leaves the padded frames' mass in the denominator, which made the pooled style tokens depend on how much padding a batch happened to carry; the tokens are now invariant to padding down to float noise.

Checkpoint loading no longer tolerates a partial match. Both the frozen-autoencoder load in the training stages and the export path hard-error when a checkpoint holds no weights for the module being filled, and reject a checkpoint whose recorded stage does not match the slot it was passed in — swapping the text-to-latent and duration-predictor checkpoints at export used to succeed and write graphs full of random weights.

Tests cover the semantics rather than just the shapes: style pooling is invariant to padding, the flow-matching loss is zero for an oracle returning the exact optimal-transport velocity and large for the sign-flipped one, and the loss is unchanged when the reference-crop region of the target latent is replaced with garbage. Mutating any of the four behaviours above fails the suite.
