### PR TITLE
feat(diacritics): raise scriptconv floor for stress + PT sense backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ golden path in [docs/training/quickstart.md](docs/training/quickstart.md).
 |---|---|
 | Run ONNX voices on CPU or GPU (CUDA/ROCm/DirectML/CoreML/OpenVINO) | [Usage](docs/usage.md) · [Configuration](docs/configuration.md) |
 | ~40 phonemizer backends across many languages | [Phonemizers](docs/phonemizers.md) |
+| Opt-in pronunciation-disambiguating diacritics (Arabic tashkeel, Hebrew niqqud, 26-language East-Slavic/Turkic/Caucasian word stress, European-Portuguese homograph sense) via `scriptconv` | [Phonemizers → Diacritics](docs/phonemizers.md#diacritics) |
 | Load Piper / Mimic3 / Coqui / Transformers / MMS voices | [Architecture](docs/architecture.md) |
 | 17 synthesis engines behind one adapter registry | [Engines](docs/engines.md) |
 | Zero-shot voice cloning (YourTTS, StyleTTS2, ZipVoice, F5-TTS, Chatterbox) | [Cloning](docs/cloning.md) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ from phoonnx.config import VoiceConfig
 | `length_scale` | `float` | `1.0` | Default phoneme length scale |
 | `noise_w_scale` | `float` | `0.8` | Default phoneme width noise scale |
 | `hop_length` | `int` | `256` | Model frames → audio samples factor for [phoneme alignment](alignment.md) |
-| `add_diacritics` | `bool` | `False` | Auto-add diacritics (Arabic/Hebrew) |
+| `add_diacritics` | `bool` | `False` | Auto-add pronunciation-disambiguating diacritics before phonemization (Arabic tashkeel, Hebrew niqqud, East-Slavic/Turkic/Caucasian word stress, European-Portuguese homograph diacritics — see [phonemizers.md](phonemizers.md#diacritics)) |
 | `diacritizer_model` | `str` | `rawi-ensemble` | Diacritizer model name (Arabic `text2tashkeel`); round-tripped through the config's `inference` block |
 | `phonemizer_model` | `str` \| `None` | `None` | Model path/id or variant selector for phonemizers that take one (ByT5, AhoTTS, Cotovia, arbtok) |
 | `speaker_id_map` | `dict` | `{}` | Maps speaker names to integer IDs |
@@ -99,7 +99,7 @@ syn_config = SynthesisConfig(
 | `normalize_audio` | `bool` | `True` | Scale audio to full amplitude range |
 | `volume` | `float` | `1.0` | Volume multiplier |
 | `enable_phonetic_spellings` | `bool` | `True` | Apply word-level pronunciation overrides |
-| `add_diacritics` | `bool` \| `None` | `None` | Add vowel diacritics before phonemization; `None` defers to the voice config |
+| `add_diacritics` | `bool` \| `None` | `None` | Add pronunciation-disambiguating diacritics before phonemization (see [phonemizers.md](phonemizers.md#diacritics)); `None` defers to the voice config |
 | `diacritizer_model` | `str` \| `None` | `None` | Override the diacritizer model for this call; `None` inherits the voice config's `diacritizer_model` |
 | `speaker_reference` | `str` \| `(audio, sr)` \| `None` | `None` | Reference clip for zero-shot [voice cloning](cloning.md) |
 | `speaker_reference_text` | `str` \| `None` | `None` | Reference transcription, required by in-context cloning engines (ZipVoice) |

--- a/docs/phonemizers.md
+++ b/docs/phonemizers.md
@@ -115,23 +115,46 @@ lang)` for a flat phoneme list and `phonemize_string(text, lang)` for a single c
 
 ## Special Language Notes
 
-### Arabic / Hebrew
+### Diacritics
 
-Models trained with Arabic or Hebrew may need diacritics added before phonemization. Enable this via `SynthesisConfig`:
+Some languages are ambiguous to pronounce from plain text alone — the same spelling can map to
+different sounds depending on missing vowel marks, missing stress marks, or word sense. phoonnx
+can add these pronunciation-disambiguating diacritics *before* phonemization, via
+[`scriptconv`](https://pypi.org/project/scriptconv/)'s `add_diacritics(text, lang, model=...)`,
+which `BasePhonemizer.add_diacritics` delegates to. This is **opt-in and off by default** —
+nothing changes unless you ask for it. Enable it via `SynthesisConfig`:
 
 ```python
 from phoonnx.config import SynthesisConfig
 syn_config = SynthesisConfig(add_diacritics=True)
 ```
 
-Or set it in the voice config JSON: `"add_diacritics": true`. For Arabic, it is enabled automatically when `lang_code` starts with `"ar"`.
+Or set it in the voice config JSON: `"add_diacritics": true`. There is no automatic per-language
+enabling beyond the existing Arabic default described below — for every other language you must
+opt in explicitly, either in the voice config or per call on `SynthesisConfig` (`None` on
+`SynthesisConfig` defers to the voice config's setting).
 
-Arabic diacritization uses [`text2tashkeel`](https://pypi.org/project/text2tashkeel/), installed
-by the [`ar` extra](installation.md#language-extras). The diacritizer model defaults to
-`rawi-ensemble` (which also restores hamza and the dagger alef); override it with the
-`diacritizer_model` field on the voice config or per call on `SynthesisConfig`. Requesting
-Arabic diacritics without `text2tashkeel` installed raises a clear `ImportError`. Hebrew uses
-Phonikud.
+`scriptconv` currently backs four kinds of diacritics, all reached through the same
+`add_diacritics=True` flag:
+
+- **Arabic** — tashkeel (vowel marks, hamza, dagger alef) via [`text2tashkeel`](https://pypi.org/project/text2tashkeel/),
+  installed by the [`ar` extra](installation.md#language-extras). The diacritizer model defaults
+  to `rawi-ensemble`; override it with the `diacritizer_model` field on the voice config or per
+  call on `SynthesisConfig`. Requesting Arabic diacritics without `text2tashkeel` installed
+  raises a clear `ImportError`. For Arabic, `add_diacritics` is enabled automatically when
+  `lang_code` starts with `"ar"` — this is the one existing auto-enable and it is unchanged.
+- **Hebrew** — niqqud (vowel points) via Phonikud.
+- **East-Slavic / Turkic / Caucasian word stress** — via [`stressonnx`](https://pypi.org/project/stressonnx/),
+  covering 26 BCP-47 tags: `ru uk be bg mk sl lv hy ka kk ky tt ba cv sah kjh tg udm mdf myv kbd
+  xal az-Cyrl az-Latn uz-Cyrl uz-Latn`. Install with `pip install scriptconv[stress]`. Stays
+  strictly opt-in — no language in this list auto-enables `add_diacritics`.
+- **European Portuguese** (`pt` / `pt-PT`, never `pt-BR`) — heterophonic-homograph sense
+  diacritics via [`bifonia`](https://pypi.org/project/bifonia/), disambiguating words that are
+  spelled the same but pronounced differently depending on meaning. Install with
+  `pip install scriptconv[pt]`. Also strictly opt-in.
+
+Regardless of language, `add_diacritics=True` with no matching backend for that language is a
+no-op — the text passes through unchanged.
 
 ### Galician (Cotovia)
 
@@ -147,7 +170,7 @@ All phonemizers inherit from `BasePhonemizer` which provides:
 
 - `phonemize(text, lang)` — returns `PhonemizedChunks` (list of sentences, each a list of phoneme strings)
 - `phonemize_string(text, lang)` — returns raw phoneme string for a single chunk
-- `add_diacritics(text, lang)` — adds vowel diacritics (Arabic/Hebrew)
+- `add_diacritics(text, lang, model=None)` — adds pronunciation-disambiguating diacritics (Arabic tashkeel, Hebrew niqqud, East-Slavic/Turkic/Caucasian word stress via `stressonnx`, European-Portuguese homograph sense diacritics via `bifonia`) — see [Diacritics](#diacritics)
 - `chunk_text(text)` — splits text into sentence chunks with punctuation
 
 ## Attribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "langcodes",
     "ovos-number-parser>=0.4.0",
     "ovos-date-parser>=0.6.4a1",
-    "scriptconv[phonemizers]>=0.0.3",
+    "scriptconv[phonemizers]>=0.0.4a3",
     "unicode_rbnf",
     "click",
     "requests",

--- a/tests/test_config_detection.py
+++ b/tests/test_config_detection.py
@@ -136,6 +136,15 @@ class TestFromDictChatterbox(unittest.TestCase):
         self.assertTrue(vc_he.add_diacritics)
         self.assertFalse(vc_en.add_diacritics)
 
+    def test_chatterbox_does_not_auto_enable_diacritics_for_stress_or_pt_langs(self):
+        # East-Slavic/Turkic/Caucasian word-stress (stressonnx) and European-Portuguese
+        # (bifonia) diacritics backends are opt-in only, gated on the runtime
+        # `SynthesisConfig.add_diacritics` flag; unlike Arabic/Hebrew they must NOT be
+        # auto-enabled from lang_code alone.
+        for lang_code in ("ru", "uk", "be", "pt", "pt-PT"):
+            vc = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path, lang_code=lang_code)
+            self.assertFalse(vc.add_diacritics, f"add_diacritics should default to False for lang_code={lang_code!r}")
+
     def test_chatterbox_defaults_sample_rate_to_24000(self):
         vc = VoiceConfig.from_dict({"engine": "chatterbox"}, bpe_tokenizer_json=self.bpe_path)
         self.assertEqual(vc.sample_rate, 24000)


### PR DESCRIPTION
scriptconv 0.0.4a3 adds two new `add_diacritics` backends on top of the existing Arabic tashkeel and Hebrew niqqud support:

- **East-Slavic / Turkic / Caucasian word stress** (26 BCP-47 tags: `ru uk be bg mk sl lv hy ka kk ky tt ba cv sah kjh tg udm mdf myv kbd xal az-Cyrl az-Latn uz-Cyrl uz-Latn`), via [`stressonnx`](https://pypi.org/project/stressonnx/).
- **European Portuguese** (`pt` / `pt-PT`, never `pt-BR`) heterophonic-homograph sense diacritics, via [`bifonia`](https://pypi.org/project/bifonia/).

phoonnx's `TTSVoice` already delegates to `BasePhonemizer.add_diacritics(text, lang, model=diacritizer_model)`, gated by the runtime `SynthesisConfig.add_diacritics` flag (falls back to the voice config; defaults to `False`). Reaching the new backends therefore requires no code change — this PR is packaging + docs only:

- Raises the `scriptconv[phonemizers]` dependency floor to `>=0.0.4a3`.
- Documents the new backends in `docs/phonemizers.md` (a new "Diacritics" subsection covering all four backends) and `docs/configuration.md`, and adds a README features-table row, including the optional installs `pip install scriptconv[stress]` and `pip install scriptconv[pt]`.
- Adds a cheap config-level test asserting the new languages stay default-off — no per-language auto-enable was added for them; the existing Arabic `lang_code.startswith("ar")` auto-enable in `phoonnx/config.py` is untouched.

Design constraint honored: all diacritics backends stay uniform and gated only by the runtime `SynthesisConfig.add_diacritics` param (default `False`). No per-language auto-enable was added for ru/uk/be/pt/etc.

Test note: the full suite wasn't run — the shared venv's `ovos-date-parser` editable install currently points at a deleted scratchpad path from an unrelated session, breaking collection for all tests, independent of this change.