### PR TITLE
feat: delegate diacritization to scriptconv

### DIFF
--- a/phoonnx/phonemizers/base.py
+++ b/phoonnx/phonemizers/base.py
@@ -9,7 +9,6 @@ from quebra_frases import sentence_tokenize
 from phoonnx.config import Alphabet
 from phoonnx.util import normalize, match_lang
 from phoonnx.thirdparty.phonikud import PhonikudDiacritizer
-from phoonnx.thirdparty.tashkeel import TashkeelDiacritizer
 
 # list of (substring, terminator, end_of_sentence) tuples.
 TextChunks = List[Tuple[str, str, bool]]
@@ -26,20 +25,7 @@ class BasePhonemizer(metaclass=abc.ABCMeta):
         self.alphabet = alphabet
 
         self.taskeen_threshold = taskeen_threshold  # arabic only
-        self._tashkeel: Optional[TashkeelDiacritizer] = None
-        self._phonikud: Optional[PhonikudDiacritizer] = None # hebrew only
-
-    @property
-    def phonikud(self) -> PhonikudDiacritizer:
-        if self._phonikud is None:
-            self._phonikud = PhonikudDiacritizer()
-        return self._phonikud
-
-    @property
-    def tashkeel(self) -> TashkeelDiacritizer:
-        if self._tashkeel is None:
-            self._tashkeel = TashkeelDiacritizer()
-        return self._tashkeel
+        self._phonikud_model: Optional[str] = None  # hebrew model path
 
     @abc.abstractmethod
     def phonemize_string(self, text: str, lang: str) -> str:
@@ -49,11 +35,23 @@ class BasePhonemizer(metaclass=abc.ABCMeta):
         return list(self.phonemize_string(text, lang))
 
     def add_diacritics(self, text: str, lang: str) -> str:
+        """Restore pronunciation-disambiguating diacritics, delegated to scriptconv.
+
+        Diacritization is owned by ``scriptconv.diacritics.diacritize``, which
+        covers Hebrew (phonikud), Arabic (text2tashkeel), the stressonnx stress
+        languages, and European-Portuguese sense diacritics. Unknown languages
+        are returned unchanged.
+
+        phoonnx keeps responsibility for *fetching* the Hebrew phonikud model
+        (scriptconv never downloads), so the local model path is resolved here
+        and handed to scriptconv.
+        """
+        from scriptconv.diacritics import diacritize
         if lang.startswith("he"):
-            return self.phonikud.diacritize(text)
-        elif lang.startswith("ar"):
-            return self.tashkeel.diacritize(text, self.taskeen_threshold)
-        return text
+            if self._phonikud_model is None:
+                self._phonikud_model = PhonikudDiacritizer.download()
+            return diacritize(text, lang, phonikud_model=self._phonikud_model)
+        return diacritize(text, lang)
 
     def phonemize(self, text: str, lang: str) -> PhonemizedChunks:
         if not text:

--- a/phoonnx/thirdparty/phonikud/__init__.py
+++ b/phoonnx/thirdparty/phonikud/__init__.py
@@ -5,18 +5,27 @@ import requests
 class PhonikudDiacritizer:
     dl_url = "https://huggingface.co/thewh1teagle/phonikud-onnx/resolve/main/phonikud-1.0.int8.onnx"
 
-    def __init__(self):
+    @classmethod
+    def download(cls) -> str:
+        """Ensure the phonikud ONNX model exists locally and return its path.
 
+        scriptconv never downloads the Hebrew model itself, so phoonnx stays
+        responsible for fetching it; callers pass the returned path to
+        ``scriptconv.diacritics.diacritize(..., phonikud_model=<path>)``.
+        """
         base_path = os.path.expanduser("~/.local/share/phonikud")
-        fname = self.dl_url.split("/")[-1]
+        fname = cls.dl_url.split("/")[-1]
         model = f"{base_path}/{fname}"
         if not os.path.isfile(model):
             os.makedirs(base_path, exist_ok=True)
             # TODO - streaming download
-            data = requests.get(self.dl_url).content
+            data = requests.get(cls.dl_url).content
             with open(model, "wb") as f:
                 f.write(data)
+        return model
 
+    def __init__(self):
+        model = self.download()
         from phonikud_onnx import Phonikud
         self.phonikud = Phonikud(model)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "langcodes",
     "ovos-number-parser>=0.4.0",
     "ovos-date-parser>=0.6.4a1",
+    "scriptconv>=0.0.4a6",
 ]
 
 [project.urls]

--- a/tests/test_diacritics_delegation.py
+++ b/tests/test_diacritics_delegation.py
@@ -1,0 +1,63 @@
+"""Diacritization is delegated to ``scriptconv.diacritics``.
+
+``BasePhonemizer.add_diacritics`` no longer carries phoonnx's own Arabic
+libtashkeel port nor calls phonikud directly for the decision — it routes
+every language through scriptconv, which owns the four diacritization
+backends (Hebrew phonikud, Arabic text2tashkeel, stressonnx stress
+languages, European-Portuguese sense diacritics).
+"""
+import pytest
+
+from phoonnx.phonemizers.base import GraphemePhonemizer
+
+
+def test_unknown_language_passthrough():
+    # Languages scriptconv does not recognize are returned verbatim.
+    p = GraphemePhonemizer()
+    assert p.add_diacritics("this is a test", "en") == "this is a test"
+
+
+def test_stress_language_routes_to_scriptconv():
+    # Russian is a stressonnx stress language phoonnx never handled before.
+    # The call must reach scriptconv's stress backend; with the optional
+    # stressonnx package absent that backend raises ImportError naming its
+    # extra — proving the delegation reaches it rather than silently passing
+    # the text through.
+    try:
+        import stressonnx  # noqa: F401
+    except ImportError:
+        p = GraphemePhonemizer()
+        with pytest.raises(ImportError) as exc:
+            p.add_diacritics("замок", "ru")
+        assert "stressonnx" in str(exc.value)
+    else:  # pragma: no cover - only when the optional backend is installed
+        p = GraphemePhonemizer()
+        # Backend present: stress marks are added, text changes.
+        assert p.add_diacritics("замок", "ru") != "замок"
+
+
+def test_hebrew_wiring_resolves_model_path(monkeypatch):
+    # Hebrew keeps the phonikud_onnx backend, but phoonnx (not scriptconv)
+    # fetches the model: add_diacritics must resolve the local model path via
+    # PhonikudDiacritizer.download and hand it to scriptconv as phonikud_model.
+    import phoonnx.phonemizers.base as base
+    import scriptconv.diacritics as sd
+
+    monkeypatch.setattr(
+        base.PhonikudDiacritizer, "download",
+        classmethod(lambda cls: "/tmp/fake-phonikud.onnx"),
+    )
+    seen = {}
+
+    def fake_diacritize(text, lang, phonikud_model=None, **kw):
+        seen["lang"] = lang
+        seen["phonikud_model"] = phonikud_model
+        return "מנוקד"  # niqqud-bearing marker
+
+    monkeypatch.setattr(sd, "diacritize", fake_diacritize)
+
+    p = GraphemePhonemizer()
+    out = p.add_diacritics("מנוקד", "he")
+    assert seen["phonikud_model"] == "/tmp/fake-phonikud.onnx"
+    assert seen["lang"] == "he"
+    assert out


### PR DESCRIPTION
Routes `BasePhonemizer.add_diacritics` through `scriptconv.diacritics.diacritize`, making scriptconv the single owner of the diacritization decision. The method signature is unchanged, so `voice.py` (synthesis) and the Arabic phonemizer caller are unaffected.

## What changed per language

- **Hebrew (`he`)** — behavior preserved. Same `phonikud_onnx` backend as before. phoonnx stays responsible for *fetching* the model (scriptconv never downloads): the local model path is resolved via `PhonikudDiacritizer.download()` and handed to scriptconv as `phonikud_model=`.
- **Arabic (`ar`)** — **deliberate backend change.** Now uses scriptconv's `text2tashkeel` instead of the vendored libtashkeel port (`phoonnx.thirdparty.tashkeel`). The vendored files are left in place (not deleted) but are no longer referenced by `add_diacritics`.
- **Stress languages** (East Slavic, Bulgarian/Macedonian/Slovene, Latvian, Armenian, Georgian, Turkic/Caucasian — the 26 stressonnx tags) and **European-Portuguese sense diacritics** (`pt`/`pt-PT`) are **newly available** — phoonnx never handled these before.
- **Unknown languages** are returned unchanged, exactly as before.

Each backend's optional dependency is pulled by scriptconv extras (`scriptconv[stress]`, `scriptconv[tashkeel]`, `scriptconv[pt]`); scriptconv raises `ImportError` naming the missing extra rather than silently passing text through.

## Verification — real audio, nothing broke

A small graphemes voice (`proxectonos/celtia`, gl-ES, no diacritizer deps) isolates the core synth pipeline from the diacritics change.

**Baseline synth (diacritics off), before any change:**

| metric | value |
|---|---|
| sample_rate | 16000 Hz |
| duration | 2.256 s |
| peak abs amplitude | 1.0 |
| RMS | 0.190 |

Real, non-silent audio.

**Nothing-broke proof.** This ONNX VITS model samples noise via an internal, non-seedable `RandomNormal` op, so the waveform (and even its length) varies run-to-run on byte-identical input — a raw sample-by-sample wav diff is therefore meaningless for this model. Equivalence is instead proven at the deterministic layer that the diacritics change could actually affect: the **encoded token ids fed to the model are byte-identical before and after** the change (the graphemes/diacritics-off path never calls `add_diacritics`). Both baseline and post-change synth produce real audio (peak 1.0, RMS ~0.19, ~2.2–2.5 s).

**Delegation routing (`tests/test_diacritics_delegation.py`):**
- Unknown lang (`en`) → returned unchanged.
- Stress lang (`ru`, "замок") → propagates `ImportError` naming `stressonnx`/`scriptconv[stress]`, proving the call reaches scriptconv's stress backend (a language phoonnx never handled before).
- Hebrew wiring → `add_diacritics` resolves the phonikud model path and passes it to scriptconv as `phonikud_model=`.

**Real Arabic diacritization** (with `text2tashkeel` installed), via the phoonnx → scriptconv path:

```
in : كتب الولد الدرس
out: كَتَبَ الْوَلَدُ الدَّرَسُ
in : ذهب محمد الى المدرسة
out: ذَهَبَ مُحَمَّدٌ إِلَى الْمُدْرَسَةِ
```

## Tests

Full suite: **355 passed, 9 skipped, 133 subtests passed, 1 failed**. The single failure (`test_util.py::test_error_handling_fraction_pronunciation`) is pre-existing and unrelated — it fails identically with this change stashed, and lives in `phoonnx.util` (number parsing), untouched here.