### PR TITLE
fix: always resolve a voice's alphabet

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -162,6 +162,13 @@ class VoiceConfig:
             self.engine = Engine(self.engine)
         if not isinstance(self.alphabet, Alphabet) and isinstance(self.alphabet, str):
             self.alphabet = Alphabet(self.alphabet)
+        if self.alphabet is None:
+            # The alphabet names the model's token space and is what the
+            # conversion routes to, so it can never be absent. Vocab- and
+            # tokens-file voices (transformers, sherpa) carry no alphabet of
+            # their own; they are character models, like every other branch that
+            # falls back here.
+            self.alphabet = Alphabet.UNICODE
         if not isinstance(self.phoneme_type, PhonemeType) and isinstance(self.phoneme_type, str):
             self.phoneme_type = PhonemeType(self.phoneme_type)
 

--- a/tests/test_config_detection_edges.py
+++ b/tests/test_config_detection_edges.py
@@ -107,3 +107,33 @@ class TestVoiceAdapterResolutionForMissingEngines(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAlphabetAlwaysResolved(unittest.TestCase):
+    """The alphabet names the model's token space and is what the conversion
+    routes to, so it can never be left unset. Vocab-file (transformers) and
+    tokens-file (sherpa) voices carry no alphabet of their own; before this was
+    defaulted they produced alphabet=None and every synthesis raised
+    AttributeError: 'NoneType' object has no attribute 'value'."""
+
+    def test_vocab_voice_gets_a_character_alphabet(self):
+        vc = VoiceConfig.from_dict({"lang_code": "en"}, vocab={"a": 1, "b": 2, "_": 0})
+        self.assertEqual(vc.alphabet, Alphabet.UNICODE)
+
+    def test_direct_construction_without_alphabet_is_resolved(self):
+        vc = VoiceConfig(num_symbols=10, num_speakers=0, num_langs=1, sample_rate=22050,
+                         lang_code="en", phoneme_type=None, alphabet=None,
+                         phonemizer_model=None)
+        self.assertEqual(vc.alphabet, Alphabet.UNICODE)
+
+    def test_explicit_alphabet_is_not_overridden(self):
+        vc = VoiceConfig.from_dict({"lang_code": "en", "alphabet": "ipa",
+                                    "phoneme_type": "espeak", "phoneme_id_map": {"a": 1}})
+        self.assertEqual(vc.alphabet, Alphabet.IPA)
+
+    def test_conversion_builds_for_a_vocab_voice(self):
+        from phoonnx.config import get_conversion, SynthesisConfig
+        vc = VoiceConfig.from_dict({"lang_code": "en"}, vocab={"a": 1, "b": 2, "_": 0})
+        graph, prepare = get_conversion(None, vc, SynthesisConfig(), vc.alphabet)
+        self.assertIsNotNone(graph)
+        self.assertEqual(prepare("ab"), "ab")


### PR DESCRIPTION
Found while auditing `dev`. This is a **regression from the conversion refactor** (#291/#293).

## The bug
`VoiceConfig.alphabet` is `Optional[Alphabet]`. Most `from_dict` branches default it (chatterbox → UNICODE, supertonic → GRAPHEMES, …), but the **vocab-file (transformers)** and **tokens-file (sherpa)** branches never do, so those voices end up with `alphabet=None`.

That used to be harmless — the old dispatch only touched `tgt_alphabet` inside `_phonemic_chunks`, never on the grapheme hot path. Now conversion routes to `tgt_alphabet.value`, so **every synthesis for such a voice raises**:

```python
VoiceConfig.from_dict({"lang_code": "en"}, vocab={"a": 1, "b": 2, "_": 0})   # alphabet=None
voice.synthesize("ab ab.")
# AttributeError: 'NoneType' object has no attribute 'value'
```

## The fix
Resolve the alphabet in `__post_init__`, so it holds for **every** construction path (not just `from_dict` — direct `VoiceConfig(...)` too). Vocab- and tokens-file voices are character models, so they fall back to the same character alphabet the other branches already use. An explicit alphabet is never overridden.

Behaviour is otherwise unchanged: `src=GRAPHEMES` vs `tgt=UNICODE` still routes down the grapheme path exactly as before, and the text-token branch (`src == tgt == GRAPHEMES`) is unaffected.

## Verification
```
vocab voice alphabet          -> Alphabet.UNICODE
direct construction alphabet  -> Alphabet.UNICODE
explicit alphabet preserved   -> Alphabet.IPA
get_conversion(vocab voice)   -> ConversionGraph   (was AttributeError)
```
Regression tests added; 204 tests pass (7 errors are the pre-existing `tokenizers` gap in the chatterbox tests).