### PR TITLE
fix: never omit an ONNX input the graph requires

### DIFF
--- a/phoonnx/engines/shami.py
+++ b/phoonnx/engines/shami.py
@@ -48,9 +48,11 @@ class ShamiAdapter(BaseOnnxAdapter):
             else np.zeros_like(np.asarray(request.phoneme_ids), dtype=np.int64)
         )
 
-        # Single-speaker graphs may prune the speaker_id input entirely.
-        if request.speaker_id is not None and request.speaker_id > 0:
-            args["speaker_id"] = np.array([request.speaker_id], dtype=np.int64)
+        # Speaker 0 is a real speaker, not "unset": omitting it made a
+        # multi-speaker graph (which declares speaker_id) reject the default
+        # speaker outright. Always feed it; _filter_inputs prunes it again on
+        # single-speaker graphs that do not declare the input.
+        args["speaker_id"] = np.array([int(request.speaker_id or 0)], dtype=np.int64)
 
         return self._filter_inputs(args, session)
 

--- a/phoonnx/engines/styletts2.py
+++ b/phoonnx/engines/styletts2.py
@@ -100,6 +100,15 @@ class StyleTTS2Adapter(BaseOnnxAdapter):
             if style.shape[1] >= 256:       # cloning StyleTTS2: split into ref_p + ref_s
                 args["ref"] = style[:, :128]
                 args["s"] = style[:, 128:256]
+        elif any(i.name in ("style", "style_vec", "s_prev") for i in session.get_inputs()):
+            # The graph conditions on a style vector; without one onnxruntime only
+            # reports a missing required input, which says nothing about what the
+            # voice is actually missing.
+            raise ValueError(
+                "this StyleTTS2/Kokoro voice needs a conditioning style: pass a "
+                "speaker_reference to synthesize(), or give the voice a "
+                "engine_params['style_path']"
+            )
         return self._filter_inputs(args, session)
 
     def parse_outputs(

--- a/phoonnx/engines/yourtts.py
+++ b/phoonnx/engines/yourtts.py
@@ -86,6 +86,15 @@ class YourTTSAdapter(BaseOnnxAdapter):
         }
         if dv is not None:
             args["d_vector"] = dv.astype(np.float32)
+        elif any(i.name == "d_vector" for i in session.get_inputs()):
+            # d_vector is YourTTS's only speaker conditioning; silently dropping it
+            # left onnxruntime to report a missing required input, which says
+            # nothing about what the voice is actually missing.
+            raise ValueError(
+                "this YourTTS voice needs a speaker d-vector: pass a "
+                "speaker_reference to synthesize(), or give the voice a "
+                "engine_params['d_vector'] or engine_params['speaker_encoder_path']"
+            )
         return self._filter_inputs(args, session)
 
     def parse_outputs(

--- a/tests/test_shami.py
+++ b/tests/test_shami.py
@@ -153,3 +153,28 @@ class TestShamiRequiredLanguageIds(unittest.TestCase):
         supplied = np.array([[1, 1, 0]], dtype=np.int64)
         feed = ShamiAdapter().build_feed_dict(self._request(supplied), self._Session())
         np.testing.assert_array_equal(feed["language_ids"], supplied)
+
+
+class TestShamiSpeakerIdAlwaysFed(unittest.TestCase):
+    """Speaker 0 is a real speaker, not "unset". Omitting it made a multi-speaker
+    graph (which declares speaker_id) reject the default speaker outright."""
+
+    class _Session:
+        def __init__(self, *names): self._n = names
+        def get_inputs(self): return [types.SimpleNamespace(name=n) for n in self._n]
+
+    def _req(self, sid):
+        return AdapterSynthesisRequest(phoneme_ids=np.array([[1, 2, 3]], dtype=np.int64),
+                                       phoneme_lengths=np.array([3], dtype=np.int64),
+                                       language_ids=None, speaker_id=sid)
+
+    def test_default_speaker_zero_is_fed(self):
+        sess = self._Session("phoneme_ids", "phoneme_lengths", "language_ids", "speaker_id")
+        feed = ShamiAdapter().build_feed_dict(self._req(0), sess)
+        self.assertIn("speaker_id", feed)
+        np.testing.assert_array_equal(feed["speaker_id"], np.array([0]))
+
+    def test_single_speaker_graph_does_not_gain_the_input(self):
+        sess = self._Session("phoneme_ids", "phoneme_lengths", "language_ids")
+        feed = ShamiAdapter().build_feed_dict(self._req(0), sess)
+        self.assertNotIn("speaker_id", feed)

--- a/tests/test_styletts2.py
+++ b/tests/test_styletts2.py
@@ -108,3 +108,17 @@ def test_styletts2_cloning_splits_ref_and_s():
 def test_styletts2_style_encoder_registered():
     from phoonnx.engines.speaker_encoders import list_speaker_encoders
     assert "styletts2_style" in list_speaker_encoders()
+
+
+def test_missing_style_raises_a_clear_error():
+    """The graph conditions on a style vector; without one onnxruntime only
+    reported a missing required input."""
+    import types, numpy as np, pytest
+    from phoonnx.engines.styletts2 import StyleTTS2Adapter
+    from phoonnx.engines.base import AdapterSynthesisRequest
+    sess = type("S", (), {"get_inputs": lambda self: [
+        types.SimpleNamespace(name=n) for n in ("input_ids", "attention_mask", "speed", "style")]})()
+    req = AdapterSynthesisRequest(phoneme_ids=np.array([[1, 2]], dtype=np.int64),
+                                  phoneme_lengths=np.array([2], dtype=np.int64), params={})
+    with pytest.raises(ValueError, match="style"):
+        StyleTTS2Adapter().build_feed_dict(req, sess)

--- a/tests/test_yourtts.py
+++ b/tests/test_yourtts.py
@@ -103,3 +103,18 @@ def test_reference_audio_outranks_bundled_dvector():
     feed = a.build_feed_dict(_req(d_vector=np.full(512, 0.1, np.float32),
                                   reference_audio=(np.zeros(16000, np.float32), 16000)), SESS)
     assert np.allclose(feed["d_vector"][0], 0.9)
+
+
+def test_missing_d_vector_raises_a_clear_error():
+    """d_vector is YourTTS's only speaker conditioning and is always a declared
+    input; omitting it left onnxruntime to report a missing required input,
+    which says nothing about what the voice actually lacks."""
+    import types, numpy as np, pytest
+    from phoonnx.engines.yourtts import YourTTSAdapter
+    from phoonnx.engines.base import AdapterSynthesisRequest
+    sess = type("S", (), {"get_inputs": lambda self: [
+        types.SimpleNamespace(name=n) for n in ("input", "input_lengths", "scales", "langid", "d_vector")]})()
+    req = AdapterSynthesisRequest(phoneme_ids=np.array([[1, 2]], dtype=np.int64),
+                                  phoneme_lengths=np.array([2], dtype=np.int64), params={})
+    with pytest.raises(ValueError, match="d-vector"):
+        YourTTSAdapter().build_feed_dict(req, sess)


### PR DESCRIPTION
Found while auditing `dev` — the same bug class as the recent Shami `language_ids` fix, in three more places. An adapter drops a conditioning input when it is unset, so onnxruntime fails the required-input check with a message that says nothing about what the voice is missing.

## shami — the default speaker was rejected
`speaker_id` was only fed when `> 0`, but `voice.py` always sends `syn_config.speaker_id or 0`. **Speaker 0 is a real speaker, not "unset"**, so a multi-speaker ShamiVITS graph rejected its *default* speaker and worked for every other one:

```
speaker_id=0: fed keys=['language_ids','phoneme_ids','phoneme_lengths']  -> speaker_id MISSING
speaker_id=1: fed keys=[..., 'speaker_id']                               -> OK
```

Now always fed; `_filter_inputs` still prunes it on single-speaker graphs that don't declare the input (verified).

## yourtts / styletts2 — opaque failure when conditioning is absent
`d_vector` is YourTTS's **only** speaker conditioning and is always a declared input; same for StyleTTS2/Kokoro's `style`. A voice with no d-vector/style pack, no speaker encoder, and no reference clip on the call produced:

```
Required inputs (['d_vector']) are missing from input feed
```

Neither has a sensible default — a zero vector would synthesize with **no speaker identity**, which is worse than failing — so they now raise naming exactly what the voice needs (a `speaker_reference`, or `engine_params['d_vector']`/`['speaker_encoder_path']`/`['style_path']`).

## Verification
```
shami speaker_id=0            -> fed, value [0]
shami single-speaker graph    -> speaker_id correctly absent
yourtts, no d_vector          -> ValueError naming the d-vector
styletts2, no style           -> ValueError naming the style
```
Regression tests added for each. 202 tests pass.