### PR TITLE
fix: honour length_scale on every engine

### DIFF
--- a/phoonnx/engines/mixertts.py
+++ b/phoonnx/engines/mixertts.py
@@ -86,7 +86,7 @@ class MixerTTSAdapter(BaseOnnxAdapter):
         p = request.params
         args: Dict[str, np.ndarray] = {
             "token_ids": request.phoneme_ids.astype(np.int64),
-            "pace": np.array([float(p.get("pace", 1.0))], dtype=np.float32),
+            "pace": np.array([float(p.get("pace", p.get("length_scale", 1.0)))], dtype=np.float32),
             "speaker": np.array([int(request.speaker_id or 0)], dtype=np.int32),
             "emotion": np.array([int(p.get("emotion", 0))], dtype=np.int32),
             "pitch_mul": np.array([float(p.get("pitch_mul", 1.0))], dtype=np.float32),

--- a/phoonnx/engines/optispeech.py
+++ b/phoonnx/engines/optispeech.py
@@ -65,7 +65,7 @@ class OptiSpeechAdapter(BaseOnnxAdapter):
         session: onnxruntime.InferenceSession,
     ) -> Dict[str, np.ndarray]:
         params = request.params
-        d_factor = np.float32(params.get("d_factor", 1.0))
+        d_factor = np.float32(params.get("d_factor", params.get("length_scale", 1.0)))
         p_factor = np.float32(params.get("p_factor", 1.0))
         e_factor = np.float32(params.get("e_factor", 1.0))
 

--- a/phoonnx/engines/styletts2.py
+++ b/phoonnx/engines/styletts2.py
@@ -78,7 +78,8 @@ class StyleTTS2Adapter(BaseOnnxAdapter):
         # with a multi-row [N, 256] style pack.
         _trailing = 1 if (self.style_pack is not None and self.style_pack.shape[0] > 1) else 0
         ids = np.pad(ids, ((0, 0), (1, _trailing)), constant_values=_PAD_ID)
-        speed = np.float32(request.params.get("speed", self.default_params()["speed"]))
+        speed = np.float32(request.params.get(
+            "speed", request.params.get("length_scale", self.default_params()["speed"])))
         args: Dict[str, np.ndarray] = {
             "input_ids": ids, "tokens": ids,                       # name aliases
             "attention_mask": np.ones_like(ids, dtype=np.int32),

--- a/tests/test_fastpitch.py
+++ b/tests/test_fastpitch.py
@@ -50,6 +50,14 @@ def test_build_feed_dict_inherited():
     assert feed["pace"][0] == pytest.approx(0.9)
 
 
+def test_length_scale_falls_back_to_pace():
+    # FastPitch inherits build_feed_dict from Mixer-TTS: length_scale must be
+    # honoured here too.
+    sess = _Sess(["token_ids", "pace", "speaker", "pitch_mul", "pitch_add"])
+    feed = FastPitchAdapter().build_feed_dict(_req(length_scale=1.3), sess)
+    assert feed["pace"][0] == pytest.approx(1.3)
+
+
 def test_inherits_duration_output_names():
     """FastPitch reuses Mixer-TTS's parsing, including alignment detection."""
     assert FastPitchAdapter.DURATION_OUTPUT_NAMES == MixerTTSAdapter.DURATION_OUTPUT_NAMES

--- a/tests/test_mixertts.py
+++ b/tests/test_mixertts.py
@@ -116,6 +116,18 @@ def test_default_params():
     assert MixerTTSAdapter().default_params() == {"pace": 1.0, "pitch_mul": 1.0, "pitch_add": 0.0, "emotion": 0}
 
 
+def test_length_scale_falls_back_to_pace():
+    # SynthesisConfig.length_scale is the canonical speed knob; honour it when
+    # the adapter's native "pace" key is not explicitly set.
+    feed = MixerTTSAdapter().build_feed_dict(_req(length_scale=1.3), MIXER_SESSION)
+    assert feed["pace"][0] == pytest.approx(1.3)
+
+
+def test_pace_takes_precedence_over_length_scale():
+    feed = MixerTTSAdapter().build_feed_dict(_req(pace=0.7, length_scale=1.3), MIXER_SESSION)
+    assert feed["pace"][0] == pytest.approx(0.7)
+
+
 def test_config_bridge():
     # mirror of models/symbols.py order: [pad] + punctuation + letters + ipa
     symbols = ["$", ";", ":", "a", "b", "ɑ", "ɛ", "ˈ"]

--- a/tests/test_optispeech.py
+++ b/tests/test_optispeech.py
@@ -102,6 +102,19 @@ def test_default_params():
     assert OptiSpeechAdapter().default_params() == {"d_factor": 1.0, "p_factor": 1.0, "e_factor": 1.0}
 
 
+def test_length_scale_falls_back_to_d_factor():
+    # SynthesisConfig.length_scale is the canonical speed knob; honour it when
+    # the adapter's native "d_factor" key is not explicitly set.
+    feed = OptiSpeechAdapter().build_feed_dict(_req(length_scale=1.3), OPTISPEECH_SESSION)
+    assert feed["scales"] == pytest.approx([1.3, 1.0, 1.0])
+
+
+def test_d_factor_takes_precedence_over_length_scale():
+    feed = OptiSpeechAdapter().build_feed_dict(
+        _req(d_factor=0.7, length_scale=1.3), OPTISPEECH_SESSION)
+    assert feed["scales"] == pytest.approx([0.7, 1.0, 1.0])
+
+
 def test_config_bridge():
     vc = voice_config_from_optispeech_meta(META)
     assert vc.engine == Engine.OPTISPEECH

--- a/tests/test_styletts2.py
+++ b/tests/test_styletts2.py
@@ -52,6 +52,20 @@ def test_kokoro_style_pack_length_indexed():
     assert "attention_mask" not in feed   # filtered (not a model input)
 
 
+def test_length_scale_falls_back_to_speed():
+    # SynthesisConfig.length_scale is the canonical speed knob; honour it when
+    # the adapter's native "speed" key is not explicitly set.
+    sess = _Sess(["input_ids", "attention_mask", "speed"])
+    feed = StyleTTS2Adapter().build_feed_dict(_req(5, length_scale=1.3), sess)
+    assert feed["speed"][0] == pytest.approx(1.3)
+
+
+def test_speed_takes_precedence_over_length_scale():
+    sess = _Sess(["input_ids", "attention_mask", "speed"])
+    feed = StyleTTS2Adapter().build_feed_dict(_req(5, speed=0.7, length_scale=1.3), sess)
+    assert feed["speed"][0] == pytest.approx(0.7)
+
+
 def test_parse_outputs_picks_waveform():
     r = StyleTTS2Adapter().parse_outputs([np.zeros((1, 512, 8), np.float32), np.ones(20000, np.float32)], _req())
     assert r.audio.ndim == 1 and r.audio.size == 20000


### PR DESCRIPTION
## Bug

`phoonnx/voice.py` merges `noise_scale`/`length_scale`/`noise_w_scale` into every engine's `params`, and `SynthesisConfig.length_scale` is documented as the speed/duration control. Four adapters silently ignored it because their `build_feed_dict` reads a differently-named native key:

| Adapter | Native key read |
|---|---|
| `phoonnx/engines/optispeech.py` | `d_factor` |
| `phoonnx/engines/mixertts.py` | `pace` |
| `phoonnx/engines/fastpitch.py` (inherits Mixer-TTS's `build_feed_dict`) | `pace` |
| `phoonnx/engines/styletts2.py` | `speed` |

`SynthesisConfig(length_scale=1.3)` was a no-op on all four. Matcha-TTS, GlowTTS and VITS already read `length_scale` directly and were unaffected.

## Fix

Each adapter now falls back to the generic `length_scale` only when its own native key is absent from `params`:

```python
d_factor = np.float32(params.get("d_factor", params.get("length_scale", 1.0)))
```

Precedence is preserved: an explicitly-set native key (from voice config / `engine_params`) still wins over the generic `length_scale`. No default values changed.

## Tests

Added a fallback test + a precedence test per adapter (`tests/test_optispeech.py`, `tests/test_mixertts.py`, `tests/test_fastpitch.py`, `tests/test_styletts2.py`).

```
tests/test_mixertts.py tests/test_fastpitch.py tests/test_styletts2.py tests/test_engines.py: 60 passed
tests/test_optispeech.py: 13 passed, 1 pre-existing torch collection failure (unrelated, torch unavailable)
```