### PR TITLE
fix: select the Kokoro style row with the unpadded token count

### DIFF
--- a/phoonnx/engines/styletts2.py
+++ b/phoonnx/engines/styletts2.py
@@ -71,6 +71,10 @@ class StyleTTS2Adapter(BaseOnnxAdapter):
         session: onnxruntime.InferenceSession,
     ) -> Dict[str, np.ndarray]:
         ids = np.asarray(request.phoneme_ids, dtype=np.int64)
+        # Kokoro's style pack is indexed by the token count BEFORE padding
+        # (upstream kokoro-onnx does voices[voice][len(tokens)] and pads after),
+        # so capture it here rather than reading it back off the padded ids.
+        unpadded_len = ids.shape[1]
         # Padding with the pad id ($): Kokoro pads BOTH ends (its tokenizer emits
         # [0, *tokens, 0]); the plain StyleTTS2 lineage (single reference style or
         # a baked-in style) pads the START only -- a trailing pad makes those
@@ -92,8 +96,9 @@ class StyleTTS2Adapter(BaseOnnxAdapter):
             audio, sr = ref
             style = self.speaker_encoder.encode(audio, sr).reshape(1, -1).astype(np.float32)
         elif self.style_pack is not None:
-            n = ids.shape[1]
-            style = self.style_pack[min(n, self.style_pack.shape[0] - 1)].reshape(1, -1).astype(np.float32)
+            style = self.style_pack[
+                min(unpadded_len, self.style_pack.shape[0] - 1)
+            ].reshape(1, -1).astype(np.float32)
         if style is not None:
             args["style"] = style          # Kokoro
             args["style_vec"] = style       # alexbeatnik StyleTTS2

--- a/tests/test_styletts2.py
+++ b/tests/test_styletts2.py
@@ -47,8 +47,9 @@ def test_kokoro_style_pack_length_indexed():
     sess = _Sess(["input_ids", "style", "speed"])
     feed = StyleTTS2Adapter(style_pack=pack).build_feed_dict(_req(5), sess)
     assert "style" in feed and feed["style"].shape == (1, 256)
-    # 5 tokens -> +2 pad = 7 -> style_pack[7]
-    assert np.allclose(feed["style"][0], pack[7])
+    # 5 tokens (unpadded) -> style_pack[5]; upstream kokoro-onnx indexes
+    # voices[voice][len(tokens)] BEFORE padding, so the padded length (7) is wrong
+    assert np.allclose(feed["style"][0], pack[5])
     assert "attention_mask" not in feed   # filtered (not a model input)
 
 
@@ -136,3 +137,15 @@ def test_missing_style_raises_a_clear_error():
                                   phoneme_lengths=np.array([2], dtype=np.int64), params={})
     with pytest.raises(ValueError, match="style"):
         StyleTTS2Adapter().build_feed_dict(req, sess)
+
+
+
+def test_kokoro_style_row_ignores_the_padding():
+    """The style row must come from the unpadded token count. Selecting it from
+    the padded ids shifted every utterance's row, worst on short ones where
+    adjacent rows differ most."""
+    pack = np.arange(510 * 256, dtype=np.float32).reshape(510, 256)
+    sess = _Sess(["input_ids", "style", "speed"])
+    for n in (1, 3, 5, 17):
+        feed = StyleTTS2Adapter(style_pack=pack).build_feed_dict(_req(n), sess)
+        assert np.allclose(feed["style"][0], pack[n]), f"{n} tokens picked the wrong row"


### PR DESCRIPTION
Found while auditing `dev`.

## The bug
Kokoro's `[N, 256]` style pack is indexed by **token count**, but the row was read off the ids *after* padding:

```python
ids = np.pad(ids, ((0, 0), (1, _trailing)), ...)   # [0, *tokens, 0]
n = ids.shape[1]                                    # padded!
style = self.style_pack[min(n, ...)]
```

Upstream `kokoro-onnx` does `voices[voice][len(tokens)]` and pads *afterwards*. So every utterance selected a row two positions too high — measured: **5 tokens selected row 7**.

The failure is silent: no exception, just prosody/timbre drift, worst on short utterances where adjacent style rows differ most.

## The fix
Capture the token count before padding and index with that.

```
5 unpadded tokens -> style row 5   (was 7)
```

## Note on tests
The existing `test_kokoro_style_pack_length_indexed` asserted `pack[7]` — it encoded the bug — so it now pins `pack[5]`, plus a new case checking several lengths (1, 3, 5, 17). 108 tests pass.

Opened fresh against current `dev`: an earlier branch carrying this fix was cut before the atomic-download and length_scale work merged, so merging it as-is would have reverted both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kokoro voice style selection by basing it on the original text length, ensuring padding does not affect the selected style.
  * Added coverage for style selection across multiple input lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->