### PR TITLE
feat: add uk_UA piper voices tetiana/mykyta/oleksa (high)

### DIFF
--- a/phoonnx/voice_index/piper.json
+++ b/phoonnx/voice_index/piper.json
@@ -1845,6 +1845,45 @@
         "engine": "piper",
         "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__uk_UA-ukrainian_tts-medium/config.json"
     },
+    "piper/uk_UA-tetiana-high": {
+        "voice_id": "piper/uk_UA-tetiana-high",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__uk_UA-tetiana-high/model.onnx",
+        "phoneme_type": "espeak",
+        "lang": "uk-UA",
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "vocab_url": null,
+        "phoneme_map_url": null,
+        "alphabet": "ipa",
+        "engine": "piper",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__uk_UA-tetiana-high/config.json"
+    },
+    "piper/uk_UA-mykyta-high": {
+        "voice_id": "piper/uk_UA-mykyta-high",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__uk_UA-mykyta-high/model.onnx",
+        "phoneme_type": "espeak",
+        "lang": "uk-UA",
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "vocab_url": null,
+        "phoneme_map_url": null,
+        "alphabet": "ipa",
+        "engine": "piper",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__uk_UA-mykyta-high/config.json"
+    },
+    "piper/uk_UA-oleksa-high": {
+        "voice_id": "piper/uk_UA-oleksa-high",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__uk_UA-oleksa-high/model.onnx",
+        "phoneme_type": "espeak",
+        "lang": "uk-UA",
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "vocab_url": null,
+        "phoneme_map_url": null,
+        "alphabet": "ipa",
+        "engine": "piper",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__uk_UA-oleksa-high/config.json"
+    },
     "piper/vi_VN-25hours_single-low": {
         "voice_id": "piper/vi_VN-25hours_single-low",
         "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper__vi_VN-25hours_single-low/model.onnx",


### PR DESCRIPTION
## Summary
- Mirrors three Apache-2.0 Ukrainian Piper voices into `OpenVoiceOS/phoonnx-vits`, following the existing `piper__<voice>/{model.onnx,config.json}` layout used by the other `uk_UA` entries.
- Registers `piper/uk_UA-tetiana-high`, `piper/uk_UA-mykyta-high`, `piper/uk_UA-oleksa-high` in `phoonnx/voice_index/piper.json`.

## Provenance
- Source repos: `RomanStasyshyn/uk_UA-tetiana-high`, `RomanStasyshyn/uk_UA-mykyta-high`, `RomanStasyshyn/uk_UA-oleksa-high` on Hugging Face.
- Author: RomanStasyshyn.
- License: Apache-2.0 (verified via HF `card_data.license` on each source repo before mirroring).
- Shared publicly via https://github.com/OHF-Voice/piper1-gpl/discussions/212.
- Mirror location: https://huggingface.co/OpenVoiceOS/phoonnx-vits (`piper__uk_UA-tetiana-high/`, `piper__uk_UA-mykyta-high/`, `piper__uk_UA-oleksa-high/`); README.md of the mirror repo updated with attribution + license + discussion link.

## Test plan
- [x] Verified Apache-2.0 license on all three source repos via `HfApi.model_info(...).card_data`.
- [x] Loaded each `.onnx` + config through phoonnx's piper/VITS path (`TTSVoice.load`) and synthesized a Ukrainian sentence — all three produced non-silent audio (durations ~3.75-5.0s @ 22050Hz, peak 1.0, RMS 0.11-0.19).
- [x] Re-verified all three through the normal public API by constructing `TTSModelInfo` from the voice-index entries and calling `.load()` + `.synthesize()` — downloads straight from the mirrored HF URLs.
- [x] All 6 mirrored URLs (`model.onnx` + `config.json` x3) return HTTP 200.
- [x] `TTSModelInfo(**entry)` constructs successfully for all three new voice-index entries.
- [x] Full test suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/` — 1502 passed, 0 failed (no regressions).