### PR TITLE
ci: bump docker workflow actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,10 +19,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -30,13 +30,13 @@ jobs:
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=ref,event=tag
             type=sha,format=short
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This PR supersedes renovate PRs #194, #185, #183, #182 and #180, which each carried a stale build-tests.yml hunk that would have reverted dev's install_extras and system_deps.

This PR bumps the following GitHub Actions to their latest versions:
- actions/checkout: v4 → v7
- docker/setup-buildx-action: v3 → v4
- docker/metadata-action: v5 → v6
- docker/login-action: v3 → v4
- docker/build-push-action: v6 → v7