### PR TITLE
fix: pad short token sequences for SpeedySpeech-style exports

### DIFF
--- a/phoonnx/engines/mixertts.py
+++ b/phoonnx/engines/mixertts.py
@@ -94,6 +94,50 @@ class MixerTTSAdapter(BaseOnnxAdapter):
         }
         return self._filter_inputs(args, session)
 
+    # Some exports in this family (notably SpeedySpeech, which shares the
+    # FastPitch ONNX contract) stack dilated residual convolutions with no
+    # padding, so the graph rejects any token sequence shorter than its
+    # receptive field with ``INVALID_ARGUMENT ... Invalid input shape``.
+    # Short utterances ("Yes.") are ordinary TTS input, so pad up to this
+    # bound and retry rather than propagating the crash.
+    MAX_PAD_TO = 32
+
+    def synthesize(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> AdapterSynthesisResult:
+        feed = self.build_feed_dict(request, session)
+        try:
+            outputs = session.run(None, feed)
+        except onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument as err:
+            if "Invalid input shape" not in str(err):
+                raise
+            outputs = self._run_padded(session, feed, err)
+        try:
+            return self.parse_outputs(
+                outputs, request, output_names=self._safe_output_names(session)
+            )
+        except TypeError:
+            return self.parse_outputs(outputs, request)
+
+    def _run_padded(self, session, feed, err):
+        """Retry ``session.run`` with ``token_ids`` right-padded with the pad id."""
+        tokens = np.asarray(feed["token_ids"])
+        length = tokens.shape[-1]
+        pad_id = int(self._engine_params.get("pad_id", 0))
+        for target in range(length + 1, self.MAX_PAD_TO + 1):
+            padded = np.pad(
+                tokens, [(0, 0)] * (tokens.ndim - 1) + [(0, target - length)],
+                constant_values=pad_id,
+            )
+            try:
+                return session.run(None, {**feed, "token_ids": padded})
+            except onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument as retry_err:
+                if "Invalid input shape" not in str(retry_err):
+                    raise
+        raise err
+
     def parse_outputs(
         self,
         outputs: List[np.ndarray],

--- a/tests/test_mixertts.py
+++ b/tests/test_mixertts.py
@@ -193,3 +193,51 @@ def test_tokenization_arabic_mantoq_pinned_buckwalter_ids():
                          'a', 'm', 'u', ' ', 'E', 'a', 'l', 'a', 'y', 'k', 'u', 'm']
     expected = [sid[p] for p in expected_symbols]
     assert ours == expected
+
+
+class _ShortInputSession(DummySession):
+    """Mimics SpeedySpeech: dilated convs reject sequences below a minimum."""
+
+    def __init__(self, min_len):
+        super().__init__(["token_ids"])
+        self.min_len = min_len
+        self.seen_lengths = []
+
+    def run(self, output_names, feed):
+        from onnxruntime.capi.onnxruntime_pybind11_state import InvalidArgument
+        n = np.asarray(feed["token_ids"]).shape[-1]
+        self.seen_lengths.append(n)
+        if n < self.min_len:
+            raise InvalidArgument(
+                "[ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Non-zero status code "
+                f"returned while running Conv node. Invalid input shape: {{{n}}}"
+            )
+        return [np.zeros((1, 80, n * 2), dtype=np.float32)]
+
+
+def test_short_input_is_padded_until_the_graph_accepts_it():
+    session = _ShortInputSession(min_len=13)
+    adapter = MixerTTSAdapter(vocoder=FakeVocoder())
+    result = adapter.synthesize(_req(4), session)
+    assert result.audio.size > 0
+    assert session.seen_lengths[0] == 4
+    assert session.seen_lengths[-1] == 13
+
+
+def test_long_enough_input_is_not_padded():
+    session = _ShortInputSession(min_len=13)
+    adapter = MixerTTSAdapter(vocoder=FakeVocoder())
+    adapter.synthesize(_req(20), session)
+    assert session.seen_lengths == [20]
+
+
+def test_unrelated_invalid_argument_is_not_swallowed():
+    from onnxruntime.capi.onnxruntime_pybind11_state import InvalidArgument
+
+    class _Boom(DummySession):
+        def run(self, output_names, feed):
+            raise InvalidArgument("INVALID_ARGUMENT : unexpected data type")
+
+    adapter = MixerTTSAdapter(vocoder=FakeVocoder())
+    with pytest.raises(InvalidArgument):
+        adapter.synthesize(_req(4), _Boom(["token_ids"]))


### PR DESCRIPTION
`coqui/en-ljspeech-speedy-speech` (engine `fastpitch`) crashes on any utterance shorter than 13 tokens.

## Reproduction (current `dev`)

```python
from phoonnx.model_manager import TTSModelManager
import wave
m = TTSModelManager(); m.merge_default_voices()
v = m.voices['coqui/en-ljspeech-speedy-speech'].load()
with wave.open('/tmp/out.wav', 'wb') as w:
    v.synthesize_wav('Yes.', w)
```

```
onnxruntime ... INVALID_ARGUMENT : Non-zero status code returned while running Conv node ... Invalid input shape: {4}
```

Probing the graph directly, the exact threshold is 13 tokens — `Yes.` (4 ids) and `Hello world.` (12 ids) fail, `Hello there world.` (17 ids) works.

## Cause

SpeedySpeech reuses the FastPitch/Mixer-TTS ONNX I/O, so `FastPitchAdapter` (a `MixerTTSAdapter` subclass) drives it, but its dilated residual conv stack has no padding and rejects sequences below its receptive field.

## Fix

`MixerTTSAdapter.synthesize` now catches that specific `InvalidArgument` and retries with `token_ids` right-padded with the pad id, up to 32 tokens. Graph-accepted lengths take the unchanged fast path; unrelated `InvalidArgument`s still propagate.

## Verification

Live, on the real voices:

| voice | `Yes.` | `Hello world.` | long sentence |
|---|---|---|---|
| coqui/en-ljspeech-speedy-speech | 0.88 s (was crash) | 0.96 s (was crash) | 3.23 s |
| nipponjo/mixer-tts-ljspeech-80 | 0.28 s | 0.67 s | 2.91 s (unchanged) |

Plus three unit tests in `tests/test_mixertts.py`. `tests/test_mixertts.py tests/test_fastpitch.py tests/test_engines.py` → 56 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech synthesis reliability for inputs shorter than the model’s minimum sequence length.
  * Automatically retries eligible inference failures with safe padding.
  * Preserves unrelated runtime errors instead of masking them.
  * Maintains output processing, including audio conversion and optional duration information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->