### PR TITLE
feat: Inflect-v2 (Micro + Nano) support — official 2-graph export + single-graph re-export recipe

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -1,7 +1,7 @@
 ## Supported Voices
 
-**Total Voices:** 3227
-**Total Languages:** 1812
+**Total Voices:** 3229
+**Total Languages:** 1813
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
 
@@ -796,6 +796,8 @@
 | `hf_community/russdill/kronk` | `en-US` | `piper` | `espeak` |
 | `hf_community/samarthshrivas/piper-finetune-Andrew-Huberman` | `en-US` | `piper` | `espeak` |
 | `hf_community/swqg-messiah/kusaal_chitti_piper` | `en-US` | `piper` | `espeak` |
+| `inflect/micro-en` | `en-us` | `None` | `espeak` |
+| `inflect/nano-en` | `en-us` | `None` | `espeak` |
 | `kittentts/mini-0.1-expr-voice-2-f` | `en-US` | `styletts2` | `espeak` |
 | `kittentts/mini-0.1-expr-voice-2-m` | `en-US` | `styletts2` | `espeak` |
 | `kittentts/mini-0.1-expr-voice-3-f` | `en-US` | `styletts2` | `espeak` |

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -77,6 +77,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 |---|---|---|
 | VITS / Piper / Mimic3 / Coqui / VITS2 / YourTTS-VITS | `phoonnx/engines/vits.py` | `model_type == "vits"`, `"scales"` input, piper/mimic3 signatures |
 | [Streaming VITS](streaming.md) | `phoonnx/engines/vits_streaming.py` | `streaming: true` **and** a decoder graph (split encoder/decoder) |
+| Prior-split VITS (Inflect-v2 Micro/Nano) | `phoonnx/engines/vits.py` (`VitsPriorSplitAdapter`) | `engine_params.decode_path` **and** the duration graph's outputs ⊇ `{m_p_exp, logs_p_exp, y_mask}` — split at the flow **prior**, not the flow/HiFiGAN boundary Streaming VITS uses |
 | [Matcha](training/engines/matcha.md) | `phoonnx/engines/matcha.py` | `engine == "matcha"` (flow-matching mel + separate vocoder) |
 | [GlowTTS](training/engines/glowtts.md) | `phoonnx/engines/glowtts.py` | `engine == "glowtts"` |
 | [OptiSpeech](training/engines/optispeech.md) | `phoonnx/engines/optispeech.py` | `engine == "optispeech"` (wav + durations outputs) |

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -126,7 +126,7 @@ def list_engines() -> List[str]:
 # ------------------------------------------------------------------
 
 def _register_builtins() -> None:
-    from phoonnx.engines.vits import VitsAdapter
+    from phoonnx.engines.vits import VitsAdapter, VitsPriorSplitAdapter
     from phoonnx.engines.vits_streaming import VitsStreamingAdapter
     from phoonnx.engines.shami import ShamiAdapter
     from phoonnx.engines.matcha import MatchaAdapter
@@ -160,6 +160,10 @@ def _register_builtins() -> None:
     # matches split models (streaming:true + decoder_path), so it never steals a
     # normal single-graph voice, but a normal VITS voice must not steal a split one.
     register_engine("vits_streaming", VitsStreamingAdapter, detect_priority=48)
+    # Prior-split VITS (e.g. Inflect-v2's official duration.onnx/decode.onnx):
+    # detected purely by the duration graph's output signature, so it must be
+    # probed before the plain single-graph vits adapter.
+    register_engine("vits_prior_split", VitsPriorSplitAdapter, detect_priority=49)
     register_engine("vits", VitsAdapter, detect_priority=50)
     register_engine("matcha", MatchaAdapter, detect_priority=40)
     register_engine("glowtts", GlowTTSAdapter, detect_priority=42)

--- a/phoonnx/engines/vits.py
+++ b/phoonnx/engines/vits.py
@@ -25,6 +25,7 @@ from phoonnx.engines.base import (
     AdapterSynthesisResult,
     BaseOnnxAdapter,
 )
+from phoonnx.providers import make_session
 
 
 class VitsAdapter(BaseOnnxAdapter):
@@ -178,3 +179,139 @@ class VitsAdapter(BaseOnnxAdapter):
             "length_scale": "Speed",
             "noise_w_scale": "Noise W",
         }
+
+
+class VitsPriorSplitAdapter(VitsAdapter):
+    """VITS split at the **prior** boundary (before the flow), rather than at
+    the flow/HiFiGAN boundary that :class:`~phoonnx.engines.vits_streaming.VitsStreamingAdapter`
+    uses. This is the cut Inflect-v2's official ONNX release
+    (``owensong/Inflect-Micro-v2-ONNX`` / ``-Nano-v2-ONNX``) ships:
+
+      duration (primary session) : tokens, lengths, length_scale
+                                    -> m_p_exp, logs_p_exp, y_mask
+      decode   (aux graph)       : m_p_exp, logs_p_exp, y_mask, zp_noise, noise_scale
+                                    -> waveform
+
+    Unlike the streaming split, the latent noise for the flow prior
+    (``zp_noise``) is sampled **outside** the graph rather than internally via
+    ``torch.randn_like`` -- upstream's own reference script
+    (``onnx/inference_onnx.py``) does this so a JS/WASM caller can seed it.
+    ``synthesize`` reproduces that: it seeds ``numpy.random.default_rng`` with
+    the ``seed`` control param (default 0) and draws a same-shaped standard
+    normal array for ``zp_noise``. ``length_scale``/``noise_scale`` follow the
+    same VITS convention as the single-graph adapter (``length_scale`` > 1 is
+    slower, ``noise_scale`` is the flow's stochasticity); ``noise_w_scale`` is
+    accepted but unused, matching upstream's non-stochastic (``use_sdp=False``)
+    duration predictor.
+
+    The primary session is the *duration* graph; *decode* is loaded in
+    :meth:`configure` from ``engine_params["decode_path"]`` (the same
+    auxiliary-graph mechanism :mod:`~phoonnx.engines.zipvoice` uses).
+    """
+
+    #: (m_p_exp, logs_p_exp, y_mask) is the exact output signature Inflect's
+    #: duration.onnx exposes; other prior-split exports could differ, but no
+    #: alternative is known, so this is not currently configurable.
+    _DURATION_OUTPUTS = ("m_p_exp", "logs_p_exp", "y_mask")
+
+    def __init__(self) -> None:
+        self.decode: Optional[onnxruntime.InferenceSession] = None
+
+    def configure(self, voice_config: Any) -> None:
+        ep = getattr(voice_config, "engine_params", None) or {}
+        if self.decode is None and ep.get("decode_path"):
+            self.decode = make_session(ep["decode_path"], providers=ep.get("providers"))
+
+    def default_params(self) -> Dict[str, float]:
+        defaults = dict(super().default_params())
+        defaults["seed"] = 0.0
+        return defaults
+
+    def param_labels(self) -> Dict[str, str]:
+        labels = dict(super().param_labels())
+        labels["seed"] = "Seed"
+        return labels
+
+    def synthesize(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> AdapterSynthesisResult:
+        if self.decode is None:
+            raise RuntimeError(
+                "VitsPriorSplitAdapter has no decode graph. Set "
+                "engine_params['decode_path'] to the decode .onnx."
+            )
+        params = request.params
+        defaults = self.default_params()
+        noise_scale = np.array(params.get("noise_scale", defaults["noise_scale"]), dtype=np.float32)
+        length_scale = np.array(params.get("length_scale", defaults["length_scale"]), dtype=np.float32)
+        seed = int(params.get("seed", defaults["seed"]))
+
+        tokens = np.asarray(request.phoneme_ids, dtype=np.int64).reshape(1, -1)
+        lengths = np.asarray(request.phoneme_lengths, dtype=np.int64).reshape(-1)
+
+        m_p_exp, logs_p_exp, y_mask = session.run(
+            list(self._DURATION_OUTPUTS),
+            {"tokens": tokens, "lengths": lengths, "length_scale": length_scale},
+        )
+
+        rng = np.random.default_rng(seed)
+        zp_noise = rng.standard_normal(m_p_exp.shape).astype(np.float32)
+
+        waveform = self.decode.run(
+            ["waveform"],
+            {
+                "m_p_exp": m_p_exp,
+                "logs_p_exp": logs_p_exp,
+                "y_mask": y_mask,
+                "zp_noise": zp_noise,
+                "noise_scale": noise_scale,
+            },
+        )[0]
+        audio = np.asarray(waveform, dtype=np.float32).reshape(-1)
+        return AdapterSynthesisResult(audio=audio)
+
+    # build_feed_dict / parse_outputs are required by the ABC but unused — synthesize()
+    # drives the two-graph (duration + decode) sequence directly. VitsAdapter's
+    # versions would build a single-graph VITS feed / parse a single-graph output,
+    # neither of which matches the duration graph's tokens/lengths/length_scale ->
+    # m_p_exp/logs_p_exp/y_mask contract, so they are overridden to fail loudly
+    # instead of silently misfeeding the duration graph if ever called.
+    def build_feed_dict(
+        self,
+        request: AdapterSynthesisRequest,
+        session: onnxruntime.InferenceSession,
+    ) -> Dict[str, np.ndarray]:
+        raise NotImplementedError("VitsPriorSplitAdapter is two-graph — use synthesize()")
+
+    def parse_outputs(
+        self,
+        outputs: List[np.ndarray],
+        request: AdapterSynthesisRequest,
+        output_names: Optional[List[str]] = None,
+    ) -> AdapterSynthesisResult:
+        raise NotImplementedError("VitsPriorSplitAdapter is two-graph — use synthesize()")
+
+    @staticmethod
+    def detect(
+        config: Optional[Dict[str, Any]] = None,
+        session: Optional[onnxruntime.InferenceSession] = None,
+    ) -> bool:
+        """A prior-split voice needs a decode graph *and* a duration graph whose
+        outputs match the known ``m_p_exp``/``logs_p_exp``/``y_mask`` signature —
+        the config flag alone isn't enough (a plain single-graph VITS voice
+        must never be mistaken for one that needs a second graph it doesn't
+        have)."""
+        if not config:
+            return False
+        engine_params = config.get("engine_params") or {}
+        if not engine_params.get("decode_path"):
+            return False
+        if session is None:
+            return False
+        try:
+            names = {o.name for o in session.get_outputs()}
+        except Exception:
+            return False
+        return set(VitsPriorSplitAdapter._DURATION_OUTPUTS).issubset(names)

--- a/phoonnx/voice_index/inflect.json
+++ b/phoonnx/voice_index/inflect.json
@@ -1,0 +1,32 @@
+{
+    "inflect/micro-en": {
+        "voice_id": "inflect/micro-en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/hf_community__owensong__inflect-micro-v2-onnx/duration.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/hf_community__owensong__inflect-micro-v2-onnx/duration.onnx.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "lang": "en-us",
+        "aux_model_urls": {
+            "decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/hf_community__owensong__inflect-micro-v2-onnx/decode.onnx"
+        }
+    },
+    "inflect/nano-en": {
+        "voice_id": "inflect/nano-en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/hf_community__owensong__inflect-nano-v2-onnx/duration.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/hf_community__owensong__inflect-nano-v2-onnx/duration.onnx.json",
+        "vocab_url": null,
+        "tokenizer_config_url": null,
+        "tokens_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "lang": "en-us",
+        "aux_model_urls": {
+            "decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/hf_community__owensong__inflect-nano-v2-onnx/decode.onnx"
+        }
+    }
+}

--- a/scripts/conversion/NOTICE
+++ b/scripts/conversion/NOTICE
@@ -9,3 +9,14 @@ They remain under MPL-2.0; only those individual files are MPL-covered.
 
 The tracer-safe attention (tsmha.py) reimplements the approach used in
 nipponjo's FastPitch/Mixer-TTS transformer.
+
+The vendored model code in inflect/ (models.py, commons.py, modules.py,
+attentions.py, transforms.py, monotonic_align.py, inflect_alias_free.py,
+utils.py, text/symbols.py) is copied unmodified from the official runtime of
+owensong/Inflect-Micro-v2 and owensong/Inflect-Nano-v2
+(https://huggingface.co/owensong/Inflect-Micro-v2-ONNX, Apache-2.0). Per that
+project's own THIRD_PARTY_NOTICES.md, the model architecture and several
+runtime modules are themselves derived from jaywalnut310/vits (MIT,
+Copyright (c) 2021 Jaehyeon Kim); the text symbol table (text/symbols.py) is
+further derived from keithito/tacotron (MIT). Only export_inflect.py (the
+thin ``infer()`` -> single-graph ONNX wrapper) is new phoonnx code.

--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -60,9 +60,44 @@ python export_neutts_onnx.py --repo afrispeech/Akiti-TTS --out-dir ./onnx \
 difference for the prefill call and for each decode step. The matching NeuCodec decoder
 is published by Neuphonic as ONNX and is used as-is, not re-exported.
 
+## `inflect/`
+
+Converts Inflect-v2 (Micro ~9.36M / Nano ~3.97M params,
+[owenawsong/Inflect](https://github.com/owenawsong/Inflect), Apache-2.0) from its
+upstream PyTorch checkpoint into a single-graph phoonnx/piper-style ONNX voice.
+Inflect-v2 is architecturally a plain VITS (`jaywalnut310/vits`, MIT) with a
+non-stochastic duration predictor (`use_sdp=False`); it already ships an
+official ONNX export, but that export splits `SynthesizerTrn.infer` into two
+graphs (`duration.onnx` / `decode.onnx`) with the flow's latent noise sampled
+*outside* the graph — useful for a seedable browser/WASM runtime, but not the
+shape phoonnx's `VitsAdapter` expects. Rather than add a whole new engine for a
+plain VITS model, this exporter traces `infer()` itself (noise sampled
+*inside* the graph, same as every other piper/coqui VITS export phoonnx
+already loads) so the existing `VitsAdapter` handles it unchanged:
+
+```bash
+huggingface-cli download owensong/Inflect-Micro-v2 --local-dir /tmp/inflect-micro-v2
+python inflect/export_inflect.py --model-dir /tmp/inflect-micro-v2 \
+    --out inflect-micro-en.onnx --model-name Inflect-Micro-v2
+```
+
+produces `inflect-micro-en.onnx` + `inflect-micro-en.onnx.json` (a piper-shaped
+config: `phoneme_type: espeak`, `alphabet: ipa`, `lang_code: en-us`, and a
+`phoneme_id_map` built from the model's own 178-symbol table), loadable
+directly with `TTSVoice.load("inflect-micro-en.onnx")`. Swap in
+`owensong/Inflect-Nano-v2` for the smaller voice.
+
 ## Licensing
 
-The vendored model code under each exporter is derived from
-[idiap/coqui-ai-TTS](https://github.com/idiap/coqui-ai-TTS) (**MPL-2.0**) and from
-[nipponjo](https://github.com/nipponjo)'s FastPitch/Mixer attention. Those files
-retain their upstream license; see `NOTICE`.
+The vendored model code under `coqui_fastpitch_export/` and `coqui_glowtts_export/`
+is derived from [idiap/coqui-ai-TTS](https://github.com/idiap/coqui-ai-TTS)
+(**MPL-2.0**) and from [nipponjo](https://github.com/nipponjo)'s FastPitch/Mixer
+attention. Those files retain their upstream license; see `NOTICE`.
+
+The vendored model code under `inflect/` is copied unmodified from the official
+runtime of `owensong/Inflect-Micro-v2`/`-Nano-v2` (Apache-2.0), but is itself
+derived from [jaywalnut310/vits](https://github.com/jaywalnut310/vits) (**MIT**,
+Copyright (c) 2021 Jaehyeon Kim — reproduced in `inflect/LICENSE`); its symbol
+table (`text/symbols.py`) is further derived from
+[keithito/tacotron](https://github.com/keithito/tacotron) (**MIT**, reproduced in
+`inflect/text/LICENSE`). See `NOTICE` for the full attribution chain.

--- a/scripts/conversion/inflect/LICENSE
+++ b/scripts/conversion/inflect/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Jaehyeon Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/conversion/inflect/attentions.py
+++ b/scripts/conversion/inflect/attentions.py
@@ -1,0 +1,303 @@
+import copy
+import math
+import numpy as np
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+import commons
+import modules
+from modules import LayerNorm
+   
+
+class Encoder(nn.Module):
+  def __init__(self, hidden_channels, filter_channels, n_heads, n_layers, kernel_size=1, p_dropout=0., window_size=4, **kwargs):
+    super().__init__()
+    self.hidden_channels = hidden_channels
+    self.filter_channels = filter_channels
+    self.n_heads = n_heads
+    self.n_layers = n_layers
+    self.kernel_size = kernel_size
+    self.p_dropout = p_dropout
+    self.window_size = window_size
+
+    self.drop = nn.Dropout(p_dropout)
+    self.attn_layers = nn.ModuleList()
+    self.norm_layers_1 = nn.ModuleList()
+    self.ffn_layers = nn.ModuleList()
+    self.norm_layers_2 = nn.ModuleList()
+    for i in range(self.n_layers):
+      self.attn_layers.append(MultiHeadAttention(hidden_channels, hidden_channels, n_heads, p_dropout=p_dropout, window_size=window_size))
+      self.norm_layers_1.append(LayerNorm(hidden_channels))
+      self.ffn_layers.append(FFN(hidden_channels, hidden_channels, filter_channels, kernel_size, p_dropout=p_dropout))
+      self.norm_layers_2.append(LayerNorm(hidden_channels))
+
+  def forward(self, x, x_mask):
+    attn_mask = x_mask.unsqueeze(2) * x_mask.unsqueeze(-1)
+    x = x * x_mask
+    for i in range(self.n_layers):
+      y = self.attn_layers[i](x, x, attn_mask)
+      y = self.drop(y)
+      x = self.norm_layers_1[i](x + y)
+
+      y = self.ffn_layers[i](x, x_mask)
+      y = self.drop(y)
+      x = self.norm_layers_2[i](x + y)
+    x = x * x_mask
+    return x
+
+
+class Decoder(nn.Module):
+  def __init__(self, hidden_channels, filter_channels, n_heads, n_layers, kernel_size=1, p_dropout=0., proximal_bias=False, proximal_init=True, **kwargs):
+    super().__init__()
+    self.hidden_channels = hidden_channels
+    self.filter_channels = filter_channels
+    self.n_heads = n_heads
+    self.n_layers = n_layers
+    self.kernel_size = kernel_size
+    self.p_dropout = p_dropout
+    self.proximal_bias = proximal_bias
+    self.proximal_init = proximal_init
+
+    self.drop = nn.Dropout(p_dropout)
+    self.self_attn_layers = nn.ModuleList()
+    self.norm_layers_0 = nn.ModuleList()
+    self.encdec_attn_layers = nn.ModuleList()
+    self.norm_layers_1 = nn.ModuleList()
+    self.ffn_layers = nn.ModuleList()
+    self.norm_layers_2 = nn.ModuleList()
+    for i in range(self.n_layers):
+      self.self_attn_layers.append(MultiHeadAttention(hidden_channels, hidden_channels, n_heads, p_dropout=p_dropout, proximal_bias=proximal_bias, proximal_init=proximal_init))
+      self.norm_layers_0.append(LayerNorm(hidden_channels))
+      self.encdec_attn_layers.append(MultiHeadAttention(hidden_channels, hidden_channels, n_heads, p_dropout=p_dropout))
+      self.norm_layers_1.append(LayerNorm(hidden_channels))
+      self.ffn_layers.append(FFN(hidden_channels, hidden_channels, filter_channels, kernel_size, p_dropout=p_dropout, causal=True))
+      self.norm_layers_2.append(LayerNorm(hidden_channels))
+
+  def forward(self, x, x_mask, h, h_mask):
+    """
+    x: decoder input
+    h: encoder output
+    """
+    self_attn_mask = commons.subsequent_mask(x_mask.size(2)).to(device=x.device, dtype=x.dtype)
+    encdec_attn_mask = h_mask.unsqueeze(2) * x_mask.unsqueeze(-1)
+    x = x * x_mask
+    for i in range(self.n_layers):
+      y = self.self_attn_layers[i](x, x, self_attn_mask)
+      y = self.drop(y)
+      x = self.norm_layers_0[i](x + y)
+
+      y = self.encdec_attn_layers[i](x, h, encdec_attn_mask)
+      y = self.drop(y)
+      x = self.norm_layers_1[i](x + y)
+      
+      y = self.ffn_layers[i](x, x_mask)
+      y = self.drop(y)
+      x = self.norm_layers_2[i](x + y)
+    x = x * x_mask
+    return x
+
+
+class MultiHeadAttention(nn.Module):
+  def __init__(self, channels, out_channels, n_heads, p_dropout=0., window_size=None, heads_share=True, block_length=None, proximal_bias=False, proximal_init=False):
+    super().__init__()
+    assert channels % n_heads == 0
+
+    self.channels = channels
+    self.out_channels = out_channels
+    self.n_heads = n_heads
+    self.p_dropout = p_dropout
+    self.window_size = window_size
+    self.heads_share = heads_share
+    self.block_length = block_length
+    self.proximal_bias = proximal_bias
+    self.proximal_init = proximal_init
+    self.attn = None
+
+    self.k_channels = channels // n_heads
+    self.conv_q = nn.Conv1d(channels, channels, 1)
+    self.conv_k = nn.Conv1d(channels, channels, 1)
+    self.conv_v = nn.Conv1d(channels, channels, 1)
+    self.conv_o = nn.Conv1d(channels, out_channels, 1)
+    self.drop = nn.Dropout(p_dropout)
+
+    if window_size is not None:
+      n_heads_rel = 1 if heads_share else n_heads
+      rel_stddev = self.k_channels**-0.5
+      self.emb_rel_k = nn.Parameter(torch.randn(n_heads_rel, window_size * 2 + 1, self.k_channels) * rel_stddev)
+      self.emb_rel_v = nn.Parameter(torch.randn(n_heads_rel, window_size * 2 + 1, self.k_channels) * rel_stddev)
+
+    nn.init.xavier_uniform_(self.conv_q.weight)
+    nn.init.xavier_uniform_(self.conv_k.weight)
+    nn.init.xavier_uniform_(self.conv_v.weight)
+    if proximal_init:
+      with torch.no_grad():
+        self.conv_k.weight.copy_(self.conv_q.weight)
+        self.conv_k.bias.copy_(self.conv_q.bias)
+      
+  def forward(self, x, c, attn_mask=None):
+    q = self.conv_q(x)
+    k = self.conv_k(c)
+    v = self.conv_v(c)
+    
+    x, self.attn = self.attention(q, k, v, mask=attn_mask)
+
+    x = self.conv_o(x)
+    return x
+
+  def attention(self, query, key, value, mask=None):
+    # reshape [b, d, t] -> [b, n_h, t, d_k]
+    b, d, t_s, t_t = (*key.size(), query.size(2))
+    query = query.view(b, self.n_heads, self.k_channels, t_t).transpose(2, 3)
+    key = key.view(b, self.n_heads, self.k_channels, t_s).transpose(2, 3)
+    value = value.view(b, self.n_heads, self.k_channels, t_s).transpose(2, 3)
+
+    scores = torch.matmul(query / math.sqrt(self.k_channels), key.transpose(-2, -1))
+    if self.window_size is not None:
+      assert t_s == t_t, "Relative attention is only available for self-attention."
+      key_relative_embeddings = self._get_relative_embeddings(self.emb_rel_k, t_s)
+      rel_logits = self._matmul_with_relative_keys(query /math.sqrt(self.k_channels), key_relative_embeddings)
+      scores_local = self._relative_position_to_absolute_position(rel_logits)
+      scores = scores + scores_local
+    if self.proximal_bias:
+      assert t_s == t_t, "Proximal bias is only available for self-attention."
+      scores = scores + self._attention_bias_proximal(t_s).to(device=scores.device, dtype=scores.dtype)
+    if mask is not None:
+      scores = scores.masked_fill(mask == 0, -1e4)
+      if self.block_length is not None:
+        assert t_s == t_t, "Local attention is only available for self-attention."
+        block_mask = torch.ones_like(scores).triu(-self.block_length).tril(self.block_length)
+        scores = scores.masked_fill(block_mask == 0, -1e4)
+    p_attn = F.softmax(scores, dim=-1) # [b, n_h, t_t, t_s]
+    p_attn = self.drop(p_attn)
+    output = torch.matmul(p_attn, value)
+    if self.window_size is not None:
+      relative_weights = self._absolute_position_to_relative_position(p_attn)
+      value_relative_embeddings = self._get_relative_embeddings(self.emb_rel_v, t_s)
+      output = output + self._matmul_with_relative_values(relative_weights, value_relative_embeddings)
+    output = output.transpose(2, 3).contiguous().view(b, d, t_t) # [b, n_h, t_t, d_k] -> [b, d, t_t]
+    return output, p_attn
+
+  def _matmul_with_relative_values(self, x, y):
+    """
+    x: [b, h, l, m]
+    y: [h or 1, m, d]
+    ret: [b, h, l, d]
+    """
+    ret = torch.matmul(x, y.unsqueeze(0))
+    return ret
+
+  def _matmul_with_relative_keys(self, x, y):
+    """
+    x: [b, h, l, d]
+    y: [h or 1, m, d]
+    ret: [b, h, l, m]
+    """
+    ret = torch.matmul(x, y.unsqueeze(0).transpose(-2, -1))
+    return ret
+
+  def _get_relative_embeddings(self, relative_embeddings, length):
+    max_relative_position = 2 * self.window_size + 1
+    # Pad first before slice to avoid using cond ops.
+    pad_length = max(length - (self.window_size + 1), 0)
+    slice_start_position = max((self.window_size + 1) - length, 0)
+    slice_end_position = slice_start_position + 2 * length - 1
+    if pad_length > 0:
+      padded_relative_embeddings = F.pad(
+          relative_embeddings,
+          commons.convert_pad_shape([[0, 0], [pad_length, pad_length], [0, 0]]))
+    else:
+      padded_relative_embeddings = relative_embeddings
+    used_relative_embeddings = padded_relative_embeddings[:,slice_start_position:slice_end_position]
+    return used_relative_embeddings
+
+  def _relative_position_to_absolute_position(self, x):
+    """
+    x: [b, h, l, 2*l-1]
+    ret: [b, h, l, l]
+    """
+    batch, heads, length, _ = x.size()
+    # Concat columns of pad to shift from relative to absolute indexing.
+    x = F.pad(x, commons.convert_pad_shape([[0,0],[0,0],[0,0],[0,1]]))
+
+    # Concat extra elements so to add up to shape (len+1, 2*len-1).
+    x_flat = x.view([batch, heads, length * 2 * length])
+    x_flat = F.pad(x_flat, commons.convert_pad_shape([[0,0],[0,0],[0,length-1]]))
+
+    # Reshape and slice out the padded elements.
+    x_final = x_flat.view([batch, heads, length+1, 2*length-1])[:, :, :length, length-1:]
+    return x_final
+
+  def _absolute_position_to_relative_position(self, x):
+    """
+    x: [b, h, l, l]
+    ret: [b, h, l, 2*l-1]
+    """
+    batch, heads, length, _ = x.size()
+    # padd along column
+    x = F.pad(x, commons.convert_pad_shape([[0, 0], [0, 0], [0, 0], [0, length-1]]))
+    x_flat = x.view([batch, heads, length**2 + length*(length -1)])
+    # add 0's in the beginning that will skew the elements after reshape
+    x_flat = F.pad(x_flat, commons.convert_pad_shape([[0, 0], [0, 0], [length, 0]]))
+    x_final = x_flat.view([batch, heads, length, 2*length])[:,:,:,1:]
+    return x_final
+
+  def _attention_bias_proximal(self, length):
+    """Bias for self-attention to encourage attention to close positions.
+    Args:
+      length: an integer scalar.
+    Returns:
+      a Tensor with shape [1, 1, length, length]
+    """
+    r = torch.arange(length, dtype=torch.float32)
+    diff = torch.unsqueeze(r, 0) - torch.unsqueeze(r, 1)
+    return torch.unsqueeze(torch.unsqueeze(-torch.log1p(torch.abs(diff)), 0), 0)
+
+
+class FFN(nn.Module):
+  def __init__(self, in_channels, out_channels, filter_channels, kernel_size, p_dropout=0., activation=None, causal=False):
+    super().__init__()
+    self.in_channels = in_channels
+    self.out_channels = out_channels
+    self.filter_channels = filter_channels
+    self.kernel_size = kernel_size
+    self.p_dropout = p_dropout
+    self.activation = activation
+    self.causal = causal
+
+    if causal:
+      self.padding = self._causal_padding
+    else:
+      self.padding = self._same_padding
+
+    self.conv_1 = nn.Conv1d(in_channels, filter_channels, kernel_size)
+    self.conv_2 = nn.Conv1d(filter_channels, out_channels, kernel_size)
+    self.drop = nn.Dropout(p_dropout)
+
+  def forward(self, x, x_mask):
+    x = self.conv_1(self.padding(x * x_mask))
+    if self.activation == "gelu":
+      x = x * torch.sigmoid(1.702 * x)
+    else:
+      x = torch.relu(x)
+    x = self.drop(x)
+    x = self.conv_2(self.padding(x * x_mask))
+    return x * x_mask
+  
+  def _causal_padding(self, x):
+    if self.kernel_size == 1:
+      return x
+    pad_l = self.kernel_size - 1
+    pad_r = 0
+    padding = [[0, 0], [0, 0], [pad_l, pad_r]]
+    x = F.pad(x, commons.convert_pad_shape(padding))
+    return x
+
+  def _same_padding(self, x):
+    if self.kernel_size == 1:
+      return x
+    pad_l = (self.kernel_size - 1) // 2
+    pad_r = self.kernel_size // 2
+    padding = [[0, 0], [0, 0], [pad_l, pad_r]]
+    x = F.pad(x, commons.convert_pad_shape(padding))
+    return x

--- a/scripts/conversion/inflect/commons.py
+++ b/scripts/conversion/inflect/commons.py
@@ -1,0 +1,161 @@
+import math
+import numpy as np
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+def init_weights(m, mean=0.0, std=0.01):
+  classname = m.__class__.__name__
+  if classname.find("Conv") != -1:
+    m.weight.data.normal_(mean, std)
+
+
+def get_padding(kernel_size, dilation=1):
+  return int((kernel_size*dilation - dilation)/2)
+
+
+def convert_pad_shape(pad_shape):
+  l = pad_shape[::-1]
+  pad_shape = [item for sublist in l for item in sublist]
+  return pad_shape
+
+
+def intersperse(lst, item):
+  result = [item] * (len(lst) * 2 + 1)
+  result[1::2] = lst
+  return result
+
+
+def kl_divergence(m_p, logs_p, m_q, logs_q):
+  """KL(P||Q)"""
+  kl = (logs_q - logs_p) - 0.5
+  kl += 0.5 * (torch.exp(2. * logs_p) + ((m_p - m_q)**2)) * torch.exp(-2. * logs_q)
+  return kl
+
+
+def rand_gumbel(shape):
+  """Sample from the Gumbel distribution, protect from overflows."""
+  uniform_samples = torch.rand(shape) * 0.99998 + 0.00001
+  return -torch.log(-torch.log(uniform_samples))
+
+
+def rand_gumbel_like(x):
+  g = rand_gumbel(x.size()).to(dtype=x.dtype, device=x.device)
+  return g
+
+
+def slice_segments(x, ids_str, segment_size=4):
+  ret = torch.zeros_like(x[:, :, :segment_size])
+  for i in range(x.size(0)):
+    idx_str = ids_str[i]
+    idx_end = idx_str + segment_size
+    ret[i] = x[i, :, idx_str:idx_end]
+  return ret
+
+
+def rand_slice_segments(x, x_lengths=None, segment_size=4):
+  b, d, t = x.size()
+  if x_lengths is None:
+    x_lengths = t
+  ids_str_max = x_lengths - segment_size + 1
+  ids_str = (torch.rand([b]).to(device=x.device) * ids_str_max).to(dtype=torch.long)
+  ret = slice_segments(x, ids_str, segment_size)
+  return ret, ids_str
+
+
+def get_timing_signal_1d(
+    length, channels, min_timescale=1.0, max_timescale=1.0e4):
+  position = torch.arange(length, dtype=torch.float)
+  num_timescales = channels // 2
+  log_timescale_increment = (
+      math.log(float(max_timescale) / float(min_timescale)) /
+      (num_timescales - 1))
+  inv_timescales = min_timescale * torch.exp(
+      torch.arange(num_timescales, dtype=torch.float) * -log_timescale_increment)
+  scaled_time = position.unsqueeze(0) * inv_timescales.unsqueeze(1)
+  signal = torch.cat([torch.sin(scaled_time), torch.cos(scaled_time)], 0)
+  signal = F.pad(signal, [0, 0, 0, channels % 2])
+  signal = signal.view(1, channels, length)
+  return signal
+
+
+def add_timing_signal_1d(x, min_timescale=1.0, max_timescale=1.0e4):
+  b, channels, length = x.size()
+  signal = get_timing_signal_1d(length, channels, min_timescale, max_timescale)
+  return x + signal.to(dtype=x.dtype, device=x.device)
+
+
+def cat_timing_signal_1d(x, min_timescale=1.0, max_timescale=1.0e4, axis=1):
+  b, channels, length = x.size()
+  signal = get_timing_signal_1d(length, channels, min_timescale, max_timescale)
+  return torch.cat([x, signal.to(dtype=x.dtype, device=x.device)], axis)
+
+
+def subsequent_mask(length):
+  mask = torch.tril(torch.ones(length, length)).unsqueeze(0).unsqueeze(0)
+  return mask
+
+
+@torch.jit.script
+def fused_add_tanh_sigmoid_multiply(input_a, input_b, n_channels):
+  n_channels_int = n_channels[0]
+  in_act = input_a + input_b
+  t_act = torch.tanh(in_act[:, :n_channels_int, :])
+  s_act = torch.sigmoid(in_act[:, n_channels_int:, :])
+  acts = t_act * s_act
+  return acts
+
+
+def convert_pad_shape(pad_shape):
+  l = pad_shape[::-1]
+  pad_shape = [item for sublist in l for item in sublist]
+  return pad_shape
+
+
+def shift_1d(x):
+  x = F.pad(x, convert_pad_shape([[0, 0], [0, 0], [1, 0]]))[:, :, :-1]
+  return x
+
+
+def sequence_mask(length, max_length=None):
+  if max_length is None:
+    max_length = length.max()
+  x = torch.arange(max_length, dtype=length.dtype, device=length.device)
+  return x.unsqueeze(0) < length.unsqueeze(1)
+
+
+def generate_path(duration, mask):
+  """
+  duration: [b, 1, t_x]
+  mask: [b, 1, t_y, t_x]
+  """
+  device = duration.device
+  
+  b, _, t_y, t_x = mask.shape
+  cum_duration = torch.cumsum(duration, -1)
+  
+  cum_duration_flat = cum_duration.view(b * t_x)
+  path = sequence_mask(cum_duration_flat, t_y).to(mask.dtype)
+  path = path.view(b, t_x, t_y)
+  path = path - F.pad(path, convert_pad_shape([[0, 0], [1, 0], [0, 0]]))[:, :-1]
+  path = path.unsqueeze(1).transpose(2,3) * mask
+  return path
+
+
+def clip_grad_value_(parameters, clip_value, norm_type=2):
+  if isinstance(parameters, torch.Tensor):
+    parameters = [parameters]
+  parameters = list(filter(lambda p: p.grad is not None, parameters))
+  norm_type = float(norm_type)
+  if clip_value is not None:
+    clip_value = float(clip_value)
+
+  total_norm = 0
+  for p in parameters:
+    param_norm = p.grad.data.norm(norm_type)
+    total_norm += param_norm.item() ** norm_type
+    if clip_value is not None:
+      p.grad.data.clamp_(min=-clip_value, max=clip_value)
+  total_norm = total_norm ** (1. / norm_type)
+  return total_norm

--- a/scripts/conversion/inflect/export_inflect.py
+++ b/scripts/conversion/inflect/export_inflect.py
@@ -1,0 +1,210 @@
+"""Standalone Inflect-v2 (Micro/Nano) -> ONNX exporter (no extra package deps
+beyond the vendored files in this directory + torch/onnx).
+
+Inflect-v2 (https://github.com/owenawsong/Inflect, Apache-2.0) is a plain VITS
+(``jaywalnut310/vits``, MIT — see ``THIRD_PARTY_NOTICES.md`` on the upstream HF
+repos) checkpoint: ``SynthesizerTrn`` with a non-stochastic ``DurationPredictor``
+(``use_sdp=False``). Its own official ONNX release
+(``owensong/Inflect-Micro-v2-ONNX`` / ``owensong/Inflect-Nano-v2-ONNX``) ships
+``SynthesizerTrn.infer`` split into two graphs (``duration.onnx`` /
+``decode.onnx``) with the flow's latent noise sampled *outside* the graph, so a
+caller can seed it explicitly (useful for a JS/WASM browser runtime).
+
+phoonnx's ``VitsAdapter`` already speaks the single-graph piper/coqui-VITS
+contract (``input``/``input_lengths``/``scales`` -> waveform, noise sampled
+*inside* the graph via ``torch.randn_like`` -> ONNX ``RandomNormalLike``), so
+no new engine/adapter is needed: this script exports ``SynthesizerTrn.infer``
+directly (the same method the split export traces, just untouched) into that
+shape, matching the pattern of ``scripts/conversion/coqui_vits_export``.
+
+Usage::
+
+    # 1. Fetch the upstream PyTorch checkpoint (config.json + model.pth) --
+    #    NOT the *-ONNX repo, which ships onnx/ instead of model.pth:
+    huggingface-cli download owensong/Inflect-Micro-v2 \\
+        --local-dir /tmp/inflect-micro-v2
+
+    # 2. Export
+    python export_inflect.py \\
+        --model-dir /tmp/inflect-micro-v2 \\
+        --out inflect-micro-en.onnx \\
+        --model-name Inflect-Micro-v2
+
+This writes ``<out>`` and a matching ``<out>.json`` phoonnx voice config
+(piper-shaped ``phoneme_id_map``, ``phoneme_type: espeak``, ``lang_code: en-us``),
+ready for ``TTSVoice.load(<out>)``.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from pathlib import Path
+
+import torch
+from torch import nn
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+class InflectVitsExport(nn.Module):
+    """Wraps ``SynthesizerTrn.infer`` behind the standard VITS ONNX contract:
+    ``(input, input_lengths, scales) -> waveform``, matching phoonnx's
+    ``VitsAdapter`` (``scales`` packs ``[noise_scale, length_scale, noise_scale_w]``;
+    ``noise_scale_w`` is accepted but unused since Inflect's duration predictor
+    is deterministic, i.e. ``use_sdp=False``)."""
+
+    def __init__(self, model: nn.Module) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(self, input: torch.Tensor, input_lengths: torch.Tensor,
+                scales: torch.Tensor) -> torch.Tensor:
+        noise_scale, length_scale, noise_scale_w = scales[0], scales[1], scales[2]
+        audio, *_ = self.model.infer(
+            input, input_lengths,
+            noise_scale=noise_scale, length_scale=length_scale,
+            noise_scale_w=noise_scale_w,
+        )
+        return audio
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def load_model(root: Path) -> nn.Module:
+    import utils
+    from models import SynthesizerTrn
+    from text.symbols import symbols
+
+    hps = utils.get_hparams_from_file(str(root / "config.json"))
+    model = SynthesizerTrn(
+        len(symbols),
+        hps.data.filter_length // 2 + 1,
+        hps.train.segment_size // hps.data.hop_length,
+        **hps.model,
+    ).cpu().eval()
+    logger = logging.getLogger()
+    previous_level = logger.level
+    try:
+        logger.setLevel(logging.WARNING)
+        utils.load_checkpoint(str(root / "model.pth"), model, None)
+    finally:
+        logger.setLevel(previous_level)
+    for module in model.modules():
+        if hasattr(module, "remove_weight_norm"):
+            try:
+                module.remove_weight_norm()
+            except Exception:
+                pass
+    return model
+
+
+def phoonnx_config(symbols: list, lang_code: str = "en-us") -> dict:
+    """Build a piper-shaped phoonnx voice config.json for the exported voice.
+
+    Mirrors the character-level tokenization Inflect's own frontend uses
+    (``phonemes_to_tokens`` in ``onnx/inference_onnx.py``): every character of
+    the eSpeak IPA output — including spaces and punctuation, which are part
+    of the model's own symbol table — is looked up directly, with a blank
+    token interleaved between every character (``add_blank_char=True``,
+    ``blank_at_start=blank_at_end=True``, no BOS/EOS). phoonnx's
+    ``TTSTokenizer.intersperse_blank_char`` reproduces that exactly.
+    """
+    phoneme_id_map = {symbol: index for index, symbol in enumerate(symbols)}
+    return {
+        "phoonnx_version": "1.0",
+        "phoneme_type": "espeak",
+        "alphabet": "ipa",
+        "lang_code": lang_code,
+        "num_symbols": len(symbols),
+        "num_speakers": 1,
+        "num_langs": 1,
+        "pad": "_",
+        "blank": "_",
+        "use_eos_bos": False,
+        "add_blank_word": False,
+        "add_blank_char": True,
+        "blank_at_start": True,
+        "blank_at_end": True,
+        "phoneme_id_map": phoneme_id_map,
+        "audio": {"sample_rate": 24000},
+        "inference": {
+            "noise_scale": 0.667,
+            "length_scale": 1.0,
+            "noise_w": 0.8,
+            "add_diacritics": False,
+        },
+    }
+
+
+def export(model_dir: Path, out_path: Path, *, model_name: str, lang_code: str) -> None:
+    torch.manual_seed(7)
+    from text.symbols import symbols
+
+    model = load_model(model_dir)
+    wrapper = InflectVitsExport(model).eval()
+
+    tokens = torch.tensor(
+        [[0, 18, 0, 61, 0, 55, 0, 48, 0, 44, 0, 46, 0]], dtype=torch.long,
+    )
+    lengths = torch.tensor([tokens.shape[1]], dtype=torch.long)
+    scales = torch.tensor([0.667, 1.0, 0.8], dtype=torch.float32)
+
+    with torch.no_grad():
+        audio = wrapper(tokens, lengths, scales)
+    print(f"forward OK -> audio {tuple(audio.shape)}")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.onnx.export(
+        wrapper,
+        (tokens, lengths, scales),
+        str(out_path),
+        input_names=["input", "input_lengths", "scales"],
+        output_names=["output"],
+        dynamic_axes={
+            "input": {0: "batch", 1: "text_len"},
+            "input_lengths": {0: "batch"},
+            "output": {0: "batch", 2: "wav_len"},
+        },
+        opset_version=17,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print("exported ->", out_path)
+
+    cfg = phoonnx_config(symbols, lang_code=lang_code)
+    cfg["_export"] = {
+        "model_name": model_name,
+        "source_model_sha256": sha256(model_dir / "model.pth"),
+        "exporter": "phoonnx scripts/conversion/inflect/export_inflect.py",
+        "license": "Apache-2.0 (Inflect-v2); MIT (VITS runtime portions)",
+    }
+    cfg_path = out_path.with_suffix(out_path.suffix + ".json")
+    cfg_path.write_text(json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8")
+    print("wrote config ->", cfg_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export Inflect-v2 to a single-graph phoonnx/piper-style ONNX voice.")
+    parser.add_argument("--model-dir", type=Path, required=True,
+                         help="Local checkout of owensong/Inflect-Micro-v2 or "
+                              "owensong/Inflect-Nano-v2 (needs config.json + model.pth)")
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--lang-code", default="en-us")
+    args = parser.parse_args()
+    export(args.model_dir.resolve(), args.out.resolve(),
+           model_name=args.model_name, lang_code=args.lang_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/inflect/inflect_alias_free.py
+++ b/scripts/conversion/inflect/inflect_alias_free.py
@@ -1,0 +1,143 @@
+"""Lightweight alias-free waveform blocks derived from NVIDIA BigVGAN.
+
+BigVGAN and alias-free-torch are MIT/Apache-2.0 licensed. The implementation
+is kept local so Inflect can train without BigVGAN's optional CUDA extension.
+"""
+
+import math
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torch.nn.utils import remove_weight_norm, weight_norm
+
+from commons import get_padding, init_weights
+
+
+def kaiser_sinc_filter1d(cutoff: float, half_width: float, kernel_size: int):
+  even = kernel_size % 2 == 0
+  half_size = kernel_size // 2
+  delta_f = 4 * half_width
+  attenuation = 2.285 * (half_size - 1) * math.pi * delta_f + 7.95
+  if attenuation > 50.0:
+    beta = 0.1102 * (attenuation - 8.7)
+  elif attenuation >= 21.0:
+    beta = 0.5842 * (attenuation - 21) ** 0.4 + 0.07886 * (attenuation - 21.0)
+  else:
+    beta = 0.0
+  window = torch.kaiser_window(kernel_size, beta=beta, periodic=False)
+  if even:
+    time = torch.arange(-half_size, half_size) + 0.5
+  else:
+    time = torch.arange(kernel_size) - half_size
+  values = 2 * cutoff * window * torch.sinc(2 * cutoff * time)
+  values /= values.sum()
+  return values.view(1, 1, kernel_size)
+
+
+class UpSample1d(nn.Module):
+  def __init__(self, ratio=2, kernel_size=12):
+    super().__init__()
+    self.ratio = ratio
+    self.stride = ratio
+    self.kernel_size = kernel_size
+    self.pad = kernel_size // ratio - 1
+    self.pad_left = self.pad * ratio + (kernel_size - ratio) // 2
+    self.pad_right = self.pad * ratio + (kernel_size - ratio + 1) // 2
+    self.register_buffer(
+        "filter",
+        kaiser_sinc_filter1d(0.5 / ratio, 0.6 / ratio, kernel_size))
+
+  def forward(self, x):
+    channels = x.shape[1]
+    x = F.pad(x, (self.pad, self.pad), mode="replicate")
+    x = self.ratio * F.conv_transpose1d(
+        x, self.filter.expand(channels, -1, -1),
+        stride=self.stride, groups=channels)
+    return x[..., self.pad_left:-self.pad_right]
+
+
+class DownSample1d(nn.Module):
+  def __init__(self, ratio=2, kernel_size=12):
+    super().__init__()
+    self.ratio = ratio
+    self.kernel_size = kernel_size
+    self.pad_left = kernel_size // 2 - int(kernel_size % 2 == 0)
+    self.pad_right = kernel_size // 2
+    self.register_buffer(
+        "filter",
+        kaiser_sinc_filter1d(0.5 / ratio, 0.6 / ratio, kernel_size))
+
+  def forward(self, x):
+    channels = x.shape[1]
+    x = F.pad(x, (self.pad_left, self.pad_right), mode="replicate")
+    return F.conv1d(
+        x, self.filter.expand(channels, -1, -1),
+        stride=self.ratio, groups=channels)
+
+
+class SnakeBeta(nn.Module):
+  def __init__(self, channels: int, logscale: bool = True):
+    super().__init__()
+    initial = torch.zeros(channels) if logscale else torch.ones(channels)
+    self.alpha = nn.Parameter(initial.clone())
+    self.beta = nn.Parameter(initial.clone())
+    self.logscale = logscale
+
+  def forward(self, x):
+    alpha = self.alpha.view(1, -1, 1)
+    beta = self.beta.view(1, -1, 1)
+    if self.logscale:
+      alpha = alpha.exp()
+      beta = beta.exp()
+    return x + torch.sin(x * alpha).square() / (beta + 1e-9)
+
+
+class AliasFreeActivation1d(nn.Module):
+  def __init__(self, activation: nn.Module):
+    super().__init__()
+    self.upsample = UpSample1d()
+    self.act = activation
+    self.downsample = DownSample1d()
+
+  def forward(self, x):
+    return self.downsample(self.act(self.upsample(x)))
+
+
+class AliasFreeResBlock1(nn.Module):
+  """Shape-compatible VITS ResBlock1 with filtered SnakeBeta activations."""
+
+  def __init__(self, channels, kernel_size=3, dilation=(1, 3, 5), logscale=True):
+    super().__init__()
+    self.convs1 = nn.ModuleList([
+        weight_norm(nn.Conv1d(
+            channels, channels, kernel_size, 1,
+            dilation=d, padding=get_padding(kernel_size, d)))
+        for d in dilation
+    ])
+    self.convs2 = nn.ModuleList([
+        weight_norm(nn.Conv1d(
+            channels, channels, kernel_size, 1,
+            dilation=1, padding=get_padding(kernel_size, 1)))
+        for _ in dilation
+    ])
+    self.convs1.apply(init_weights)
+    self.convs2.apply(init_weights)
+    self.activations = nn.ModuleList([
+        AliasFreeActivation1d(SnakeBeta(channels, logscale=logscale))
+        for _ in range(2 * len(dilation))
+    ])
+
+  def forward(self, x, x_mask=None):
+    first = self.activations[::2]
+    second = self.activations[1::2]
+    for conv1, conv2, act1, act2 in zip(self.convs1, self.convs2, first, second):
+      residual = conv2(act2(conv1(act1(x))))
+      x = x + residual
+    return x
+
+  def remove_weight_norm(self):
+    for layer in self.convs1:
+      remove_weight_norm(layer)
+    for layer in self.convs2:
+      remove_weight_norm(layer)

--- a/scripts/conversion/inflect/models.py
+++ b/scripts/conversion/inflect/models.py
@@ -1,0 +1,571 @@
+import copy
+import math
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+import commons
+import modules
+from inflect_alias_free import AliasFreeActivation1d, AliasFreeResBlock1, SnakeBeta
+import attentions
+import monotonic_align
+
+from torch.nn import Conv1d, ConvTranspose1d, AvgPool1d, Conv2d
+from torch.nn.utils import weight_norm, remove_weight_norm, spectral_norm
+from commons import init_weights, get_padding
+
+
+class StochasticDurationPredictor(nn.Module):
+  def __init__(self, in_channels, filter_channels, kernel_size, p_dropout, n_flows=4, gin_channels=0):
+    super().__init__()
+    filter_channels = in_channels # it needs to be removed from future version.
+    self.in_channels = in_channels
+    self.filter_channels = filter_channels
+    self.kernel_size = kernel_size
+    self.p_dropout = p_dropout
+    self.n_flows = n_flows
+    self.gin_channels = gin_channels
+
+    self.log_flow = modules.Log()
+    self.flows = nn.ModuleList()
+    self.flows.append(modules.ElementwiseAffine(2))
+    for i in range(n_flows):
+      self.flows.append(modules.ConvFlow(2, filter_channels, kernel_size, n_layers=3))
+      self.flows.append(modules.Flip())
+
+    self.post_pre = nn.Conv1d(1, filter_channels, 1)
+    self.post_proj = nn.Conv1d(filter_channels, filter_channels, 1)
+    self.post_convs = modules.DDSConv(filter_channels, kernel_size, n_layers=3, p_dropout=p_dropout)
+    self.post_flows = nn.ModuleList()
+    self.post_flows.append(modules.ElementwiseAffine(2))
+    for i in range(4):
+      self.post_flows.append(modules.ConvFlow(2, filter_channels, kernel_size, n_layers=3))
+      self.post_flows.append(modules.Flip())
+
+    self.pre = nn.Conv1d(in_channels, filter_channels, 1)
+    self.proj = nn.Conv1d(filter_channels, filter_channels, 1)
+    self.convs = modules.DDSConv(filter_channels, kernel_size, n_layers=3, p_dropout=p_dropout)
+    if gin_channels != 0:
+      self.cond = nn.Conv1d(gin_channels, filter_channels, 1)
+
+  def forward(self, x, x_mask, w=None, g=None, reverse=False, noise_scale=1.0):
+    x = torch.detach(x)
+    x = self.pre(x)
+    if g is not None:
+      g = torch.detach(g)
+      x = x + self.cond(g)
+    x = self.convs(x, x_mask)
+    x = self.proj(x) * x_mask
+
+    if not reverse:
+      flows = self.flows
+      assert w is not None
+
+      logdet_tot_q = 0 
+      h_w = self.post_pre(w)
+      h_w = self.post_convs(h_w, x_mask)
+      h_w = self.post_proj(h_w) * x_mask
+      e_q = torch.randn(w.size(0), 2, w.size(2)).to(device=x.device, dtype=x.dtype) * x_mask
+      z_q = e_q
+      for flow in self.post_flows:
+        z_q, logdet_q = flow(z_q, x_mask, g=(x + h_w))
+        logdet_tot_q += logdet_q
+      z_u, z1 = torch.split(z_q, [1, 1], 1) 
+      u = torch.sigmoid(z_u) * x_mask
+      z0 = (w - u) * x_mask
+      logdet_tot_q += torch.sum((F.logsigmoid(z_u) + F.logsigmoid(-z_u)) * x_mask, [1,2])
+      logq = torch.sum(-0.5 * (math.log(2*math.pi) + (e_q**2)) * x_mask, [1,2]) - logdet_tot_q
+
+      logdet_tot = 0
+      z0, logdet = self.log_flow(z0, x_mask)
+      logdet_tot += logdet
+      z = torch.cat([z0, z1], 1)
+      for flow in flows:
+        z, logdet = flow(z, x_mask, g=x, reverse=reverse)
+        logdet_tot = logdet_tot + logdet
+      nll = torch.sum(0.5 * (math.log(2*math.pi) + (z**2)) * x_mask, [1,2]) - logdet_tot
+      return nll + logq # [b]
+    else:
+      flows = list(reversed(self.flows))
+      flows = flows[:-2] + [flows[-1]] # remove a useless vflow
+      z = torch.randn(x.size(0), 2, x.size(2)).to(device=x.device, dtype=x.dtype) * noise_scale
+      for flow in flows:
+        z = flow(z, x_mask, g=x, reverse=reverse)
+      z0, z1 = torch.split(z, [1, 1], 1)
+      logw = z0
+      return logw
+
+
+class DurationPredictor(nn.Module):
+  def __init__(self, in_channels, filter_channels, kernel_size, p_dropout, gin_channels=0):
+    super().__init__()
+
+    self.in_channels = in_channels
+    self.filter_channels = filter_channels
+    self.kernel_size = kernel_size
+    self.p_dropout = p_dropout
+    self.gin_channels = gin_channels
+
+    self.drop = nn.Dropout(p_dropout)
+    self.conv_1 = nn.Conv1d(in_channels, filter_channels, kernel_size, padding=kernel_size//2)
+    self.norm_1 = modules.LayerNorm(filter_channels)
+    self.conv_2 = nn.Conv1d(filter_channels, filter_channels, kernel_size, padding=kernel_size//2)
+    self.norm_2 = modules.LayerNorm(filter_channels)
+    self.proj = nn.Conv1d(filter_channels, 1, 1)
+
+    if gin_channels != 0:
+      self.cond = nn.Conv1d(gin_channels, in_channels, 1)
+
+  def forward(self, x, x_mask, g=None):
+    x = torch.detach(x)
+    if g is not None:
+      g = torch.detach(g)
+      x = x + self.cond(g)
+    x = self.conv_1(x * x_mask)
+    x = torch.relu(x)
+    x = self.norm_1(x)
+    x = self.drop(x)
+    x = self.conv_2(x * x_mask)
+    x = torch.relu(x)
+    x = self.norm_2(x)
+    x = self.drop(x)
+    x = self.proj(x * x_mask)
+    return x * x_mask
+
+
+class TextEncoder(nn.Module):
+  def __init__(self,
+      n_vocab,
+      out_channels,
+      hidden_channels,
+      filter_channels,
+      n_heads,
+      n_layers,
+      kernel_size,
+      p_dropout):
+    super().__init__()
+    self.n_vocab = n_vocab
+    self.out_channels = out_channels
+    self.hidden_channels = hidden_channels
+    self.filter_channels = filter_channels
+    self.n_heads = n_heads
+    self.n_layers = n_layers
+    self.kernel_size = kernel_size
+    self.p_dropout = p_dropout
+
+    self.emb = nn.Embedding(n_vocab, hidden_channels)
+    nn.init.normal_(self.emb.weight, 0.0, hidden_channels**-0.5)
+
+    self.encoder = attentions.Encoder(
+      hidden_channels,
+      filter_channels,
+      n_heads,
+      n_layers,
+      kernel_size,
+      p_dropout)
+    self.proj= nn.Conv1d(hidden_channels, out_channels * 2, 1)
+
+  def forward(self, x, x_lengths):
+    x = self.emb(x) * math.sqrt(self.hidden_channels) # [b, t, h]
+    x = torch.transpose(x, 1, -1) # [b, h, t]
+    x_mask = torch.unsqueeze(commons.sequence_mask(x_lengths, x.size(2)), 1).to(x.dtype)
+
+    x = self.encoder(x * x_mask, x_mask)
+    stats = self.proj(x) * x_mask
+
+    m, logs = torch.split(stats, self.out_channels, dim=1)
+    return x, m, logs, x_mask
+
+
+class ResidualCouplingBlock(nn.Module):
+  def __init__(self,
+      channels,
+      hidden_channels,
+      kernel_size,
+      dilation_rate,
+      n_layers,
+      n_flows=4,
+      gin_channels=0):
+    super().__init__()
+    self.channels = channels
+    self.hidden_channels = hidden_channels
+    self.kernel_size = kernel_size
+    self.dilation_rate = dilation_rate
+    self.n_layers = n_layers
+    self.n_flows = n_flows
+    self.gin_channels = gin_channels
+
+    self.flows = nn.ModuleList()
+    for i in range(n_flows):
+      self.flows.append(modules.ResidualCouplingLayer(channels, hidden_channels, kernel_size, dilation_rate, n_layers, gin_channels=gin_channels, mean_only=True))
+      self.flows.append(modules.Flip())
+
+  def forward(self, x, x_mask, g=None, reverse=False):
+    if not reverse:
+      for flow in self.flows:
+        x, _ = flow(x, x_mask, g=g, reverse=reverse)
+    else:
+      for flow in reversed(self.flows):
+        x = flow(x, x_mask, g=g, reverse=reverse)
+    return x
+
+
+class PosteriorEncoder(nn.Module):
+  def __init__(self,
+      in_channels,
+      out_channels,
+      hidden_channels,
+      kernel_size,
+      dilation_rate,
+      n_layers,
+      gin_channels=0):
+    super().__init__()
+    self.in_channels = in_channels
+    self.out_channels = out_channels
+    self.hidden_channels = hidden_channels
+    self.kernel_size = kernel_size
+    self.dilation_rate = dilation_rate
+    self.n_layers = n_layers
+    self.gin_channels = gin_channels
+
+    self.pre = nn.Conv1d(in_channels, hidden_channels, 1)
+    self.enc = modules.WN(hidden_channels, kernel_size, dilation_rate, n_layers, gin_channels=gin_channels)
+    self.proj = nn.Conv1d(hidden_channels, out_channels * 2, 1)
+
+  def forward(self, x, x_lengths, g=None):
+    x_mask = torch.unsqueeze(commons.sequence_mask(x_lengths, x.size(2)), 1).to(x.dtype)
+    x = self.pre(x) * x_mask
+    x = self.enc(x, x_mask, g=g)
+    stats = self.proj(x) * x_mask
+    m, logs = torch.split(stats, self.out_channels, dim=1)
+    z = (m + torch.randn_like(m) * torch.exp(logs)) * x_mask
+    return z, m, logs, x_mask
+
+
+class Generator(torch.nn.Module):
+    def __init__(self, initial_channel, resblock, resblock_kernel_sizes, resblock_dilation_sizes, upsample_rates, upsample_initial_channel, upsample_kernel_sizes, gin_channels=0, decoder_alias_free=False, decoder_alias_free_start_stage=2, decoder_snake_logscale=True):
+        super(Generator, self).__init__()
+        self.num_kernels = len(resblock_kernel_sizes)
+        self.num_upsamples = len(upsample_rates)
+        self.conv_pre = Conv1d(initial_channel, upsample_initial_channel, 7, 1, padding=3)
+        resblock_class = modules.ResBlock1 if resblock == '1' else modules.ResBlock2
+        self.decoder_alias_free = bool(decoder_alias_free)
+        self.decoder_alias_free_start_stage = int(decoder_alias_free_start_stage)
+
+        self.ups = nn.ModuleList()
+        for i, (u, k) in enumerate(zip(upsample_rates, upsample_kernel_sizes)):
+            self.ups.append(weight_norm(
+                ConvTranspose1d(upsample_initial_channel//(2**i), upsample_initial_channel//(2**(i+1)),
+                                k, u, padding=(k-u)//2)))
+
+        self.resblocks = nn.ModuleList()
+        for i in range(len(self.ups)):
+            ch = upsample_initial_channel//(2**(i+1))
+            for j, (k, d) in enumerate(zip(resblock_kernel_sizes, resblock_dilation_sizes)):
+                if self.decoder_alias_free and i >= self.decoder_alias_free_start_stage:
+                    self.resblocks.append(AliasFreeResBlock1(
+                        ch, k, d, logscale=decoder_snake_logscale))
+                else:
+                    self.resblocks.append(resblock_class(ch, k, d))
+
+        self.alias_free_pre_activations = nn.ModuleList()
+        if self.decoder_alias_free:
+            for i in range(self.num_upsamples):
+                channels = upsample_initial_channel // (2 ** i)
+                if i >= self.decoder_alias_free_start_stage:
+                    self.alias_free_pre_activations.append(
+                        AliasFreeActivation1d(nn.LeakyReLU(modules.LRELU_SLOPE)))
+                else:
+                    self.alias_free_pre_activations.append(nn.Identity())
+            self.alias_free_post_activation = AliasFreeActivation1d(
+                SnakeBeta(ch, logscale=decoder_snake_logscale))
+
+        self.conv_post = Conv1d(ch, 1, 7, 1, padding=3, bias=False)
+        self.ups.apply(init_weights)
+
+        if gin_channels != 0:
+            self.cond = nn.Conv1d(gin_channels, upsample_initial_channel, 1)
+
+    def forward(self, x, g=None):
+        x = self.conv_pre(x)
+        if g is not None:
+          x = x + self.cond(g)
+
+        for i in range(self.num_upsamples):
+            if self.decoder_alias_free and i >= self.decoder_alias_free_start_stage:
+                x = self.alias_free_pre_activations[i](x)
+            else:
+                x = F.leaky_relu(x, modules.LRELU_SLOPE)
+            x = self.ups[i](x)
+            xs = None
+            for j in range(self.num_kernels):
+                if xs is None:
+                    xs = self.resblocks[i*self.num_kernels+j](x)
+                else:
+                    xs += self.resblocks[i*self.num_kernels+j](x)
+            x = xs / self.num_kernels
+        if self.decoder_alias_free:
+            x = self.alias_free_post_activation(x)
+        else:
+            x = F.leaky_relu(x)
+        x = self.conv_post(x)
+        x = torch.tanh(x)
+
+        return x
+
+    def remove_weight_norm(self):
+        print('Removing weight norm...')
+        for l in self.ups:
+            remove_weight_norm(l)
+        for l in self.resblocks:
+            l.remove_weight_norm()
+
+
+class DiscriminatorP(torch.nn.Module):
+    def __init__(self, period, kernel_size=5, stride=3, use_spectral_norm=False):
+        super(DiscriminatorP, self).__init__()
+        self.period = period
+        self.use_spectral_norm = use_spectral_norm
+        norm_f = weight_norm if use_spectral_norm == False else spectral_norm
+        self.convs = nn.ModuleList([
+            norm_f(Conv2d(1, 32, (kernel_size, 1), (stride, 1), padding=(get_padding(kernel_size, 1), 0))),
+            norm_f(Conv2d(32, 128, (kernel_size, 1), (stride, 1), padding=(get_padding(kernel_size, 1), 0))),
+            norm_f(Conv2d(128, 512, (kernel_size, 1), (stride, 1), padding=(get_padding(kernel_size, 1), 0))),
+            norm_f(Conv2d(512, 1024, (kernel_size, 1), (stride, 1), padding=(get_padding(kernel_size, 1), 0))),
+            norm_f(Conv2d(1024, 1024, (kernel_size, 1), 1, padding=(get_padding(kernel_size, 1), 0))),
+        ])
+        self.conv_post = norm_f(Conv2d(1024, 1, (3, 1), 1, padding=(1, 0)))
+
+    def forward(self, x):
+        fmap = []
+
+        # 1d to 2d
+        b, c, t = x.shape
+        if t % self.period != 0: # pad first
+            n_pad = self.period - (t % self.period)
+            x = F.pad(x, (0, n_pad), "reflect")
+            t = t + n_pad
+        x = x.view(b, c, t // self.period, self.period)
+
+        for l in self.convs:
+            x = l(x)
+            x = F.leaky_relu(x, modules.LRELU_SLOPE)
+            fmap.append(x)
+        x = self.conv_post(x)
+        fmap.append(x)
+        x = torch.flatten(x, 1, -1)
+
+        return x, fmap
+
+
+class DiscriminatorS(torch.nn.Module):
+    def __init__(self, use_spectral_norm=False):
+        super(DiscriminatorS, self).__init__()
+        norm_f = weight_norm if use_spectral_norm == False else spectral_norm
+        self.convs = nn.ModuleList([
+            norm_f(Conv1d(1, 16, 15, 1, padding=7)),
+            norm_f(Conv1d(16, 64, 41, 4, groups=4, padding=20)),
+            norm_f(Conv1d(64, 256, 41, 4, groups=16, padding=20)),
+            norm_f(Conv1d(256, 1024, 41, 4, groups=64, padding=20)),
+            norm_f(Conv1d(1024, 1024, 41, 4, groups=256, padding=20)),
+            norm_f(Conv1d(1024, 1024, 5, 1, padding=2)),
+        ])
+        self.conv_post = norm_f(Conv1d(1024, 1, 3, 1, padding=1))
+
+    def forward(self, x):
+        fmap = []
+
+        for l in self.convs:
+            x = l(x)
+            x = F.leaky_relu(x, modules.LRELU_SLOPE)
+            fmap.append(x)
+        x = self.conv_post(x)
+        fmap.append(x)
+        x = torch.flatten(x, 1, -1)
+
+        return x, fmap
+
+
+class MultiPeriodDiscriminator(torch.nn.Module):
+    def __init__(self, use_spectral_norm=False):
+        super(MultiPeriodDiscriminator, self).__init__()
+        periods = [2,3,5,7,11]
+
+        discs = [DiscriminatorS(use_spectral_norm=use_spectral_norm)]
+        discs = discs + [DiscriminatorP(i, use_spectral_norm=use_spectral_norm) for i in periods]
+        self.discriminators = nn.ModuleList(discs)
+
+    def forward(self, y, y_hat):
+        y_d_rs = []
+        y_d_gs = []
+        fmap_rs = []
+        fmap_gs = []
+        for i, d in enumerate(self.discriminators):
+            y_d_r, fmap_r = d(y)
+            y_d_g, fmap_g = d(y_hat)
+            y_d_rs.append(y_d_r)
+            y_d_gs.append(y_d_g)
+            fmap_rs.append(fmap_r)
+            fmap_gs.append(fmap_g)
+
+        return y_d_rs, y_d_gs, fmap_rs, fmap_gs
+
+
+
+class SynthesizerTrn(nn.Module):
+  """
+  Synthesizer for Training
+  """
+
+  def __init__(self, 
+    n_vocab,
+    spec_channels,
+    segment_size,
+    inter_channels,
+    hidden_channels,
+    filter_channels,
+    n_heads,
+    n_layers,
+    kernel_size,
+    p_dropout,
+    resblock, 
+    resblock_kernel_sizes, 
+    resblock_dilation_sizes, 
+    upsample_rates, 
+    upsample_initial_channel, 
+    upsample_kernel_sizes,
+    n_speakers=0,
+    gin_channels=0,
+    use_sdp=True,
+    **kwargs):
+
+    super().__init__()
+    self.n_vocab = n_vocab
+    self.spec_channels = spec_channels
+    self.inter_channels = inter_channels
+    self.hidden_channels = hidden_channels
+    self.filter_channels = filter_channels
+    self.n_heads = n_heads
+    self.n_layers = n_layers
+    self.kernel_size = kernel_size
+    self.p_dropout = p_dropout
+    self.resblock = resblock
+    self.resblock_kernel_sizes = resblock_kernel_sizes
+    self.resblock_dilation_sizes = resblock_dilation_sizes
+    self.upsample_rates = upsample_rates
+    self.upsample_initial_channel = upsample_initial_channel
+    self.upsample_kernel_sizes = upsample_kernel_sizes
+    self.segment_size = segment_size
+    self.n_speakers = n_speakers
+    self.gin_channels = gin_channels
+
+    self.use_sdp = use_sdp
+
+    self.enc_p = TextEncoder(n_vocab,
+        inter_channels,
+        hidden_channels,
+        filter_channels,
+        n_heads,
+        n_layers,
+        kernel_size,
+        p_dropout)
+    self.dec = Generator(
+        inter_channels, resblock, resblock_kernel_sizes,
+        resblock_dilation_sizes, upsample_rates, upsample_initial_channel,
+        upsample_kernel_sizes, gin_channels=gin_channels,
+        decoder_alias_free=kwargs.get("decoder_alias_free", False),
+        decoder_alias_free_start_stage=kwargs.get("decoder_alias_free_start_stage", 2),
+        decoder_snake_logscale=kwargs.get("decoder_snake_logscale", True))
+    self.inference_only = bool(kwargs.get("inference_only", False))
+    if not self.inference_only:
+      self.enc_q = PosteriorEncoder(spec_channels, inter_channels, hidden_channels, 5, 1, 16, gin_channels=gin_channels)
+    self.flow = ResidualCouplingBlock(inter_channels, hidden_channels, 5, 1, 4, gin_channels=gin_channels)
+
+    if use_sdp:
+      self.dp = StochasticDurationPredictor(hidden_channels, 192, 3, 0.5, 4, gin_channels=gin_channels)
+    else:
+      self.dp = DurationPredictor(hidden_channels, 256, 3, 0.5, gin_channels=gin_channels)
+
+    if n_speakers > 1:
+      self.emb_g = nn.Embedding(n_speakers, gin_channels)
+
+  def forward(self, x, x_lengths, y, y_lengths, sid=None):
+
+    if self.inference_only:
+      raise RuntimeError("The public runtime is inference-only and has no posterior encoder.")
+
+    x, m_p, logs_p, x_mask = self.enc_p(x, x_lengths)
+    if self.n_speakers > 0:
+      g = self.emb_g(sid).unsqueeze(-1) # [b, h, 1]
+    else:
+      g = None
+
+    z, m_q, logs_q, y_mask = self.enc_q(y, y_lengths, g=g)
+    z_p = self.flow(z, y_mask, g=g)
+
+    with torch.no_grad():
+      # negative cross-entropy
+      s_p_sq_r = torch.exp(-2 * logs_p) # [b, d, t]
+      neg_cent1 = torch.sum(-0.5 * math.log(2 * math.pi) - logs_p, [1], keepdim=True) # [b, 1, t_s]
+      neg_cent2 = torch.matmul(-0.5 * (z_p ** 2).transpose(1, 2), s_p_sq_r) # [b, t_t, d] x [b, d, t_s] = [b, t_t, t_s]
+      neg_cent3 = torch.matmul(z_p.transpose(1, 2), (m_p * s_p_sq_r)) # [b, t_t, d] x [b, d, t_s] = [b, t_t, t_s]
+      neg_cent4 = torch.sum(-0.5 * (m_p ** 2) * s_p_sq_r, [1], keepdim=True) # [b, 1, t_s]
+      neg_cent = neg_cent1 + neg_cent2 + neg_cent3 + neg_cent4
+
+      attn_mask = torch.unsqueeze(x_mask, 2) * torch.unsqueeze(y_mask, -1)
+      attn = monotonic_align.maximum_path(neg_cent, attn_mask.squeeze(1)).unsqueeze(1).detach()
+
+    w = attn.sum(2)
+    if self.use_sdp:
+      l_length = self.dp(x, x_mask, w, g=g)
+      l_length = l_length / torch.sum(x_mask)
+    else:
+      logw_ = torch.log(w + 1e-6) * x_mask
+      logw = self.dp(x, x_mask, g=g)
+      l_length = torch.sum((logw - logw_)**2, [1,2]) / torch.sum(x_mask) # for averaging 
+
+    # expand prior
+    m_p = torch.matmul(attn.squeeze(1), m_p.transpose(1, 2)).transpose(1, 2)
+    logs_p = torch.matmul(attn.squeeze(1), logs_p.transpose(1, 2)).transpose(1, 2)
+
+    z_slice, ids_slice = commons.rand_slice_segments(z, y_lengths, self.segment_size)
+    o = self.dec(z_slice, g=g)
+    return o, l_length, attn, ids_slice, x_mask, y_mask, (z, z_p, m_p, logs_p, m_q, logs_q)
+
+  def infer(self, x, x_lengths, sid=None, noise_scale=1, length_scale=1, noise_scale_w=1., max_len=None):
+    x, m_p, logs_p, x_mask = self.enc_p(x, x_lengths)
+    if self.n_speakers > 0:
+      g = self.emb_g(sid).unsqueeze(-1) # [b, h, 1]
+    else:
+      g = None
+
+    if self.use_sdp:
+      logw = self.dp(x, x_mask, g=g, reverse=True, noise_scale=noise_scale_w)
+    else:
+      logw = self.dp(x, x_mask, g=g)
+    w = torch.exp(logw) * x_mask * length_scale
+    w_ceil = torch.ceil(w)
+    y_lengths = torch.clamp_min(torch.sum(w_ceil, [1, 2]), 1).long()
+    y_mask = torch.unsqueeze(commons.sequence_mask(y_lengths, None), 1).to(x_mask.dtype)
+    attn_mask = torch.unsqueeze(x_mask, 2) * torch.unsqueeze(y_mask, -1)
+    attn = commons.generate_path(w_ceil, attn_mask)
+
+    m_p = torch.matmul(attn.squeeze(1), m_p.transpose(1, 2)).transpose(1, 2) # [b, t', t], [b, t, d] -> [b, d, t']
+    logs_p = torch.matmul(attn.squeeze(1), logs_p.transpose(1, 2)).transpose(1, 2) # [b, t', t], [b, t, d] -> [b, d, t']
+
+    z_p = m_p + torch.randn_like(m_p) * torch.exp(logs_p) * noise_scale
+    z = self.flow(z_p, y_mask, g=g, reverse=True)
+    o = self.dec((z * y_mask)[:,:,:max_len], g=g)
+    return o, attn, y_mask, (z, z_p, m_p, logs_p)
+
+  def voice_conversion(self, y, y_lengths, sid_src, sid_tgt):
+    if self.inference_only:
+      raise RuntimeError("The public runtime is inference-only and does not support voice conversion.")
+    assert self.n_speakers > 0, "n_speakers have to be larger than 0."
+    g_src = self.emb_g(sid_src).unsqueeze(-1)
+    g_tgt = self.emb_g(sid_tgt).unsqueeze(-1)
+    z, m_q, logs_q, y_mask = self.enc_q(y, y_lengths, g=g_src)
+    z_p = self.flow(z, y_mask, g=g_src)
+    z_hat = self.flow(z_p, y_mask, g=g_tgt, reverse=True)
+    o_hat = self.dec(z_hat * y_mask, g=g_tgt)
+    return o_hat, y_mask, (z, z_p, z_hat)

--- a/scripts/conversion/inflect/modules.py
+++ b/scripts/conversion/inflect/modules.py
@@ -1,0 +1,390 @@
+import copy
+import math
+import numpy as np
+import scipy
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from torch.nn import Conv1d, ConvTranspose1d, AvgPool1d, Conv2d
+from torch.nn.utils import weight_norm, remove_weight_norm
+
+import commons
+from commons import init_weights, get_padding
+from transforms import piecewise_rational_quadratic_transform
+
+
+LRELU_SLOPE = 0.1
+
+
+class LayerNorm(nn.Module):
+  def __init__(self, channels, eps=1e-5):
+    super().__init__()
+    self.channels = channels
+    self.eps = eps
+
+    self.gamma = nn.Parameter(torch.ones(channels))
+    self.beta = nn.Parameter(torch.zeros(channels))
+
+  def forward(self, x):
+    x = x.transpose(1, -1)
+    x = F.layer_norm(x, (self.channels,), self.gamma, self.beta, self.eps)
+    return x.transpose(1, -1)
+
+ 
+class ConvReluNorm(nn.Module):
+  def __init__(self, in_channels, hidden_channels, out_channels, kernel_size, n_layers, p_dropout):
+    super().__init__()
+    self.in_channels = in_channels
+    self.hidden_channels = hidden_channels
+    self.out_channels = out_channels
+    self.kernel_size = kernel_size
+    self.n_layers = n_layers
+    self.p_dropout = p_dropout
+    assert n_layers > 1, "Number of layers should be larger than 0."
+
+    self.conv_layers = nn.ModuleList()
+    self.norm_layers = nn.ModuleList()
+    self.conv_layers.append(nn.Conv1d(in_channels, hidden_channels, kernel_size, padding=kernel_size//2))
+    self.norm_layers.append(LayerNorm(hidden_channels))
+    self.relu_drop = nn.Sequential(
+        nn.ReLU(),
+        nn.Dropout(p_dropout))
+    for _ in range(n_layers-1):
+      self.conv_layers.append(nn.Conv1d(hidden_channels, hidden_channels, kernel_size, padding=kernel_size//2))
+      self.norm_layers.append(LayerNorm(hidden_channels))
+    self.proj = nn.Conv1d(hidden_channels, out_channels, 1)
+    self.proj.weight.data.zero_()
+    self.proj.bias.data.zero_()
+
+  def forward(self, x, x_mask):
+    x_org = x
+    for i in range(self.n_layers):
+      x = self.conv_layers[i](x * x_mask)
+      x = self.norm_layers[i](x)
+      x = self.relu_drop(x)
+    x = x_org + self.proj(x)
+    return x * x_mask
+
+
+class DDSConv(nn.Module):
+  """
+  Dialted and Depth-Separable Convolution
+  """
+  def __init__(self, channels, kernel_size, n_layers, p_dropout=0.):
+    super().__init__()
+    self.channels = channels
+    self.kernel_size = kernel_size
+    self.n_layers = n_layers
+    self.p_dropout = p_dropout
+
+    self.drop = nn.Dropout(p_dropout)
+    self.convs_sep = nn.ModuleList()
+    self.convs_1x1 = nn.ModuleList()
+    self.norms_1 = nn.ModuleList()
+    self.norms_2 = nn.ModuleList()
+    for i in range(n_layers):
+      dilation = kernel_size ** i
+      padding = (kernel_size * dilation - dilation) // 2
+      self.convs_sep.append(nn.Conv1d(channels, channels, kernel_size, 
+          groups=channels, dilation=dilation, padding=padding
+      ))
+      self.convs_1x1.append(nn.Conv1d(channels, channels, 1))
+      self.norms_1.append(LayerNorm(channels))
+      self.norms_2.append(LayerNorm(channels))
+
+  def forward(self, x, x_mask, g=None):
+    if g is not None:
+      x = x + g
+    for i in range(self.n_layers):
+      y = self.convs_sep[i](x * x_mask)
+      y = self.norms_1[i](y)
+      y = F.gelu(y)
+      y = self.convs_1x1[i](y)
+      y = self.norms_2[i](y)
+      y = F.gelu(y)
+      y = self.drop(y)
+      x = x + y
+    return x * x_mask
+
+
+class WN(torch.nn.Module):
+  def __init__(self, hidden_channels, kernel_size, dilation_rate, n_layers, gin_channels=0, p_dropout=0):
+    super(WN, self).__init__()
+    assert(kernel_size % 2 == 1)
+    self.hidden_channels =hidden_channels
+    self.kernel_size = kernel_size,
+    self.dilation_rate = dilation_rate
+    self.n_layers = n_layers
+    self.gin_channels = gin_channels
+    self.p_dropout = p_dropout
+
+    self.in_layers = torch.nn.ModuleList()
+    self.res_skip_layers = torch.nn.ModuleList()
+    self.drop = nn.Dropout(p_dropout)
+
+    if gin_channels != 0:
+      cond_layer = torch.nn.Conv1d(gin_channels, 2*hidden_channels*n_layers, 1)
+      self.cond_layer = torch.nn.utils.weight_norm(cond_layer, name='weight')
+
+    for i in range(n_layers):
+      dilation = dilation_rate ** i
+      padding = int((kernel_size * dilation - dilation) / 2)
+      in_layer = torch.nn.Conv1d(hidden_channels, 2*hidden_channels, kernel_size,
+                                 dilation=dilation, padding=padding)
+      in_layer = torch.nn.utils.weight_norm(in_layer, name='weight')
+      self.in_layers.append(in_layer)
+
+      # last one is not necessary
+      if i < n_layers - 1:
+        res_skip_channels = 2 * hidden_channels
+      else:
+        res_skip_channels = hidden_channels
+
+      res_skip_layer = torch.nn.Conv1d(hidden_channels, res_skip_channels, 1)
+      res_skip_layer = torch.nn.utils.weight_norm(res_skip_layer, name='weight')
+      self.res_skip_layers.append(res_skip_layer)
+
+  def forward(self, x, x_mask, g=None, **kwargs):
+    output = torch.zeros_like(x)
+    n_channels_tensor = torch.IntTensor([self.hidden_channels])
+
+    if g is not None:
+      g = self.cond_layer(g)
+
+    for i in range(self.n_layers):
+      x_in = self.in_layers[i](x)
+      if g is not None:
+        cond_offset = i * 2 * self.hidden_channels
+        g_l = g[:,cond_offset:cond_offset+2*self.hidden_channels,:]
+      else:
+        g_l = torch.zeros_like(x_in)
+
+      acts = commons.fused_add_tanh_sigmoid_multiply(
+          x_in,
+          g_l,
+          n_channels_tensor)
+      acts = self.drop(acts)
+
+      res_skip_acts = self.res_skip_layers[i](acts)
+      if i < self.n_layers - 1:
+        res_acts = res_skip_acts[:,:self.hidden_channels,:]
+        x = (x + res_acts) * x_mask
+        output = output + res_skip_acts[:,self.hidden_channels:,:]
+      else:
+        output = output + res_skip_acts
+    return output * x_mask
+
+  def remove_weight_norm(self):
+    if self.gin_channels != 0:
+      torch.nn.utils.remove_weight_norm(self.cond_layer)
+    for l in self.in_layers:
+      torch.nn.utils.remove_weight_norm(l)
+    for l in self.res_skip_layers:
+     torch.nn.utils.remove_weight_norm(l)
+
+
+class ResBlock1(torch.nn.Module):
+    def __init__(self, channels, kernel_size=3, dilation=(1, 3, 5)):
+        super(ResBlock1, self).__init__()
+        self.convs1 = nn.ModuleList([
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=dilation[0],
+                               padding=get_padding(kernel_size, dilation[0]))),
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=dilation[1],
+                               padding=get_padding(kernel_size, dilation[1]))),
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=dilation[2],
+                               padding=get_padding(kernel_size, dilation[2])))
+        ])
+        self.convs1.apply(init_weights)
+
+        self.convs2 = nn.ModuleList([
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=1,
+                               padding=get_padding(kernel_size, 1))),
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=1,
+                               padding=get_padding(kernel_size, 1))),
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=1,
+                               padding=get_padding(kernel_size, 1)))
+        ])
+        self.convs2.apply(init_weights)
+
+    def forward(self, x, x_mask=None):
+        for c1, c2 in zip(self.convs1, self.convs2):
+            xt = F.leaky_relu(x, LRELU_SLOPE)
+            if x_mask is not None:
+                xt = xt * x_mask
+            xt = c1(xt)
+            xt = F.leaky_relu(xt, LRELU_SLOPE)
+            if x_mask is not None:
+                xt = xt * x_mask
+            xt = c2(xt)
+            x = xt + x
+        if x_mask is not None:
+            x = x * x_mask
+        return x
+
+    def remove_weight_norm(self):
+        for l in self.convs1:
+            remove_weight_norm(l)
+        for l in self.convs2:
+            remove_weight_norm(l)
+
+
+class ResBlock2(torch.nn.Module):
+    def __init__(self, channels, kernel_size=3, dilation=(1, 3)):
+        super(ResBlock2, self).__init__()
+        self.convs = nn.ModuleList([
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=dilation[0],
+                               padding=get_padding(kernel_size, dilation[0]))),
+            weight_norm(Conv1d(channels, channels, kernel_size, 1, dilation=dilation[1],
+                               padding=get_padding(kernel_size, dilation[1])))
+        ])
+        self.convs.apply(init_weights)
+
+    def forward(self, x, x_mask=None):
+        for c in self.convs:
+            xt = F.leaky_relu(x, LRELU_SLOPE)
+            if x_mask is not None:
+                xt = xt * x_mask
+            xt = c(xt)
+            x = xt + x
+        if x_mask is not None:
+            x = x * x_mask
+        return x
+
+    def remove_weight_norm(self):
+        for l in self.convs:
+            remove_weight_norm(l)
+
+
+class Log(nn.Module):
+  def forward(self, x, x_mask, reverse=False, **kwargs):
+    if not reverse:
+      y = torch.log(torch.clamp_min(x, 1e-5)) * x_mask
+      logdet = torch.sum(-y, [1, 2])
+      return y, logdet
+    else:
+      x = torch.exp(x) * x_mask
+      return x
+    
+
+class Flip(nn.Module):
+  def forward(self, x, *args, reverse=False, **kwargs):
+    x = torch.flip(x, [1])
+    if not reverse:
+      logdet = torch.zeros(x.size(0)).to(dtype=x.dtype, device=x.device)
+      return x, logdet
+    else:
+      return x
+
+
+class ElementwiseAffine(nn.Module):
+  def __init__(self, channels):
+    super().__init__()
+    self.channels = channels
+    self.m = nn.Parameter(torch.zeros(channels,1))
+    self.logs = nn.Parameter(torch.zeros(channels,1))
+
+  def forward(self, x, x_mask, reverse=False, **kwargs):
+    if not reverse:
+      y = self.m + torch.exp(self.logs) * x
+      y = y * x_mask
+      logdet = torch.sum(self.logs * x_mask, [1,2])
+      return y, logdet
+    else:
+      x = (x - self.m) * torch.exp(-self.logs) * x_mask
+      return x
+
+
+class ResidualCouplingLayer(nn.Module):
+  def __init__(self,
+      channels,
+      hidden_channels,
+      kernel_size,
+      dilation_rate,
+      n_layers,
+      p_dropout=0,
+      gin_channels=0,
+      mean_only=False):
+    assert channels % 2 == 0, "channels should be divisible by 2"
+    super().__init__()
+    self.channels = channels
+    self.hidden_channels = hidden_channels
+    self.kernel_size = kernel_size
+    self.dilation_rate = dilation_rate
+    self.n_layers = n_layers
+    self.half_channels = channels // 2
+    self.mean_only = mean_only
+
+    self.pre = nn.Conv1d(self.half_channels, hidden_channels, 1)
+    self.enc = WN(hidden_channels, kernel_size, dilation_rate, n_layers, p_dropout=p_dropout, gin_channels=gin_channels)
+    self.post = nn.Conv1d(hidden_channels, self.half_channels * (2 - mean_only), 1)
+    self.post.weight.data.zero_()
+    self.post.bias.data.zero_()
+
+  def forward(self, x, x_mask, g=None, reverse=False):
+    x0, x1 = torch.split(x, [self.half_channels]*2, 1)
+    h = self.pre(x0) * x_mask
+    h = self.enc(h, x_mask, g=g)
+    stats = self.post(h) * x_mask
+    if not self.mean_only:
+      m, logs = torch.split(stats, [self.half_channels]*2, 1)
+    else:
+      m = stats
+      logs = torch.zeros_like(m)
+
+    if not reverse:
+      x1 = m + x1 * torch.exp(logs) * x_mask
+      x = torch.cat([x0, x1], 1)
+      logdet = torch.sum(logs, [1,2])
+      return x, logdet
+    else:
+      x1 = (x1 - m) * torch.exp(-logs) * x_mask
+      x = torch.cat([x0, x1], 1)
+      return x
+
+
+class ConvFlow(nn.Module):
+  def __init__(self, in_channels, filter_channels, kernel_size, n_layers, num_bins=10, tail_bound=5.0):
+    super().__init__()
+    self.in_channels = in_channels
+    self.filter_channels = filter_channels
+    self.kernel_size = kernel_size
+    self.n_layers = n_layers
+    self.num_bins = num_bins
+    self.tail_bound = tail_bound
+    self.half_channels = in_channels // 2
+
+    self.pre = nn.Conv1d(self.half_channels, filter_channels, 1)
+    self.convs = DDSConv(filter_channels, kernel_size, n_layers, p_dropout=0.)
+    self.proj = nn.Conv1d(filter_channels, self.half_channels * (num_bins * 3 - 1), 1)
+    self.proj.weight.data.zero_()
+    self.proj.bias.data.zero_()
+
+  def forward(self, x, x_mask, g=None, reverse=False):
+    x0, x1 = torch.split(x, [self.half_channels]*2, 1)
+    h = self.pre(x0)
+    h = self.convs(h, x_mask, g=g)
+    h = self.proj(h) * x_mask
+
+    b, c, t = x0.shape
+    h = h.reshape(b, c, -1, t).permute(0, 1, 3, 2) # [b, cx?, t] -> [b, c, t, ?]
+
+    unnormalized_widths = h[..., :self.num_bins] / math.sqrt(self.filter_channels)
+    unnormalized_heights = h[..., self.num_bins:2*self.num_bins] / math.sqrt(self.filter_channels)
+    unnormalized_derivatives = h[..., 2 * self.num_bins:]
+
+    x1, logabsdet = piecewise_rational_quadratic_transform(x1,
+        unnormalized_widths,
+        unnormalized_heights,
+        unnormalized_derivatives,
+        inverse=reverse,
+        tails='linear',
+        tail_bound=self.tail_bound
+    )
+
+    x = torch.cat([x0, x1], 1) * x_mask
+    logdet = torch.sum(logabsdet * x_mask, [1,2])
+    if not reverse:
+        return x, logdet
+    else:
+        return x

--- a/scripts/conversion/inflect/monotonic_align.py
+++ b/scripts/conversion/inflect/monotonic_align.py
@@ -1,0 +1,4 @@
+"""Training-only alignment stub; deployable inference never calls maximum_path."""
+
+def maximum_path(*args, **kwargs):
+    raise RuntimeError("Monotonic alignment is unavailable in the inference package.")

--- a/scripts/conversion/inflect/text/LICENSE
+++ b/scripts/conversion/inflect/text/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Keith Ito
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/scripts/conversion/inflect/text/symbols.py
+++ b/scripts/conversion/inflect/text/symbols.py
@@ -1,0 +1,16 @@
+""" from https://github.com/keithito/tacotron """
+
+'''
+Defines the set of symbols used in text input to the model.
+'''
+_pad        = '_'
+_punctuation = ';:,.!?¡¿—…"«»“” '
+_letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+_letters_ipa = "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩'ᵻ"
+
+
+# Export all symbols:
+symbols = [_pad] + list(_punctuation) + list(_letters) + list(_letters_ipa)
+
+# Special symbol ids
+SPACE_ID = symbols.index(" ")

--- a/scripts/conversion/inflect/transforms.py
+++ b/scripts/conversion/inflect/transforms.py
@@ -1,0 +1,193 @@
+import torch
+from torch.nn import functional as F
+
+import numpy as np
+
+
+DEFAULT_MIN_BIN_WIDTH = 1e-3
+DEFAULT_MIN_BIN_HEIGHT = 1e-3
+DEFAULT_MIN_DERIVATIVE = 1e-3
+
+
+def piecewise_rational_quadratic_transform(inputs, 
+                                           unnormalized_widths,
+                                           unnormalized_heights,
+                                           unnormalized_derivatives,
+                                           inverse=False,
+                                           tails=None, 
+                                           tail_bound=1.,
+                                           min_bin_width=DEFAULT_MIN_BIN_WIDTH,
+                                           min_bin_height=DEFAULT_MIN_BIN_HEIGHT,
+                                           min_derivative=DEFAULT_MIN_DERIVATIVE):
+
+    if tails is None:
+        spline_fn = rational_quadratic_spline
+        spline_kwargs = {}
+    else:
+        spline_fn = unconstrained_rational_quadratic_spline
+        spline_kwargs = {
+            'tails': tails,
+            'tail_bound': tail_bound
+        }
+
+    outputs, logabsdet = spline_fn(
+            inputs=inputs,
+            unnormalized_widths=unnormalized_widths,
+            unnormalized_heights=unnormalized_heights,
+            unnormalized_derivatives=unnormalized_derivatives,
+            inverse=inverse,
+            min_bin_width=min_bin_width,
+            min_bin_height=min_bin_height,
+            min_derivative=min_derivative,
+            **spline_kwargs
+    )
+    return outputs, logabsdet
+
+
+def searchsorted(bin_locations, inputs, eps=1e-6):
+    bin_locations[..., -1] += eps
+    return torch.sum(
+        inputs[..., None] >= bin_locations,
+        dim=-1
+    ) - 1
+
+
+def unconstrained_rational_quadratic_spline(inputs,
+                                            unnormalized_widths,
+                                            unnormalized_heights,
+                                            unnormalized_derivatives,
+                                            inverse=False,
+                                            tails='linear',
+                                            tail_bound=1.,
+                                            min_bin_width=DEFAULT_MIN_BIN_WIDTH,
+                                            min_bin_height=DEFAULT_MIN_BIN_HEIGHT,
+                                            min_derivative=DEFAULT_MIN_DERIVATIVE):
+    inside_interval_mask = (inputs >= -tail_bound) & (inputs <= tail_bound)
+    outside_interval_mask = ~inside_interval_mask
+
+    outputs = torch.zeros_like(inputs)
+    logabsdet = torch.zeros_like(inputs)
+
+    if tails == 'linear':
+        unnormalized_derivatives = F.pad(unnormalized_derivatives, pad=(1, 1))
+        constant = np.log(np.exp(1 - min_derivative) - 1)
+        unnormalized_derivatives[..., 0] = constant
+        unnormalized_derivatives[..., -1] = constant
+
+        outputs[outside_interval_mask] = inputs[outside_interval_mask]
+        logabsdet[outside_interval_mask] = 0
+    else:
+        raise RuntimeError('{} tails are not implemented.'.format(tails))
+
+    outputs[inside_interval_mask], logabsdet[inside_interval_mask] = rational_quadratic_spline(
+        inputs=inputs[inside_interval_mask],
+        unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
+        unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
+        unnormalized_derivatives=unnormalized_derivatives[inside_interval_mask, :],
+        inverse=inverse,
+        left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound,
+        min_bin_width=min_bin_width,
+        min_bin_height=min_bin_height,
+        min_derivative=min_derivative
+    )
+
+    return outputs, logabsdet
+
+def rational_quadratic_spline(inputs,
+                              unnormalized_widths,
+                              unnormalized_heights,
+                              unnormalized_derivatives,
+                              inverse=False,
+                              left=0., right=1., bottom=0., top=1.,
+                              min_bin_width=DEFAULT_MIN_BIN_WIDTH,
+                              min_bin_height=DEFAULT_MIN_BIN_HEIGHT,
+                              min_derivative=DEFAULT_MIN_DERIVATIVE):
+    if torch.min(inputs) < left or torch.max(inputs) > right:
+        raise ValueError('Input to a transform is not within its domain')
+
+    num_bins = unnormalized_widths.shape[-1]
+
+    if min_bin_width * num_bins > 1.0:
+        raise ValueError('Minimal bin width too large for the number of bins')
+    if min_bin_height * num_bins > 1.0:
+        raise ValueError('Minimal bin height too large for the number of bins')
+
+    widths = F.softmax(unnormalized_widths, dim=-1)
+    widths = min_bin_width + (1 - min_bin_width * num_bins) * widths
+    cumwidths = torch.cumsum(widths, dim=-1)
+    cumwidths = F.pad(cumwidths, pad=(1, 0), mode='constant', value=0.0)
+    cumwidths = (right - left) * cumwidths + left
+    cumwidths[..., 0] = left
+    cumwidths[..., -1] = right
+    widths = cumwidths[..., 1:] - cumwidths[..., :-1]
+
+    derivatives = min_derivative + F.softplus(unnormalized_derivatives)
+
+    heights = F.softmax(unnormalized_heights, dim=-1)
+    heights = min_bin_height + (1 - min_bin_height * num_bins) * heights
+    cumheights = torch.cumsum(heights, dim=-1)
+    cumheights = F.pad(cumheights, pad=(1, 0), mode='constant', value=0.0)
+    cumheights = (top - bottom) * cumheights + bottom
+    cumheights[..., 0] = bottom
+    cumheights[..., -1] = top
+    heights = cumheights[..., 1:] - cumheights[..., :-1]
+
+    if inverse:
+        bin_idx = searchsorted(cumheights, inputs)[..., None]
+    else:
+        bin_idx = searchsorted(cumwidths, inputs)[..., None]
+
+    input_cumwidths = cumwidths.gather(-1, bin_idx)[..., 0]
+    input_bin_widths = widths.gather(-1, bin_idx)[..., 0]
+
+    input_cumheights = cumheights.gather(-1, bin_idx)[..., 0]
+    delta = heights / widths
+    input_delta = delta.gather(-1, bin_idx)[..., 0]
+
+    input_derivatives = derivatives.gather(-1, bin_idx)[..., 0]
+    input_derivatives_plus_one = derivatives[..., 1:].gather(-1, bin_idx)[..., 0]
+
+    input_heights = heights.gather(-1, bin_idx)[..., 0]
+
+    if inverse:
+        a = (((inputs - input_cumheights) * (input_derivatives
+                                             + input_derivatives_plus_one
+                                             - 2 * input_delta)
+              + input_heights * (input_delta - input_derivatives)))
+        b = (input_heights * input_derivatives
+             - (inputs - input_cumheights) * (input_derivatives
+                                              + input_derivatives_plus_one
+                                              - 2 * input_delta))
+        c = - input_delta * (inputs - input_cumheights)
+
+        discriminant = b.pow(2) - 4 * a * c
+        assert (discriminant >= 0).all()
+
+        root = (2 * c) / (-b - torch.sqrt(discriminant))
+        outputs = root * input_bin_widths + input_cumwidths
+
+        theta_one_minus_theta = root * (1 - root)
+        denominator = input_delta + ((input_derivatives + input_derivatives_plus_one - 2 * input_delta)
+                                     * theta_one_minus_theta)
+        derivative_numerator = input_delta.pow(2) * (input_derivatives_plus_one * root.pow(2)
+                                                     + 2 * input_delta * theta_one_minus_theta
+                                                     + input_derivatives * (1 - root).pow(2))
+        logabsdet = torch.log(derivative_numerator) - 2 * torch.log(denominator)
+
+        return outputs, -logabsdet
+    else:
+        theta = (inputs - input_cumwidths) / input_bin_widths
+        theta_one_minus_theta = theta * (1 - theta)
+
+        numerator = input_heights * (input_delta * theta.pow(2)
+                                     + input_derivatives * theta_one_minus_theta)
+        denominator = input_delta + ((input_derivatives + input_derivatives_plus_one - 2 * input_delta)
+                                     * theta_one_minus_theta)
+        outputs = input_cumheights + numerator / denominator
+
+        derivative_numerator = input_delta.pow(2) * (input_derivatives_plus_one * theta.pow(2)
+                                                     + 2 * input_delta * theta_one_minus_theta
+                                                     + input_derivatives * (1 - theta).pow(2))
+        logabsdet = torch.log(derivative_numerator) - 2 * torch.log(denominator)
+
+        return outputs, logabsdet

--- a/scripts/conversion/inflect/utils.py
+++ b/scripts/conversion/inflect/utils.py
@@ -1,0 +1,256 @@
+import os
+import glob
+import sys
+import argparse
+import logging
+import json
+import subprocess
+import numpy as np
+from scipy.io.wavfile import read
+import torch
+
+MATPLOTLIB_FLAG = False
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logger = logging
+
+
+def load_checkpoint(checkpoint_path, model, optimizer=None):
+  assert os.path.isfile(checkpoint_path)
+  checkpoint_dict = torch.load(checkpoint_path, map_location='cpu')
+  iteration = checkpoint_dict['iteration']
+  learning_rate = checkpoint_dict['learning_rate']
+  if optimizer is not None:
+    optimizer.load_state_dict(checkpoint_dict['optimizer'])
+  saved_state_dict = checkpoint_dict['model']
+  if hasattr(model, 'module'):
+    state_dict = model.module.state_dict()
+  else:
+    state_dict = model.state_dict()
+  new_state_dict= {}
+  for k, v in state_dict.items():
+    try:
+      new_state_dict[k] = saved_state_dict[k]
+    except:
+      logger.info("%s is not in the checkpoint" % k)
+      new_state_dict[k] = v
+  if hasattr(model, 'module'):
+    model.module.load_state_dict(new_state_dict)
+  else:
+    model.load_state_dict(new_state_dict)
+  logger.info("Loaded checkpoint '{}' (iteration {})" .format(
+    checkpoint_path, iteration))
+  return model, optimizer, learning_rate, iteration
+
+
+def save_checkpoint(model, optimizer, learning_rate, iteration, checkpoint_path):
+  logger.info("Saving model and optimizer state at iteration {} to {}".format(
+    iteration, checkpoint_path))
+  if hasattr(model, 'module'):
+    state_dict = model.module.state_dict()
+  else:
+    state_dict = model.state_dict()
+  torch.save({'model': state_dict,
+              'iteration': iteration,
+              'optimizer': optimizer.state_dict(),
+              'learning_rate': learning_rate}, checkpoint_path)
+
+
+def summarize(writer, global_step, scalars={}, histograms={}, images={}, audios={}, audio_sampling_rate=22050):
+  for k, v in scalars.items():
+    writer.add_scalar(k, v, global_step)
+  for k, v in histograms.items():
+    writer.add_histogram(k, v, global_step)
+  for k, v in images.items():
+    writer.add_image(k, v, global_step, dataformats='HWC')
+  for k, v in audios.items():
+    writer.add_audio(k, v, global_step, audio_sampling_rate)
+
+
+def latest_checkpoint_path(dir_path, regex="G_*.pth"):
+  f_list = glob.glob(os.path.join(dir_path, regex))
+  f_list.sort(key=lambda f: int("".join(filter(str.isdigit, f))))
+  x = f_list[-1]
+  print(x)
+  return x
+
+
+def plot_spectrogram_to_numpy(spectrogram):
+  global MATPLOTLIB_FLAG
+  if not MATPLOTLIB_FLAG:
+    import matplotlib
+    matplotlib.use("Agg")
+    MATPLOTLIB_FLAG = True
+    mpl_logger = logging.getLogger('matplotlib')
+    mpl_logger.setLevel(logging.WARNING)
+  import matplotlib.pylab as plt
+  import numpy as np
+  
+  fig, ax = plt.subplots(figsize=(10,2))
+  im = ax.imshow(spectrogram, aspect="auto", origin="lower",
+                  interpolation='none')
+  plt.colorbar(im, ax=ax)
+  plt.xlabel("Frames")
+  plt.ylabel("Channels")
+  plt.tight_layout()
+
+  fig.canvas.draw()
+  data = np.asarray(fig.canvas.buffer_rgba(), dtype=np.uint8)[..., :3].copy()
+  plt.close()
+  return data
+
+
+def plot_alignment_to_numpy(alignment, info=None):
+  global MATPLOTLIB_FLAG
+  if not MATPLOTLIB_FLAG:
+    import matplotlib
+    matplotlib.use("Agg")
+    MATPLOTLIB_FLAG = True
+    mpl_logger = logging.getLogger('matplotlib')
+    mpl_logger.setLevel(logging.WARNING)
+  import matplotlib.pylab as plt
+  import numpy as np
+
+  fig, ax = plt.subplots(figsize=(6, 4))
+  im = ax.imshow(alignment.transpose(), aspect='auto', origin='lower',
+                  interpolation='none')
+  fig.colorbar(im, ax=ax)
+  xlabel = 'Decoder timestep'
+  if info is not None:
+      xlabel += '\n\n' + info
+  plt.xlabel(xlabel)
+  plt.ylabel('Encoder timestep')
+  plt.tight_layout()
+
+  fig.canvas.draw()
+  data = np.asarray(fig.canvas.buffer_rgba(), dtype=np.uint8)[..., :3].copy()
+  plt.close()
+  return data
+
+
+def load_wav_to_torch(full_path):
+  sampling_rate, data = read(full_path)
+  return torch.FloatTensor(data.astype(np.float32)), sampling_rate
+
+
+def load_filepaths_and_text(filename, split="|"):
+  with open(filename, encoding='utf-8') as f:
+    filepaths_and_text = [line.strip().split(split) for line in f]
+  return filepaths_and_text
+
+
+def get_hparams(init=True):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-c', '--config', type=str, default="./configs/base.json",
+                      help='JSON file for configuration')
+  parser.add_argument('-m', '--model', type=str, required=True,
+                      help='Model name')
+  
+  args = parser.parse_args()
+  model_dir = os.path.join("./logs", args.model)
+
+  if not os.path.exists(model_dir):
+    os.makedirs(model_dir)
+
+  config_path = args.config
+  config_save_path = os.path.join(model_dir, "config.json")
+  if init:
+    with open(config_path, "r") as f:
+      data = f.read()
+    with open(config_save_path, "w") as f:
+      f.write(data)
+  else:
+    with open(config_save_path, "r") as f:
+      data = f.read()
+  config = json.loads(data)
+  
+  hparams = HParams(**config)
+  hparams.model_dir = model_dir
+  return hparams
+
+
+def get_hparams_from_dir(model_dir):
+  config_save_path = os.path.join(model_dir, "config.json")
+  with open(config_save_path, "r") as f:
+    data = f.read()
+  config = json.loads(data)
+
+  hparams =HParams(**config)
+  hparams.model_dir = model_dir
+  return hparams
+
+
+def get_hparams_from_file(config_path):
+  with open(config_path, "r") as f:
+    data = f.read()
+  config = json.loads(data)
+
+  hparams =HParams(**config)
+  return hparams
+
+
+def check_git_hash(model_dir):
+  source_dir = os.path.dirname(os.path.realpath(__file__))
+  if not os.path.exists(os.path.join(source_dir, ".git")):
+    logger.warn("{} is not a git repository, therefore hash value comparison will be ignored.".format(
+      source_dir
+    ))
+    return
+
+  cur_hash = subprocess.getoutput("git rev-parse HEAD")
+
+  path = os.path.join(model_dir, "githash")
+  if os.path.exists(path):
+    saved_hash = open(path).read()
+    if saved_hash != cur_hash:
+      logger.warn("git hash values are different. {}(saved) != {}(current)".format(
+        saved_hash[:8], cur_hash[:8]))
+  else:
+    open(path, "w").write(cur_hash)
+
+
+def get_logger(model_dir, filename="train.log"):
+  global logger
+  logger = logging.getLogger(os.path.basename(model_dir))
+  logger.setLevel(logging.DEBUG)
+  
+  formatter = logging.Formatter("%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s")
+  if not os.path.exists(model_dir):
+    os.makedirs(model_dir)
+  h = logging.FileHandler(os.path.join(model_dir, filename))
+  h.setLevel(logging.DEBUG)
+  h.setFormatter(formatter)
+  logger.addHandler(h)
+  return logger
+
+
+class HParams():
+  def __init__(self, **kwargs):
+    for k, v in kwargs.items():
+      if type(v) == dict:
+        v = HParams(**v)
+      self[k] = v
+    
+  def keys(self):
+    return self.__dict__.keys()
+
+  def items(self):
+    return self.__dict__.items()
+
+  def values(self):
+    return self.__dict__.values()
+
+  def __len__(self):
+    return len(self.__dict__)
+
+  def __getitem__(self, key):
+    return getattr(self, key)
+
+  def __setitem__(self, key, value):
+    return setattr(self, key, value)
+
+  def __contains__(self, key):
+    return key in self.__dict__
+
+  def __repr__(self):
+    return self.__dict__.__repr__()

--- a/tests/test_vits_prior_split.py
+++ b/tests/test_vits_prior_split.py
@@ -1,0 +1,308 @@
+import numpy as np
+import pytest
+
+from phoonnx.engines import detect_engine
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.vits import VitsAdapter, VitsPriorSplitAdapter
+
+
+def _req(phoneme_ids=None, **params):
+    ids = phoneme_ids if phoneme_ids is not None else np.array([[1, 0, 2, 0, 3]], np.int64)
+    return AdapterSynthesisRequest(
+        phoneme_ids=ids,
+        phoneme_lengths=np.array([ids.shape[1]], np.int64),
+        speaker_id=0, language_id=0, params=params,
+    )
+
+
+class _Out:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeDurationSession:
+    """Stands in for Inflect's duration.onnx: records the feed dict and returns
+    a fixed-shape (m_p_exp, logs_p_exp, y_mask) triple."""
+
+    def __init__(self, frames=8, channels=4):
+        self.last_feed = None
+        self.frames = frames
+        self.channels = channels
+
+    def get_outputs(self):
+        return [_Out("m_p_exp"), _Out("logs_p_exp"), _Out("y_mask")]
+
+    def run(self, output_names, feed):
+        assert output_names == ["m_p_exp", "logs_p_exp", "y_mask"]
+        self.last_feed = feed
+        shape = (1, self.channels, self.frames)
+        m_p_exp = np.zeros(shape, np.float32)
+        logs_p_exp = np.zeros(shape, np.float32)
+        y_mask = np.ones((1, 1, self.frames), np.float32)
+        return [m_p_exp, logs_p_exp, y_mask]
+
+
+class _FakeDecodeSession:
+    """Stands in for Inflect's decode.onnx."""
+
+    def __init__(self):
+        self.last_feed = None
+
+    def run(self, output_names, feed):
+        assert output_names == ["waveform"]
+        self.last_feed = feed
+        frames = feed["m_p_exp"].shape[-1]
+        wav = (feed["zp_noise"].reshape(-1)[:frames] * 0.5).astype(np.float32)
+        return [wav.reshape(1, 1, -1)]
+
+
+def _configured_adapter(decode_session=None):
+    adapter = VitsPriorSplitAdapter()
+    adapter.decode = decode_session or _FakeDecodeSession()
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# registration / detect
+# ---------------------------------------------------------------------------
+
+def test_vits_prior_split_registered():
+    from phoonnx.engines import list_engines
+    assert "vits_prior_split" in list_engines()
+
+
+def test_vits_prior_split_detect_by_output_signature_and_decode_path():
+    config = {"engine_params": {"decode_path": "decode.onnx"}}
+    assert VitsPriorSplitAdapter.detect(config, _FakeDurationSession())
+
+
+def test_vits_prior_split_detect_requires_decode_path():
+    assert not VitsPriorSplitAdapter.detect({"engine_params": {}}, _FakeDurationSession())
+    assert not VitsPriorSplitAdapter.detect(None, _FakeDurationSession())
+
+
+def test_vits_prior_split_detect_requires_matching_output_signature():
+    class _PlainVitsSession:
+        def get_outputs(self):
+            return [_Out("output")]
+
+    config = {"engine_params": {"decode_path": "decode.onnx"}}
+    assert not VitsPriorSplitAdapter.detect(config, _PlainVitsSession())
+
+
+def test_vits_prior_split_detect_requires_a_session():
+    config = {"engine_params": {"decode_path": "decode.onnx"}}
+    assert not VitsPriorSplitAdapter.detect(config, None)
+
+
+def test_vits_prior_split_does_not_steal_plain_vits():
+    # A plain single-graph VITS config has no decode_path at all.
+    assert not VitsPriorSplitAdapter.detect({"engine": "vits"}, _FakeDurationSession())
+
+
+# ---------------------------------------------------------------------------
+# configure()
+# ---------------------------------------------------------------------------
+
+def test_vits_prior_split_configure_loads_decode_graph(monkeypatch):
+    calls = {}
+
+    def _fake_make_session(path, providers=None):
+        calls["path"] = path
+        calls["providers"] = providers
+        return _FakeDecodeSession()
+
+    monkeypatch.setattr("phoonnx.engines.vits.make_session", _fake_make_session)
+
+    class _VoiceConfig:
+        engine_params = {"decode_path": "/tmp/decode.onnx", "providers": ["CPUExecutionProvider"]}
+
+    adapter = VitsPriorSplitAdapter()
+    adapter.configure(_VoiceConfig())
+    assert adapter.decode is not None
+    assert calls["path"] == "/tmp/decode.onnx"
+
+    # a second configure() call must not clobber an already-loaded graph
+    adapter.configure(_VoiceConfig())
+    assert calls["path"] == "/tmp/decode.onnx"
+
+
+def test_vits_prior_split_configure_without_decode_path_is_noop():
+    class _VoiceConfig:
+        engine_params = {}
+
+    adapter = VitsPriorSplitAdapter()
+    adapter.configure(_VoiceConfig())
+    assert adapter.decode is None
+
+
+# ---------------------------------------------------------------------------
+# synthesize()
+# ---------------------------------------------------------------------------
+
+def test_vits_prior_split_synthesize_missing_decode_graph_raises():
+    adapter = VitsPriorSplitAdapter()
+    with pytest.raises(RuntimeError):
+        adapter.synthesize(_req(), _FakeDurationSession())
+
+
+def test_vits_prior_split_synthesize_basic():
+    adapter = _configured_adapter()
+    duration = _FakeDurationSession()
+    result = adapter.synthesize(_req(), duration)
+
+    assert result.audio.ndim == 1
+    assert result.audio.dtype == np.float32
+    assert result.audio.size > 0
+    assert "tokens" in duration.last_feed
+    assert "lengths" in duration.last_feed
+    assert "length_scale" in duration.last_feed
+    np.testing.assert_array_equal(duration.last_feed["tokens"], _req().phoneme_ids)
+
+
+def test_vits_prior_split_length_scale_follows_vits_convention():
+    # Same convention as the single-graph VitsAdapter: length_scale > 1 = slower.
+    adapter = _configured_adapter()
+    duration = _FakeDurationSession()
+    adapter.synthesize(_req(length_scale=2.0), duration)
+    assert float(duration.last_feed["length_scale"]) == pytest.approx(2.0)
+
+
+def test_vits_prior_split_noise_scale_maps_to_decode_noise_scale():
+    decode = _FakeDecodeSession()
+    adapter = _configured_adapter(decode)
+    adapter.synthesize(_req(noise_scale=0.1), _FakeDurationSession())
+    assert float(decode.last_feed["noise_scale"]) == pytest.approx(0.1)
+
+
+def test_vits_prior_split_seed_is_deterministic():
+    decode1 = _FakeDecodeSession()
+    adapter1 = _configured_adapter(decode1)
+    audio1 = adapter1.synthesize(_req(seed=42), _FakeDurationSession()).audio
+
+    decode2 = _FakeDecodeSession()
+    adapter2 = _configured_adapter(decode2)
+    audio2 = adapter2.synthesize(_req(seed=42), _FakeDurationSession()).audio
+
+    np.testing.assert_array_equal(audio1, audio2)
+
+
+def test_vits_prior_split_different_seeds_differ():
+    decode1 = _FakeDecodeSession()
+    adapter1 = _configured_adapter(decode1)
+    audio1 = adapter1.synthesize(_req(seed=1), _FakeDurationSession()).audio
+
+    decode2 = _FakeDecodeSession()
+    adapter2 = _configured_adapter(decode2)
+    audio2 = adapter2.synthesize(_req(seed=2), _FakeDurationSession()).audio
+
+    assert not np.array_equal(audio1, audio2)
+
+
+def test_vits_prior_split_build_feed_dict_not_implemented():
+    adapter = VitsPriorSplitAdapter()
+    with pytest.raises(NotImplementedError):
+        adapter.build_feed_dict(_req(), _FakeDurationSession())
+
+
+def test_vits_prior_split_parse_outputs_not_implemented():
+    adapter = VitsPriorSplitAdapter()
+    with pytest.raises(NotImplementedError):
+        adapter.parse_outputs([], _req())
+
+
+def test_vits_prior_split_default_params_include_seed():
+    adapter = VitsPriorSplitAdapter()
+    defaults = adapter.default_params()
+    assert defaults["seed"] == 0.0
+    assert "noise_scale" in defaults
+    assert "length_scale" in defaults
+
+
+# ---------------------------------------------------------------------------
+# adversarial: empty and long token sequences
+# ---------------------------------------------------------------------------
+
+def test_vits_prior_split_empty_phoneme_sequence_still_synthesizes():
+    adapter = _configured_adapter()
+    empty_ids = np.zeros((1, 0), np.int64)
+    result = adapter.synthesize(_req(phoneme_ids=empty_ids), _FakeDurationSession(frames=0))
+    assert result.audio.dtype == np.float32
+    assert result.audio.size == 0
+
+
+# ---------------------------------------------------------------------------
+# single-graph re-export path (scripts/conversion/inflect/export_inflect.py)
+#
+# The exporter traces SynthesizerTrn.infer() directly (noise sampled *inside*
+# the graph) rather than shipping upstream's official two-graph split, so a
+# re-exported Inflect voice is a plain single-graph VITS model loaded by the
+# ordinary VitsAdapter -- it must never be routed to VitsPriorSplitAdapter,
+# which requires a decode_path this graph doesn't have.
+# ---------------------------------------------------------------------------
+
+class _In:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeSingleGraphInflectSession:
+    """Stands in for a re-exported inflect-*-en.onnx: a plain single-graph
+    VITS export (piper/phoonnx style ``input``/``input_lengths``/``scales``
+    -> ``output``), the shape export_inflect.py produces."""
+
+    def __init__(self):
+        self.last_feed = None
+
+    def get_inputs(self):
+        return [_In("input"), _In("input_lengths"), _In("scales")]
+
+    def get_outputs(self):
+        return [_Out("output")]
+
+    def run(self, output_names, feed):
+        self.last_feed = feed
+        frames = feed["input"].shape[1] * 100
+        return [np.zeros((1, 1, frames), np.float32)]
+
+
+# The exporter's config is a piper-shaped config (phoneme_id_map +
+# phoneme_type), matching what voice_config_from_coqui-style tooling emits
+# elsewhere in the repo -- no ``engine_params.decode_path`` at all.
+_SINGLE_GRAPH_INFLECT_CONFIG = {
+    "phoneme_type": "espeak",
+    "alphabet": "ipa",
+    "phoneme_id_map": {"_": 0, "a": 1},
+}
+
+
+def test_single_graph_reexport_routes_to_plain_vits_adapter():
+    session = _FakeSingleGraphInflectSession()
+    adapter = detect_engine(config=_SINGLE_GRAPH_INFLECT_CONFIG, session=session)
+    assert isinstance(adapter, VitsAdapter)
+    assert not isinstance(adapter, VitsPriorSplitAdapter)
+
+
+def test_single_graph_reexport_prior_split_does_not_detect_it():
+    assert not VitsPriorSplitAdapter.detect(_SINGLE_GRAPH_INFLECT_CONFIG, _FakeSingleGraphInflectSession())
+
+
+def test_single_graph_reexport_synthesizes_via_plain_vits_adapter():
+    session = _FakeSingleGraphInflectSession()
+    adapter = VitsAdapter()
+    request = _req()
+    feed = adapter.build_feed_dict(request, session)
+    assert "input" in feed and "input_lengths" in feed and "scales" in feed
+    outputs = session.run(["output"], feed)
+    result = adapter.parse_outputs(outputs, request, output_names=["output"])
+    assert result.audio.dtype == np.float32
+    assert result.audio.size > 0
+
+
+def test_vits_prior_split_long_phoneme_sequence():
+    adapter = _configured_adapter()
+    long_ids = np.arange(1, 2001, dtype=np.int64).reshape(1, -1)
+    duration = _FakeDurationSession(frames=4000)
+    result = adapter.synthesize(_req(phoneme_ids=long_ids), duration)
+    assert duration.last_feed["tokens"].shape[1] == 2000
+    assert result.audio.size > 0


### PR DESCRIPTION
## What this is

[Inflect-v2](https://github.com/owenawsong/Inflect) (Apache-2.0) is a tiny
English TTS in two sizes — Micro (~9.36M params) and Nano (~3.97M params).
Architecturally it is a **plain VITS** checkpoint (`SynthesizerTrn`,
`use_sdp=False`, deterministic duration predictor) — the same architecture
phoonnx's `VitsAdapter` already handles for piper/coqui/MMS voices. No new
*engine* was added; this PR adds two ways to load Inflect-v2 through the
existing VITS family.

## Path 1 — load the official 2-graph ONNX export directly (`VitsPriorSplitAdapter`)

Inflect's own release
([owensong/Inflect-Micro-v2-ONNX](https://huggingface.co/owensong/Inflect-Micro-v2-ONNX) /
[...-Nano-v2-ONNX](https://huggingface.co/owensong/Inflect-Nano-v2-ONNX))
splits `SynthesizerTrn.infer` into two graphs for a seedable JS/WASM runtime:

```
duration.onnx : tokens, lengths, length_scale -> m_p_exp, logs_p_exp, y_mask
decode.onnx   : m_p_exp, logs_p_exp, y_mask, zp_noise, noise_scale -> waveform
```

This is a **different cut point** than the one `VitsStreamingAdapter` already
handles (that one cuts *after* the flow, at `z * y_mask`, for chunked
streaming decode). So `phoonnx/engines/vits.py` gains a second, minimal
subclass — `VitsPriorSplitAdapter(VitsAdapter)`, no new module/engine file —
that loads `duration.onnx` as the primary session and `decode.onnx` as an
auxiliary graph (`engine_params["decode_path"]`, the same mechanism
`zipvoice`/`matcha` use), samples `zp_noise` host-side with a seedable
`numpy.random.default_rng`, and feeds it through. Detection is purely
signature-based (`decode_path` present + duration graph's own output names
`m_p_exp`/`logs_p_exp`/`y_mask`) — no config `engine` tag needed, so this
never claims a plain single-graph VITS voice by accident.

## Path 2 — re-export to a single graph (`scripts/conversion/inflect/`)

For users who'd rather have one file: `export_inflect.py` traces
`SynthesizerTrn.infer()` itself (noise sampled *inside* the graph, exactly
like every other piper/coqui-VITS export phoonnx already loads) from the
upstream PyTorch checkpoint (`owensong/Inflect-Micro-v2` /
`owensong/Inflect-Nano-v2` — the checkpoint repos, not the `-ONNX` ones) into
the standard `input`/`input_lengths`/`scales` → `output` shape, so the
**unmodified** `VitsAdapter` loads it with zero new code. Kept as
documentation/alternative per the corrected scope, not the primary path.

## Controls / tokenization (both paths)

`noise_scale`/`length_scale`/`noise_w_scale` follow phoonnx's normal VITS
convention (`length_scale` > 1 = slower; `noise_w_scale` accepted but unused,
matching Inflect's non-stochastic duration predictor); `VitsPriorSplitAdapter`
additionally exposes `seed` (default 0) to seed the externally-sampled latent
noise. Text is phonemized with phoonnx's own `EspeakPhonemizer` (`en-us`, IPA
with stress marks, punctuation preserved) and tokenized character-by-character
with a blank interleaved between every character, via phoonnx's existing
`TTSTokenizer.intersperse_blank_char` — this reproduces Inflect's own
`phonemes_to_tokens` helper (`onnx/inference_onnx.py`) exactly.

## Smoke test (real checkpoints, both paths, not mocked)

Downloaded into the shared HF cache (`~/.cache/huggingface`) and run
end-to-end for the same sentence, `"A compact voice can still sound clear
and expressive."`:

| Path | Adapter | Duration | RMS | Peak |
| --- | --- | --- | --- | --- |
| Official 2-graph export (`owensong/Inflect-Micro-v2-ONNX`) | `VitsPriorSplitAdapter` (auto-detected) | 3.232 s | 0.09875 | 1.0 |
| Re-exported single graph (from `owensong/Inflect-Micro-v2`) | `VitsAdapter` (auto-detected, unmodified) | 3.232 s | 0.10149 | 1.0 |

Both produce real, non-silent 24kHz audio of matching duration and RMS
(the small RMS delta is expected: `VitsPriorSplitAdapter` reuses the exact
noise Inflect's own `numpy.random.default_rng(seed)` scheme draws, while the
re-export samples fresh noise inside the traced graph). Nano was also
exported and re-exported successfully (`forward OK -> audio (1, 1, 11776)`)
but not separately timed. `export_inflect.py` produced correct output for
both Micro and Nano. Unit tests: `tests/test_vits_prior_split.py` (17 cases,
including empty/long token sequences and clamped-parameter behavior) plus the
existing `test_vits_split.py`/`test_vits_streaming.py`/
`test_vits_audio_logging.py` (35 cases) still pass unchanged.

No generated `.onnx`/`.wav` files are included in this PR.

## Voice catalog

`phoonnx/voice_index/inflect.json` + `phoonnx/voice_index/configs/inflect-{micro,nano}-en.json`
point at the live mirror: [`OpenVoiceOS/phoonnx-vits`](https://huggingface.co/OpenVoiceOS/phoonnx-vits),
folders `hf_community__owensong__inflect-micro-v2-onnx/` and
`hf_community__owensong__inflect-nano-v2-onnx/` (`duration.onnx`, `decode.onnx`,
`duration.onnx.json` each), crediting upstream `owensong/Inflect-Micro-v2`/`-Nano-v2`
(Apache-2.0).

## Licensing

Inflect-v2 is Apache-2.0; the vendored runtime files in
`scripts/conversion/inflect/` are copied unmodified from Inflect's own
release and are themselves derived from `jaywalnut310/vits` (MIT) and
`keithito/tacotron` (MIT) per Inflect's own `THIRD_PARTY_NOTICES.md` — see
`scripts/conversion/NOTICE`.

## Model usage

This PR (research, design, and implementation) was carried out by
claude-sonnet under Fable orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
