### PR TITLE
feat: MOSS-TTS-Nano training + finetuning pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ how to obtain or train it, and a synthesis example:
 [Qwen3-TTS](training/engines/qwen3tts.md) ·
 [ArkTTS](training/engines/arktts.md) ·
 [F5-TTS](training/engines/f5tts.md) ·
+[MOSS-TTS-Nano](training/engines/mosstts.md) ·
 [Shami](training/engines/shami.md) ·
 [Pocket TTS](pockettts.md) ·
 [OuteTTS](training/engines/outetts.md) ·

--- a/docs/training/engines/mosstts.md
+++ b/docs/training/engines/mosstts.md
@@ -1,0 +1,158 @@
+# MOSS-TTS-Nano — training and finetuning
+
+MOSS-TTS-Nano is a ~100M-parameter autoregressive **codec LM**: a 12-layer GPT-2-style
+backbone with RoPE predicts frames of RVQ-16 audio tokens, which the frozen
+MOSS-Audio-Tokenizer-Nano decodes to 48 kHz stereo audio. It clones a voice zero-shot from
+a reference clip, with no speaker table and no transcript of the reference.
+
+The pipeline lives in `phoonnx_train/mosstts/` and is fully vendored: the architecture is
+implemented in-repo, no `transformers`, no `trust_remote_code`, no upstream package at
+runtime.
+
+## Which scheme this implements
+
+The MOSS-TTS technical report (arXiv:2603.18090) describes two ways to model the 16 RVQ
+channels. Nano uses the **global-local (RQ-Transformer) scheme**, and that is what this
+trainer implements:
+
+* the **global** transformer consumes one row of `1 + n_vq = 17` token ids per frame —
+  column 0 is a text or slot token, columns 1..16 are the codebook ids — sums their
+  embeddings, and emits one hidden state per frame;
+* a 1-layer **local** transformer then walks the `n_vq + 1 = 17` channels of that frame:
+  position 0 is the global hidden state, position 1 is the text target's embedding,
+  positions 2..16 are the embeddings of codebook channels 0..14. Its outputs feed
+  `text_lm_head` (position 0) and `audio_lm_heads[c]` (position `c + 1`).
+
+There is **no delay pattern**: channels stay time-aligned, and no per-codebook loss
+schedule is applied.
+
+## Data format
+
+Training consumes a JSONL where the audio has already been turned into codec tokens. The
+codec is frozen and never part of training — it runs exactly once, offline, through the
+published ONNX encode graph.
+
+```json
+{"audio": "wavs/0001.wav", "text": "Bom dia.", "language": "pt",
+ "ref_audio": "wavs/ref.wav",
+ "audio_codes": [[c0, ..., c15], ...],
+ "ref_audio_codes": [[c0, ..., c15], ...]}
+```
+
+`instruction`, `tokens`, `quality`, `sound_event`, `ambient_sound` and `language` are
+optional metadata lines of the chat template; anything missing renders as `None`.
+
+Build it from a manifest — either a JSONL with `audio` / `text`, or an LJSpeech-style
+`metadata.csv` plus `--wav-dir`:
+
+```bash
+python -m phoonnx_train.mosstts.prepare_data \
+  --codec-encode-onnx models/moss_audio_tokenizer_encode.onnx \
+  --input-manifest data/metadata.csv --wav-dir data/wavs \
+  --output-jsonl data/train.codes.jsonl
+```
+
+Audio is resampled to 48 kHz and duplicated to stereo automatically. `--n-vq N` keeps only
+the first `N` codebook layers, for models configured with a narrower stack.
+
+Each record is packed into a `[T, 17]` row matrix — instruction prefix, optional reference
+frames (user slot), text, assistant prefix, then the target frames (assistant slot) and a
+closing `audio_end`. Labels are that matrix shifted left by one, with everything before the
+assistant turn masked to `-100`, so the loss only sees the audio the model must generate.
+
+## Finetuning from the released weights
+
+```bash
+python -m phoonnx_train.mosstts.train \
+  --train-jsonl data/train.codes.jsonl \
+  --tokenizer-model models/MOSS-TTS-Nano/tokenizer.model \
+  --config models/MOSS-TTS-Nano/config.json \
+  --warm-start-from models/MOSS-TTS-Nano \
+  --output-dir runs/moss-pt \
+  --max-steps 20000 --batch-size 1 --max-length 1024
+```
+
+`--warm-start-from` accepts an upstream checkpoint directory (`config.json` +
+`pytorch_model.bin` or `model.safetensors`), a single weights file, or a previous phoonnx
+`.ckpt`. Weights are copied through an explicit key mapping and the matched-parameter
+fraction is logged:
+
+```
+warm start: .../pytorch_model.bin: matched 194 tensors / 142,477,056 of 142,477,056
+parameters (100.00%), missing=0 unexpected=0 shape_mismatch=0
+```
+
+Anything below 100% means part of the model is still at its random initialisation — treat
+it as a failure, not a warning.
+
+To check coverage without training:
+
+```bash
+python -m phoonnx_train.mosstts.warmstart --checkpoint models/MOSS-TTS-Nano
+```
+
+## Resuming
+
+`--warm-start-from` copies weights only; the optimizer and LR schedule start fresh. To
+continue an interrupted run *exactly* — optimizer moments, scheduler position and global
+step included — use `--resume-from`:
+
+```bash
+python -m phoonnx_train.mosstts.train ... --resume-from runs/moss-pt/last.ckpt
+```
+
+The two flags are mutually exclusive.
+
+## Objective and defaults
+
+Loss is the weighted mean of per-head cross-entropies:
+`sum(w_i * CE_i) / sum(w_i)` over the text head and the 16 audio heads, all teacher-forced
+through the local transformer. `--channelwise-loss-weight` accepts either 17 explicit
+weights or the shorthand `text,total_audio` — the default `1,32` gives the text head 1.0
+and splits 32 evenly across the 16 audio heads (2.0 each).
+
+Optimizer defaults match upstream: AdamW `lr=1e-5`, `betas=(0.9, 0.95)`, `eps=1e-8`,
+`weight_decay=0.1`, linear decay with a 3% warmup ratio, gradient-norm clip 1.0. Upstream
+measured ~3.23 GiB peak VRAM at batch size 1, sequence length 1024, bf16.
+
+`--prompt-style` selects the chat template. The default, `inference`, is the one the
+checkpoint's own `prompting.py` (and `phoonnx.engines.mosstts`) builds, including the
+`im_end` token that closes the user turn. `finetuning` reproduces upstream's
+`finetuning/dataset.py`, which omits that token — kept for bit-comparison with upstream
+runs, but it desynchronises the finetune from the prompt used at synthesis time.
+
+## Export
+
+```bash
+python -m phoonnx_train.mosstts.export_onnx \
+  --checkpoint runs/moss-pt/last.ckpt \
+  --output-dir exported/moss-pt \
+  --external-data \
+  --tokenizer-model models/MOSS-TTS-Nano/tokenizer.model
+```
+
+This writes the same multi-graph layout the runtime engine loads:
+
+| file | role |
+|---|---|
+| `moss_tts_prefill.onnx` | prompt rows → `global_hidden` + 12 present KV pairs |
+| `moss_tts_decode_step.onnx` | one row + past KV → `global_hidden` + present KV |
+| `moss_tts_local_fixed_sampled_frame.onnx` | `global_hidden` → `should_continue` + 16 sampled tokens (sampling baked in at the upstream defaults) |
+| `moss_tts_local_cached_step.onnx` | per-channel local step with its own KV cache, for host-side sampling |
+| `moss_tts_local_decoder.onnx` | whole-frame local pass with a teacher-forced audio prefix |
+| `tts_browser_onnx_meta.json` | file map, model geometry, baked sampling constants |
+
+`--external-data` de-duplicates the weights into `moss_tts_global_shared.data` and
+`moss_tts_local_shared.data`, as the released export does. Drop the flag for a small model
+where inlined weights are simpler.
+
+The exported graphs are validated against the live PyTorch module in
+`tests/test_mosstts_export.py`, including the full
+`prefill → local frame → decode_step` loop.
+
+## Licensing
+
+The upstream repository (github.com/OpenMOSS/MOSS-TTS-Nano) now carries an Apache-2.0
+`LICENSE` file at its root, matching the Hugging Face model cards. This pipeline is an
+independent implementation guided by the published architecture and the upstream reference
+code; no upstream source file is copied.

--- a/docs/training/training.md
+++ b/docs/training/training.md
@@ -119,6 +119,25 @@ python -m phoonnx_train.export_onnx last.ckpt \
 
 See the [ZipVoice guide](engines/zipvoice.md).
 
+## MOSS-TTS-Nano (standalone pipeline)
+
+MOSS-TTS-Nano is an autoregressive codec LM, so it does not consume the phoneme-based
+preprocessed dataset the `--engine` trainers share — it trains on pre-encoded RVQ tokens
+and raw text, from its own CLI in `phoonnx_train/mosstts/`:
+
+```bash
+python -m phoonnx_train.mosstts.prepare_data --codec-encode-onnx ... \
+  --input-manifest data/metadata.csv --output-jsonl data/train.codes.jsonl
+python -m phoonnx_train.mosstts.train --train-jsonl data/train.codes.jsonl \
+  --tokenizer-model tokenizer.model --warm-start-from models/MOSS-TTS-Nano \
+  --output-dir runs/moss-pt
+python -m phoonnx_train.mosstts.export_onnx --checkpoint runs/moss-pt/last.ckpt \
+  --output-dir exported/moss-pt --external-data
+```
+
+See the [MOSS-TTS-Nano guide](engines/mosstts.md) for the data format, warm-start, resume
+and export details.
+
 ## GlowTTS engine (`--engine glowtts`)
 
 Trains GlowTTS, a flow-based text→mel acoustic model with Monotonic Alignment Search, vendored

--- a/phoonnx_train/mosstts/__init__.py
+++ b/phoonnx_train/mosstts/__init__.py
@@ -1,0 +1,24 @@
+"""MOSS-TTS-Nano training / finetuning pipeline (vendored, self-contained).
+
+MOSS-TTS-Nano is a ~100M-parameter **global-local (RQ-Transformer) codec LM**: a
+12-layer GPT-2-style backbone with RoPE consumes rows of ``1 + n_vq`` tokens and emits
+one *global* hidden state per frame; a 1-layer *local* transformer then walks the
+``n_vq + 1`` channels of that frame autoregressively (text-continuation channel first,
+then the 16 RVQ codebooks) to produce the frame's tokens. See arXiv:2603.18090 for the
+architecture; this package implements it in-repo rather than depending on the upstream
+package, so phoonnx never needs ``trust_remote_code`` or the upstream repo at runtime.
+
+Modules
+-------
+``config``       vendored configuration dataclasses (mirrors the upstream ``config.json``)
+``model``        the vendored backbone + local transformer
+``dataset``      JSONL of pre-encoded RVQ codes -> packed ``[T, n_vq + 1]`` rows
+``lightning``    :class:`~pytorch_lightning.LightningModule` wrapper (loss, optim, sched)
+``prepare_data`` CLI: audio manifest -> JSONL with codes from the frozen ONNX codec
+``warmstart``    explicit state-dict mapping from the upstream safetensors checkpoint
+``export_onnx``  checkpoint -> the multi-graph ONNX layout ``phoonnx.engines.mosstts`` uses
+"""
+
+from phoonnx_train.mosstts.config import GPT2DecoderConfig, MossTTSNanoConfig
+
+__all__ = ["GPT2DecoderConfig", "MossTTSNanoConfig"]

--- a/phoonnx_train/mosstts/config.py
+++ b/phoonnx_train/mosstts/config.py
@@ -1,0 +1,245 @@
+"""Configuration classes for the vendored MOSS-TTS-Nano trainer.
+
+These mirror the fields of the upstream ``config.json`` (``model_type:
+moss_tts_nano``) so :mod:`phoonnx_train.mosstts.warmstart` can load an upstream
+checkpoint without ``transformers`` or ``trust_remote_code``. Only the fields the
+vendored model actually reads are kept; everything else in the upstream JSON is
+``transformers`` boilerplate.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+# The GPT-2 knobs the vendored decoder honours. Anything else in the upstream
+# ``gpt2_config`` block is transformers plumbing and is dropped on load.
+_GPT2_FIELDS = (
+    "vocab_size",
+    "n_positions",
+    "n_embd",
+    "n_layer",
+    "n_head",
+    "n_inner",
+    "activation_function",
+    "resid_pdrop",
+    "embd_pdrop",
+    "attn_pdrop",
+    "layer_norm_epsilon",
+    "initializer_range",
+    "scale_attn_weights",
+    "scale_attn_by_inverse_layer_idx",
+    "position_embedding_type",
+    "rope_base",
+    "pad_token_id",
+)
+
+
+@dataclass
+class GPT2DecoderConfig:
+    """GPT-2 decoder geometry. MOSS-TTS-Nano uses RoPE instead of learned positions."""
+
+    vocab_size: int = 16384
+    n_positions: int = 32768
+    n_embd: int = 768
+    n_layer: int = 12
+    n_head: int = 12
+    n_inner: Optional[int] = 3072
+    activation_function: str = "gelu_new"
+    resid_pdrop: float = 0.0
+    embd_pdrop: float = 0.0
+    attn_pdrop: float = 0.0
+    layer_norm_epsilon: float = 1e-5
+    initializer_range: float = 0.02
+    scale_attn_weights: bool = True
+    scale_attn_by_inverse_layer_idx: bool = False
+    position_embedding_type: str = "rope"
+    rope_base: float = 10000.0
+    pad_token_id: int = 3
+
+    def __post_init__(self) -> None:
+        if self.n_embd % self.n_head != 0:
+            raise ValueError(f"n_embd={self.n_embd} must be divisible by n_head={self.n_head}")
+        if self.position_embedding_type not in {"absolute", "rope"}:
+            raise ValueError(f"unsupported position_embedding_type={self.position_embedding_type!r}")
+        if self.activation_function not in {"gelu_new", "gelu", "relu", "silu"}:
+            raise ValueError(f"unsupported activation_function={self.activation_function!r}")
+
+    @property
+    def hidden_size(self) -> int:
+        return int(self.n_embd)
+
+    @property
+    def num_attention_heads(self) -> int:
+        return int(self.n_head)
+
+    @property
+    def head_dim(self) -> int:
+        return int(self.n_embd) // int(self.n_head)
+
+    @property
+    def inner_size(self) -> int:
+        return int(self.n_inner or 4 * self.n_embd)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "GPT2DecoderConfig":
+        return cls(**{k: v for k, v in payload.items() if k in _GPT2_FIELDS})
+
+
+@dataclass
+class MossTTSNanoConfig:
+    """Full MOSS-TTS-Nano configuration (global backbone + local transformer).
+
+    ``audio_pad_token_id`` deliberately sits *outside* every codebook: a text row
+    carries it in all ``n_vq`` audio columns and the model masks those embeddings out.
+    """
+
+    gpt2: GPT2DecoderConfig = field(default_factory=GPT2DecoderConfig)
+    n_vq: int = 16
+    audio_codebook_sizes: List[int] = field(default_factory=lambda: [1024] * 16)
+    audio_pad_token_id: int = 1024
+    pad_token_id: int = 3
+    im_start_token_id: int = 4
+    im_end_token_id: int = 5
+    audio_start_token_id: int = 6
+    audio_end_token_id: int = 7
+    audio_user_slot_token_id: int = 8
+    audio_assistant_slot_token_id: int = 9
+    local_transformer_layers: int = 1
+    initializer_range: float = 0.02
+    audio_tokenizer_sample_rate: int = 48000
+    audio_tokenizer_downsample_rate: int = 3840
+    audio_tokenizer_channels: int = 2
+    attn_implementation: str = "sdpa"
+    local_transformer_attn_implementation: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.gpt2, dict):
+            self.gpt2 = GPT2DecoderConfig.from_dict(self.gpt2)
+        self.n_vq = int(self.n_vq)
+        if self.n_vq <= 0:
+            raise ValueError("n_vq must be > 0")
+        self.audio_codebook_sizes = [int(size) for size in self.audio_codebook_sizes]
+        if len(self.audio_codebook_sizes) != self.n_vq:
+            raise ValueError(
+                f"audio_codebook_sizes must have length n_vq={self.n_vq}, "
+                f"got {len(self.audio_codebook_sizes)}"
+            )
+        if any(size <= 0 for size in self.audio_codebook_sizes):
+            raise ValueError("audio_codebook_sizes must be positive")
+        if self.audio_pad_token_id < max(self.audio_codebook_sizes):
+            raise ValueError(
+                "audio_pad_token_id must be >= max(audio_codebook_sizes) so pad stays "
+                f"outside every codebook (got {self.audio_pad_token_id})"
+            )
+        if self.local_transformer_layers <= 0:
+            raise ValueError("local_transformer_layers must be > 0")
+        if self.local_transformer_attn_implementation is None:
+            self.local_transformer_attn_implementation = self.attn_implementation
+
+    # ------------------------------------------------------------------
+    @property
+    def hidden_size(self) -> int:
+        return self.gpt2.hidden_size
+
+    @property
+    def row_width(self) -> int:
+        """Width of one input row: the text/slot column plus ``n_vq`` codebook columns."""
+        return self.n_vq + 1
+
+    @property
+    def frames_per_second(self) -> float:
+        return self.audio_tokenizer_sample_rate / float(self.audio_tokenizer_downsample_rate)
+
+    def local_gpt2(self) -> GPT2DecoderConfig:
+        """Geometry of the local transformer: same width, ``local_transformer_layers`` deep."""
+        payload = asdict(self.gpt2)
+        payload["n_layer"] = int(self.local_transformer_layers)
+        payload["n_positions"] = self.row_width
+        return GPT2DecoderConfig.from_dict(payload)
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["gpt2"] = asdict(self.gpt2)
+        return payload
+
+    def save_json(self, path: Union[str, Path]) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        return path
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "MossTTSNanoConfig":
+        payload = dict(payload)
+        gpt2_payload = payload.pop("gpt2", None) or payload.pop("gpt2_config", None) or {}
+        known = {f for f in cls.__dataclass_fields__ if f != "gpt2"}
+        kwargs = {k: v for k, v in payload.items() if k in known}
+        return cls(gpt2=GPT2DecoderConfig.from_dict(gpt2_payload), **kwargs)
+
+    @classmethod
+    def from_json_file(cls, path: Union[str, Path]) -> "MossTTSNanoConfig":
+        """Load either a vendored config or an upstream HF ``config.json``."""
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        model_type = payload.get("model_type")
+        if model_type is not None and model_type != "moss_tts_nano":
+            raise ValueError(f"expected model_type='moss_tts_nano', got {model_type!r}")
+        architecture = payload.get("model_architecture")
+        if architecture is not None and architecture != "global_local_transformer":
+            raise ValueError(
+                "this trainer only implements the global-local (RQ-Transformer) scheme, "
+                f"but the checkpoint declares model_architecture={architecture!r}"
+            )
+        return cls.from_dict(payload)
+
+    @classmethod
+    def from_pretrained_dir(cls, path: Union[str, Path]) -> "MossTTSNanoConfig":
+        return cls.from_json_file(Path(path) / "config.json")
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def tiny(n_vq: int = 4, codebook_size: int = 32, vocab_size: int = 64) -> "MossTTSNanoConfig":
+        """A few-thousand-parameter config for tests and smoke runs."""
+        return MossTTSNanoConfig(
+            gpt2=GPT2DecoderConfig(
+                vocab_size=vocab_size,
+                n_positions=256,
+                n_embd=16,
+                n_layer=2,
+                n_head=2,
+                n_inner=32,
+            ),
+            n_vq=n_vq,
+            audio_codebook_sizes=[codebook_size] * n_vq,
+            audio_pad_token_id=codebook_size,
+            local_transformer_layers=1,
+            attn_implementation="eager",
+        )
+
+
+@dataclass
+class TrainingConfig:
+    """Optimizer / scheduler defaults, taken from upstream ``finetuning/sft.py``."""
+
+    learning_rate: float = 1e-5
+    weight_decay: float = 0.1
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.95
+    adam_eps: float = 1e-8
+    warmup_steps: int = 0
+    warmup_ratio: float = 0.03
+    lr_scheduler_type: str = "linear"
+    max_grad_norm: float = 1.0
+    #: ``"1,32"`` in upstream shorthand: text head weight 1, total audio weight 32 split
+    #: evenly across the ``n_vq`` audio heads.
+    channelwise_loss_weight: str = "1,32"
+    max_length: int = 1024
+    batch_size: int = 1
+    gradient_accumulation_steps: int = 1
+    num_workers: int = 0
+    seed: int = 42
+
+
+__all__ = ["GPT2DecoderConfig", "MossTTSNanoConfig", "TrainingConfig"]

--- a/phoonnx_train/mosstts/dataset.py
+++ b/phoonnx_train/mosstts/dataset.py
@@ -1,0 +1,366 @@
+"""Dataset + collation for MOSS-TTS-Nano finetuning.
+
+Input is a JSONL produced by :mod:`phoonnx_train.mosstts.prepare_data`, one record per
+utterance::
+
+    {"audio": "wavs/0001.wav",          # informational after preprocessing
+     "text": "Bom dia.",
+     "language": "pt",                  # optional
+     "ref_audio": "wavs/ref.wav",       # optional
+     "audio_codes": [[c0, ..., c15], ...],       # [frames, n_vq], REQUIRED
+     "ref_audio_codes": [[c0, ..., c15], ...]}   # optional
+
+Audio never touches this module — the codec is frozen and runs once, offline. Each
+record is packed into a ``[T, n_vq + 1]`` row matrix:
+
+* text rows put a SentencePiece id in column 0 and ``audio_pad_token_id`` in the rest,
+* audio rows put a *slot* token in column 0 (user slot for the reference clip, assistant
+  slot for the target) and the frame's RVQ codes in columns ``1..n_vq``.
+
+Labels are the row matrix shifted left by one, with everything before the assistant turn
+masked to ``-100``, so the loss only sees the audio the model is asked to generate (plus
+the ``audio_end`` token that terminates it).
+
+There is no delay pattern: MOSS-TTS-Nano predicts a whole frame per timestep through its
+local transformer, so channels stay time-aligned (see :mod:`phoonnx_train.mosstts.model`).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
+
+import torch
+from torch.utils.data import Dataset
+
+from phoonnx_train.mosstts.config import MossTTSNanoConfig
+
+# The chat template MOSS-TTS-Nano was pretrained with (upstream ``prompting.py``).
+USER_ROLE_PREFIX = "user\n"
+USER_TEMPLATE_REFERENCE_PREFIX = "<user_inst>\n- Reference(s):\n"
+USER_TEMPLATE_SUFFIX = "\n</user_inst>"
+ASSISTANT_TURN_PREFIX = "\n"
+ASSISTANT_ROLE_PREFIX = "assistant\n"
+
+#: Optional metadata lines, in the order the template expects them.
+OPTIONAL_MESSAGE_FIELDS = (
+    ("instruction", "Instruction"),
+    ("tokens", "Tokens"),
+    ("quality", "Quality"),
+    ("sound_event", "Sound Event"),
+    ("ambient_sound", "Ambient Sound"),
+    ("language", "Language"),
+)
+
+IGNORE_INDEX = -100
+
+
+class SentencePieceTextTokenizer:
+    """Thin wrapper over the checkpoint's ``tokenizer.model``.
+
+    Upstream wraps the same SentencePiece model in a ``PreTrainedTokenizer`` subclass;
+    nothing in the training path needs that, and avoiding it keeps ``transformers`` out
+    of phoonnx's dependency set.
+    """
+
+    def __init__(self, model_file: Union[str, Path]) -> None:
+        import sentencepiece as spm
+
+        self.model_file = str(model_file)
+        self.sp = spm.SentencePieceProcessor(model_file=self.model_file)
+
+    def encode(self, text: str) -> List[int]:
+        return [int(token) for token in self.sp.encode(text, out_type=int)]
+
+    def decode(self, token_ids: Sequence[int]) -> str:
+        return str(self.sp.decode([int(token) for token in token_ids]))
+
+    @property
+    def vocab_size(self) -> int:
+        return int(self.sp.get_piece_size())
+
+
+def load_jsonl(path: Union[str, Path]) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number} is not valid JSON") from exc
+    return records
+
+
+def dump_jsonl(records: Iterable[Dict[str, Any]], path: Union[str, Path]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False))
+            handle.write("\n")
+    return path
+
+
+def _as_code_matrix(value: Any, field_name: str) -> torch.Tensor:
+    tensor = torch.as_tensor(value, dtype=torch.long)
+    if tensor.ndim != 2:
+        raise ValueError(f"`{field_name}` must have shape [frames, n_vq], got {tuple(tensor.shape)}")
+    return tensor.cpu().contiguous()
+
+
+class MossTTSNanoDataset(Dataset):
+    """Pre-encoded JSONL -> packed rows, ready for :class:`MossTTSNanoCollator`."""
+
+    def __init__(
+        self,
+        records: Iterable[Dict[str, Any]],
+        tokenizer: SentencePieceTextTokenizer,
+        config: MossTTSNanoConfig,
+        max_length: int = 1024,
+        prompt_style: str = "inference",
+    ) -> None:
+        self.records = list(records)
+        self.tokenizer = tokenizer
+        self.config = config
+        self.max_length = int(max_length)
+        if prompt_style not in {"inference", "finetuning"}:
+            raise ValueError(f"prompt_style must be 'inference' or 'finetuning', got {prompt_style!r}")
+        self.prompt_style = prompt_style
+        if self.max_length < 8:
+            raise ValueError("max_length must be >= 8")
+        if not self.records:
+            raise ValueError("dataset is empty")
+
+    @classmethod
+    def from_jsonl(
+        cls,
+        paths: Union[str, Path, Sequence[Union[str, Path]]],
+        tokenizer: SentencePieceTextTokenizer,
+        config: MossTTSNanoConfig,
+        max_length: int = 1024,
+        prompt_style: str = "inference",
+    ) -> "MossTTSNanoDataset":
+        if isinstance(paths, (str, Path)):
+            paths = [paths]
+        records: List[Dict[str, Any]] = []
+        for path in paths:
+            records.extend(load_jsonl(path))
+        return cls(
+            records,
+            tokenizer=tokenizer,
+            config=config,
+            max_length=max_length,
+            prompt_style=prompt_style,
+        )
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __getitem__(self, index: int) -> Dict[str, torch.Tensor]:
+        return self.build_example(self.records[index], index=index)
+
+    # ------------------------------------------------------------------
+    # row builders
+    # ------------------------------------------------------------------
+    def text_rows(self, token_ids: Sequence[int]) -> torch.Tensor:
+        rows = torch.full(
+            (len(token_ids), self.config.row_width),
+            int(self.config.audio_pad_token_id),
+            dtype=torch.long,
+        )
+        if len(token_ids):
+            rows[:, 0] = torch.as_tensor(list(token_ids), dtype=torch.long)
+        return rows
+
+    def audio_rows(self, codes: torch.Tensor, slot_token_id: int) -> torch.Tensor:
+        rows = torch.full(
+            (int(codes.shape[0]), self.config.row_width),
+            int(self.config.audio_pad_token_id),
+            dtype=torch.long,
+        )
+        if rows.shape[0]:
+            rows[:, 0] = int(slot_token_id)
+            rows[:, 1:] = codes
+        return rows
+
+    def _pad_codes_to_width(self, codes: torch.Tensor, field_name: str, index: int) -> torch.Tensor:
+        target = self.config.n_vq
+        source = int(codes.shape[1])
+        if source > target:
+            raise ValueError(
+                f"record {index}: `{field_name}` has n_vq={source}, model expects at most {target}"
+            )
+        if source == target:
+            return codes
+        padded = torch.full(
+            (int(codes.shape[0]), target), int(self.config.audio_pad_token_id), dtype=torch.long
+        )
+        if source:
+            padded[:, :source] = codes
+        return padded
+
+    def _metadata_suffix(self, record: Dict[str, Any]) -> str:
+        lines = [""]
+        for field_name, display_name in OPTIONAL_MESSAGE_FIELDS:
+            value = record.get(field_name)
+            lines.append(f"- {display_name}:")
+            lines.append("None" if value in (None, "") else str(value))
+        lines.append("- Text:")
+        lines.append(str(record["text"]))
+        return "\n".join(lines)
+
+    def build_prompt_rows(
+        self,
+        record: Dict[str, Any],
+        reference_codes: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Everything before the target audio: instruction, optional reference, text.
+
+        .. note::
+
+           This follows the checkpoint's own ``prompting.py`` — including the
+           ``im_end`` token that closes the user turn. Upstream's ``finetuning/dataset.py``
+           drops that token, which silently desynchronises finetunes from the prompt the
+           inference path (and :class:`phoonnx.engines.mosstts.MossTTSNanoAdapter`)
+           actually builds. Pass ``prompt_style="finetuning"`` to reproduce the upstream
+           finetuning variant instead.
+        """
+        encode = self.tokenizer.encode
+        cfg = self.config
+        sections = [
+            self.text_rows(
+                [cfg.im_start_token_id]
+                + encode(USER_ROLE_PREFIX)
+                + encode(USER_TEMPLATE_REFERENCE_PREFIX)
+            )
+        ]
+        suffix_text = self._metadata_suffix(record)
+
+        if reference_codes is None:
+            sections.append(self.text_rows(encode("None" + suffix_text)))
+        else:
+            sections.append(self.text_rows([cfg.audio_start_token_id]))
+            sections.append(self.audio_rows(reference_codes, cfg.audio_user_slot_token_id))
+            sections.append(
+                self.text_rows([cfg.audio_end_token_id] + encode(suffix_text))
+            )
+
+        assistant_prefix = encode(USER_TEMPLATE_SUFFIX)
+        if self.prompt_style == "inference":
+            assistant_prefix = assistant_prefix + [cfg.im_end_token_id]
+        assistant_prefix = (
+            assistant_prefix
+            + encode(ASSISTANT_TURN_PREFIX)
+            + [cfg.im_start_token_id]
+            + encode(ASSISTANT_ROLE_PREFIX)
+            + [cfg.audio_start_token_id]
+        )
+        sections.append(self.text_rows(assistant_prefix))
+        return torch.cat(sections, dim=0)
+
+    # ------------------------------------------------------------------
+    def build_example(self, record: Dict[str, Any], index: int = 0) -> Dict[str, torch.Tensor]:
+        if "text" not in record or not str(record["text"]).strip():
+            raise ValueError(f"record {index} has no non-empty `text`")
+        if record.get("audio_codes") is None:
+            raise ValueError(f"record {index} has no `audio_codes` — run prepare_data.py first")
+
+        target_codes = self._pad_codes_to_width(
+            _as_code_matrix(record["audio_codes"], "audio_codes"), "audio_codes", index
+        )
+        if target_codes.shape[0] == 0:
+            raise ValueError(f"record {index} has zero audio frames")
+
+        reference_codes = None
+        if record.get("ref_audio_codes") is not None:
+            reference_codes = self._pad_codes_to_width(
+                _as_code_matrix(record["ref_audio_codes"], "ref_audio_codes"), "ref_audio_codes", index
+            )
+        elif record.get("ref_audio") is not None:
+            raise ValueError(
+                f"record {index} has `ref_audio` but no `ref_audio_codes` — run prepare_data.py "
+                "first so training never touches the codec"
+            )
+
+        prompt_rows = self.build_prompt_rows(record, reference_codes)
+        target_rows = self.audio_rows(target_codes, self.config.audio_assistant_slot_token_id)
+        end_rows = self.text_rows([self.config.audio_end_token_id])
+        rows = torch.cat([prompt_rows, target_rows, end_rows], dim=0)
+
+        prompt_length = int(prompt_rows.shape[0])
+        if prompt_length >= self.max_length:
+            raise ValueError(
+                f"record {index}: prompt length {prompt_length} >= max_length {self.max_length}; "
+                "raise --max-length or shorten the text / reference clip"
+            )
+        if rows.shape[0] > self.max_length:
+            rows = rows[: self.max_length]
+        if rows.shape[0] < 2:
+            raise ValueError(f"record {index}: packed sequence is too short ({rows.shape[0]})")
+
+        return {
+            "rows": rows,
+            "seq_len": torch.tensor(int(rows.shape[0]), dtype=torch.long),
+            "prompt_length": torch.tensor(prompt_length, dtype=torch.long),
+        }
+
+
+class MossTTSNanoCollator:
+    """Pad a batch of packed row matrices and build shifted, masked labels.
+
+    Sequences are padded to the batch maximum rather than to ``max_length``; the
+    attention mask makes this exactly equivalent to upstream's fixed-length padding while
+    avoiding the wasted compute on short batches.
+    """
+
+    def __init__(self, config: MossTTSNanoConfig) -> None:
+        self.config = config
+
+    def __call__(self, batch: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+        if not batch:
+            raise ValueError("empty batch")
+        batch_size = len(batch)
+        total_length = max(int(item["seq_len"]) for item in batch)
+        if total_length < 2:
+            raise ValueError("every sequence in the batch is shorter than 2 rows")
+        width = self.config.row_width
+
+        rows = torch.full((batch_size, total_length, width), int(self.config.audio_pad_token_id), dtype=torch.long)
+        rows[:, :, 0] = int(self.config.pad_token_id)
+        mask = torch.zeros((batch_size, total_length), dtype=torch.bool)
+        loss_mask = torch.zeros((batch_size, total_length - 1), dtype=torch.bool)
+
+        for batch_index, item in enumerate(batch):
+            seq_len = int(item["seq_len"])
+            prompt_length = int(item["prompt_length"])
+            rows[batch_index, :seq_len, :] = item["rows"]
+            mask[batch_index, :seq_len] = True
+            # the row at prompt_length - 1 is the one that *predicts* the first audio frame
+            loss_mask[batch_index, prompt_length - 1 : seq_len - 1] = True
+
+        labels = rows[:, 1:, :].clone()
+        labels = labels.masked_fill(~loss_mask.unsqueeze(-1), IGNORE_INDEX)
+        labels = labels.masked_fill(~mask[:, 1:].unsqueeze(-1), IGNORE_INDEX)
+        # padded audio columns of text rows are not targets
+        labels[:, :, 1:] = labels[:, :, 1:].masked_fill(
+            labels[:, :, 1:] == int(self.config.audio_pad_token_id), IGNORE_INDEX
+        )
+
+        return {
+            "input_ids": rows[:, :-1, :].contiguous(),
+            "attention_mask": mask[:, :-1].contiguous(),
+            "labels": labels.contiguous(),
+        }
+
+
+__all__ = [
+    "MossTTSNanoDataset",
+    "MossTTSNanoCollator",
+    "SentencePieceTextTokenizer",
+    "load_jsonl",
+    "dump_jsonl",
+    "IGNORE_INDEX",
+]

--- a/phoonnx_train/mosstts/export_onnx.py
+++ b/phoonnx_train/mosstts/export_onnx.py
@@ -1,0 +1,861 @@
+"""Export a trained MOSS-TTS-Nano checkpoint to the multi-graph ONNX layout.
+
+The layout is the one :class:`phoonnx.engines.mosstts.MossTTSNanoAdapter` consumes, and
+the one upstream's ``onnx/export_hf_to_tts_onnx.py`` produces:
+
+``moss_tts_prefill.onnx``
+    ``input_ids [B, S, n_vq+1] i32``, ``attention_mask [B, S] i32``
+    -> ``global_hidden [B, S, H]`` + ``present_key_i`` / ``present_value_i``
+``moss_tts_decode_step.onnx``
+    one row + ``past_valid_lengths`` + past KV -> ``global_hidden`` + present KV
+``moss_tts_local_decoder.onnx``
+    ``global_hidden``, ``text_token_id``, ``audio_prefix_token_ids`` -> all-channel logits
+``moss_tts_local_cached_step.onnx``
+    a single cached local step, so the host can sample with arbitrary parameters
+``moss_tts_local_fixed_sampled_frame.onnx``
+    a whole frame sampled in-graph at the upstream default temperature / top-p / top-k /
+    repetition penalty, driven by host-supplied uniform randoms
+
+The KV caches are ``[batch, seq, heads, head_dim]``, matching the adapter.
+
+The attention math is written out explicitly here rather than reusing
+:class:`~phoonnx_train.mosstts.model.MossAttention`, because the exported decode graphs
+mask by a scalar ``past_valid_lengths`` (a fixed-capacity cache with a valid prefix)
+instead of a boolean mask tensor. The weights are shared with the live module — nothing
+is copied — so the graphs stay in sync with training by construction.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import torch
+from torch import nn
+
+from phoonnx_train.mosstts.config import MossTTSNanoConfig
+from phoonnx_train.mosstts.model import MossDecoder, MossTTSNano
+
+_LOGGER = logging.getLogger("mosstts.export")
+
+# Sampling constants baked into moss_tts_local_fixed_sampled_frame.onnx (upstream defaults).
+FIXED_SAMPLED_TEXT_TEMPERATURE = 1.0
+FIXED_SAMPLED_TEXT_TOP_P = 1.0
+FIXED_SAMPLED_TEXT_TOP_K = 50
+FIXED_SAMPLED_AUDIO_TEMPERATURE = 0.8
+FIXED_SAMPLED_AUDIO_TOP_P = 0.95
+FIXED_SAMPLED_AUDIO_TOP_K = 25
+FIXED_SAMPLED_AUDIO_REPETITION_PENALTY = 1.2
+
+KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+
+def _flatten_kv(past_key_values: Iterable[KVCache]) -> Tuple[torch.Tensor, ...]:
+    flat: List[torch.Tensor] = []
+    for key, value in past_key_values:
+        flat.extend([key.to(torch.float32), value.to(torch.float32)])
+    return tuple(flat)
+
+
+def _rotate_half(hidden_states: torch.Tensor) -> torch.Tensor:
+    """Export-safe ``rotate_half``.
+
+    ``torch.stack(..., dim=-1)`` is mis-lowered by the legacy ONNX tracer (it emits a
+    Concat on the wrong axis, which silently breaks RoPE); an explicit unsqueeze + cat on
+    a positive axis is not.
+    """
+    neg_odd = (-hidden_states[..., 1::2]).unsqueeze(4)
+    even = hidden_states[..., ::2].unsqueeze(4)
+    return torch.cat((neg_odd, even), dim=4).reshape_as(hidden_states)
+
+
+def _apply_rope(hidden_states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    return (hidden_states * cos) + (_rotate_half(hidden_states) * sin)
+
+
+class ExportDecoderCore(nn.Module):
+    """Trace-friendly re-expression of :class:`~phoonnx_train.mosstts.model.MossDecoder`."""
+
+    def __init__(self, decoder: MossDecoder) -> None:
+        super().__init__()
+        self.decoder = decoder
+        self.hidden_size = decoder.config.hidden_size
+        self.num_heads = decoder.config.num_attention_heads
+        self.head_dim = decoder.config.head_dim
+
+    def _split_heads(self, tensor: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = tensor.shape
+        return tensor.view(batch_size, seq_len, self.num_heads, self.head_dim)
+
+    def _merge_heads(self, tensor: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len = tensor.shape[0], tensor.shape[1]
+        return tensor.reshape(batch_size, seq_len, self.hidden_size)
+
+    @staticmethod
+    def _positions_from_mask(attention_mask: torch.Tensor) -> torch.Tensor:
+        position_ids = attention_mask.to(torch.long).cumsum(dim=-1) - 1
+        return position_ids.masked_fill(~attention_mask, 0)
+
+    @staticmethod
+    def _scale(attn: nn.Module, head_dim: int) -> float:
+        scale = 1.0
+        if attn.scale_attn_weights:
+            scale /= math.sqrt(head_dim)
+        if attn.scale_attn_by_inverse_layer_idx:
+            scale /= float(attn.layer_idx + 1)
+        return scale
+
+    def _qkv(self, attn: nn.Module, hidden_states: torch.Tensor, position_ids: torch.Tensor):
+        query, key, value = attn.c_attn(hidden_states).split(self.hidden_size, dim=-1)
+        query = self._split_heads(query)
+        key = self._split_heads(key)
+        value = self._split_heads(value)
+        if attn.rotary_emb is not None:
+            cos, sin = attn.rotary_emb(position_ids.to(torch.long), dtype=query.dtype)
+            query = _apply_rope(query, cos, sin)
+            key = _apply_rope(key, cos, sin)
+        return query, key, value
+
+    def _finish(self, attn: nn.Module, probs: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+        attn_output = torch.matmul(probs, value.permute(0, 2, 1, 3)).permute(0, 2, 1, 3).contiguous()
+        return attn.resid_dropout(attn.c_proj(self._merge_heads(attn_output)))
+
+    # ------------------------------------------------------------------
+    def run_prefill(
+        self,
+        inputs_embeds: torch.Tensor,
+        attention_mask: torch.Tensor,
+        use_cache: bool = True,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[KVCache, ...]]]:
+        query_mask = attention_mask[:, -inputs_embeds.shape[1]:]
+        position_ids = self._positions_from_mask(attention_mask)[:, -inputs_embeds.shape[1]:]
+
+        hidden_states = inputs_embeds
+        if self.decoder.position_embedding_type == "absolute":
+            hidden_states = hidden_states + self.decoder.wpe(position_ids)
+        hidden_states = self.decoder.drop(hidden_states)
+        hidden_states = hidden_states * query_mask.unsqueeze(-1).to(hidden_states.dtype)
+
+        query_length = hidden_states.shape[1]
+        key_length = attention_mask.shape[1]
+        device = hidden_states.device
+        query_positions = torch.arange(query_length, device=device) + (key_length - query_length)
+        key_positions = torch.arange(key_length, device=device)
+        causal = (key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)).unsqueeze(0).unsqueeze(0)
+        mask = causal & attention_mask[:, None, None, :]
+
+        presents: List[KVCache] = []
+        for block in self.decoder.h:
+            normed = block.ln_1(hidden_states)
+            query, key, value = self._qkv(block.attn, normed, position_ids)
+            if use_cache:
+                presents.append((key, value))
+            scores = torch.matmul(
+                query.permute(0, 2, 1, 3), key.permute(0, 2, 1, 3).transpose(2, 3)
+            )
+            scores = scores * self._scale(block.attn, self.head_dim)
+            scores = scores.masked_fill(~mask, torch.finfo(scores.dtype).min)
+            # positive axis: the tracer mis-lowers a negative softmax axis here
+            attn_output = self._finish(block.attn, torch.softmax(scores, dim=3), value)
+            hidden_states = hidden_states + attn_output
+            hidden_states = hidden_states + block.mlp(block.ln_2(hidden_states))
+            hidden_states = hidden_states * query_mask.unsqueeze(-1).to(hidden_states.dtype)
+
+        hidden_states = self.decoder.ln_f(hidden_states)
+        hidden_states = hidden_states * query_mask.unsqueeze(-1).to(hidden_states.dtype)
+        return hidden_states, (tuple(presents) if use_cache else None)
+
+    def run_decode_step(
+        self,
+        inputs_embeds: torch.Tensor,
+        past_valid_lengths: torch.Tensor,
+        past_key_values: Optional[Tuple[KVCache, ...]],
+        use_cache: bool = True,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[KVCache, ...]]]:
+        """One row against a fixed-capacity cache whose valid prefix is ``past_valid_lengths``."""
+        query_position_ids = past_valid_lengths.to(torch.long).unsqueeze(1)
+        hidden_states = inputs_embeds
+        if self.decoder.position_embedding_type == "absolute":
+            hidden_states = hidden_states + self.decoder.wpe(query_position_ids)
+        hidden_states = self.decoder.drop(hidden_states)
+        batch_size = hidden_states.shape[0]
+
+        presents: List[KVCache] = []
+        for layer_index, block in enumerate(self.decoder.h):
+            normed = block.ln_1(hidden_states)
+            query, key, value = self._qkv(block.attn, normed, query_position_ids)
+            if past_key_values is not None:
+                past_key, past_value = past_key_values[layer_index]
+                key = torch.cat([past_key.to(key.dtype), key], dim=1)
+                value = torch.cat([past_value.to(value.dtype), value], dim=1)
+            if use_cache:
+                presents.append((key, value))
+
+            key_length = key.shape[1]
+            key_positions = torch.arange(key_length, device=key.device).view(1, 1, 1, key_length)
+            valid = past_valid_lengths.to(torch.long).view(batch_size, 1, 1, 1) + 1
+            queries = query_position_ids.to(torch.long).view(batch_size, 1, 1, 1)
+            mask = (key_positions < valid) & (key_positions <= queries)
+
+            scores = torch.matmul(
+                query.permute(0, 2, 1, 3), key.permute(0, 2, 1, 3).transpose(2, 3)
+            )
+            scores = scores * self._scale(block.attn, self.head_dim)
+            scores = scores.masked_fill(~mask, torch.finfo(scores.dtype).min)
+            # positive axis: the tracer mis-lowers a negative softmax axis here
+            attn_output = self._finish(block.attn, torch.softmax(scores, dim=3), value)
+            hidden_states = hidden_states + attn_output
+            hidden_states = hidden_states + block.mlp(block.ln_2(hidden_states))
+
+        hidden_states = self.decoder.ln_f(hidden_states)
+        return hidden_states, (tuple(presents) if use_cache else None)
+
+
+def _build_inputs_embeds(model: MossTTSNano, input_ids_i32: torch.Tensor) -> torch.Tensor:
+    input_ids = input_ids_i32.to(torch.long)
+    inputs_embeds = model.transformer.wte(input_ids[..., 0])
+    pad = int(model.config.audio_pad_token_id)
+    for channel_index, embedding in enumerate(model.audio_embeddings):
+        channel_ids = input_ids[..., channel_index + 1]
+        valid = channel_ids.ne(pad)
+        safe = torch.where(valid, channel_ids, torch.zeros_like(channel_ids))
+        inputs_embeds = inputs_embeds + embedding(safe) * valid.unsqueeze(-1).to(inputs_embeds.dtype)
+    return inputs_embeds.to(torch.float32)
+
+
+class PrefillWrapper(nn.Module):
+    def __init__(self, model: MossTTSNano) -> None:
+        super().__init__()
+        self.model = model
+        self.core = ExportDecoderCore(model.transformer)
+
+    def forward(self, input_ids_i32: torch.Tensor, attention_mask_i32: torch.Tensor):
+        hidden_states, present = self.core.run_prefill(
+            inputs_embeds=_build_inputs_embeds(self.model, input_ids_i32),
+            attention_mask=attention_mask_i32.to(torch.bool),
+            use_cache=True,
+        )
+        return (hidden_states.to(torch.float32), *_flatten_kv(present or ()))
+
+
+class DecodeStepWrapper(nn.Module):
+    def __init__(self, model: MossTTSNano) -> None:
+        super().__init__()
+        self.model = model
+        self.core = ExportDecoderCore(model.transformer)
+        self.num_layers = int(model.config.gpt2.n_layer)
+
+    def forward(self, input_ids_i32: torch.Tensor, past_valid_lengths_i32: torch.Tensor, *past: torch.Tensor):
+        if len(past) != self.num_layers * 2:
+            raise ValueError(f"expected {self.num_layers * 2} KV tensors, got {len(past)}")
+        rebuilt = tuple(
+            (past[i * 2].to(torch.float32), past[i * 2 + 1].to(torch.float32))
+            for i in range(self.num_layers)
+        )
+        hidden_states, present = self.core.run_decode_step(
+            inputs_embeds=_build_inputs_embeds(self.model, input_ids_i32),
+            past_valid_lengths=past_valid_lengths_i32.to(torch.int32).reshape(-1),
+            past_key_values=rebuilt,
+            use_cache=True,
+        )
+        return (hidden_states.to(torch.float32), *_flatten_kv(present or ()))
+
+
+class LocalDecoderWrapper(nn.Module):
+    """Whole-frame local pass with a teacher-forced audio prefix (no cache)."""
+
+    def __init__(self, model: MossTTSNano) -> None:
+        super().__init__()
+        self.model = model
+        self.core = ExportDecoderCore(model.local_transformer)
+        self.max_audio_prefix_length = int(model.config.n_vq - 1)
+
+    def forward(
+        self,
+        global_hidden: torch.Tensor,
+        text_token_id_i32: torch.Tensor,
+        audio_prefix_token_ids_i32: torch.Tensor,
+    ):
+        batch_size = global_hidden.shape[0]
+        pieces = [
+            global_hidden.unsqueeze(1),
+            self.model.transformer.wte(text_token_id_i32.to(torch.long).reshape(batch_size)).unsqueeze(1),
+        ]
+        prefix_ids = audio_prefix_token_ids_i32.to(torch.long)
+        pad = int(self.model.config.audio_pad_token_id)
+        for prefix_index in range(self.max_audio_prefix_length):
+            current = prefix_ids[:, prefix_index]
+            valid = current.ne(pad)
+            safe = torch.where(valid, current, torch.zeros_like(current))
+            embed = self.model.audio_embeddings[prefix_index](safe)
+            pieces.append((embed * valid.unsqueeze(-1).to(embed.dtype)).unsqueeze(1))
+
+        local_inputs = torch.cat(pieces, dim=1)
+        local_hidden, _ = self.core.run_prefill(
+            inputs_embeds=local_inputs,
+            attention_mask=torch.ones(local_inputs.shape[:2], dtype=torch.bool, device=local_inputs.device),
+            use_cache=False,
+        )
+        text_logits = self.model.text_lm_head(local_hidden[:, 0, :]).to(torch.float32)
+        audio_logits = torch.stack(
+            [head(local_hidden[:, index + 1, :]).to(torch.float32)
+             for index, head in enumerate(self.model.audio_lm_heads)],
+            dim=1,
+        )
+        return text_logits, audio_logits
+
+
+class LocalCachedStepWrapper(nn.Module):
+    """One cached local step. ``step_type`` picks the input: 0 global, 1 text, 2 audio."""
+
+    def __init__(self, model: MossTTSNano) -> None:
+        super().__init__()
+        self.model = model
+        self.core = ExportDecoderCore(model.local_transformer)
+        self.num_layers = int(model.config.local_transformer_layers)
+
+    def _audio_embedding(self, audio_token_ids: torch.Tensor, channel_indices: torch.Tensor) -> torch.Tensor:
+        pieces = []
+        for channel_index, embedding in enumerate(self.model.audio_embeddings):
+            active = channel_indices.eq(channel_index)
+            safe = torch.where(active, audio_token_ids, torch.zeros_like(audio_token_ids))
+            embed = embedding(safe)
+            pieces.append(embed * active.unsqueeze(-1).to(embed.dtype))
+        return torch.stack(pieces, dim=0).sum(dim=0)
+
+    def forward(
+        self,
+        global_hidden: torch.Tensor,
+        text_token_id_i32: torch.Tensor,
+        audio_token_id_i32: torch.Tensor,
+        channel_index_i32: torch.Tensor,
+        step_type_i32: torch.Tensor,
+        past_valid_lengths_i32: torch.Tensor,
+        *past: torch.Tensor,
+    ):
+        if len(past) != self.num_layers * 2:
+            raise ValueError(f"expected {self.num_layers * 2} KV tensors, got {len(past)}")
+        batch_size = global_hidden.shape[0]
+        rebuilt = tuple(
+            (past[i * 2].to(torch.float32), past[i * 2 + 1].to(torch.float32))
+            for i in range(self.num_layers)
+        )
+        step_type = step_type_i32.to(torch.long).reshape(batch_size)
+        text_embed = self.model.transformer.wte(text_token_id_i32.to(torch.long).reshape(batch_size))
+        audio_embed = self._audio_embedding(
+            audio_token_id_i32.to(torch.long).reshape(batch_size),
+            channel_index_i32.to(torch.long).reshape(batch_size),
+        )
+        dtype = text_embed.dtype
+        input_embed = (
+            global_hidden.to(dtype) * step_type.eq(0).unsqueeze(-1).to(dtype)
+            + text_embed * step_type.eq(1).unsqueeze(-1).to(dtype)
+            + audio_embed * step_type.eq(2).unsqueeze(-1).to(dtype)
+        )
+        local_hidden, present = self.core.run_decode_step(
+            inputs_embeds=input_embed.unsqueeze(1),
+            past_valid_lengths=past_valid_lengths_i32.to(torch.int32).reshape(-1),
+            past_key_values=rebuilt,
+            use_cache=True,
+        )
+        last_hidden = local_hidden[:, 0, :]
+        text_logits = self.model.text_lm_head(last_hidden).to(torch.float32)
+        audio_logits = torch.stack(
+            [head(last_hidden).to(torch.float32) for head in self.model.audio_lm_heads], dim=1
+        )
+        return (text_logits, audio_logits, *_flatten_kv(present or ()))
+
+
+def apply_repetition_penalty_from_seen_mask(
+    logits: torch.Tensor, seen_mask_i32: torch.Tensor, penalty: torch.Tensor
+) -> torch.Tensor:
+    penalty = penalty.to(dtype=logits.dtype).reshape(-1, 1)
+    penalized = torch.where(logits < 0, logits * penalty, logits / penalty)
+    return torch.where(seen_mask_i32.to(torch.bool), penalized, logits)
+
+
+def sample_from_topk_topp_with_random_u(
+    logits: torch.Tensor, random_u: torch.Tensor, *, temperature: float, top_k: int, top_p: float
+) -> torch.Tensor:
+    """Inverse-CDF sampling over the top-k/top-p tail, with the RNG supplied by the host."""
+    scores = logits.to(torch.float32)
+    if temperature != 1.0:
+        scores = scores / float(temperature)
+    topk_scores, topk_indices = torch.topk(scores, k=int(top_k), dim=1, largest=True, sorted=True)
+    if 0.0 < top_p < 1.0:
+        probs = torch.softmax(topk_scores, dim=1)
+        prev_cumsum = torch.cumsum(probs, dim=1) - probs
+        topk_scores = topk_scores.masked_fill(~(prev_cumsum < float(top_p)), float("-inf"))
+    cdf = torch.cumsum(torch.softmax(topk_scores, dim=1), dim=1)
+    clamped = torch.clamp(random_u.to(cdf.dtype).reshape(-1, 1), min=0.0, max=0.99999994)
+    positions = torch.clamp(torch.sum((cdf < clamped).to(torch.int64), dim=1), max=topk_indices.shape[1] - 1)
+    return topk_indices.gather(1, positions.unsqueeze(1)).squeeze(1).to(torch.long)
+
+
+class LocalFixedSampledFrameWrapper(nn.Module):
+    """A whole frame, sampled in-graph at the upstream default parameters."""
+
+    def __init__(self, model: MossTTSNano) -> None:
+        super().__init__()
+        self.model = model
+        self.core = ExportDecoderCore(model.local_transformer)
+        self.num_layers = int(model.config.local_transformer_layers)
+        self.num_heads = model.local_transformer.config.num_attention_heads
+        self.head_dim = model.local_transformer.config.head_dim
+        self.num_channels = int(model.config.n_vq)
+        sizes = set(int(size) for size in model.config.audio_codebook_sizes)
+        if len(sizes) != 1:
+            raise ValueError("the fixed-frame graph requires one codebook size across all channels")
+        self.audio_codebook_size = sizes.pop()
+        self.top_k = min(FIXED_SAMPLED_AUDIO_TOP_K, self.audio_codebook_size)
+
+    def _empty_past(self, batch_size: int, device: torch.device) -> Tuple[KVCache, ...]:
+        return tuple(
+            (
+                torch.zeros((batch_size, 0, self.num_heads, self.head_dim), dtype=torch.float32, device=device),
+                torch.zeros((batch_size, 0, self.num_heads, self.head_dim), dtype=torch.float32, device=device),
+            )
+            for _ in range(self.num_layers)
+        )
+
+    def forward(
+        self,
+        global_hidden: torch.Tensor,
+        repetition_seen_mask_i32: torch.Tensor,
+        assistant_random_u_f32: torch.Tensor,
+        audio_random_u_f32: torch.Tensor,
+    ):
+        batch_size = global_hidden.shape[0]
+        device = global_hidden.device
+        past_valid_lengths = torch.zeros((batch_size,), dtype=torch.int32, device=device)
+        present = self._empty_past(batch_size, device)
+        penalty = torch.full(
+            (batch_size,), FIXED_SAMPLED_AUDIO_REPETITION_PENALTY, dtype=torch.float32, device=device
+        )
+
+        local_hidden, present = self.core.run_decode_step(
+            inputs_embeds=global_hidden.unsqueeze(1),
+            past_valid_lengths=past_valid_lengths,
+            past_key_values=present,
+            use_cache=True,
+        )
+        text_logits = self.model.text_lm_head(local_hidden[:, 0, :]).to(torch.float32)
+        candidates = torch.stack(
+            [
+                text_logits[:, int(self.model.config.audio_assistant_slot_token_id)],
+                text_logits[:, int(self.model.config.audio_end_token_id)],
+            ],
+            dim=1,
+        )
+        if FIXED_SAMPLED_TEXT_TEMPERATURE != 1.0:
+            candidates = candidates / float(FIXED_SAMPLED_TEXT_TEMPERATURE)
+        assistant_probs = torch.softmax(candidates, dim=1)[:, 0]
+        assistant_u = torch.clamp(
+            assistant_random_u_f32.to(assistant_probs.dtype).reshape(-1), min=0.0, max=0.99999994
+        )
+        assistant_selected = assistant_u <= assistant_probs
+        next_text_token = torch.where(
+            assistant_selected,
+            torch.full((batch_size,), int(self.model.config.audio_assistant_slot_token_id),
+                       dtype=torch.long, device=device),
+            torch.full((batch_size,), int(self.model.config.audio_end_token_id),
+                       dtype=torch.long, device=device),
+        )
+
+        generated: List[torch.Tensor] = []
+        current_embed = self.model.transformer.wte(next_text_token).unsqueeze(1)
+        current_valid = past_valid_lengths + 1
+        audio_u = audio_random_u_f32.to(torch.float32)
+
+        for channel_index in range(self.num_channels):
+            local_hidden, present = self.core.run_decode_step(
+                inputs_embeds=current_embed,
+                past_valid_lengths=current_valid,
+                past_key_values=present,
+                use_cache=True,
+            )
+            audio_logits = self.model.audio_lm_heads[channel_index](local_hidden[:, 0, :]).to(torch.float32)
+            penalized = apply_repetition_penalty_from_seen_mask(
+                audio_logits, repetition_seen_mask_i32[:, channel_index, : self.audio_codebook_size], penalty
+            )
+            sampled = sample_from_topk_topp_with_random_u(
+                penalized,
+                audio_u[:, channel_index],
+                temperature=FIXED_SAMPLED_AUDIO_TEMPERATURE,
+                top_k=self.top_k,
+                top_p=FIXED_SAMPLED_AUDIO_TOP_P,
+            )
+            generated.append(sampled.to(torch.int32))
+            current_valid = current_valid + 1
+            if channel_index + 1 < self.num_channels:
+                current_embed = self.model.audio_embeddings[channel_index](sampled).unsqueeze(1)
+
+        return assistant_selected.to(torch.int32).reshape(batch_size, 1), torch.stack(generated, dim=1)
+
+
+# ----------------------------------------------------------------------
+# external data handling (ported from upstream export_hf_to_tts_onnx.py)
+# ----------------------------------------------------------------------
+def externalize_onnx_file(onnx_path: Path) -> Tuple[Path, Path]:
+    import onnx
+    from onnx import external_data_helper
+
+    resolved = onnx_path.expanduser().resolve()
+    data_path = resolved.with_suffix(".data")
+    temp_path = resolved.with_suffix(".onnx.tmp")
+    model = onnx.load_model(str(resolved), load_external_data=True)
+    for path in (data_path, temp_path):
+        if path.exists():
+            path.unlink()
+    external_data_helper.convert_model_to_external_data(
+        model, all_tensors_to_one_file=True, location=data_path.name,
+        size_threshold=1024, convert_attribute=False,
+    )
+    onnx.save_model(model, str(temp_path))
+    temp_path.replace(resolved)
+    return resolved, data_path
+
+
+def merge_shared_external_data(onnx_paths: Sequence[Path], shared_data_path: Path) -> None:
+    """De-duplicate identical initializers across graphs into one ``.data`` blob."""
+    import onnx
+    from onnx import TensorProto, external_data_helper
+
+    resolved_paths = [path.expanduser().resolve() for path in onnx_paths]
+    if not resolved_paths:
+        raise ValueError("onnx_paths must not be empty")
+    shared_data_path = shared_data_path.expanduser().resolve()
+    models = [
+        (path,
+         onnx.load_model(str(path), load_external_data=False),
+         onnx.load_model(str(path), load_external_data=True))
+        for path in resolved_paths
+    ]
+
+    def is_external(tensor) -> bool:
+        return tensor.data_location == TensorProto.EXTERNAL or bool(tensor.external_data)
+
+    unique: Dict[str, Tuple[int, int]] = {}
+    blob = bytearray()
+    for _path, meta, data in models:
+        for tensor_meta, tensor_data in zip(meta.graph.initializer, data.graph.initializer):
+            if not is_external(tensor_meta):
+                continue
+            raw = bytes(tensor_data.raw_data)
+            digest = hashlib.sha256(raw).hexdigest()
+            if digest in unique:
+                continue
+            unique[digest] = (len(blob), len(raw))
+            blob.extend(raw)
+
+    shared_data_path.parent.mkdir(parents=True, exist_ok=True)
+    shared_data_path.write_bytes(bytes(blob))
+
+    for path, meta, data in models:
+        for tensor_meta, tensor_data in zip(meta.graph.initializer, data.graph.initializer):
+            if not is_external(tensor_meta):
+                continue
+            raw = bytes(tensor_data.raw_data)
+            offset, length = unique[hashlib.sha256(raw).hexdigest()]
+            # set_external_data reads raw_data before clearing it, so it has to be present
+            tensor_meta.raw_data = raw
+            tensor_meta.data_location = TensorProto.EXTERNAL
+            external_data_helper.set_external_data(
+                tensor_meta, location=shared_data_path.name, offset=offset, length=length
+            )
+            tensor_meta.ClearField("raw_data")
+        path.write_bytes(meta.SerializeToString())
+
+
+# ----------------------------------------------------------------------
+def export_moss_tts_onnx(
+    model: MossTTSNano,
+    output_dir: Path,
+    opset: int = 17,
+    sample_seq_len: int = 24,
+    sample_past_len: int = 24,
+    external_data: bool = False,
+    checkpoint_path: str = "",
+) -> Path:
+    """Write the five graphs plus ``tts_browser_onnx_meta.json``; returns the meta path."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model = model.to(device="cpu", dtype=torch.float32).eval()
+    model.set_attention_implementation("eager")
+    config: MossTTSNanoConfig = model.config
+
+    n_layer = int(config.gpt2.n_layer)
+    n_head = int(config.gpt2.n_head)
+    head_dim = int(config.gpt2.head_dim)
+    hidden = int(config.hidden_size)
+    row_width = int(config.row_width)
+    local_layers = int(config.local_transformer_layers)
+    local_heads = int(model.local_transformer.config.num_attention_heads)
+    local_head_dim = int(model.local_transformer.config.head_dim)
+
+    present_names = ["global_hidden"] + [
+        name for i in range(n_layer) for name in (f"present_key_{i}", f"present_value_{i}")
+    ]
+    decode_inputs = ["input_ids", "past_valid_lengths"] + [
+        name for i in range(n_layer) for name in (f"past_key_{i}", f"past_value_{i}")
+    ]
+    local_cached_inputs = [
+        "global_hidden", "text_token_id", "audio_token_id", "channel_index",
+        "step_type", "past_valid_lengths",
+    ] + [name for i in range(local_layers) for name in (f"local_past_key_{i}", f"local_past_value_{i}")]
+    local_cached_outputs = ["text_logits", "audio_logits"] + [
+        name for i in range(local_layers) for name in (f"local_present_key_{i}", f"local_present_value_{i}")
+    ]
+
+    prefill_axes = {
+        "input_ids": {0: "batch", 1: "prefill_seq"},
+        "attention_mask": {0: "batch", 1: "prefill_seq"},
+        "global_hidden": {0: "batch", 1: "prefill_seq"},
+    }
+    decode_axes = {
+        "input_ids": {0: "batch", 1: "step_seq"},
+        "past_valid_lengths": {0: "batch"},
+        "global_hidden": {0: "batch", 1: "step_seq"},
+    }
+    for i in range(n_layer):
+        prefill_axes[f"present_key_{i}"] = {0: "batch", 1: "prefill_seq"}
+        prefill_axes[f"present_value_{i}"] = {0: "batch", 1: "prefill_seq"}
+        decode_axes[f"past_key_{i}"] = {0: "batch", 1: "past_seq"}
+        decode_axes[f"past_value_{i}"] = {0: "batch", 1: "past_seq"}
+        decode_axes[f"present_key_{i}"] = {0: "batch", 1: "total_seq"}
+        decode_axes[f"present_value_{i}"] = {0: "batch", 1: "total_seq"}
+    local_cached_axes = {
+        name: {0: "batch"}
+        for name in ("global_hidden", "text_token_id", "audio_token_id", "channel_index",
+                     "step_type", "past_valid_lengths", "text_logits", "audio_logits")
+    }
+    for i in range(local_layers):
+        local_cached_axes[f"local_past_key_{i}"] = {0: "batch", 1: "local_past_seq"}
+        local_cached_axes[f"local_past_value_{i}"] = {0: "batch", 1: "local_past_seq"}
+        local_cached_axes[f"local_present_key_{i}"] = {0: "batch", 1: "local_total_seq"}
+        local_cached_axes[f"local_present_value_{i}"] = {0: "batch", 1: "local_total_seq"}
+    fixed_axes = {
+        name: {0: "batch"}
+        for name in ("global_hidden", "repetition_seen_mask", "assistant_random_u",
+                     "audio_random_u", "should_continue", "frame_token_ids")
+    }
+
+    prefill_ids = torch.full((1, sample_seq_len, row_width), int(config.audio_pad_token_id), dtype=torch.int32)
+    prefill_ids[:, :, 0] = int(config.pad_token_id)
+    prefill_mask = torch.ones((1, sample_seq_len), dtype=torch.int32)
+    decode_ids = torch.full((1, 1, row_width), int(config.audio_pad_token_id), dtype=torch.int32)
+    decode_ids[:, :, 0] = int(config.pad_token_id)
+    past = tuple(
+        tensor
+        for _ in range(n_layer)
+        for tensor in (
+            torch.zeros((1, sample_past_len, n_head, head_dim), dtype=torch.float32),
+            torch.zeros((1, sample_past_len, n_head, head_dim), dtype=torch.float32),
+        )
+    )
+    local_past = tuple(
+        tensor
+        for _ in range(local_layers)
+        for tensor in (
+            torch.zeros((1, sample_past_len, local_heads, local_head_dim), dtype=torch.float32),
+            torch.zeros((1, sample_past_len, local_heads, local_head_dim), dtype=torch.float32),
+        )
+    )
+
+    from phoonnx_train.torch_compat import onnx_export_kwargs
+
+    def export(module, name, args, input_names, output_names, dynamic_axes):
+        path = output_dir / name
+        with torch.no_grad():
+            torch.onnx.export(
+                module, args, str(path),
+                input_names=input_names, output_names=output_names,
+                dynamic_axes=dynamic_axes, opset_version=int(opset),
+                do_constant_folding=True, **onnx_export_kwargs(),
+            )
+        _LOGGER.info("exported %s", path)
+        return path
+
+    export(PrefillWrapper(model), "moss_tts_prefill.onnx",
+           (prefill_ids, prefill_mask), ["input_ids", "attention_mask"], present_names, prefill_axes)
+    export(DecodeStepWrapper(model), "moss_tts_decode_step.onnx",
+           (decode_ids, torch.full((1,), sample_past_len, dtype=torch.int32), *past),
+           decode_inputs, present_names, decode_axes)
+    export(LocalDecoderWrapper(model), "moss_tts_local_decoder.onnx",
+           (torch.zeros((1, hidden), dtype=torch.float32),
+            torch.zeros((1,), dtype=torch.int32),
+            torch.full((1, config.n_vq - 1), int(config.audio_pad_token_id), dtype=torch.int32)),
+           ["global_hidden", "text_token_id", "audio_prefix_token_ids"],
+           ["text_logits", "audio_logits"], {})
+    export(LocalCachedStepWrapper(model), "moss_tts_local_cached_step.onnx",
+           (torch.zeros((1, hidden), dtype=torch.float32),
+            torch.zeros((1,), dtype=torch.int32), torch.zeros((1,), dtype=torch.int32),
+            torch.zeros((1,), dtype=torch.int32), torch.zeros((1,), dtype=torch.int32),
+            torch.full((1,), sample_past_len, dtype=torch.int32), *local_past),
+           local_cached_inputs, local_cached_outputs, local_cached_axes)
+    export(LocalFixedSampledFrameWrapper(model), "moss_tts_local_fixed_sampled_frame.onnx",
+           (torch.zeros((1, hidden), dtype=torch.float32),
+            torch.zeros((1, config.n_vq, config.audio_codebook_sizes[0]), dtype=torch.int32),
+            torch.full((1,), 0.5, dtype=torch.float32),
+            torch.full((1, config.n_vq), 0.5, dtype=torch.float32)),
+           ["global_hidden", "repetition_seen_mask", "assistant_random_u", "audio_random_u"],
+           ["should_continue", "frame_token_ids"], fixed_axes)
+
+    files = {
+        "prefill": "moss_tts_prefill.onnx",
+        "decode_step": "moss_tts_decode_step.onnx",
+        "local_decoder": "moss_tts_local_decoder.onnx",
+        "local_cached_step": "moss_tts_local_cached_step.onnx",
+        "local_fixed_sampled_frame": "moss_tts_local_fixed_sampled_frame.onnx",
+    }
+    external_data_files: Dict[str, List[str]] = {}
+    if external_data:
+        for name in files.values():
+            externalize_onnx_file(output_dir / name)
+        merge_shared_external_data(
+            [output_dir / files["prefill"], output_dir / files["decode_step"]],
+            output_dir / "moss_tts_global_shared.data",
+        )
+        merge_shared_external_data(
+            [output_dir / files["local_decoder"], output_dir / files["local_cached_step"],
+             output_dir / files["local_fixed_sampled_frame"]],
+            output_dir / "moss_tts_local_shared.data",
+        )
+        for key in ("prefill", "decode_step"):
+            external_data_files[files[key]] = ["moss_tts_global_shared.data"]
+        for key in ("local_decoder", "local_cached_step", "local_fixed_sampled_frame"):
+            external_data_files[files[key]] = ["moss_tts_local_shared.data"]
+        for name in files.values():
+            stale = (output_dir / name).with_suffix(".data")
+            if stale.exists():
+                stale.unlink()
+
+    metadata = {
+        "format_version": 1,
+        "checkpoint_path": checkpoint_path,
+        "files": files,
+        "external_data_files": external_data_files,
+        "model_config": {
+            "n_vq": config.n_vq,
+            "row_width": row_width,
+            "hidden_size": hidden,
+            "global_layers": n_layer,
+            "global_heads": n_head,
+            "head_dim": head_dim,
+            "local_layers": local_layers,
+            "local_heads": local_heads,
+            "local_head_dim": local_head_dim,
+            "vocab_size": int(config.gpt2.vocab_size),
+            "audio_codebook_sizes": list(config.audio_codebook_sizes),
+            "audio_pad_token_id": config.audio_pad_token_id,
+            "pad_token_id": config.pad_token_id,
+            "im_start_token_id": config.im_start_token_id,
+            "im_end_token_id": config.im_end_token_id,
+            "audio_start_token_id": config.audio_start_token_id,
+            "audio_end_token_id": config.audio_end_token_id,
+            "audio_user_slot_token_id": config.audio_user_slot_token_id,
+            "audio_assistant_slot_token_id": config.audio_assistant_slot_token_id,
+        },
+        "onnx": {
+            "opset": int(opset),
+            "prefill_output_names": present_names,
+            "decode_input_names": decode_inputs,
+            "decode_output_names": present_names,
+            "local_cached_input_names": local_cached_inputs,
+            "local_cached_output_names": local_cached_outputs,
+            "fixed_sampled_frame_constants": {
+                "text_temperature": FIXED_SAMPLED_TEXT_TEMPERATURE,
+                "text_top_p": FIXED_SAMPLED_TEXT_TOP_P,
+                "text_top_k": FIXED_SAMPLED_TEXT_TOP_K,
+                "audio_temperature": FIXED_SAMPLED_AUDIO_TEMPERATURE,
+                "audio_top_p": FIXED_SAMPLED_AUDIO_TOP_P,
+                "audio_top_k": FIXED_SAMPLED_AUDIO_TOP_K,
+                "audio_repetition_penalty": FIXED_SAMPLED_AUDIO_REPETITION_PENALTY,
+            },
+        },
+    }
+    meta_path = output_dir / "tts_browser_onnx_meta.json"
+    meta_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+    return meta_path
+
+
+def load_model_for_export(
+    checkpoint: Path, config_path: Optional[Path] = None
+) -> Tuple[MossTTSNano, MossTTSNanoConfig]:
+    """Build a model from a Lightning ``.ckpt`` or an upstream checkpoint directory."""
+    from phoonnx_train.mosstts.warmstart import warm_start
+
+    checkpoint = Path(checkpoint)
+    if config_path is not None:
+        config = MossTTSNanoConfig.from_json_file(config_path)
+    elif checkpoint.is_dir():
+        config = MossTTSNanoConfig.from_pretrained_dir(checkpoint)
+    else:
+        payload = torch.load(str(checkpoint), map_location="cpu", weights_only=False)
+        hparams = payload.get("hyper_parameters") or {}
+        if "config" not in hparams:
+            raise ValueError(
+                f"{checkpoint} has no `config` hyper-parameter; pass --config explicitly"
+            )
+        config = MossTTSNanoConfig.from_dict(hparams["config"])
+    model = MossTTSNano(config)
+    report = warm_start(model, checkpoint)
+    if report.missing:
+        raise RuntimeError(
+            f"refusing to export a partially loaded model: {len(report.missing)} parameters "
+            f"missing from {checkpoint} ({report.summary()})"
+        )
+    return model, config
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Export MOSS-TTS-Nano to phoonnx's ONNX layout.")
+    parser.add_argument("--checkpoint", required=True, help="Lightning .ckpt or upstream checkpoint dir")
+    parser.add_argument("--config", default=None, help="config JSON override")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--sample-seq-len", type=int, default=24)
+    parser.add_argument("--sample-past-len", type=int, default=24)
+    parser.add_argument("--external-data", action="store_true",
+                        help="store weights in shared .data blobs (upstream layout)")
+    parser.add_argument("--tokenizer-model", default=None, help="tokenizer.model to copy next to the graphs")
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    model, _config = load_model_for_export(
+        Path(args.checkpoint), Path(args.config) if args.config else None
+    )
+    meta_path = export_moss_tts_onnx(
+        model,
+        Path(args.output_dir),
+        opset=args.opset,
+        sample_seq_len=args.sample_seq_len,
+        sample_past_len=args.sample_past_len,
+        external_data=args.external_data,
+        checkpoint_path=str(args.checkpoint),
+    )
+    if args.tokenizer_model:
+        import shutil
+
+        shutil.copy2(args.tokenizer_model, Path(args.output_dir) / "tokenizer.model")
+    print(f"export complete: {meta_path.parent}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "export_moss_tts_onnx",
+    "load_model_for_export",
+    "PrefillWrapper",
+    "DecodeStepWrapper",
+    "LocalDecoderWrapper",
+    "LocalCachedStepWrapper",
+    "LocalFixedSampledFrameWrapper",
+]

--- a/phoonnx_train/mosstts/lightning.py
+++ b/phoonnx_train/mosstts/lightning.py
@@ -1,0 +1,279 @@
+"""LightningModule for MOSS-TTS-Nano supervised finetuning.
+
+Objective (mirrors upstream ``finetuning/sft.py::compute_supervised_loss``):
+
+1. run the global transformer over the packed rows -> ``global_hidden [B, S, H]``;
+2. for every timestep, teacher-force the local transformer with
+   ``[global_hidden, emb(text_target), emb(code_0), ..., emb(code_{n_vq-2})]``;
+3. cross-entropy per head — the text head on position 0, audio head ``c`` on position
+   ``c + 1`` — with ``ignore_index=-100``;
+4. combine as a **weighted mean**: ``sum(w_i * CE_i) / sum(w_i)`` over the heads that
+   have at least one live target. The default weights come from upstream's ``"1,32"``
+   shorthand: 1 for the text head, 32 split evenly across the ``n_vq`` audio heads
+   (2.0 each at ``n_vq=16``).
+
+This is the global-local (RQ-Transformer) objective of arXiv:2603.18090, *not* the
+delay-pattern one: there is no per-codebook time shift and no ``λ`` schedule over
+codebook index — every audio head carries the same weight.
+
+Optimizer and schedule defaults are upstream's: AdamW ``lr=1e-5``, ``betas=(0.9, 0.95)``,
+``eps=1e-8``, ``weight_decay=0.1``, linear decay with a 3% warmup ratio, grad-norm clip 1.0.
+
+Resume vs. finetune
+-------------------
+* **resume** — ``Trainer(...).fit(module, ckpt_path=...)``: Lightning restores model,
+  optimizer, scheduler and global step exactly.
+* **finetune** — build the module with ``warm_start_from=<upstream dir or .ckpt>``: only
+  the weights are copied, and training starts a fresh optimizer/schedule.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import pytorch_lightning as pl
+import torch
+from torch.nn import functional as F
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import LambdaLR
+
+from phoonnx_train.mosstts.config import MossTTSNanoConfig
+from phoonnx_train.mosstts.dataset import IGNORE_INDEX
+from phoonnx_train.mosstts.model import MossTTSNano
+
+_LOGGER = logging.getLogger("mosstts.lightning")
+
+SCHEDULER_CHOICES = (
+    "linear",
+    "cosine",
+    "constant",
+    "constant_with_warmup",
+    "inverse_sqrt",
+    "polynomial",
+)
+
+
+def parse_channelwise_loss_weight(spec: Union[str, Sequence[float]], n_heads: int) -> List[float]:
+    """``"1,32"`` -> ``[1.0, 32/n_vq, ...]``; an explicit ``n_heads``-long list is kept as-is."""
+    if isinstance(spec, str):
+        values = [float(item.strip()) for item in spec.split(",") if item.strip()]
+    else:
+        values = [float(item) for item in spec]
+    if len(values) == n_heads:
+        resolved = values
+    elif len(values) == 2 and n_heads > 1:
+        text_weight, total_audio_weight = values
+        resolved = [text_weight] + [total_audio_weight / float(n_heads - 1)] * (n_heads - 1)
+    else:
+        raise ValueError(
+            f"channelwise_loss_weight expects either {n_heads} values or 2 values, got {len(values)}"
+        )
+    if any(weight < 0 for weight in resolved):
+        raise ValueError("channelwise_loss_weight must not contain negative values")
+    if sum(resolved) <= 0:
+        raise ValueError("channelwise_loss_weight must sum to a positive value")
+    return resolved
+
+
+def build_lr_lambda(name: str, num_warmup_steps: int, num_training_steps: int, power: float = 1.0):
+    """The subset of HuggingFace ``get_scheduler`` shapes upstream exposes, re-implemented."""
+    if name not in SCHEDULER_CHOICES:
+        raise ValueError(f"unsupported lr_scheduler_type={name!r}, expected one of {SCHEDULER_CHOICES}")
+    num_warmup_steps = max(int(num_warmup_steps), 0)
+    num_training_steps = max(int(num_training_steps), 1)
+
+    def warmup(step: int) -> float:
+        return float(step) / float(max(1, num_warmup_steps))
+
+    def lr_lambda(step: int) -> float:
+        if name == "constant":
+            return 1.0
+        if step < num_warmup_steps:
+            return warmup(step)
+        if name == "constant_with_warmup":
+            return 1.0
+        if name == "inverse_sqrt":
+            return math.sqrt(max(1, num_warmup_steps) / float(max(step, 1)))
+        progress = float(step - num_warmup_steps) / float(max(1, num_training_steps - num_warmup_steps))
+        progress = min(max(progress, 0.0), 1.0)
+        if name == "cosine":
+            return 0.5 * (1.0 + math.cos(math.pi * progress))
+        if name == "polynomial":
+            return (1.0 - progress) ** power
+        return 1.0 - progress  # linear
+
+    return lr_lambda
+
+
+class MossTTSNanoModule(pl.LightningModule):
+    """Lightning wrapper around :class:`~phoonnx_train.mosstts.model.MossTTSNano`."""
+
+    def __init__(
+        self,
+        config: Optional[Union[MossTTSNanoConfig, Dict[str, Any]]] = None,
+        learning_rate: float = 1e-5,
+        weight_decay: float = 0.1,
+        adam_beta1: float = 0.9,
+        adam_beta2: float = 0.95,
+        adam_eps: float = 1e-8,
+        warmup_steps: int = 0,
+        warmup_ratio: float = 0.03,
+        lr_scheduler_type: str = "linear",
+        max_train_steps: Optional[int] = None,
+        channelwise_loss_weight: Union[str, Sequence[float]] = "1,32",
+        warm_start_from: Optional[Union[str, Path]] = None,
+        gradient_checkpointing: bool = False,
+        attn_implementation: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        if config is None:
+            config = MossTTSNanoConfig()
+        elif isinstance(config, dict):
+            config = MossTTSNanoConfig.from_dict(config)
+        if attn_implementation is not None:
+            config.attn_implementation = attn_implementation
+            config.local_transformer_attn_implementation = attn_implementation
+        self.save_hyperparameters(
+            {
+                "config": config.to_dict(),
+                "learning_rate": learning_rate,
+                "weight_decay": weight_decay,
+                "adam_beta1": adam_beta1,
+                "adam_beta2": adam_beta2,
+                "adam_eps": adam_eps,
+                "warmup_steps": warmup_steps,
+                "warmup_ratio": warmup_ratio,
+                "lr_scheduler_type": lr_scheduler_type,
+                "max_train_steps": max_train_steps,
+                "channelwise_loss_weight": channelwise_loss_weight,
+                "gradient_checkpointing": gradient_checkpointing,
+            }
+        )
+        self.config = config
+        self.model = MossTTSNano(config)
+        if gradient_checkpointing:
+            self.model.gradient_checkpointing_enable(True)
+        self.channelwise_loss_weight = parse_channelwise_loss_weight(
+            channelwise_loss_weight, config.n_vq + 1
+        )
+        if warm_start_from is not None:
+            from phoonnx_train.mosstts.warmstart import warm_start
+
+            report = warm_start(self.model, warm_start_from)
+            _LOGGER.info("warm start: %s", report.summary())
+
+    # ------------------------------------------------------------------
+    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        global_hidden, _ = self.model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False)
+        return global_hidden
+
+    def compute_loss(self, batch: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        input_ids = batch["input_ids"]
+        attention_mask = batch["attention_mask"]
+        labels = batch["labels"]
+
+        global_hidden = self(input_ids, attention_mask)
+        batch_size, seq_len, hidden_size = global_hidden.shape
+        n_vq = self.config.n_vq
+
+        flat_hidden = global_hidden.reshape(batch_size * seq_len, hidden_size)
+        flat_labels = labels.reshape(batch_size * seq_len, n_vq + 1)
+
+        # Timesteps whose labels are all -100 contribute nothing to any head, so the
+        # local transformer never has to see them. Dropping them is exact, and turns the
+        # local pass from O(padded length) into O(supervised length).
+        live = (flat_labels != IGNORE_INDEX).any(dim=-1)
+        if not bool(live.any()):
+            raise RuntimeError(
+                "every label is ignored — check the dataset packing and max_length"
+            )
+        flat_hidden = flat_hidden[live]
+        flat_labels = flat_labels[live]
+
+        text_logits, audio_logits = self.model.local_logits(flat_hidden, flat_labels)
+
+        total_loss = torch.zeros((), device=flat_hidden.device, dtype=torch.float32)
+        total_weight = 0.0
+        per_head: Dict[str, torch.Tensor] = {}
+
+        text_targets = flat_labels[:, 0]
+        if bool((text_targets != IGNORE_INDEX).any()):
+            text_loss = F.cross_entropy(text_logits.float(), text_targets, ignore_index=IGNORE_INDEX)
+            weight = float(self.channelwise_loss_weight[0])
+            total_loss = total_loss + weight * text_loss
+            total_weight += weight
+            per_head["loss_text"] = text_loss.detach()
+
+        audio_targets = flat_labels[:, 1:]
+        for channel_index in range(n_vq):
+            channel_targets = audio_targets[:, channel_index]
+            if not bool((channel_targets != IGNORE_INDEX).any()):
+                continue
+            channel_loss = F.cross_entropy(
+                audio_logits[channel_index].float(), channel_targets, ignore_index=IGNORE_INDEX
+            )
+            weight = float(self.channelwise_loss_weight[channel_index + 1])
+            total_loss = total_loss + weight * channel_loss
+            total_weight += weight
+            per_head[f"loss_vq{channel_index}"] = channel_loss.detach()
+
+        if total_weight <= 0:
+            raise RuntimeError("no head had a live target — check the dataset packing and max_length")
+        return {"loss": total_loss / total_weight, "supervised_positions": int(live.sum()), **per_head}
+
+    def training_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> torch.Tensor:
+        outputs = self.compute_loss(batch)
+        loss = outputs["loss"]
+        self.log("train/loss", loss, prog_bar=True, on_step=True, on_epoch=True)
+        for name, value in outputs.items():
+            if name.startswith("loss_"):
+                self.log(f"train/{name}", value, on_step=True, on_epoch=False)
+        return loss
+
+    def validation_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> torch.Tensor:
+        loss = self.compute_loss(batch)["loss"]
+        self.log("val/loss", loss, prog_bar=True, on_step=False, on_epoch=True)
+        return loss
+
+    # ------------------------------------------------------------------
+    def _resolve_total_steps(self) -> int:
+        configured = self.hparams.get("max_train_steps")
+        if configured:
+            return int(configured)
+        trainer = getattr(self, "trainer", None)
+        if trainer is not None:
+            estimated = getattr(trainer, "estimated_stepping_batches", None)
+            if estimated is not None and math.isfinite(float(estimated)):
+                return max(int(estimated), 1)
+        return 1
+
+    def configure_optimizers(self):
+        optimizer = AdamW(
+            self.model.parameters(),
+            lr=float(self.hparams["learning_rate"]),
+            weight_decay=float(self.hparams["weight_decay"]),
+            betas=(float(self.hparams["adam_beta1"]), float(self.hparams["adam_beta2"])),
+            eps=float(self.hparams["adam_eps"]),
+        )
+        total_steps = self._resolve_total_steps()
+        warmup_steps = int(self.hparams["warmup_steps"])
+        if warmup_steps <= 0 and float(self.hparams["warmup_ratio"]) > 0:
+            warmup_steps = math.ceil(total_steps * float(self.hparams["warmup_ratio"]))
+        scheduler = LambdaLR(
+            optimizer,
+            build_lr_lambda(str(self.hparams["lr_scheduler_type"]), warmup_steps, total_steps),
+        )
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "interval": "step", "frequency": 1},
+        }
+
+
+__all__ = [
+    "MossTTSNanoModule",
+    "parse_channelwise_loss_weight",
+    "build_lr_lambda",
+    "SCHEDULER_CHOICES",
+]

--- a/phoonnx_train/mosstts/model.py
+++ b/phoonnx_train/mosstts/model.py
@@ -1,0 +1,498 @@
+"""Vendored MOSS-TTS-Nano backbone (global-local / RQ-Transformer codec LM).
+
+Architecture, per arXiv:2603.18090 ("MOSS-TTS: ...") and the upstream reference
+implementation, is the **global-latent + local autoregressive** scheme, *not* the
+delay-pattern parallel-head scheme the report also describes:
+
+* the **global** transformer (12 layers, 768 hidden, RoPE, GPT-2 blocks) consumes one
+  row of ``1 + n_vq`` token ids per timestep — column 0 is a text/slot token, columns
+  ``1..n_vq`` are RVQ codebook ids — and sums their embeddings into a single vector. It
+  emits one *global hidden state* per timestep.
+* the **local** transformer (1 layer, same width) then runs over ``n_vq + 1`` positions
+  for that timestep: position 0 is the global hidden state, position 1 is the embedding
+  of the *text* target, positions ``2..n_vq`` are the embeddings of audio channels
+  ``0..n_vq-2``. Its outputs feed ``text_lm_head`` (position 0) and
+  ``audio_lm_heads[c]`` (position ``c + 1``). At training time all of those inputs are
+  teacher-forced, which makes one local forward per timestep enough for the whole frame.
+
+Module and parameter names are chosen to match the upstream checkpoint 1:1 so
+:mod:`phoonnx_train.mosstts.warmstart` is a near-identity mapping. Nothing here imports
+``transformers``; the GPT-2 pieces are re-implemented from the published architecture.
+"""
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from phoonnx_train.mosstts.config import GPT2DecoderConfig, MossTTSNanoConfig
+
+KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+
+def _activation(name: str):
+    if name == "gelu_new":
+        return lambda x: F.gelu(x, approximate="tanh")
+    if name == "gelu":
+        return F.gelu
+    if name == "relu":
+        return F.relu
+    if name == "silu":
+        return F.silu
+    raise ValueError(f"unsupported activation_function={name!r}")
+
+
+class RotaryEmbedding(nn.Module):
+    """Interleaved-pair RoPE, matching the upstream ``repeat_interleave(2)`` layout."""
+
+    def __init__(self, dim: int, base: float = 10000.0) -> None:
+        super().__init__()
+        if dim % 2 != 0:
+            raise ValueError(f"RoPE head_dim must be even, got {dim}")
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, position_ids: torch.Tensor, dtype: torch.dtype) -> Tuple[torch.Tensor, torch.Tensor]:
+        if position_ids.ndim == 1:
+            position_ids = position_ids.unsqueeze(0)
+        freqs = torch.einsum(
+            "bs,d->bsd",
+            position_ids.to(device=self.inv_freq.device, dtype=self.inv_freq.dtype),
+            self.inv_freq,
+        )
+        cos = freqs.cos().repeat_interleave(2, dim=-1).unsqueeze(2).to(dtype=dtype)
+        sin = freqs.sin().repeat_interleave(2, dim=-1).unsqueeze(2).to(dtype=dtype)
+        return cos, sin
+
+
+def rotate_half(hidden_states: torch.Tensor) -> torch.Tensor:
+    even = hidden_states[..., ::2]
+    odd = hidden_states[..., 1::2]
+    return torch.stack((-odd, even), dim=-1).reshape_as(hidden_states)
+
+
+def apply_rotary_pos_emb(hidden_states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    return (hidden_states * cos) + (rotate_half(hidden_states) * sin)
+
+
+class MossMLP(nn.Module):
+    def __init__(self, config: GPT2DecoderConfig) -> None:
+        super().__init__()
+        self.fc_in = nn.Linear(config.hidden_size, config.inner_size)
+        self.fc_out = nn.Linear(config.inner_size, config.hidden_size)
+        self.act = _activation(config.activation_function)
+        self.dropout = nn.Dropout(config.resid_pdrop)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.dropout(self.fc_out(self.act(self.fc_in(hidden_states))))
+
+
+class MossAttention(nn.Module):
+    """Causal self-attention with RoPE and an optional KV cache.
+
+    Q/K/V are kept in ``[batch, seq, heads, head_dim]`` layout (upstream's convention,
+    and the one the exported ONNX caches use) and only transposed inside the kernels.
+    """
+
+    def __init__(self, config: GPT2DecoderConfig, layer_idx: int, attn_implementation: str = "sdpa") -> None:
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.layer_idx = layer_idx
+        self.attn_implementation = attn_implementation
+        self.attn_dropout = float(config.attn_pdrop)
+        self.scale_attn_weights = bool(config.scale_attn_weights)
+        self.scale_attn_by_inverse_layer_idx = bool(config.scale_attn_by_inverse_layer_idx)
+        self.c_attn = nn.Linear(self.embed_dim, 3 * self.embed_dim)
+        self.c_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.resid_dropout = nn.Dropout(config.resid_pdrop)
+        self.rotary_emb: Optional[RotaryEmbedding] = None
+        if config.position_embedding_type == "rope":
+            self.rotary_emb = RotaryEmbedding(self.head_dim, base=config.rope_base)
+
+    @property
+    def scale(self) -> float:
+        scale = 1.0
+        if self.scale_attn_weights:
+            scale /= math.sqrt(self.head_dim)
+        if self.scale_attn_by_inverse_layer_idx:
+            scale /= float(self.layer_idx + 1)
+        return scale
+
+    def _split_heads(self, tensor: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = tensor.shape
+        return tensor.view(batch_size, seq_len, self.num_heads, self.head_dim)
+
+    def _merge_heads(self, tensor: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len = tensor.shape[0], tensor.shape[1]
+        return tensor.reshape(batch_size, seq_len, self.embed_dim)
+
+    @staticmethod
+    def _causal_mask(attention_mask: torch.Tensor, query_length: int, key_length: int) -> torch.Tensor:
+        device = attention_mask.device
+        query_positions = torch.arange(query_length, device=device) + max(key_length - query_length, 0)
+        key_positions = torch.arange(key_length, device=device)
+        causal = (key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)).unsqueeze(0).unsqueeze(0)
+        return causal & attention_mask[:, None, None, :].to(torch.bool)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        layer_past: Optional[KVCache] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[KVCache]]:
+        query, key, value = self.c_attn(hidden_states).split(self.embed_dim, dim=-1)
+        query = self._split_heads(query)
+        key = self._split_heads(key)
+        value = self._split_heads(value)
+
+        if self.rotary_emb is not None:
+            cos, sin = self.rotary_emb(position_ids, dtype=query.dtype)
+            query = apply_rotary_pos_emb(query, cos, sin)
+            key = apply_rotary_pos_emb(key, cos, sin)
+
+        if layer_past is not None:
+            past_key, past_value = layer_past
+            key = torch.cat([past_key.to(key.dtype), key], dim=1)
+            value = torch.cat([past_value.to(value.dtype), value], dim=1)
+        present = (key, value) if use_cache else None
+
+        mask = self._causal_mask(attention_mask, query.shape[1], key.shape[1])
+        q = query.transpose(1, 2)
+        k = key.transpose(1, 2)
+        v = value.transpose(1, 2)
+
+        if self.attn_implementation == "sdpa":
+            # A fully masked query row makes SDPA emit NaNs; unmask one aligned key for
+            # padded query positions and zero their output afterwards.
+            query_mask = attention_mask[:, -query.shape[1]:].to(torch.bool)
+            sdpa_mask = mask
+            if not bool(query_mask.all()):
+                sdpa_mask = mask.expand(q.shape[0], -1, -1, -1).clone()
+                bad_batch, bad_query = torch.nonzero(~query_mask, as_tuple=True)
+                aligned = bad_query + max(key.shape[1] - query.shape[1], 0)
+                sdpa_mask[bad_batch, :, bad_query, aligned] = True
+            output = F.scaled_dot_product_attention(
+                q, k, v,
+                attn_mask=sdpa_mask,
+                dropout_p=self.attn_dropout if self.training else 0.0,
+                scale=self.scale,
+            )
+            if not bool(query_mask.all()):
+                output = output.masked_fill(~query_mask[:, None, :, None], 0.0)
+        else:
+            scores = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+            scores = scores.masked_fill(~mask, torch.finfo(scores.dtype).min)
+            probs = torch.softmax(scores, dim=-1)
+            if self.training and self.attn_dropout > 0:
+                probs = F.dropout(probs, self.attn_dropout)
+            output = torch.matmul(probs, v)
+
+        output = self._merge_heads(output.transpose(1, 2).contiguous())
+        return self.resid_dropout(self.c_proj(output)), present
+
+
+class MossBlock(nn.Module):
+    def __init__(self, config: GPT2DecoderConfig, layer_idx: int, attn_implementation: str = "sdpa") -> None:
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_epsilon)
+        self.attn = MossAttention(config, layer_idx=layer_idx, attn_implementation=attn_implementation)
+        self.ln_2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_epsilon)
+        self.mlp = MossMLP(config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        layer_past: Optional[KVCache] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[KVCache]]:
+        attn_output, present = self.attn(
+            self.ln_1(hidden_states),
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            layer_past=layer_past,
+            use_cache=use_cache,
+        )
+        hidden_states = hidden_states + attn_output
+        hidden_states = hidden_states + self.mlp(self.ln_2(hidden_states))
+        return hidden_states, present
+
+
+class MossDecoder(nn.Module):
+    """Embedding-in / hidden-out GPT-2 stack, used for both the global and local halves.
+
+    ``wte`` exists only on the global stack; the local stack is fed pre-built embeddings,
+    so upstream replaces its ``wte`` with :class:`torch.nn.Identity` (and the checkpoint
+    carries no ``local_transformer.wte.weight``).
+    """
+
+    def __init__(
+        self,
+        config: GPT2DecoderConfig,
+        attn_implementation: str = "sdpa",
+        with_wte: bool = True,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.attn_implementation = attn_implementation
+        self.position_embedding_type = config.position_embedding_type
+        self.wte: nn.Module = nn.Embedding(config.vocab_size, config.hidden_size) if with_wte else nn.Identity()
+        self.wpe: nn.Module = (
+            nn.Embedding(config.n_positions, config.hidden_size)
+            if self.position_embedding_type == "absolute"
+            else nn.Identity()
+        )
+        self.drop = nn.Dropout(config.embd_pdrop)
+        self.h = nn.ModuleList(
+            [MossBlock(config, layer_idx=i, attn_implementation=attn_implementation) for i in range(config.n_layer)]
+        )
+        self.ln_f = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_epsilon)
+        self.gradient_checkpointing = False
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        std = float(self.config.initializer_range)
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                nn.init.normal_(module.weight, mean=0.0, std=std)
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+            elif isinstance(module, nn.Embedding):
+                nn.init.normal_(module.weight, mean=0.0, std=std)
+            elif isinstance(module, nn.LayerNorm):
+                nn.init.ones_(module.weight)
+                nn.init.zeros_(module.bias)
+
+    def set_attention_implementation(self, attn_implementation: str) -> None:
+        self.attn_implementation = attn_implementation
+        for block in self.h:
+            block.attn.attn_implementation = attn_implementation
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Tuple[KVCache, ...]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[KVCache, ...]]]:
+        batch_size, seq_len, _ = inputs_embeds.shape
+        if attention_mask is None:
+            attention_mask = torch.ones((batch_size, seq_len), dtype=torch.bool, device=inputs_embeds.device)
+        attention_mask = attention_mask.to(dtype=torch.bool, device=inputs_embeds.device)
+        query_mask = attention_mask[:, -seq_len:]
+
+        if position_ids is None:
+            position_ids = attention_mask.long().cumsum(dim=-1) - 1
+            position_ids = position_ids.masked_fill(~attention_mask, 0)[:, -seq_len:]
+
+        hidden_states = inputs_embeds
+        if self.position_embedding_type == "absolute":
+            hidden_states = hidden_states + self.wpe(position_ids)
+        hidden_states = self.drop(hidden_states)
+        hidden_states = hidden_states * query_mask.unsqueeze(-1).to(hidden_states.dtype)
+
+        presents: Optional[List[KVCache]] = [] if use_cache else None
+        for layer_index, block in enumerate(self.h):
+            layer_past = None if past_key_values is None else past_key_values[layer_index]
+            if self.gradient_checkpointing and self.training:
+                if use_cache:
+                    raise ValueError("use_cache=True is incompatible with gradient checkpointing")
+                hidden_states = torch.utils.checkpoint.checkpoint(
+                    lambda h, m, p, b=block: b(h, attention_mask=m, position_ids=p, use_cache=False)[0],
+                    hidden_states, attention_mask, position_ids,
+                    use_reentrant=False,
+                )
+                present = None
+            else:
+                hidden_states, present = block(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    layer_past=layer_past,
+                    use_cache=use_cache,
+                )
+            hidden_states = hidden_states * query_mask.unsqueeze(-1).to(hidden_states.dtype)
+            if presents is not None:
+                presents.append(present)
+
+        hidden_states = self.ln_f(hidden_states)
+        hidden_states = hidden_states * query_mask.unsqueeze(-1).to(hidden_states.dtype)
+        return hidden_states, (tuple(presents) if presents is not None else None)
+
+
+class MossTTSNano(nn.Module):
+    """The full global-local codec LM.
+
+    ``forward`` returns only the global hidden states, matching upstream
+    ``MossTTSNanoForCausalLM.forward``; the per-channel logits are produced by
+    :meth:`local_logits`, which is what the training loss consumes.
+    """
+
+    def __init__(self, config: MossTTSNanoConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.transformer = MossDecoder(config.gpt2, attn_implementation=config.attn_implementation)
+        hidden_size = config.hidden_size
+
+        self.audio_embeddings = nn.ModuleList(
+            [nn.Embedding(size, hidden_size) for size in config.audio_codebook_sizes]
+        )
+        self.text_lm_head = nn.Linear(hidden_size, config.gpt2.vocab_size, bias=False)
+        self.audio_lm_heads = nn.ModuleList(
+            [nn.Linear(hidden_size, size, bias=False) for size in config.audio_codebook_sizes]
+        )
+        self.local_transformer = MossDecoder(
+            config.local_gpt2(),
+            attn_implementation=config.local_transformer_attn_implementation,
+            with_wte=False,
+        )
+
+        std = float(config.initializer_range)
+        for module in list(self.audio_embeddings) + [self.text_lm_head] + list(self.audio_lm_heads):
+            nn.init.normal_(module.weight, mean=0.0, std=std)
+        self.tie_weights()
+
+    # ------------------------------------------------------------------
+    def tie_weights(self) -> None:
+        """Every head shares its input embedding, exactly as upstream does."""
+        self.text_lm_head.weight = self.transformer.wte.weight
+        for embedding, head in zip(self.audio_embeddings, self.audio_lm_heads):
+            head.weight = embedding.weight
+
+    @property
+    def tied_weight_keys(self) -> dict:
+        tied = {"text_lm_head.weight": "transformer.wte.weight"}
+        tied.update(
+            {f"audio_lm_heads.{i}.weight": f"audio_embeddings.{i}.weight" for i in range(self.config.n_vq)}
+        )
+        return tied
+
+    def set_attention_implementation(self, attn_implementation: str, local: Optional[str] = None) -> None:
+        self.transformer.set_attention_implementation(attn_implementation)
+        self.local_transformer.set_attention_implementation(local or attn_implementation)
+
+    def gradient_checkpointing_enable(self, enabled: bool = True) -> None:
+        self.transformer.gradient_checkpointing = enabled
+
+    # ------------------------------------------------------------------
+    def build_inputs_embeds(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Sum the text/slot embedding and the ``n_vq`` codebook embeddings of each row.
+
+        Columns holding ``audio_pad_token_id`` (every audio column of a text row)
+        contribute nothing.
+        """
+        if input_ids.ndim != 3 or input_ids.shape[-1] != self.config.row_width:
+            raise ValueError(
+                f"expected input_ids of shape [batch, seq, {self.config.row_width}], "
+                f"got {tuple(input_ids.shape)}"
+            )
+        inputs_embeds = self.transformer.wte(input_ids[..., 0])
+        pad = int(self.config.audio_pad_token_id)
+        for channel_index, embedding in enumerate(self.audio_embeddings):
+            channel_ids = input_ids[..., channel_index + 1]
+            valid = channel_ids.ne(pad)
+            out_of_range = valid & ((channel_ids < 0) | (channel_ids >= embedding.num_embeddings))
+            if bool(out_of_range.any()):
+                bad = channel_ids[out_of_range]
+                raise ValueError(
+                    f"out-of-range audio token ids for channel {channel_index}: "
+                    f"min={int(bad.min())} max={int(bad.max())} "
+                    f"codebook_size={embedding.num_embeddings} audio_pad_token_id={pad}"
+                )
+            safe = channel_ids.masked_fill(~valid, 0)
+            inputs_embeds = inputs_embeds + embedding(safe) * valid.unsqueeze(-1).to(inputs_embeds.dtype)
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Tuple[KVCache, ...]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[KVCache, ...]]]:
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("either input_ids or inputs_embeds must be given")
+            inputs_embeds = self.build_inputs_embeds(input_ids)
+        return self.transformer(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+        )
+
+    # ------------------------------------------------------------------
+    def build_local_inputs(self, global_hidden: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        """Teacher-forced local-transformer inputs for a flat batch of timesteps.
+
+        ``global_hidden`` is ``[N, hidden]`` and ``labels`` is ``[N, n_vq + 1]`` (column 0
+        the text target, columns ``1..n_vq`` the codebook targets, ``-100`` where ignored).
+        The returned ``[N, n_vq + 1, hidden]`` stack is the RQ-Transformer teacher forcing:
+        channel ``c``'s prediction is conditioned on the *true* channel ``c - 1``.
+        """
+        n_vq = self.config.n_vq
+        if labels.shape[-1] != n_vq + 1:
+            raise ValueError(f"labels must be [N, {n_vq + 1}], got {tuple(labels.shape)}")
+        dtype = self.local_transformer.ln_f.weight.dtype
+        local_inputs = torch.zeros(
+            (global_hidden.shape[0], n_vq + 1, self.config.hidden_size),
+            dtype=dtype,
+            device=global_hidden.device,
+        )
+        local_inputs[:, 0, :] = global_hidden.to(dtype)
+
+        text_targets = labels[:, 0]
+        safe_text = text_targets.masked_fill(text_targets.lt(0), int(self.config.pad_token_id))
+        local_inputs[:, 1, :] = self.transformer.wte(safe_text).to(dtype)
+
+        audio_targets = labels[:, 1:]
+        for channel_index in range(n_vq - 1):
+            teacher_ids = audio_targets[:, channel_index]
+            embedding = self.audio_embeddings[channel_index]
+            valid = (teacher_ids >= 0) & (teacher_ids < embedding.num_embeddings)
+            safe = teacher_ids.masked_fill(~valid, 0)
+            channel_embeds = embedding(safe) * valid.unsqueeze(-1).to(embedding.weight.dtype)
+            local_inputs[:, channel_index + 2, :] = channel_embeds.to(dtype)
+        return local_inputs
+
+    def local_logits(
+        self,
+        global_hidden: torch.Tensor,
+        labels: torch.Tensor,
+    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        """One teacher-forced local pass -> ``(text_logits, [audio_logits per channel])``."""
+        local_inputs = self.build_local_inputs(global_hidden, labels)
+        local_hidden, _ = self.local_transformer(
+            inputs_embeds=local_inputs,
+            attention_mask=torch.ones(local_inputs.shape[:2], dtype=torch.bool, device=local_inputs.device),
+            use_cache=False,
+        )
+        text_logits = self.text_lm_head(local_hidden[:, 0, :])
+        audio_logits = [
+            head(local_hidden[:, channel_index + 1, :])
+            for channel_index, head in enumerate(self.audio_lm_heads)
+        ]
+        return text_logits, audio_logits
+
+    def num_parameters(self) -> int:
+        seen = set()
+        total = 0
+        for parameter in self.parameters():
+            if id(parameter) in seen:
+                continue
+            seen.add(id(parameter))
+            total += parameter.numel()
+        return total
+
+
+__all__ = ["MossTTSNano", "MossDecoder", "MossBlock", "MossAttention", "RotaryEmbedding"]

--- a/phoonnx_train/mosstts/prepare_data.py
+++ b/phoonnx_train/mosstts/prepare_data.py
@@ -1,0 +1,244 @@
+"""Pre-encode a dataset's audio with the frozen MOSS audio tokenizer.
+
+The codec (``MOSS-Audio-Tokenizer-Nano``, RVQ-16 @ 12.5 fps, 48 kHz stereo) is **frozen**
+and is never part of training. It runs exactly once, here, through the published ONNX
+encode graph (``moss_audio_tokenizer_encode.onnx``) under onnxruntime — no torch codec, no
+``trust_remote_code`` — and the resulting code matrices are written into the JSONL the
+trainer consumes.
+
+Input manifest, either
+
+* a JSONL with ``{"audio": ..., "text": ..., "language": ..., "ref_audio": ...}`` records
+  (upstream's ``prepare_data.py`` shape), or
+* an LJSpeech-style ``metadata.csv`` (``<wav-stem>|<text>`` per line) plus ``--wav-dir``.
+
+Output is the same JSONL with ``audio_codes`` (and ``ref_audio_codes`` when a reference
+clip is given) attached::
+
+    python -m phoonnx_train.mosstts.prepare_data \\
+        --codec-encode-onnx models/moss_audio_tokenizer_encode.onnx \\
+        --input-manifest data/train.jsonl \\
+        --output-jsonl data/train.codes.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from phoonnx_train.mosstts.dataset import dump_jsonl, load_jsonl
+
+_LOGGER = logging.getLogger("mosstts.prepare_data")
+
+DEFAULT_SAMPLE_RATE = 48000
+DEFAULT_CHANNELS = 2
+
+
+def read_audio(path: Path) -> Tuple[np.ndarray, int]:
+    """Read *path* as ``[channels, samples]`` float32 plus its sample rate."""
+    try:
+        import soundfile as sf
+    except ImportError as exc:  # pragma: no cover - depends on the install extra
+        raise ImportError(
+            "reading audio needs `soundfile` (pip install phoonnx[train])"
+        ) from exc
+    data, sample_rate = sf.read(str(path), dtype="float32", always_2d=True)
+    return np.ascontiguousarray(data.T), int(sample_rate)
+
+
+def resample(audio: np.ndarray, sample_rate: int, target_sample_rate: int) -> np.ndarray:
+    if sample_rate == target_sample_rate:
+        return audio
+    from math import gcd
+
+    try:
+        from scipy.signal import resample_poly
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError("resampling needs `scipy` (pip install phoonnx[train])") from exc
+    divisor = gcd(sample_rate, target_sample_rate)
+    return resample_poly(
+        audio, target_sample_rate // divisor, sample_rate // divisor, axis=-1
+    ).astype(np.float32)
+
+
+def fit_channels(audio: np.ndarray, target_channels: int) -> np.ndarray:
+    """Match the codec's channel count: mono is duplicated, extra channels are averaged."""
+    channels = audio.shape[0]
+    if channels == target_channels:
+        return audio
+    if channels == 1:
+        return np.repeat(audio, target_channels, axis=0)
+    if target_channels == 1:
+        return audio.mean(axis=0, keepdims=True)
+    if channels > target_channels:
+        return audio[:target_channels]
+    raise ValueError(f"cannot map {channels} channels to {target_channels}")
+
+
+class OnnxAudioTokenizer:
+    """Frozen RVQ encoder: waveform -> ``[frames, n_vq]`` code matrix."""
+
+    def __init__(
+        self,
+        encode_onnx: str,
+        providers: Optional[Sequence[str]] = None,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        channels: int = DEFAULT_CHANNELS,
+    ) -> None:
+        import onnxruntime
+
+        self.session = onnxruntime.InferenceSession(
+            str(encode_onnx),
+            providers=list(providers) if providers else ["CPUExecutionProvider"],
+        )
+        self.sample_rate = int(sample_rate)
+        self.channels = int(channels)
+        self._input_names = [item.name for item in self.session.get_inputs()]
+
+    def encode_file(self, path: Path, n_vq: Optional[int] = None) -> List[List[int]]:
+        audio, sample_rate = read_audio(path)
+        audio = fit_channels(resample(audio, sample_rate, self.sample_rate), self.channels)
+        return self.encode_waveform(audio, n_vq=n_vq)
+
+    def encode_waveform(self, audio: np.ndarray, n_vq: Optional[int] = None) -> List[List[int]]:
+        batch = np.asarray(audio, dtype=np.float32)[None, ...]
+        feed: Dict[str, np.ndarray] = {self._input_names[0]: batch}
+        if len(self._input_names) > 1:
+            feed[self._input_names[1]] = np.asarray([batch.shape[-1]], dtype=np.int32)
+        outputs = self.session.run(None, feed)
+        codes = np.asarray(outputs[0])
+        frames = int(codes.shape[1])
+        if len(outputs) > 1:
+            lengths = np.asarray(outputs[1]).reshape(-1)
+            if lengths.size:
+                frames = int(lengths[0])
+        codes = codes[0, :frames, :]
+        if n_vq is not None:
+            if n_vq > codes.shape[1]:
+                raise ValueError(f"asked for n_vq={n_vq} but the codec emits {codes.shape[1]}")
+            codes = codes[:, :n_vq]
+        return codes.astype(np.int64).tolist()
+
+
+def load_manifest(
+    path: Path,
+    wav_dir: Optional[Path] = None,
+    delimiter: str = "|",
+) -> List[Dict[str, Any]]:
+    """Read a JSONL or LJSpeech-style CSV manifest into upstream's record shape."""
+    if path.suffix.lower() in {".jsonl", ".json", ".ndjson"}:
+        return load_jsonl(path)
+    records: List[Dict[str, Any]] = []
+    base = wav_dir or path.parent
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(delimiter)
+        if len(parts) < 2:
+            raise ValueError(f"{path}:{line_number} has no '{delimiter}' separated text column")
+        stem, text = parts[0], parts[-1]
+        audio_path = Path(stem)
+        if not audio_path.suffix:
+            audio_path = audio_path.with_suffix(".wav")
+        records.append({"audio": str(base / audio_path), "text": text})
+    return records
+
+
+def resolve_audio_paths(records: Iterable[Dict[str, Any]], base_dir: Path) -> List[Dict[str, Any]]:
+    resolved = []
+    for record in records:
+        record = dict(record)
+        for key in ("audio", "ref_audio"):
+            value = record.get(key)
+            if isinstance(value, str) and value:
+                candidate = Path(value)
+                record[key] = str(candidate if candidate.is_absolute() else (base_dir / candidate))
+        resolved.append(record)
+    return resolved
+
+
+def encode_records(
+    records: List[Dict[str, Any]],
+    tokenizer: OnnxAudioTokenizer,
+    n_vq: Optional[int] = None,
+    encode_reference: bool = True,
+) -> List[Dict[str, Any]]:
+    cache: Dict[str, List[List[int]]] = {}
+
+    def encode(path: str) -> List[List[int]]:
+        if path not in cache:
+            cache[path] = tokenizer.encode_file(Path(path), n_vq=n_vq)
+        return cache[path]
+
+    for index, record in enumerate(records):
+        if record.get("audio_codes") is None:
+            audio_path = record.get("audio")
+            if not isinstance(audio_path, str) or not audio_path:
+                raise ValueError(f"record {index} has no `audio` path and no `audio_codes`")
+            record["audio_codes"] = encode(audio_path)
+            if not record["audio_codes"]:
+                raise ValueError(f"record {index}: {audio_path} produced zero codec frames")
+        if encode_reference and record.get("ref_audio_codes") is None:
+            reference = record.get("ref_audio")
+            if isinstance(reference, str) and reference:
+                record["ref_audio_codes"] = encode(reference)
+        if index and index % 50 == 0:
+            _LOGGER.info("encoded %d/%d records", index, len(records))
+    return records
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--codec-encode-onnx", required=True, help="moss_audio_tokenizer_encode.onnx")
+    parser.add_argument("--input-manifest", required=True, help="JSONL or LJSpeech-style CSV")
+    parser.add_argument("--output-jsonl", required=True)
+    parser.add_argument("--wav-dir", default=None, help="audio root for CSV manifests")
+    parser.add_argument("--n-vq", type=int, default=None, help="keep only the first N codec layers")
+    parser.add_argument("--sample-rate", type=int, default=DEFAULT_SAMPLE_RATE)
+    parser.add_argument("--channels", type=int, default=DEFAULT_CHANNELS)
+    parser.add_argument("--providers", nargs="*", default=None, help="onnxruntime execution providers")
+    parser.add_argument(
+        "--skip-reference-audio",
+        dest="encode_reference",
+        action="store_false",
+        help="do not encode `ref_audio`",
+    )
+    parser.set_defaults(encode_reference=True)
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    manifest_path = Path(args.input_manifest).expanduser().resolve()
+    records = load_manifest(
+        manifest_path, wav_dir=Path(args.wav_dir).expanduser() if args.wav_dir else None
+    )
+    if not records:
+        raise SystemExit(f"{manifest_path} has no records")
+    records = resolve_audio_paths(records, manifest_path.parent)
+
+    tokenizer = OnnxAudioTokenizer(
+        args.codec_encode_onnx,
+        providers=args.providers,
+        sample_rate=args.sample_rate,
+        channels=args.channels,
+    )
+    records = encode_records(
+        records, tokenizer, n_vq=args.n_vq, encode_reference=args.encode_reference
+    )
+    output = dump_jsonl(records, args.output_jsonl)
+    frames = sum(len(record["audio_codes"]) for record in records)
+    _LOGGER.info(
+        "wrote %d records (%d frames, %.1f s of audio) to %s",
+        len(records), frames, frames / 12.5, output,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = ["OnnxAudioTokenizer", "load_manifest", "encode_records", "read_audio", "resample", "fit_channels"]

--- a/phoonnx_train/mosstts/train.py
+++ b/phoonnx_train/mosstts/train.py
@@ -1,0 +1,166 @@
+"""Training / finetuning CLI for MOSS-TTS-Nano.
+
+Two mutually exclusive ways to start from existing weights:
+
+``--warm-start-from PATH``
+    *finetune*: copy weights from an upstream checkpoint directory, a ``.safetensors``
+    file, or a previous phoonnx ``.ckpt``. The optimizer and LR schedule start fresh.
+``--resume-from PATH.ckpt``
+    *resume*: Lightning restores model **and** optimizer/scheduler state and the global
+    step, so an interrupted run continues exactly where it stopped.
+
+Example::
+
+    python -m phoonnx_train.mosstts.train \\
+        --train-jsonl data/train.codes.jsonl \\
+        --tokenizer-model models/MOSS-TTS-Nano/tokenizer.model \\
+        --config models/MOSS-TTS-Nano/config.json \\
+        --warm-start-from models/MOSS-TTS-Nano \\
+        --output-dir runs/moss-pt --max-steps 2000 --batch-size 1
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import pytorch_lightning as pl
+import torch
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.loggers import CSVLogger
+from torch.utils.data import DataLoader
+
+from phoonnx_train.mosstts.config import MossTTSNanoConfig
+from phoonnx_train.mosstts.dataset import (
+    MossTTSNanoCollator,
+    MossTTSNanoDataset,
+    SentencePieceTextTokenizer,
+)
+from phoonnx_train.mosstts.lightning import SCHEDULER_CHOICES, MossTTSNanoModule
+
+_LOGGER = logging.getLogger("mosstts.train")
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Finetune MOSS-TTS-Nano.")
+    parser.add_argument("--train-jsonl", nargs="+", required=True,
+                        help="JSONL(s) produced by prepare_data.py")
+    parser.add_argument("--tokenizer-model", required=True, help="SentencePiece tokenizer.model")
+    parser.add_argument("--config", default=None,
+                        help="config JSON (upstream config.json works); defaults to the "
+                             "released MOSS-TTS-Nano geometry")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--warm-start-from", default=None, help="finetune: copy weights only")
+    parser.add_argument("--resume-from", default=None, help="resume: restore optimizer + scheduler too")
+    parser.add_argument("--max-length", type=int, default=1024)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=1)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--max-epochs", type=int, default=3)
+    parser.add_argument("--max-steps", type=int, default=-1)
+    parser.add_argument("--learning-rate", type=float, default=1e-5)
+    parser.add_argument("--weight-decay", type=float, default=0.1)
+    parser.add_argument("--adam-beta1", type=float, default=0.9)
+    parser.add_argument("--adam-beta2", type=float, default=0.95)
+    parser.add_argument("--adam-eps", type=float, default=1e-8)
+    parser.add_argument("--warmup-steps", type=int, default=0)
+    parser.add_argument("--warmup-ratio", type=float, default=0.03)
+    parser.add_argument("--lr-scheduler-type", default="linear", choices=SCHEDULER_CHOICES)
+    parser.add_argument("--max-grad-norm", type=float, default=1.0)
+    parser.add_argument("--channelwise-loss-weight", default="1,32",
+                        help="either n_vq+1 weights or 'text,total_audio'")
+    parser.add_argument("--prompt-style", default="inference", choices=("inference", "finetuning"))
+    parser.add_argument("--precision", default=None,
+                        help="Lightning precision string, e.g. bf16-mixed (default: 32 on CPU)")
+    parser.add_argument("--accelerator", default="auto")
+    parser.add_argument("--devices", default="auto")
+    parser.add_argument("--gradient-checkpointing", action="store_true")
+    parser.add_argument("--attn-implementation", default=None, choices=(None, "eager", "sdpa"))
+    parser.add_argument("--save-every-n-steps", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--log-every-n-steps", type=int, default=1)
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_argparser().parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    pl.seed_everything(args.seed, workers=True)
+
+    if args.warm_start_from and args.resume_from:
+        raise SystemExit("--warm-start-from and --resume-from are mutually exclusive")
+
+    config = (
+        MossTTSNanoConfig.from_json_file(args.config) if args.config else MossTTSNanoConfig()
+    )
+    if args.attn_implementation:
+        config.attn_implementation = args.attn_implementation
+        config.local_transformer_attn_implementation = args.attn_implementation
+
+    tokenizer = SentencePieceTextTokenizer(args.tokenizer_model)
+    dataset = MossTTSNanoDataset.from_jsonl(
+        args.train_jsonl,
+        tokenizer=tokenizer,
+        config=config,
+        max_length=args.max_length,
+        prompt_style=args.prompt_style,
+    )
+    _LOGGER.info("loaded %d training records", len(dataset))
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        collate_fn=MossTTSNanoCollator(config),
+        pin_memory=torch.cuda.is_available(),
+    )
+
+    module = MossTTSNanoModule(
+        config=config,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        adam_beta1=args.adam_beta1,
+        adam_beta2=args.adam_beta2,
+        adam_eps=args.adam_eps,
+        warmup_steps=args.warmup_steps,
+        warmup_ratio=args.warmup_ratio,
+        lr_scheduler_type=args.lr_scheduler_type,
+        max_train_steps=args.max_steps if args.max_steps > 0 else None,
+        channelwise_loss_weight=args.channelwise_loss_weight,
+        warm_start_from=args.warm_start_from,
+        gradient_checkpointing=args.gradient_checkpointing,
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config.save_json(output_dir / "config.json")
+    checkpoint_callback = ModelCheckpoint(
+        dirpath=str(output_dir),
+        filename="moss-tts-nano-{step:07d}",
+        save_last=True,
+        save_top_k=-1,
+        every_n_train_steps=args.save_every_n_steps or None,
+    )
+
+    trainer = pl.Trainer(
+        default_root_dir=str(output_dir),
+        max_epochs=args.max_epochs,
+        max_steps=args.max_steps,
+        accelerator=args.accelerator,
+        devices=args.devices,
+        precision=args.precision or ("bf16-mixed" if torch.cuda.is_available() else "32-true"),
+        accumulate_grad_batches=args.gradient_accumulation_steps,
+        gradient_clip_val=args.max_grad_norm if args.max_grad_norm > 0 else None,
+        log_every_n_steps=args.log_every_n_steps,
+        callbacks=[checkpoint_callback],
+        logger=CSVLogger(save_dir=str(output_dir), name="logs"),
+        enable_progress_bar=True,
+    )
+    trainer.fit(module, loader, ckpt_path=args.resume_from)
+    _LOGGER.info("done; checkpoints in %s", output_dir)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/phoonnx_train/mosstts/warmstart.py
+++ b/phoonnx_train/mosstts/warmstart.py
@@ -1,0 +1,209 @@
+"""Warm-start a vendored :class:`~phoonnx_train.mosstts.model.MossTTSNano` from a checkpoint.
+
+Supported sources:
+
+* an upstream Hugging Face checkpoint directory (``model.safetensors``, a sharded
+  ``model.safetensors.index.json``, or ``pytorch_model.bin``) — read with ``safetensors``
+  / ``torch.load`` directly, never through ``transformers`` and never with
+  ``trust_remote_code``;
+* a single ``.safetensors`` / ``.bin`` / ``.pt`` file;
+* a Lightning ``.ckpt`` written by a previous phoonnx run (keys are ``model.*``).
+
+The vendored module names were chosen to match upstream, so the mapping is close to the
+identity — but it is applied *explicitly* here (rather than relying on it) and the
+matched-parameter fraction is reported, so a checkpoint that silently fails to load is
+impossible to miss.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import torch
+
+_LOGGER = logging.getLogger("mosstts.warmstart")
+
+#: Renames applied to source keys before matching. Empty today (upstream and the vendored
+#: module agree), kept explicit so future upstream renames land in one place.
+KEY_RENAMES: Dict[str, str] = {}
+
+#: Source keys that are expected to be absent from the vendored module.
+IGNORED_SOURCE_KEYS = (
+    "local_transformer.wte.weight",  # upstream replaces the local wte with nn.Identity
+)
+
+
+@dataclass
+class WarmStartReport:
+    """What the mapping actually did, in tensors and in parameters."""
+
+    source: str
+    matched: List[str] = field(default_factory=list)
+    missing: List[str] = field(default_factory=list)
+    unexpected: List[str] = field(default_factory=list)
+    shape_mismatch: List[Tuple[str, tuple, tuple]] = field(default_factory=list)
+    matched_parameters: int = 0
+    total_parameters: int = 0
+    tied_from_source: List[str] = field(default_factory=list)
+
+    @property
+    def matched_fraction(self) -> float:
+        if self.total_parameters == 0:
+            return 0.0
+        return self.matched_parameters / float(self.total_parameters)
+
+    def summary(self) -> str:
+        return (
+            f"{self.source}: matched {len(self.matched)} tensors / "
+            f"{self.matched_parameters:,} of {self.total_parameters:,} parameters "
+            f"({100.0 * self.matched_fraction:.2f}%), "
+            f"missing={len(self.missing)} unexpected={len(self.unexpected)} "
+            f"shape_mismatch={len(self.shape_mismatch)}"
+        )
+
+
+def _load_safetensors(path: Path) -> Dict[str, torch.Tensor]:
+    from safetensors.torch import load_file
+
+    return dict(load_file(str(path), device="cpu"))
+
+
+def _load_torch(path: Path) -> Dict[str, torch.Tensor]:
+    payload = torch.load(str(path), map_location="cpu", weights_only=False)
+    if isinstance(payload, dict) and "state_dict" in payload:
+        payload = payload["state_dict"]
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} does not contain a state dict")
+    return {key: value for key, value in payload.items() if isinstance(value, torch.Tensor)}
+
+
+def load_source_state_dict(source: Union[str, Path]) -> Tuple[Dict[str, torch.Tensor], str]:
+    """Read a checkpoint into a flat ``{key: tensor}`` mapping, whatever its container."""
+    path = Path(source).expanduser()
+    if path.is_dir():
+        index_path = path / "model.safetensors.index.json"
+        if index_path.exists():
+            index = json.loads(index_path.read_text(encoding="utf-8"))
+            state: Dict[str, torch.Tensor] = {}
+            for shard in sorted(set(index["weight_map"].values())):
+                state.update(_load_safetensors(path / shard))
+            return state, str(index_path)
+        for candidate in ("model.safetensors", "pytorch_model.bin", "model.ckpt"):
+            candidate_path = path / candidate
+            if candidate_path.exists():
+                return load_source_state_dict(candidate_path)
+        raise FileNotFoundError(
+            f"no model.safetensors / model.safetensors.index.json / pytorch_model.bin under {path}"
+        )
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if path.suffix == ".safetensors":
+        return _load_safetensors(path), str(path)
+    return _load_torch(path), str(path)
+
+
+def normalize_source_keys(state: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """Strip Lightning's ``model.`` prefix and apply :data:`KEY_RENAMES`."""
+    keys = list(state)
+    # Only strip the prefix when it is universal; a bare upstream checkpoint has none.
+    strip = bool(keys) and all(key.startswith("model.") for key in keys)
+    normalized: Dict[str, torch.Tensor] = {}
+    for key, value in state.items():
+        new_key = key[len("model."):] if strip else key
+        new_key = KEY_RENAMES.get(new_key, new_key)
+        normalized[new_key] = value
+    return normalized
+
+
+def warm_start(
+    model: torch.nn.Module,
+    source: Union[str, Path],
+    strict_shapes: bool = True,
+    logger: Optional[logging.Logger] = None,
+) -> WarmStartReport:
+    """Copy every compatible tensor from *source* into *model*, in place.
+
+    Tied heads (``text_lm_head.weight`` / ``audio_lm_heads.*``) share storage with their
+    embedding, so a checkpoint that only stores the embedding still warm-starts them; the
+    report lists those under ``tied_from_source`` and counts them as matched.
+    """
+    logger = logger or _LOGGER
+    raw_state, resolved_source = load_source_state_dict(source)
+    source_state = normalize_source_keys(raw_state)
+    target_state = model.state_dict()
+    tied = getattr(model, "tied_weight_keys", {})
+
+    report = WarmStartReport(source=resolved_source)
+    report.total_parameters = sum(int(tensor.numel()) for tensor in target_state.values())
+
+    to_load: Dict[str, torch.Tensor] = {}
+    for key, target_tensor in target_state.items():
+        candidate = source_state.get(key)
+        if candidate is None and key in tied:
+            candidate = source_state.get(tied[key])
+            if candidate is not None:
+                report.tied_from_source.append(key)
+        if candidate is None:
+            report.missing.append(key)
+            continue
+        if tuple(candidate.shape) != tuple(target_tensor.shape):
+            report.shape_mismatch.append((key, tuple(candidate.shape), tuple(target_tensor.shape)))
+            if strict_shapes:
+                continue
+            continue
+        to_load[key] = candidate.to(dtype=target_tensor.dtype)
+        report.matched.append(key)
+        report.matched_parameters += int(target_tensor.numel())
+
+    consumed = set(report.matched) | {tied[key] for key in report.tied_from_source}
+    for key in source_state:
+        if key in consumed or key in IGNORED_SOURCE_KEYS:
+            continue
+        report.unexpected.append(key)
+
+    model.load_state_dict(to_load, strict=False)
+    if hasattr(model, "tie_weights"):
+        model.tie_weights()
+
+    logger.info("warm start %s", report.summary())
+    if report.missing:
+        logger.warning("warm start: %d parameters left at their initial values: %s",
+                       len(report.missing), ", ".join(report.missing[:8]))
+    if report.shape_mismatch:
+        logger.warning("warm start: %d shape mismatches: %s",
+                       len(report.shape_mismatch), report.shape_mismatch[:4])
+    return report
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """``python -m phoonnx_train.mosstts.warmstart --checkpoint <dir> [--config <json>]``"""
+    import argparse
+
+    from phoonnx_train.mosstts.config import MossTTSNanoConfig
+    from phoonnx_train.mosstts.model import MossTTSNano
+
+    parser = argparse.ArgumentParser(description="Report the warm-start coverage of a checkpoint.")
+    parser.add_argument("--checkpoint", required=True, help="upstream checkpoint dir/file or a .ckpt")
+    parser.add_argument("--config", default=None, help="config JSON (defaults to <checkpoint>/config.json)")
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config) if args.config else Path(args.checkpoint) / "config.json"
+    config = MossTTSNanoConfig.from_json_file(config_path)
+    model = MossTTSNano(config)
+    report = warm_start(model, args.checkpoint)
+    print(report.summary())
+    if report.missing:
+        print("missing:", *report.missing, sep="\n  ")
+    if report.unexpected:
+        print("unexpected:", *report.unexpected, sep="\n  ")
+    return 0 if not report.missing and not report.shape_mismatch else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = ["warm_start", "WarmStartReport", "load_source_state_dict", "normalize_source_keys"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,18 @@ train-fastpitch = []
 # alignment search) are also already pulled in via [train] (numba
 # transitively through librosa on <3.13).
 train-mixer = []
+# extra deps for the MOSS-TTS-Nano training pipeline (phoonnx_train/mosstts/)
+# on top of [train]: sentencepiece for the text tokenizer, safetensors to read
+# the released checkpoint without transformers, soundfile to read audio in
+# prepare_data (the codec itself runs under onnxruntime, already a core dep),
+# and onnx for the external-data layout of the exported graphs. scipy
+# (resampling) is already in [train].
+train-mosstts = [
+    "sentencepiece",
+    "safetensors",
+    "soundfile",
+    "onnx",
+]
 # extra deps for the OptiSpeech training engine
 # (phoonnx_train/optispeech/ + phoonnx_train/engines/optispeech.py) on top of
 # [train]: scipy for pitch interpolation (the pitch extractor itself uses

--- a/tests/test_mosstts_export.py
+++ b/tests/test_mosstts_export.py
@@ -1,0 +1,254 @@
+"""ONNX export round-trip for the vendored MOSS-TTS-Nano trainer.
+
+A tiny randomly-initialised model is exported and then driven through exactly the graph
+protocol :class:`phoonnx.engines.mosstts.MossTTSNanoAdapter` uses::
+
+    global_hidden, past = prefill(rows, attention_mask)
+    should_continue, frame = local_fixed_sampled_frame(global_hidden, ...)
+    global_hidden, past = decode_step(row, past_valid_lengths, past)
+
+so a change that breaks the exported layout fails here rather than at synthesis time.
+"""
+import numpy as np
+import pytest
+import torch
+
+onnxruntime = pytest.importorskip("onnxruntime")
+
+from phoonnx_train.mosstts.config import MossTTSNanoConfig
+from phoonnx_train.mosstts.export_onnx import export_moss_tts_onnx
+from phoonnx_train.mosstts.model import MossTTSNano
+
+
+@pytest.fixture(scope="module")
+def exported(tmp_path_factory):
+    torch.manual_seed(0)
+    config = MossTTSNanoConfig.tiny(n_vq=4, codebook_size=32, vocab_size=64)
+    model = MossTTSNano(config)
+    output_dir = tmp_path_factory.mktemp("moss_onnx")
+    meta_path = export_moss_tts_onnx(
+        model, output_dir, opset=17, sample_seq_len=6, sample_past_len=6
+    )
+    return model, config, output_dir, meta_path
+
+
+def _session(path):
+    return onnxruntime.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+
+
+def _named(session, outputs):
+    return dict(zip([item.name for item in session.get_outputs()], outputs))
+
+
+def _rows(config, length, rng):
+    rows = np.full((1, length, config.row_width), config.audio_pad_token_id, dtype=np.int32)
+    rows[0, :, 0] = rng.integers(0, config.gpt2.vocab_size, size=length)
+    return rows
+
+
+def test_metadata_describes_the_expected_layout(exported):
+    import json
+
+    _model, config, _output_dir, meta_path = exported
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert set(meta["files"]) == {
+        "prefill", "decode_step", "local_decoder", "local_cached_step",
+        "local_fixed_sampled_frame",
+    }
+    assert meta["model_config"]["row_width"] == config.row_width
+    assert meta["model_config"]["n_vq"] == config.n_vq
+    assert meta["onnx"]["prefill_output_names"][0] == "global_hidden"
+
+
+def test_prefill_matches_torch(exported):
+    model, config, output_dir, _meta = exported
+    rng = np.random.default_rng(0)
+    rows = _rows(config, 6, rng)
+    mask = np.ones((1, 6), dtype=np.int32)
+
+    session = _session(output_dir / "moss_tts_prefill.onnx")
+    outputs = _named(session, session.run(None, {"input_ids": rows, "attention_mask": mask}))
+
+    with torch.no_grad():
+        model.set_attention_implementation("eager")
+        reference, _ = model(
+            input_ids=torch.as_tensor(rows, dtype=torch.long),
+            attention_mask=torch.as_tensor(mask, dtype=torch.bool),
+        )
+    assert np.allclose(outputs["global_hidden"], reference.numpy(), atol=1e-4)
+    assert outputs["present_key_0"].shape == (1, 6, config.gpt2.n_head, config.gpt2.head_dim)
+
+
+def test_prefill_handles_a_different_length_than_it_was_traced_with(exported):
+    _model, config, output_dir, _meta = exported
+    rng = np.random.default_rng(1)
+    session = _session(output_dir / "moss_tts_prefill.onnx")
+    for length in (3, 11):
+        rows = _rows(config, length, rng)
+        outputs = _named(
+            session, session.run(None, {"input_ids": rows, "attention_mask": np.ones((1, length), np.int32)})
+        )
+        assert outputs["global_hidden"].shape == (1, length, config.hidden_size)
+
+
+def test_decode_step_continues_the_prefill(exported):
+    """decode_step over the cache must reproduce a full prefill of the same rows."""
+    _model, config, output_dir, _meta = exported
+    rng = np.random.default_rng(2)
+    rows = _rows(config, 7, rng)
+
+    prefill = _session(output_dir / "moss_tts_prefill.onnx")
+    decode = _session(output_dir / "moss_tts_decode_step.onnx")
+
+    full = _named(prefill, prefill.run(
+        None, {"input_ids": rows, "attention_mask": np.ones((1, 7), np.int32)}
+    ))
+    head = _named(prefill, prefill.run(
+        None, {"input_ids": rows[:, :6], "attention_mask": np.ones((1, 6), np.int32)}
+    ))
+    past = {k.replace("present_", "past_"): v for k, v in head.items() if k.startswith("present_")}
+    stepped = _named(decode, decode.run(None, {
+        "input_ids": rows[:, 6:],
+        "past_valid_lengths": np.asarray([6], np.int32),
+        **past,
+    }))
+    assert np.allclose(
+        stepped["global_hidden"].reshape(-1), full["global_hidden"][0, -1], atol=1e-4
+    )
+
+
+def test_local_fixed_frame_emits_a_full_frame(exported):
+    _model, config, output_dir, _meta = exported
+    session = _session(output_dir / "moss_tts_local_fixed_sampled_frame.onnx")
+    rng = np.random.default_rng(3)
+    outputs = _named(session, session.run(None, {
+        "global_hidden": rng.standard_normal((1, config.hidden_size)).astype(np.float32),
+        "repetition_seen_mask": np.zeros((1, config.n_vq, config.audio_codebook_sizes[0]), np.int32),
+        "assistant_random_u": np.asarray([0.1], np.float32),
+        "audio_random_u": np.full((1, config.n_vq), 0.3, np.float32),
+    }))
+    frame = np.asarray(outputs["frame_token_ids"]).reshape(-1)
+    assert frame.shape[0] == config.n_vq
+    assert frame.min() >= 0 and frame.max() < config.audio_codebook_sizes[0]
+    assert int(np.asarray(outputs["should_continue"]).reshape(-1)[0]) in (0, 1)
+
+
+def test_local_cached_step_matches_the_uncached_local_decoder(exported):
+    """Walking the local transformer channel by channel must equal one full local pass."""
+    _model, config, output_dir, _meta = exported
+    cached = _session(output_dir / "moss_tts_local_cached_step.onnx")
+    whole = _session(output_dir / "moss_tts_local_decoder.onnx")
+    rng = np.random.default_rng(4)
+    global_hidden = rng.standard_normal((1, config.hidden_size)).astype(np.float32)
+
+    text_token = 3
+    prefix = rng.integers(0, config.audio_codebook_sizes[0], size=config.n_vq - 1).astype(np.int32)
+
+    reference = _named(whole, whole.run(None, {
+        "global_hidden": global_hidden,
+        "text_token_id": np.asarray([text_token], np.int32),
+        "audio_prefix_token_ids": prefix.reshape(1, -1),
+    }))
+
+    layers = sum(1 for item in cached.get_inputs() if item.name.startswith("local_past_key_"))
+    heads = int(cached.get_inputs()[6].shape[2])
+    head_dim = int(cached.get_inputs()[6].shape[3])
+    past = {
+        name: np.zeros((1, 0, heads, head_dim), np.float32)
+        for i in range(layers)
+        for name in (f"local_past_key_{i}", f"local_past_value_{i}")
+    }
+
+    def step(text_id, audio_id, channel, step_type, valid):
+        outputs = _named(cached, cached.run(None, {
+            "global_hidden": global_hidden,
+            "text_token_id": np.asarray([text_id], np.int32),
+            "audio_token_id": np.asarray([audio_id], np.int32),
+            "channel_index": np.asarray([channel], np.int32),
+            "step_type": np.asarray([step_type], np.int32),
+            "past_valid_lengths": np.asarray([valid], np.int32),
+            **past,
+        }))
+        nxt = {k.replace("local_present_", "local_past_"): v
+               for k, v in outputs.items() if k.startswith("local_present_")}
+        past.update(nxt)
+        return outputs
+
+    first = step(0, 0, 0, 0, 0)
+    assert np.allclose(first["text_logits"].reshape(-1), reference["text_logits"].reshape(-1), atol=1e-4)
+
+    second = step(text_token, 0, 0, 1, 1)
+    assert np.allclose(
+        second["audio_logits"][0, 0], reference["audio_logits"][0, 0], atol=1e-4
+    )
+    for channel in range(1, config.n_vq):
+        outputs = step(0, int(prefix[channel - 1]), channel - 1, 2, channel + 1)
+        assert np.allclose(
+            outputs["audio_logits"][0, channel], reference["audio_logits"][0, channel], atol=1e-4
+        )
+
+
+def test_full_adapter_loop_runs(exported):
+    """The exact prefill -> local frame -> decode_step loop the phoonnx adapter drives."""
+    _model, config, output_dir, _meta = exported
+    prefill = _session(output_dir / "moss_tts_prefill.onnx")
+    decode = _session(output_dir / "moss_tts_decode_step.onnx")
+    local = _session(output_dir / "moss_tts_local_fixed_sampled_frame.onnx")
+    rng = np.random.default_rng(5)
+
+    rows = _rows(config, 5, rng)
+    outputs = _named(prefill, prefill.run(
+        None, {"input_ids": rows, "attention_mask": np.ones((1, 5), np.int32)}
+    ))
+    global_hidden = outputs["global_hidden"][:, -1, :]
+    past = {k.replace("present_", "past_"): v for k, v in outputs.items() if k.startswith("present_")}
+    valid_length = 5
+
+    frames = []
+    seen = np.zeros((1, config.n_vq, config.audio_codebook_sizes[0]), np.int32)
+    for _ in range(4):
+        frame_outputs = _named(local, local.run(None, {
+            "global_hidden": global_hidden.astype(np.float32),
+            "repetition_seen_mask": seen,
+            "assistant_random_u": np.asarray([float(rng.random())], np.float32),
+            "audio_random_u": rng.random((1, config.n_vq)).astype(np.float32),
+        }))
+        if not int(np.asarray(frame_outputs["should_continue"]).reshape(-1)[0]):
+            break
+        frame = np.asarray(frame_outputs["frame_token_ids"]).reshape(-1)
+        for channel, token in enumerate(frame):
+            seen[0, channel, int(token)] = 1
+        frames.append(frame.tolist())
+
+        row = np.full((1, 1, config.row_width), config.audio_pad_token_id, np.int32)
+        row[0, 0, 0] = config.audio_assistant_slot_token_id
+        row[0, 0, 1:] = frame
+        outputs = _named(decode, decode.run(None, {
+            "input_ids": row,
+            "past_valid_lengths": np.asarray([valid_length], np.int32),
+            **past,
+        }))
+        global_hidden = outputs["global_hidden"].reshape(1, -1)
+        past = {k.replace("present_", "past_"): v for k, v in outputs.items() if k.startswith("present_")}
+        valid_length += 1
+
+    assert all(len(frame) == config.n_vq for frame in frames)
+
+
+def test_external_data_layout(tmp_path):
+    """``--external-data`` must produce the shared blobs the upstream layout uses."""
+    torch.manual_seed(0)
+    config = MossTTSNanoConfig.tiny()
+    meta_path = export_moss_tts_onnx(
+        MossTTSNano(config), tmp_path / "ext", opset=17,
+        sample_seq_len=4, sample_past_len=4, external_data=True,
+    )
+    output_dir = meta_path.parent
+    assert (output_dir / "moss_tts_global_shared.data").exists()
+    assert (output_dir / "moss_tts_local_shared.data").exists()
+    assert not (output_dir / "moss_tts_prefill.data").exists()
+    session = _session(output_dir / "moss_tts_prefill.onnx")
+    rows = np.full((1, 3, config.row_width), config.audio_pad_token_id, np.int32)
+    rows[0, :, 0] = 1
+    outputs = session.run(None, {"input_ids": rows, "attention_mask": np.ones((1, 3), np.int32)})
+    assert outputs[0].shape == (1, 3, config.hidden_size)

--- a/tests/test_mosstts_training.py
+++ b/tests/test_mosstts_training.py
@@ -1,0 +1,588 @@
+"""Unit tests for the vendored MOSS-TTS-Nano training pipeline."""
+import json
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from phoonnx_train.mosstts.config import GPT2DecoderConfig, MossTTSNanoConfig
+from phoonnx_train.mosstts.dataset import (
+    IGNORE_INDEX,
+    MossTTSNanoCollator,
+    MossTTSNanoDataset,
+    dump_jsonl,
+    load_jsonl,
+)
+from phoonnx_train.mosstts.lightning import (
+    MossTTSNanoModule,
+    build_lr_lambda,
+    parse_channelwise_loss_weight,
+)
+from phoonnx_train.mosstts.model import MossTTSNano
+from phoonnx_train.mosstts.warmstart import normalize_source_keys, warm_start
+
+
+class StubTokenizer:
+    """Deterministic byte-ish tokenizer: enough for row-shape assertions, no model file."""
+
+    def __init__(self, vocab_size: int = 64):
+        self.vocab_size = vocab_size
+
+    def encode(self, text):
+        # ids 16.. keep the special ids (0-15) free
+        return [16 + (ord(char) % (self.vocab_size - 16)) for char in text]
+
+    def decode(self, ids):
+        return "".join(chr(int(i)) for i in ids)
+
+
+@pytest.fixture
+def config():
+    return MossTTSNanoConfig.tiny()
+
+
+@pytest.fixture
+def tokenizer(config):
+    return StubTokenizer(vocab_size=config.gpt2.vocab_size)
+
+
+def make_record(frames=5, n_vq=4, codebook=32, text="hi", ref_frames=0):
+    rng = np.random.default_rng(0)
+    record = {
+        "audio": "fake.wav",
+        "text": text,
+        "audio_codes": rng.integers(0, codebook, size=(frames, n_vq)).tolist(),
+    }
+    if ref_frames:
+        record["ref_audio"] = "ref.wav"
+        record["ref_audio_codes"] = rng.integers(0, codebook, size=(ref_frames, n_vq)).tolist()
+    return record
+
+
+# ----------------------------------------------------------------------
+# config
+# ----------------------------------------------------------------------
+def test_config_rejects_pad_inside_codebook():
+    with pytest.raises(ValueError, match="audio_pad_token_id"):
+        MossTTSNanoConfig(n_vq=2, audio_codebook_sizes=[1024, 1024], audio_pad_token_id=512)
+
+
+def test_config_rejects_wrong_codebook_count():
+    with pytest.raises(ValueError, match="length n_vq"):
+        MossTTSNanoConfig(n_vq=3, audio_codebook_sizes=[1024, 1024])
+
+
+def test_config_rejects_delay_pattern_architecture(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"model_type": "moss_tts_nano", "model_architecture": "delay_pattern"}))
+    with pytest.raises(ValueError, match="global-local"):
+        MossTTSNanoConfig.from_json_file(path)
+
+
+def test_config_roundtrip(tmp_path, config):
+    path = config.save_json(tmp_path / "config.json")
+    restored = MossTTSNanoConfig.from_json_file(path)
+    assert restored.to_dict() == config.to_dict()
+
+
+def test_upstream_config_shape_is_accepted(tmp_path):
+    """The real checkpoint's ``config.json`` layout must load without transformers."""
+    payload = {
+        "model_type": "moss_tts_nano",
+        "model_architecture": "global_local_transformer",
+        "n_vq": 16,
+        "audio_codebook_sizes": [1024] * 16,
+        "audio_pad_token_id": 1024,
+        "pad_token_id": 3,
+        "im_start_token_id": 4,
+        "im_end_token_id": 5,
+        "audio_start_token_id": 6,
+        "audio_end_token_id": 7,
+        "audio_user_slot_token_id": 8,
+        "audio_assistant_slot_token_id": 9,
+        "local_transformer_layers": 1,
+        "gpt2_config": {
+            "vocab_size": 16384, "n_positions": 32768, "n_embd": 768, "n_layer": 12,
+            "n_head": 12, "n_inner": 3072, "activation_function": "gelu_new",
+            "position_embedding_type": "rope", "rope_base": 10000.0,
+            "layer_norm_epsilon": 1e-5, "pad_token_id": 3,
+            "tie_word_embeddings": True, "summary_type": "cls_index",
+        },
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(payload))
+    config = MossTTSNanoConfig.from_json_file(path)
+    assert config.n_vq == 16
+    assert config.row_width == 17
+    assert config.gpt2.n_layer == 12
+    assert config.local_gpt2().n_layer == 1
+    assert config.local_gpt2().n_positions == 17
+
+
+# ----------------------------------------------------------------------
+# dataset / collation
+# ----------------------------------------------------------------------
+def test_rows_have_slot_and_code_columns(config, tokenizer):
+    dataset = MossTTSNanoDataset([make_record()], tokenizer, config, max_length=256)
+    example = dataset[0]
+    rows = example["rows"]
+    assert rows.shape[1] == config.row_width
+    prompt_length = int(example["prompt_length"])
+    # the prompt is all text rows: audio columns are pad
+    assert torch.all(rows[:prompt_length, 1:] == config.audio_pad_token_id)
+    # the target rows carry the assistant slot in column 0
+    audio_rows = rows[prompt_length:-1]
+    assert torch.all(audio_rows[:, 0] == config.audio_assistant_slot_token_id)
+    assert torch.all(audio_rows[:, 1:] < config.audio_pad_token_id)
+    # the sequence terminates with the audio-end text token
+    assert int(rows[-1, 0]) == config.audio_end_token_id
+
+
+def test_reference_codes_use_the_user_slot(config, tokenizer):
+    dataset = MossTTSNanoDataset([make_record(ref_frames=3)], tokenizer, config, max_length=256)
+    rows = dataset[0]["rows"]
+    user_slot_rows = rows[rows[:, 0] == config.audio_user_slot_token_id]
+    assert user_slot_rows.shape[0] == 3
+
+
+def test_prompt_style_controls_the_im_end_token(config, tokenizer):
+    record = make_record()
+    inference = MossTTSNanoDataset([record], tokenizer, config, max_length=256, prompt_style="inference")
+    finetuning = MossTTSNanoDataset([record], tokenizer, config, max_length=256, prompt_style="finetuning")
+    inference_ids = inference[0]["rows"][:, 0].tolist()
+    finetuning_ids = finetuning[0]["rows"][:, 0].tolist()
+    assert config.im_end_token_id in inference_ids
+    assert config.im_end_token_id not in finetuning_ids
+    assert len(inference_ids) == len(finetuning_ids) + 1
+
+
+def test_collate_masks_the_prompt_and_shifts_by_one(config, tokenizer):
+    dataset = MossTTSNanoDataset([make_record(frames=4)], tokenizer, config, max_length=256)
+    batch = MossTTSNanoCollator(config)([dataset[0]])
+    rows = dataset[0]["rows"]
+    prompt_length = int(dataset[0]["prompt_length"])
+
+    assert batch["input_ids"].shape[1] == rows.shape[0] - 1
+    assert batch["labels"].shape == batch["input_ids"].shape
+    # labels are the next row, wherever supervision is live
+    assert torch.equal(batch["input_ids"][0, 1], rows[1])
+    assert torch.equal(batch["labels"][0, prompt_length - 1], rows[prompt_length])
+    # nothing before the last prompt row is supervised
+    assert torch.all(batch["labels"][0, : prompt_length - 1] == IGNORE_INDEX)
+    # the first supervised step predicts the first audio frame
+    assert int(batch["labels"][0, prompt_length - 1, 0]) == config.audio_assistant_slot_token_id
+
+
+def test_collate_pads_a_ragged_batch(config, tokenizer):
+    dataset = MossTTSNanoDataset(
+        [make_record(frames=3), make_record(frames=9, text="a much longer sentence")],
+        tokenizer, config, max_length=256,
+    )
+    batch = MossTTSNanoCollator(config)([dataset[0], dataset[1]])
+    assert batch["input_ids"].shape[0] == 2
+    lengths = batch["attention_mask"].sum(dim=1)
+    assert lengths[0] != lengths[1]
+    # padded positions never produce a target
+    padded = ~batch["attention_mask"]
+    assert torch.all(batch["labels"][padded] == IGNORE_INDEX)
+    # padded rows carry pad ids, not stale data
+    assert torch.all(batch["input_ids"][padded][:, 0] == config.pad_token_id)
+    assert torch.all(batch["input_ids"][padded][:, 1:] == config.audio_pad_token_id)
+
+
+def test_audio_pad_columns_are_never_targets(config, tokenizer):
+    dataset = MossTTSNanoDataset([make_record()], tokenizer, config, max_length=256)
+    batch = MossTTSNanoCollator(config)([dataset[0]])
+    assert not bool((batch["labels"][:, :, 1:] == config.audio_pad_token_id).any())
+
+
+def test_narrow_codes_are_padded_to_model_width(config, tokenizer):
+    record = make_record(n_vq=2, codebook=config.audio_codebook_sizes[0])
+    dataset = MossTTSNanoDataset([record], tokenizer, config, max_length=256)
+    rows = dataset[0]["rows"]
+    audio_rows = rows[rows[:, 0] == config.audio_assistant_slot_token_id]
+    assert torch.all(audio_rows[:, 3:] == config.audio_pad_token_id)
+
+
+def test_too_wide_codes_are_rejected(config, tokenizer):
+    record = make_record(n_vq=config.n_vq + 1)
+    dataset = MossTTSNanoDataset([record], tokenizer, config, max_length=256)
+    with pytest.raises(ValueError, match="model expects at most"):
+        dataset[0]
+
+
+def test_missing_codes_are_rejected(config, tokenizer):
+    dataset = MossTTSNanoDataset([{"text": "hi"}], tokenizer, config, max_length=256)
+    with pytest.raises(ValueError, match="prepare_data"):
+        dataset[0]
+
+
+def test_reference_audio_without_codes_is_rejected(config, tokenizer):
+    record = make_record()
+    record["ref_audio"] = "ref.wav"
+    dataset = MossTTSNanoDataset([record], tokenizer, config, max_length=256)
+    with pytest.raises(ValueError, match="ref_audio_codes"):
+        dataset[0]
+
+
+def test_prompt_longer_than_max_length_is_rejected(config, tokenizer):
+    dataset = MossTTSNanoDataset([make_record(text="x" * 200)], tokenizer, config, max_length=32)
+    with pytest.raises(ValueError, match="max_length"):
+        dataset[0]
+
+
+def test_empty_dataset_is_rejected(config, tokenizer):
+    with pytest.raises(ValueError, match="empty"):
+        MossTTSNanoDataset([], tokenizer, config)
+
+
+def test_jsonl_roundtrip(tmp_path):
+    records = [make_record(), make_record(text="two")]
+    path = dump_jsonl(records, tmp_path / "train.jsonl")
+    assert load_jsonl(path) == records
+
+
+# ----------------------------------------------------------------------
+# model
+# ----------------------------------------------------------------------
+def test_heads_are_tied_to_their_embeddings(config):
+    model = MossTTSNano(config)
+    assert model.text_lm_head.weight is model.transformer.wte.weight
+    for embedding, head in zip(model.audio_embeddings, model.audio_lm_heads):
+        assert head.weight is embedding.weight
+
+
+def test_local_transformer_has_no_wte_parameters(config):
+    model = MossTTSNano(config)
+    assert not any(key.startswith("local_transformer.wte") for key in model.state_dict())
+
+
+def test_pad_columns_contribute_nothing_to_the_embedding(config):
+    model = MossTTSNano(config).eval()
+    rows = torch.full((1, 3, config.row_width), config.audio_pad_token_id, dtype=torch.long)
+    rows[:, :, 0] = 5
+    with torch.no_grad():
+        embeds = model.build_inputs_embeds(rows)
+        text_only = model.transformer.wte(rows[..., 0])
+    assert torch.allclose(embeds, text_only)
+
+
+def test_out_of_range_codes_are_rejected(config):
+    model = MossTTSNano(config)
+    rows = torch.full((1, 2, config.row_width), config.audio_pad_token_id, dtype=torch.long)
+    rows[0, 0, 1] = config.audio_codebook_sizes[0] + 5  # above pad, so not masked out
+    with pytest.raises(ValueError, match="out-of-range"):
+        model.build_inputs_embeds(rows)
+
+
+def test_local_teacher_forcing_uses_the_previous_channel(config):
+    """Channel ``c`` must be conditioned on the *true* channel ``c-1``, not its own target."""
+    model = MossTTSNano(config).eval()
+    hidden = torch.randn(4, config.hidden_size)
+    labels = torch.zeros((4, config.n_vq + 1), dtype=torch.long)
+    local_inputs = model.build_local_inputs(hidden, labels)
+    assert local_inputs.shape == (4, config.n_vq + 1, config.hidden_size)
+    assert torch.allclose(local_inputs[:, 0, :], hidden)
+    assert torch.allclose(local_inputs[:, 1, :], model.transformer.wte(labels[:, 0]))
+    for channel in range(config.n_vq - 1):
+        expected = model.audio_embeddings[channel](labels[:, channel + 1])
+        assert torch.allclose(local_inputs[:, channel + 2, :], expected)
+
+
+def test_ignored_labels_do_not_leak_into_the_local_inputs(config):
+    model = MossTTSNano(config).eval()
+    hidden = torch.randn(2, config.hidden_size)
+    labels = torch.full((2, config.n_vq + 1), IGNORE_INDEX, dtype=torch.long)
+    local_inputs = model.build_local_inputs(hidden, labels)
+    # -100 targets are masked to a zero contribution on the audio channels
+    assert torch.allclose(local_inputs[:, 2:, :], torch.zeros_like(local_inputs[:, 2:, :]))
+
+
+def test_kv_cache_matches_a_full_forward(config):
+    model = MossTTSNano(config).eval()
+    rows = torch.full((1, 6, config.row_width), config.audio_pad_token_id, dtype=torch.long)
+    rows[:, :, 0] = torch.arange(6) % 10
+    mask = torch.ones((1, 6), dtype=torch.bool)
+    with torch.no_grad():
+        full, _ = model(input_ids=rows, attention_mask=mask)
+        prefix, past = model(input_ids=rows[:, :5], attention_mask=mask[:, :5], use_cache=True)
+        step, _ = model(
+            input_ids=rows[:, 5:],
+            attention_mask=mask,
+            past_key_values=past,
+            use_cache=True,
+        )
+    assert torch.allclose(full[:, -1], step[:, -1], atol=1e-4)
+
+
+def test_eager_and_sdpa_agree(config):
+    model = MossTTSNano(config).eval()
+    rows = torch.full((1, 5, config.row_width), config.audio_pad_token_id, dtype=torch.long)
+    rows[:, :, 0] = torch.arange(5)
+    mask = torch.ones((1, 5), dtype=torch.bool)
+    mask[0, -2:] = False
+    with torch.no_grad():
+        model.set_attention_implementation("eager")
+        eager, _ = model(input_ids=rows, attention_mask=mask)
+        model.set_attention_implementation("sdpa")
+        sdpa, _ = model(input_ids=rows, attention_mask=mask)
+    assert torch.allclose(eager, sdpa, atol=1e-4)
+
+
+# ----------------------------------------------------------------------
+# loss / lightning
+# ----------------------------------------------------------------------
+def test_channelwise_weight_shorthand():
+    weights = parse_channelwise_loss_weight("1,32", 17)
+    assert weights[0] == 1.0
+    assert all(abs(weight - 2.0) < 1e-9 for weight in weights[1:])
+    assert len(weights) == 17
+
+
+def test_channelwise_weight_explicit_list():
+    weights = parse_channelwise_loss_weight([1, 2, 3], 3)
+    assert weights == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.parametrize("spec", ["1,2,3", "", "-1,32"])
+def test_channelwise_weight_rejects_bad_specs(spec):
+    with pytest.raises(ValueError):
+        parse_channelwise_loss_weight(spec, 17)
+
+
+def test_lr_lambda_warms_up_then_decays():
+    lr_lambda = build_lr_lambda("linear", num_warmup_steps=10, num_training_steps=100)
+    assert lr_lambda(0) == 0.0
+    assert lr_lambda(5) == pytest.approx(0.5)
+    assert lr_lambda(10) == pytest.approx(1.0)
+    assert lr_lambda(100) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_cosine_lr_lambda_is_monotone_after_warmup():
+    lr_lambda = build_lr_lambda("cosine", 0, 100)
+    values = [lr_lambda(step) for step in range(0, 101, 10)]
+    assert all(later <= earlier + 1e-9 for earlier, later in zip(values, values[1:]))
+
+
+def test_unknown_scheduler_is_rejected():
+    with pytest.raises(ValueError, match="unsupported lr_scheduler_type"):
+        build_lr_lambda("triangular", 0, 10)
+
+
+def _tiny_batch(config, tokenizer, records=1):
+    dataset = MossTTSNanoDataset(
+        [make_record(frames=4, text=f"sample {i}") for i in range(records)],
+        tokenizer, config, max_length=256,
+    )
+    return MossTTSNanoCollator(config)([dataset[i] for i in range(records)])
+
+
+def test_training_step_produces_a_finite_gradient(config, tokenizer):
+    module = MossTTSNanoModule(config=config)
+    batch = _tiny_batch(config, tokenizer)
+    loss = module.training_step(batch, 0)
+    assert torch.isfinite(loss)
+    loss.backward()
+    grads = [p.grad for p in module.model.parameters() if p.grad is not None]
+    assert grads
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+def test_loss_matches_a_hand_written_weighted_mean(config, tokenizer):
+    """The reported loss must be ``sum(w_i CE_i) / sum(w_i)`` over live heads."""
+    torch.manual_seed(0)
+    module = MossTTSNanoModule(config=config).eval()
+    batch = _tiny_batch(config, tokenizer)
+    with torch.no_grad():
+        outputs = module.compute_loss(batch)
+    weights = module.channelwise_loss_weight
+    manual_total = float(weights[0]) * float(outputs["loss_text"])
+    manual_weight = float(weights[0])
+    for channel in range(config.n_vq):
+        key = f"loss_vq{channel}"
+        if key not in outputs:
+            continue
+        manual_total += float(weights[channel + 1]) * float(outputs[key])
+        manual_weight += float(weights[channel + 1])
+    assert float(outputs["loss"]) == pytest.approx(manual_total / manual_weight, rel=1e-5)
+
+
+def test_loss_ignores_padded_timesteps(config, tokenizer):
+    """Padding a batch must not change the loss."""
+    torch.manual_seed(0)
+    module = MossTTSNanoModule(config=config).eval()
+    dataset = MossTTSNanoDataset(
+        [make_record(frames=4), make_record(frames=4)], tokenizer, config, max_length=256
+    )
+    collate = MossTTSNanoCollator(config)
+    single = collate([dataset[0]])
+    with torch.no_grad():
+        alone = float(module.compute_loss(single)["loss"])
+    padded = collate([dataset[0]])
+    pad_rows = torch.full((1, 6, config.row_width), config.audio_pad_token_id, dtype=torch.long)
+    pad_rows[:, :, 0] = config.pad_token_id
+    padded["input_ids"] = torch.cat([padded["input_ids"], pad_rows], dim=1)
+    padded["attention_mask"] = torch.cat(
+        [padded["attention_mask"], torch.zeros((1, 6), dtype=torch.bool)], dim=1
+    )
+    padded["labels"] = torch.cat(
+        [padded["labels"], torch.full((1, 6, config.row_width), IGNORE_INDEX, dtype=torch.long)], dim=1
+    )
+    with torch.no_grad():
+        with_padding = float(module.compute_loss(padded)["loss"])
+    assert with_padding == pytest.approx(alone, rel=1e-5)
+
+
+def test_all_ignored_labels_raise(config, tokenizer):
+    module = MossTTSNanoModule(config=config)
+    batch = _tiny_batch(config, tokenizer)
+    batch["labels"] = torch.full_like(batch["labels"], IGNORE_INDEX)
+    with pytest.raises(RuntimeError, match="every label is ignored"):
+        module.compute_loss(batch)
+
+
+def test_optimizer_and_scheduler_follow_upstream_defaults(config):
+    module = MossTTSNanoModule(config=config, max_train_steps=100)
+    bundle = module.configure_optimizers()
+    optimizer = bundle["optimizer"]
+    assert optimizer.defaults["lr"] == 1e-5
+    assert optimizer.defaults["betas"] == (0.9, 0.95)
+    assert optimizer.defaults["weight_decay"] == 0.1
+    assert bundle["lr_scheduler"]["interval"] == "step"
+
+
+# ----------------------------------------------------------------------
+# warm start
+# ----------------------------------------------------------------------
+def test_warm_start_from_a_saved_state_dict(tmp_path, config):
+    torch.manual_seed(1)
+    source = MossTTSNano(config)
+    path = tmp_path / "source.pt"
+    torch.save(source.state_dict(), path)
+
+    torch.manual_seed(2)
+    target = MossTTSNano(config)
+    report = warm_start(target, path)
+    assert report.missing == []
+    assert report.shape_mismatch == []
+    assert report.matched_fraction == pytest.approx(1.0)
+    for key, tensor in source.state_dict().items():
+        assert torch.equal(target.state_dict()[key], tensor)
+
+
+def test_warm_start_restores_tied_heads_from_the_embedding_alone(tmp_path, config):
+    """A checkpoint that stores only ``transformer.wte`` still warm-starts ``text_lm_head``."""
+    torch.manual_seed(1)
+    source = MossTTSNano(config)
+    state = {k: v for k, v in source.state_dict().items()
+             if not k.startswith(("text_lm_head", "audio_lm_heads"))}
+    path = tmp_path / "tied.pt"
+    torch.save(state, path)
+
+    target = MossTTSNano(MossTTSNanoConfig.tiny())
+    report = warm_start(target, path)
+    assert report.missing == []
+    assert "text_lm_head.weight" in report.tied_from_source
+    assert torch.equal(target.text_lm_head.weight, source.transformer.wte.weight)
+
+
+def test_warm_start_reports_shape_mismatches(tmp_path, config):
+    source = MossTTSNano(config)
+    state = source.state_dict()
+    state["transformer.wte.weight"] = torch.zeros(5, 5)
+    path = tmp_path / "bad.pt"
+    torch.save(state, path)
+    target = MossTTSNano(MossTTSNanoConfig.tiny())
+    report = warm_start(target, path)
+    assert any(key == "transformer.wte.weight" for key, _, _ in report.shape_mismatch)
+    assert report.matched_fraction < 1.0
+
+
+def test_warm_start_strips_the_lightning_prefix(tmp_path, config):
+    module = MossTTSNanoModule(config=config)
+    path = tmp_path / "run.ckpt"
+    torch.save({"state_dict": module.state_dict()}, path)
+    target = MossTTSNano(MossTTSNanoConfig.tiny())
+    report = warm_start(target, path)
+    assert report.missing == []
+    assert report.matched_fraction == pytest.approx(1.0)
+
+
+def test_normalize_keys_leaves_bare_checkpoints_alone():
+    state = {"transformer.wte.weight": torch.zeros(1), "audio_embeddings.0.weight": torch.zeros(1)}
+    assert set(normalize_source_keys(state)) == set(state)
+
+
+def test_warm_start_rejects_a_missing_checkpoint(tmp_path, config):
+    with pytest.raises(FileNotFoundError):
+        warm_start(MossTTSNano(config), tmp_path / "nope.safetensors")
+
+
+# ----------------------------------------------------------------------
+# prepare_data
+# ----------------------------------------------------------------------
+def test_fit_channels_duplicates_mono_and_averages_extra():
+    from phoonnx_train.mosstts.prepare_data import fit_channels
+
+    mono = np.ones((1, 8), np.float32)
+    assert fit_channels(mono, 2).shape == (2, 8)
+    stereo = np.stack([np.zeros(8), np.ones(8)]).astype(np.float32)
+    assert np.allclose(fit_channels(stereo, 1), 0.5)
+    assert fit_channels(stereo, 2) is stereo
+
+
+def test_resample_changes_length_proportionally():
+    from phoonnx_train.mosstts.prepare_data import resample
+
+    audio = np.zeros((2, 1000), np.float32)
+    assert resample(audio, 24000, 48000).shape[-1] == 2000
+    assert resample(audio, 48000, 48000) is audio
+
+
+def test_load_manifest_reads_ljspeech_csv(tmp_path):
+    from phoonnx_train.mosstts.prepare_data import load_manifest
+
+    csv_path = tmp_path / "metadata.csv"
+    csv_path.write_text("0001|Bom dia.\n0002|Boa noite.\n", encoding="utf-8")
+    records = load_manifest(csv_path, wav_dir=tmp_path / "wavs")
+    assert [record["text"] for record in records] == ["Bom dia.", "Boa noite."]
+    assert records[0]["audio"].endswith("wavs/0001.wav")
+
+
+def test_load_manifest_rejects_a_line_without_text(tmp_path):
+    from phoonnx_train.mosstts.prepare_data import load_manifest
+
+    csv_path = tmp_path / "metadata.csv"
+    csv_path.write_text("0001\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="separated text column"):
+        load_manifest(csv_path)
+
+
+def test_encode_records_caches_and_rejects_empty_codes():
+    from phoonnx_train.mosstts.prepare_data import encode_records
+
+    class CountingTokenizer:
+        def __init__(self, frames):
+            self.frames = frames
+            self.calls = 0
+
+        def encode_file(self, path, n_vq=None):
+            self.calls += 1
+            return [[0] * 4 for _ in range(self.frames)]
+
+    tokenizer = CountingTokenizer(3)
+    records = [{"audio": "a.wav", "text": "x"}, {"audio": "a.wav", "text": "y"}]
+    encode_records(records, tokenizer)
+    assert tokenizer.calls == 1  # the same path is encoded once
+    assert len(records[0]["audio_codes"]) == 3
+
+    with pytest.raises(ValueError, match="zero codec frames"):
+        encode_records([{"audio": "b.wav", "text": "x"}], CountingTokenizer(0))
+
+
+def test_encode_records_rejects_a_record_without_audio():
+    from phoonnx_train.mosstts.prepare_data import encode_records
+
+    with pytest.raises(ValueError, match="no `audio` path"):
+        encode_records([{"text": "x"}], object())


### PR DESCRIPTION
Adds a vendored, self-contained training / finetuning pipeline for **MOSS-TTS-Nano** under `phoonnx_train/mosstts/`, plus an exporter that produces exactly the multi-graph ONNX layout the runtime engine consumes.

Independent of #321 (the inference adapter) — this PR targets `dev` on its own and does not touch `phoonnx/`.

## Which scheme MOSS-TTS-Nano actually uses

**Global-local (RQ-Transformer), teacher-forced across the 16+1 channels. Not the delay-pattern parallel-head scheme.** arXiv:2603.18090 describes both; Nano uses the first.

Verified from the code, not the paper:

1. The released `config.json` (`OpenMOSS-Team/MOSS-TTS-Nano`) declares it outright: `"model_architecture": "global_local_transformer"`, `"local_transformer_layers": 1`, `"local_transformer_attn_implementation": "flash_attention_2"`.
2. `modeling_moss_tts_nano.py::MossTTSNanoForCausalLM.__init__` builds a second `MossTTSNanoGPT2Model` (`self.local_transformer`) with `n_positions = n_vq + 1`, and replaces its `wte` with `nn.Identity` — it is fed embeddings, not ids.
3. `finetuning/sft.py::compute_supervised_loss` is unambiguous. It flattens `global_hidden_states` to `[B*S, H]`, builds `local_inputs [B*S, n_vq+1, H]` where slot 0 is the global hidden state, slot 1 is `transformer.wte(text_target)` and slots `2..n_vq` are `audio_embeddings[c](audio_target[c])` for `c in 0..n_vq-2`, runs `local_transformer` once, then applies `text_lm_head` to position 0 and `audio_lm_heads[c]` to position `c+1`. Channel `c` is conditioned on the **true** channel `c-1` — classic RQ-Transformer teacher forcing.
4. There is **no time shift anywhere**: no delay pattern in `finetuning/dataset.py`, and no per-codebook λ schedule. The default `--channelwise-loss-weight "1,32"` gives every audio head the same weight (32/16 = 2.0), which a delay-pattern objective would not.
5. The official ONNX export corroborates it: `moss_tts_local_decoder` / `moss_tts_local_cached_step` / `moss_tts_local_fixed_sampled_frame` all walk the local transformer channel by channel.

## Objective

`loss = sum(w_i * CE_i) / sum(w_i)` over the text head and the `n_vq` audio heads, `ignore_index=-100`, mirroring `compute_supervised_loss`. Weights come from upstream's `"text,total_audio"` shorthand; the `1,32` default is 1.0 for text and 2.0 for each of the 16 audio heads. Optimizer/schedule defaults are upstream's: AdamW `lr=1e-5`, `betas=(0.9, 0.95)`, `eps=1e-8`, `weight_decay=0.1`, linear decay with a 3% warmup ratio, grad-norm clip 1.0.

Two deliberate, tested optimisations over upstream, both exactly loss-preserving:

- timesteps whose labels are all `-100` are dropped before the local pass (upstream runs the local transformer over the whole padded length);
- batches are padded to the batch maximum instead of a fixed `max_length`.

`test_loss_ignores_padded_timesteps` and `test_loss_matches_a_hand_written_weighted_mean` pin both.

## Warm-start evidence

Explicit key mapping + tied-head synthesis, against the real released checkpoint:

```
$ python -m phoonnx_train.mosstts.warmstart --checkpoint <HF cache>/MOSS-TTS-Nano
.../pytorch_model.bin: matched 194 tensors / 142,477,056 of 142,477,056 parameters
(100.00%), missing=0 unexpected=0 shape_mismatch=0
```

100.00%, zero missing, zero unexpected, zero shape mismatches. (194 state-dict entries; ~117M unique parameters, since the heads share storage with their embeddings.)

## Sanity run + resume evidence

Two-sample synthetic dataset, full-size 117M model warm-started from the released weights, CPU, `lr=5e-4`, no warmup. Trained 2 steps, stopped, resumed from `last.ckpt`, trained 6 more:

| run | step | loss |
|---|---|---|
| initial | 0 | 7.2996 |
| initial | 1 | 7.3069 |
| **resumed** | 2 | 5.3235 |
| resumed | 3 | 6.7122 |
| resumed | 4 | 5.5001 |
| resumed | 5 | 5.0758 |
| resumed | 6 | 4.2848 |
| resumed | 7 | 3.4442 |

`Restored all states from the checkpoint` — the global step continues at 2, not 0, so optimizer moments and scheduler position carried over. Loss falls 7.30 → 3.44. The starting value ≈ 7.3 is the expected chance level for uniformly random codes (ln 1024 ≈ 6.93 on the audio heads).

## Export round-trip evidence

`tests/test_mosstts_export.py` exports a tiny randomly-initialised model and drives it through the runtime graph protocol:

- `prefill` vs. the live PyTorch module: max abs diff **3.6e-7**;
- `prefill` accepts lengths it was not traced with (3, 11 vs. a traced 6);
- `decode_step` over the cache reproduces a full prefill of the same rows (1e-4);
- `local_cached_step` walked channel-by-channel equals one uncached `local_decoder` pass on every channel;
- the full `prefill → local frame → decode_step` loop runs and yields 16-wide frames;
- `--external-data` produces `moss_tts_global_shared.data` / `moss_tts_local_shared.data` and the graphs still load.

The real 117M checkpoint also exports and runs end-to-end under onnxruntime, with I/O identical to the released export (`input_ids [batch, prefill_seq, 17]`, `global_hidden [batch, 768]`, `repetition_seen_mask [batch, 16, 1024]`, `should_continue [batch, 1]`, `frame_token_ids [batch, 16]`), so the exporter's output is a drop-in for the runtime engine.

One export detail worth recording: the legacy TorchScript ONNX tracer mis-lowers `key.permute(0, 2, 3, 1)` and a negative `softmax` axis in the attention block, producing a silently wrong graph (max abs diff 1.19 against torch). Upstream patches the resulting graph after the fact; here the attention is written so the tracer cannot get it wrong (`permute(0,2,1,3).transpose(2,3)` and an explicit positive softmax axis), and the round-trip test guards it.

## Deliberate divergence: the prompt template

The checkpoint's own `prompting.py` closes the user turn with `im_end` before the assistant turn — and so does the runtime path (and #321's adapter). Upstream's `finetuning/dataset.py` **omits that token**, which silently desynchronises a finetune from the prompt used at synthesis time. The default `--prompt-style inference` follows `prompting.py`; `--prompt-style finetuning` reproduces the upstream finetuning variant for bit-comparison. Covered by `test_prompt_style_controls_the_im_end_token`.

## License findings

Checked the current state of the upstream repo root (fresh clone of `github.com/OpenMOSS/MOSS-TTS-Nano`, `2026-07-27`):

- **A root `LICENSE` file now exists and is the full Apache License 2.0 text.** The earlier state (no root license) is gone.
- `README.md` still carries the transitional wording at its License section: *"This repository will follow the license specified in the root `LICENSE` file. If you are reading this before that file is published, please treat the repository as **not yet licensed for redistribution**."* That sentence is now stale — the root `LICENSE` **is** published, and it is Apache-2.0.
- The Hugging Face model cards (`OpenMOSS-Team/MOSS-TTS-Nano` and the ONNX/codec repos) say Apache-2.0, so repo and weights now agree.

No upstream source file is copied into phoonnx. The architecture is re-implemented from the published design and the reference code, with `arXiv:2603.18090` cited in the module docstrings; no upstream file headers, no vendored upstream files.

## Files changed

- `phoonnx_train/mosstts/{__init__,config,model,dataset,lightning,prepare_data,warmstart,export_onnx,train}.py` (new)
- `tests/test_mosstts_training.py` (51 tests), `tests/test_mosstts_export.py` (8 tests) — new
- `docs/training/engines/mosstts.md` (new), `docs/training/training.md`, `docs/README.md`
- `pyproject.toml` — new `train-mosstts` extra (`sentencepiece`, `safetensors`, `soundfile`, `onnx`)

No changes under `phoonnx/`. No scratch files, wavs or checkpoints.

## Model usage

Implementation by **claude-opus** under **Fable** orchestration. Upstream reference material read for the architecture determination: `github.com/OpenMOSS/MOSS-TTS-Nano` (`finetuning/sft.py`, `finetuning/dataset.py`, `finetuning/prepare_data.py`, `onnx/export_hf_to_tts_onnx.py`, `onnx/export_moss_tts_browser_onnx.py`, root `LICENSE`, `README.md`) and the Hugging Face repo `OpenMOSS-Team/MOSS-TTS-Nano` (`config.json`, `modeling_moss_tts_nano.py`, `gpt2_decoder.py`, `configuration_moss_tts_nano.py`, `prompting.py`, `tokenization_moss_tts_nano.py`). The released `pytorch_model.bin` (117M parameters) was downloaded into the shared HuggingFace cache for the warm-start and sanity-run evidence above; no weights are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MOSS-TTS-Nano training and fine-tuning support.
  * Added data preparation for audio manifests, resampling, channel handling, and codec tokenization.
  * Added checkpoint warm-starting and training resume workflows.
  * Added ONNX export with cached decoding, sampling, metadata, and external data support.
* **Documentation**
  * Added comprehensive setup, training, export, data preparation, and licensing documentation.
* **Tests**
  * Added coverage for training, data processing, checkpoint loading, model behavior, and ONNX export validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->