### PR TITLE
Propagate providers to catalog-only engines

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -1,5 +1,4 @@
 import hashlib
-import onnxruntime
 import json
 import os
 import re
@@ -16,7 +15,7 @@ from json_database import JsonStorageXDG, JsonStorage
 
 from phoonnx.config import PhonemeType, get_phonemizer, VoiceConfig, Engine, Alphabet
 from phoonnx.util import match_lang, normalize_lang, LOG
-from phoonnx.providers import ProviderSpec
+from phoonnx.providers import ProviderSpec, make_session, resolve_providers
 from phoonnx.voice import TTSVoice
 
 
@@ -668,17 +667,19 @@ class TTSModelInfo:
         tokenizer_config_path = self.hub_path(self.tokenizer_config_url)
         tokens_path = self.hub_path(self.tokens_url)
 
-        # Voices without a published config.json (Chatterbox) can't be engine-detected
-        # from files on disk — build the voice from the index-derived VoiceConfig, which
-        # already carries the engine, BPE tokenizer and lang_tokens.
+        # Voices without a published config.json can't be engine-detected from
+        # files on disk. Build them from the index-derived VoiceConfig, which
+        # already carries the engine and its tokenizer/runtime metadata.
         if self.engine and not self.config_url:
             config = self.config
-            config.engine_params = {**(config.engine_params or {}), **self.engine_params()}
-            session = onnxruntime.InferenceSession(
-                str(model_path),
-                sess_options=onnxruntime.SessionOptions(),
-                providers=["CPUExecutionProvider"],
-            )
+            resolved_providers = resolve_providers(providers)
+            engine_params = {
+                **(config.engine_params or {}),
+                **self.engine_params(),
+            }
+            engine_params["providers"] = resolved_providers
+            config.engine_params = engine_params
+            session = make_session(model_path, providers=resolved_providers)
             return TTSVoice(session=session, config=config)
 
         voice = TTSVoice.load(model_path=model_path,
@@ -768,7 +769,7 @@ class TTSModelManager:
 
     @property
     def supported_langs(self) -> List[str]:
-        return sorted(set(l.lang for l in self.all_voices))
+        return sorted(set(voice.lang for voice in self.all_voices))
 
     def clear(self):
         self.cache.clear()

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -572,6 +572,67 @@ class TestDownloadAll(HubTestCase):
                               "tokenizer_config.json"}, pulled)
 
 
+class TestLoadProviders(HubTestCase):
+    @patch("phoonnx.model_manager.VoiceConfig")
+    @patch("phoonnx.model_manager.make_session")
+    @patch("phoonnx.model_manager.resolve_providers")
+    @patch("phoonnx.model_manager.TTSVoice")
+    @patch("phoonnx.model_manager.requests.get")
+    def test_load_engine_without_config_url_uses_requested_providers(
+            self, mock_get, mock_ttsvoice_cls, mock_resolve_providers,
+            mock_make_session, mock_voiceconfig_cls):
+        info = self.make_info(engine=Engine.SUPERTONIC,
+                              model_url="https://example.com/model.onnx")
+
+        def side_effect(url, timeout=None, stream=None):
+            if stream:
+                resp = _mock_response(200, content=b"data")
+                cm = MagicMock()
+                cm.__enter__.return_value = resp
+                return cm
+            return _mock_response(200, content=b'{"vocab": {}}')
+
+        mock_get.side_effect = side_effect
+        fake_config = MagicMock()
+        fake_config.engine_params = {}
+        mock_voiceconfig_cls.from_dict.return_value = fake_config
+        first_requested = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        first_resolved = [
+            ("CUDAExecutionProvider", {"cudnn_conv_algo_search": "HEURISTIC"}),
+            "CPUExecutionProvider",
+        ]
+        second_requested = ["CPUExecutionProvider"]
+        second_resolved = ["CPUExecutionProvider"]
+        mock_resolve_providers.side_effect = [first_resolved, second_resolved]
+        session = MagicMock()
+        mock_make_session.return_value = session
+        fake_voice = MagicMock()
+        mock_ttsvoice_cls.return_value = fake_voice
+        first_result = info.load(providers=first_requested)
+        self.assertEqual(fake_config.engine_params["providers"], first_resolved)
+
+        second_result = info.load(providers=second_requested)
+
+        self.assertEqual(
+            mock_resolve_providers.call_args_list,
+            [unittest.mock.call(first_requested),
+             unittest.mock.call(second_requested)],
+        )
+        self.assertEqual(
+            mock_make_session.call_args_list,
+            [
+                unittest.mock.call(info.voice_path / "model.onnx",
+                                   providers=first_resolved),
+                unittest.mock.call(info.voice_path / "model.onnx",
+                                   providers=second_resolved),
+            ],
+        )
+        self.assertEqual(fake_config.engine_params["providers"],
+                         second_resolved)
+        self.assertEqual(first_result, fake_voice)
+        self.assertEqual(second_result, fake_voice)
+
+
 class TestTTSModelInfoStringEnumCoercion(HubTestCase):
     def test_string_engine_alphabet_phoneme_type_coerced(self):
         info = self.make_info(engine="piper", alphabet="ipa", phoneme_type="espeak")


### PR DESCRIPTION
> 🤖 Rebased onto current `dev` by Claude Sonnet 5 via Claude Code — merge conflicts in `phoonnx/model_manager.py` and `tests/test_model_manager.py` resolved against dev's current hub-cache test fixtures (`HubTestCase`), one duplicate/obsolete test dropped, commits squashed to one, author preserved as Gaëtan Trellu. NOT human-reviewed beyond the automated test run below — verify before merging.

## What changed

- Route catalog-only engine sessions through the shared provider resolver and
  session factory instead of hard-coding `CPUExecutionProvider`.
- Propagate the same resolved provider list to engine auxiliary graphs.
- Add a Supertonic regression test covering the primary and auxiliary provider
  path.
- Refresh cached engine providers on repeated loads and cover provider changes
  with a regression test.
- Resolve the existing Ruff `E741` finding in the touched module.

## Why

Supertonic voices are catalog-defined and do not publish a `config.json`.
`TTSModelInfo.load()` therefore entered the catalog-only path, where the
primary vector-estimator session was always created on CPU. Its duration
predictor, text encoder, and vocoder could still use CUDA, producing a
surprising mixed CPU/GPU pipeline even when the OVOS plugin explicitly
requested CUDA.

This makes provider selection consistent with `TTSVoice.load()` and with the
documented `onnx_providers` configuration.

## Impact

Callers can now select CUDA, ROCm, or another supported ONNX Runtime provider
for all graphs used by catalog-only engines. CPU remains the resolver's
automatic fallback.

In a local Supertonic 3 validation using CUDA 12 and ONNX Runtime 1.26:

- all four sessions reported `CUDAExecutionProvider`;
- warm synthesis improved from approximately 1.5 seconds with the primary
  graph on CPU to approximately 0.12 seconds;
- generated audio remained 44.1 kHz.

## Validation

- `uv run --isolated --python 3.12 --with . --with pytest pytest tests/test_model_manager.py -q`
  - 69 passed
- focused provider/plugin suite: 51 passed, 2 subtests passed
- `ruff check phoonnx/model_manager.py tests/test_model_manager.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech model loading to honor the requested execution providers.
  * Ensured engine parameters and provider settings are correctly applied when creating sessions.
  * Improved supported-language reporting by removing duplicate languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
