### PR TITLE
feat: per-language default voices via lang2voice and env vars

### DIFF
--- a/docs/ovos_plugin.md
+++ b/docs/ovos_plugin.md
@@ -5,6 +5,52 @@ engine. phoonnx ships a TTS plugin for the [OpenVoiceOS](https://openvoiceos.com
 ecosystem via `PhoonnxTTSPlugin`, registered under the `opm.tts` entry point
 `ovos-tts-plugin-phoonnx`.
 
+## Per-language default voices
+
+`voice` pins one voice for every request. To serve **many languages from one
+server**, leave it unset and map languages to voices instead — the plugin then
+picks the voice for each request's language, downloading and caching it on
+first use:
+
+```json
+{
+  "tts": {
+    "module": "ovos-tts-plugin-phoonnx",
+    "ovos-tts-plugin-phoonnx": {
+      "lang2voice": {
+        "gl": "proxectonos/celtia",
+        "ca": "OpenVoiceOS/matxa-cat-multispeaker-wavenext",
+        "pt-br": "<a brazilian voice>",
+        "pt": "<a european portuguese voice>"
+      }
+    }
+  }
+}
+```
+
+Keys are BCP-47 tags: the full tag (`pt-br`) is tried before the primary
+subtag (`pt`), so regional variants can differ from the base language.
+
+The same mapping can come from the environment, which is usually easier for
+containers whose `mycroft.conf` carries no `lang2voice` entry for a given
+language — `PHOONNX_DEFAULT_VOICE_<LANG>`, with underscores standing in for
+dashes:
+
+```bash
+docker run -e PHOONNX_DEFAULT_VOICE_GL=proxectonos/celtia \
+           -e PHOONNX_DEFAULT_VOICE_PT_BR=<voice-id> \
+           -p 9666:9666 phoonnx
+```
+
+Resolution is table-major, not tag-major: every tag `lang2voice` might match
+(full tag, then primary subtag) is tried before the env table is looked at at
+all, so a `lang2voice` entry for the primary subtag (`pt`) still beats a more
+specific `PHOONNX_DEFAULT_VOICE_PT_BR` env var — the config wins outright for
+any language it names anything for, and the env vars only fill in languages
+the config leaves unconfigured. Below both, the voice index's own default for
+the language applies. Keys and tags are matched after normalisation, so
+`gl-ES`/`gl`, `pt-br`/`pt_BR` and similar spellings agree.
+
 ## Configuration
 
 In your OpenVoiceOS `mycroft.conf` or skills config, set:

--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -17,11 +17,12 @@ import wave
 from contextlib import suppress
 from collections import OrderedDict
 from threading import RLock
-from typing import List, Optional
+from typing import Dict, List, Optional
 from ovos_utils.log import LOG
 from ovos_plugin_manager.templates.tts import TTS, TTSContext
 
 from phoonnx.model_manager import TTSModelManager, TTSModelInfo
+from phoonnx.util import normalize_lang
 from phoonnx.voice import TTSVoice, SynthesisConfig
 from phoonnx.voice_cache import VoiceCache, VoiceExceedsMemoryBudget
 
@@ -45,6 +46,22 @@ class PhoonnxTTSPlugin(TTS):
         self.model_manager = TTSModelManager()
         self.model_manager.load()
         self.model_manager.merge_default_voices()
+
+        # Optional per-language default voices: {"lang2voice": {"pt-br": "...",
+        # "gl": "proxectonos/celtia"}}. Keys are BCP-47 tags (full tag or
+        # primary subtag; full tags win, regardless of which table names them -
+        # a config's own primary-subtag entry still beats a more specific
+        # PHOONNX_DEFAULT_VOICE_<LANG> full-tag env var, because the config
+        # table is tried whole before the env table is looked at at all).
+        # The env vars let a container image whose config carries no
+        # lang2voice entry for a language be re-pointed per deployment without
+        # editing mycroft.conf; they never override a language the config
+        # already names. Keys are normalised the same way the caller's ``lang``
+        # is, so "gl-ES"/"gl", "pt-br"/"pt_BR" and similar spellings agree.
+        self.lang2voice: Dict[str, str] = {
+            normalize_lang(k).lower(): v
+            for k, v in (self.config.get("lang2voice") or {}).items()
+        }
 
         self.voice_cache = VoiceCache(
             resolve=lambda voice_id: self.get_voice_info(voice_id),
@@ -151,19 +168,77 @@ class PhoonnxTTSPlugin(TTS):
             except Exception as exc:
                 LOG.warning(f"Voice refresh failed: {exc}")
 
+    ENV_PREFIX = "PHOONNX_DEFAULT_VOICE_"
+
+    @staticmethod
+    def env_lang_voices() -> Dict[str, str]:
+        """
+        Read per-language default voices from ``PHOONNX_DEFAULT_VOICE_<LANG>``
+        environment variables.
+
+        The suffix is a lang tag with underscores in place of dashes, so
+        ``PHOONNX_DEFAULT_VOICE_PT`` sets ``pt`` and
+        ``PHOONNX_DEFAULT_VOICE_PT_BR`` sets ``pt-br``. The tag is normalised
+        the same way a caller's ``lang`` is, so it matches regardless of
+        region-tag casing.
+        """
+        voices = {}
+        for key, val in os.environ.items():
+            if key.startswith(PhoonnxTTSPlugin.ENV_PREFIX) and val:
+                tag = key[len(PhoonnxTTSPlugin.ENV_PREFIX):].replace("_", "-").lower()
+                if tag:
+                    voices[normalize_lang(tag).lower()] = val
+        return voices
+
+    def configured_voice_for_lang(self, lang: str) -> Optional[str]:
+        """
+        Resolve an explicitly configured voice id for ``lang``, if any.
+
+        Checks the ``lang2voice`` plugin config first, then
+        ``PHOONNX_DEFAULT_VOICE_<LANG>`` environment variables, trying the full
+        BCP-47 tag before the primary subtag in each - so a primary-subtag
+        entry in ``lang2voice`` still beats a full-tag entry in the env table,
+        because the whole config table is tried before the env table is
+        looked at at all. ``lang`` is normalised (case, ``_``/``-``, a bare
+        subtag's default region) before matching, the same way the tables'
+        own keys are, so equivalent spellings agree. Returns None when
+        nothing is configured, leaving the voice index to pick the language
+        default.
+        """
+        full = normalize_lang(lang or "").lower()
+        primary = full.split("-")[0]
+        for table in (self.lang2voice, self.env_lang_voices()):
+            for tag in (full, primary):
+                if tag in table:
+                    return table[tag]
+        return None
+
     def get_default_voice(self, lang: str) -> TTSModelInfo:
         """
         Selects the default TTS model for the given language.
-        
+
         Parameters:
         	lang (str): Language tag used to look up available voices (e.g., "en-US", "pt-PT").
-        
+
         Returns:
         	TTSModelInfo: The first/default voice model info for the specified language.
-        
+
         Raises:
         	ValueError: If no voices are available for the given language.
         """
+        voice_id = self.configured_voice_for_lang(lang)
+        if voice_id:
+            try:
+                LOG.debug(f"using configured default voice for {lang}: {voice_id}")
+                return self.get_voice_info(voice_id)
+            except Exception as exc:
+                # A typo'd or since-removed lang2voice/env voice id is a
+                # deployment mistake, not a reason to refuse to serve the
+                # language at all - fall through to the voice index's own
+                # default the same as an unconfigured language would.
+                LOG.warning(f"configured default voice '{voice_id}' for "
+                            f"{lang} is unknown ({exc}); falling back to "
+                            f"the voice index default")
         voices = self.model_manager.get_lang_voices(lang)
         if not voices:
             LOG.info(f"{lang} voices not found - refreshing voice list")

--- a/tests/test_opm.py
+++ b/tests/test_opm.py
@@ -368,3 +368,120 @@ class TestVoiceResolvedWithoutLoading(unittest.TestCase):
                 self.assertIsNotNone(plugin.voice_info)
                 self.assertEqual(plugin.voice_cache.voices, {},
                                  "boot must not load (download) the model")
+
+
+class TestLangDefaultVoiceOverrides(unittest.TestCase):
+    """``lang2voice`` config and ``PHOONNX_DEFAULT_VOICE_<LANG>`` env vars pick
+    the per-language default voice, so one container serves every language."""
+
+    def test_lang2voice_selects_configured_voice(self):
+        chosen = _FakeVoiceInfo("proxectonos/celtia", lang="gl-ES")
+        other = _FakeVoiceInfo("some/other-voice", lang="gl-ES")
+        plugin, _ = _make_plugin(
+            config={"lang": "gl-ES", "lang2voice": {"gl": "proxectonos/celtia"}},
+            voices=(other, chosen))
+        self.assertEqual(plugin.get_default_voice("gl-ES").voice_id,
+                         "proxectonos/celtia")
+
+    def test_full_tag_beats_primary_subtag(self):
+        br = _FakeVoiceInfo("voice/br", lang="pt-BR")
+        pt = _FakeVoiceInfo("voice/pt", lang="pt-PT")
+        plugin, _ = _make_plugin(
+            config={"lang": "pt-PT",
+                    "lang2voice": {"pt-br": "voice/br", "pt": "voice/pt"}},
+            voices=(br, pt))
+        self.assertEqual(plugin.get_default_voice("pt-BR").voice_id, "voice/br")
+        self.assertEqual(plugin.get_default_voice("pt-PT").voice_id, "voice/pt")
+
+    def test_env_var_sets_default_voice(self):
+        chosen = _FakeVoiceInfo("env/voice", lang="ru-RU")
+        other = _FakeVoiceInfo("some/other", lang="ru-RU")
+        with patch.dict("os.environ", {"PHOONNX_DEFAULT_VOICE_RU": "env/voice"}):
+            plugin, _ = _make_plugin(config={"lang": "ru-RU"},
+                                     voices=(other, chosen))
+            self.assertEqual(plugin.get_default_voice("ru-RU").voice_id,
+                             "env/voice")
+
+    def test_env_var_full_bcp47_suffix(self):
+        br = _FakeVoiceInfo("env/br", lang="pt-BR")
+        other = _FakeVoiceInfo("some/other", lang="pt-BR")
+        with patch.dict("os.environ", {"PHOONNX_DEFAULT_VOICE_PT_BR": "env/br"}):
+            plugin, _ = _make_plugin(config={"lang": "pt-BR"},
+                                     voices=(other, br))
+            self.assertEqual(plugin.get_default_voice("pt-BR").voice_id, "env/br")
+
+    def test_config_beats_env(self):
+        cfg = _FakeVoiceInfo("cfg/voice", lang="gl-ES")
+        env = _FakeVoiceInfo("env/voice", lang="gl-ES")
+        with patch.dict("os.environ", {"PHOONNX_DEFAULT_VOICE_GL": "env/voice"}):
+            # env's voice is registered first (index-default voices[0]) and
+            # cfg's second, so a resolver that silently fell through to the
+            # index default instead of honouring lang2voice/env would return
+            # "env/voice" here too - it must not.
+            plugin, _ = _make_plugin(
+                config={"lang": "gl-ES", "lang2voice": {"gl": "cfg/voice"}},
+                voices=(env, cfg))
+            self.assertEqual(plugin.get_default_voice("gl-ES").voice_id,
+                             "cfg/voice")
+
+    def test_unset_lang_falls_back_to_voice_index(self):
+        first = _FakeVoiceInfo("index/first", lang="en-US")
+        plugin, _ = _make_plugin(config={"lang": "en-US"}, voices=(first,))
+        self.assertEqual(plugin.get_default_voice("en-US").voice_id,
+                         "index/first")
+
+    def test_env_ignores_unrelated_vars(self):
+        with patch.dict("os.environ", {"PHOONNX_DEFAULT_VOICE_EU": "eu/voice",
+                                       "UNRELATED_VAR": "nope"}):
+            langs = opm.PhoonnxTTSPlugin.env_lang_voices()
+        self.assertEqual(langs.get("eu"), "eu/voice")
+        self.assertNotIn("unrelated-var", langs)
+
+    def test_full_tag_config_key_matches_a_bare_request(self):
+        # an admin who wrote the config key as the full tag ("gl-ES") must
+        # still be matched by a caller that only ever sends the bare
+        # primary subtag ("gl") - normalize_lang folds both to one canonical
+        # form for a language whose primary subtag has a single default region
+        chosen = _FakeVoiceInfo("proxectonos/celtia", lang="gl-ES")
+        other = _FakeVoiceInfo("some/other", lang="gl-ES")
+        plugin, _ = _make_plugin(
+            config={"lang": "gl-ES", "lang2voice": {"gl-ES": "proxectonos/celtia"}},
+            voices=(other, chosen))
+        self.assertEqual(plugin.get_default_voice("gl").voice_id,
+                         "proxectonos/celtia")
+
+    def test_underscore_config_key_matches_a_dashed_request(self):
+        chosen = _FakeVoiceInfo("voice/br", lang="pt-BR")
+        other = _FakeVoiceInfo("some/other", lang="pt-BR")
+        plugin, _ = _make_plugin(
+            config={"lang": "pt-BR", "lang2voice": {"pt_BR": "voice/br"}},
+            voices=(other, chosen))
+        self.assertEqual(plugin.get_default_voice("pt-BR").voice_id, "voice/br")
+
+    def test_underscore_request_tag_still_matches(self):
+        # a caller using locale-style "pt_BR" (underscore) rather than BCP-47
+        # "pt-BR" must not silently disable the whole feature
+        chosen = _FakeVoiceInfo("voice/br", lang="pt-BR")
+        other = _FakeVoiceInfo("some/other", lang="pt-BR")
+        plugin, _ = _make_plugin(
+            config={"lang": "pt-BR", "lang2voice": {"pt-br": "voice/br"}},
+            voices=(other, chosen))
+        self.assertEqual(plugin.get_default_voice("pt_BR").voice_id, "voice/br")
+
+    def test_unknown_configured_voice_falls_back_instead_of_raising(self):
+        # a typo'd or since-removed lang2voice id is a deployment mistake, not
+        # a reason to refuse to serve the language - and must not abort
+        # plugin construction, which calls get_default_voice at boot
+        fallback = _FakeVoiceInfo("index/fallback", lang="gl-ES")
+        plugin, _ = _make_plugin(
+            config={"lang": "gl-ES", "lang2voice": {"gl": "does/not-exist"}},
+            voices=(fallback,))
+        self.assertEqual(plugin.get_default_voice("gl-ES").voice_id,
+                         "index/fallback")
+
+    def test_unknown_configured_voice_via_env_falls_back_too(self):
+        fallback = _FakeVoiceInfo("index/fallback", lang="ru-RU")
+        with patch.dict("os.environ", {"PHOONNX_DEFAULT_VOICE_RU": "does/not-exist"}):
+            plugin, _ = _make_plugin(config={"lang": "ru-RU"}, voices=(fallback,))
+            self.assertEqual(plugin.get_default_voice("ru-RU").voice_id,
+                             "index/fallback")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

Serving many languages from one phoonnx server otherwise means passing `voice=` on every request, since a configured `voice` pins one voice regardless of the request language. This adds a `lang2voice` map plus `PHOONNX_DEFAULT_VOICE_<LANG>` environment overrides, so `get_default_voice` resolves the right voice per request language and callers only need to send `lang`.

Keys are BCP-47 tags, full tag before primary subtag. Resolution is table-major: the whole `lang2voice` table is tried (full tag, then primary subtag) before the env table is looked at at all, so a primary-subtag config entry still beats a more specific env var — the config wins outright for any language it names anything for, and env vars only fill in what the config leaves unconfigured. `lang2voice` keys, env var suffixes and the caller's `lang` are all normalised the same way (case, `_`/`-`, a bare subtag's default region), so `gl-ES`/`gl` and `pt-br`/`pt_BR` agree regardless of which side wrote which spelling. A `lang2voice`/env entry naming a voice that turns out not to exist is a deployment mistake, not a reason to refuse to serve the language: it is logged and the voice index's own default is used instead, including at plugin construction time.

The feature is re-sited on the current plugin architecture: `opm.py` composes `lang2voice`/env resolution with `VoiceCache` and `get_voice_info` rather than the old ad hoc `self.voices` dict, so a configured default voice is resolved through the same cache lease every other voice goes through.

12 tests in `tests/test_opm.py` follow the module's existing `_make_plugin`/`_FakeVoiceInfo` fixtures, including one restructured so the index default's own selection order can't accidentally satisfy the assertion in place of the precedence logic under test. All fail against the code without the corresponding fix and pass with it, verified via patch-revert.

## Model usage
Re-sited onto current `dev` and hardened against review by Claude Sonnet 5 via Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-language default voice selection through configuration and environment variables.
  * Supports regional language tags, normalization, and precedence between specific and general language settings.
  * Unknown configured voices safely fall back to the model’s language default.

* **Documentation**
  * Added configuration guidance, including environment-variable setup and default-selection precedence.

* **Tests**
  * Added coverage for language matching, normalization, precedence, filtering, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->