### PR TITLE
docs: QA pass — verify docs against source, run all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ golden path in [docs/training/quickstart.md](docs/training/quickstart.md).
 | Run ONNX voices on CPU or GPU (CUDA/ROCm/DirectML/CoreML/OpenVINO) | [Usage](docs/usage.md) · [Configuration](docs/configuration.md) |
 | ~40 phonemizer backends across many languages | [Phonemizers](docs/phonemizers.md) |
 | Load Piper / Mimic3 / Coqui / Transformers / MMS voices | [Architecture](docs/architecture.md) |
-| 17 synthesis engines behind one adapter registry | [Engines](docs/engines.md) |
+| 14 synthesis engines behind one adapter registry | [Engines](docs/engines.md) |
 | Zero-shot voice cloning (YourTTS, StyleTTS2, ZipVoice, F5-TTS, Chatterbox) | [Cloning](docs/cloning.md) |
 | Low-latency streaming for VITS voices | [Streaming](docs/streaming.md) |
 | Optional 48 kHz audio super-resolution over synthesized audio | [OVOS plugin](docs/ovos_plugin.md#audio-super-resolution) |
@@ -91,6 +91,14 @@ docker compose up
 ```
 
 See [docs/docker.md](docs/docker.md).
+
+## Related projects
+
+`phoonnx` is part of the [OpenVoiceOS](https://github.com/OpenVoiceOS) ecosystem:
+
+- [ovos-core](https://github.com/OpenVoiceOS/ovos-core) — the voice assistant that loads this plugin
+- [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager) — the plugin framework `ovos-tts-plugin-phoonnx` registers against
+- [ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server) — a standalone HTTP server for any OVOS TTS plugin, including this one
 
 ## License and credits
 

--- a/VOICES.md
+++ b/VOICES.md
@@ -1,6 +1,6 @@
 ## Supported Voices
 
-**Total Voices:** 2235
+**Total Voices:** 2238
 **Total Languages:** 1239
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
@@ -2000,6 +2000,9 @@
 | `coqui/uk-mai-vits` | `uk-UA` | `coqui` | `graphemes` |
 | `facebook/mms-tts-ukr-Ukrainian` | `uk-UA` | `transformers` | `graphemes` |
 | `piper/uk_UA-lada-x_low` | `uk-UA` | `piper` | `espeak` |
+| `piper/uk_UA-mykyta-high` | `uk-UA` | `piper` | `espeak` |
+| `piper/uk_UA-oleksa-high` | `uk-UA` | `piper` | `espeak` |
+| `piper/uk_UA-tetiana-high` | `uk-UA` | `piper` | `espeak` |
 | `piper/uk_UA-ukrainian_tts-medium` | `uk-UA` | `piper` | `unicode` |
 | `facebook/mms-tts-unr-Mundari` | `unr` | `transformers` | `graphemes` |
 | `facebook/mms-tts-upv-Uripiv-Wala-Rano-Atchin` | `upv` | `transformers` | `graphemes` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ At load time `TTSVoice` resolves an adapter in this order (`voice.py` + `engines
    ONNX session.
 3. If nothing matches, it falls back to the VITS adapter.
 
-The 16 declared engine formats and the adapter registry are documented in
+The 17 declared engine formats and the adapter registry are documented in
 [Engines](engines.md); voice-config detection of Piper/Mimic3/Coqui/Transformers shapes is
 documented in the [Configuration reference](configuration.md).
 
@@ -83,7 +83,8 @@ Single-stage engines (VITS and its Piper/Mimic3/Coqui variants) emit a waveform 
 Two-stage engines (Matcha, GlowTTS, MixerTTS, FastPitch) emit a mel spectrogram and pair
 with a separate **vocoder** ONNX graph. Cloning and multi-graph engines load further
 auxiliary graphs — speaker encoders (YourTTS), style encoders (StyleTTS2), text/flow decoders
-(ZipVoice, F5-TTS), or the four-graph codec-LM split (Chatterbox). The voice manager
+(ZipVoice, F5-TTS), the four-graph codec-LM split (Chatterbox), or SuperTonic's four
+flow-matching graphs. The voice manager
 downloads these alongside the primary model and injects their local paths into
 `engine_params`; every auxiliary session runs on the same execution providers as the voice.
 See [Vocoders](vocoders.md) and the per-engine pages under

--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -11,10 +11,11 @@ speaker's voice from a short reference clip, without any per-speaker training.
 from phoonnx.voice import TTSVoice, SynthesisConfig
 
 voice = TTSVoice.load("model.onnx", "model.json")
-audio = voice.synthesize(
+for chunk in voice.synthesize(
     "This sentence is spoken in the cloned voice.",
     SynthesisConfig(speaker_reference="reference.wav"),
-)
+):
+    ...  # chunk.audio_float_array — see Usage for the full AudioChunk API
 ```
 
 ## Two cloning paradigms
@@ -61,10 +62,11 @@ pip install phoonnx[cloning]
 No transcription, any language — the speaker encoder summarizes timbre directly:
 
 ```python
-audio = voice.synthesize(
+for chunk in voice.synthesize(
     "Speak this in the cloned voice.",
     SynthesisConfig(speaker_reference="any_language_clip.wav"),
-)
+):
+    ...
 ```
 
 The encoders live in the **speaker-encoder registry**
@@ -95,13 +97,14 @@ reference, so it needs both the reference audio **and its transcription** — th
 aligns the audio to phonemes:
 
 ```python
-audio = voice.synthesize(
+for chunk in voice.synthesize(
     "A sentence the reference never spoke.",
     SynthesisConfig(
         speaker_reference="alice.wav",
         speaker_reference_text="hello, this is the reference clip",
     ),
-)
+):
+    ...
 ```
 
 ### Cross-lingual cloning

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ Piper, Mimic3, and Coqui config formats are also parsed automatically.
 
 ## Engine Enum
 
-`Engine` (in `phoonnx.config`) records which framework a voice was built with. It has 16
+`Engine` (in `phoonnx.config`) records which framework a voice was built with. It has 17
 members. `piper`, `mimic3` and `coqui` all run through the single VITS adapter; the rest map
 to a dedicated adapter. The adapter registry itself is described in [Engines](engines.md).
 
@@ -167,6 +167,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `shami` | Levantine Arabic / English (HamsVITS) | [Shami](training/engines/shami.md) |
 | `f5tts` | DiT flow-matching (F5-TTS / Habibi) | [F5-TTS](training/engines/f5tts.md) |
 | `chatterbox` | Autoregressive codec-LM cloning | [Chatterbox](training/engines/chatterbox.md) |
+| `supertonic` | Multi-graph flow-matching, raw-text (no phonemizer) | [Engines](engines.md) |
 
 ## Execution Providers
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -161,6 +161,17 @@ register_engine("my_engine", MyTrainingEngine)
 | Engine | File | Quality Presets |
 |---|---|---|
 | VITS | `phoonnx_train/engines/vits.py` | `x-low`, `medium`, `high` |
+| [GlowTTS](training/engines/glowtts.md) | `phoonnx_train/engines/glowtts.py` | see page |
+| [Matcha](training/engines/matcha.md) | `phoonnx_train/engines/matcha.py` | see page |
+| [OptiSpeech](training/engines/optispeech.md) | `phoonnx_train/engines/optispeech.py` | see page |
+| [FastPitch](training/engines/fastpitch.md) / `speedyspeech` | `phoonnx_train/engines/fastpitch.py` | see page |
+| [ZipVoice](training/engines/zipvoice.md) | `phoonnx_train/engines/zipvoice.py` | see page |
+| `mixer` / [MixerTTS](training/engines/mixertts.md) | `phoonnx_train/engines/mixer.py` | see page |
+| StyleTTS2 (`styletts2`, `styletts2-aligner`, `styletts2-plbert`, `styletts2-pitch`) | `phoonnx_train/engines/styletts2*.py` | see page |
+| YourTTS | `phoonnx_train/engines/yourtts.py` | see page |
+
+`Chatterbox`, `F5-TTS` and `SuperTonic` currently ship inference-only adapters
+(`phoonnx/engines/`) — there is no `phoonnx_train` training engine for them yet.
 
 ---
 
@@ -168,7 +179,7 @@ register_engine("my_engine", MyTrainingEngine)
 
 ### Training
 
-`train.py` now accepts `--engine` and delegates model creation / checkpoint loading to the selected engine:
+`train.py` accepts `--engine` and delegates model creation / checkpoint loading to the selected engine:
 
 ```bash
 python -m phoonnx_train.train \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,6 +41,7 @@ Install extras with `pip install "phoonnx[<name>]"`. Combine them with commas, e
 | `chatterbox-multilingual` | Chatterbox per-language script transforms (ja/zh) | `pykakasi`, `spacy-pkuseg` |
 | `cjk` | Same CJK script-transform deps as `chatterbox-multilingual`, under a shorter name | `pykakasi`, `spacy-pkuseg` |
 | `o2i` | The multilingual data-driven IPA backend | `orthography2ipa` |
+| `audiosr` | Optional 48 kHz [audio super-resolution](ovos_plugin.md#audio-super-resolution) over synthesized audio | `audiosronnx` |
 | `all` | Every language phonemizer + cloning (used by the Docker image) | see below |
 
 ### Language extras
@@ -83,8 +84,9 @@ several add higher-quality engines.
 |---|---|
 | `train` | The core training pipeline (PyTorch Lightning, librosa, torch) |
 | `train-eval` | Checkpoint evaluation loop (UTMOS, speaker similarity, quality filters) |
-| `train-fastpitch` | FastPitch/SpeedySpeech F0 extraction (`pyworld`) |
-| `train-mixer` | Mixer-TTS F0 sidecar (`pyworld`) |
+| `train-pyworld` | The `pyworld` F0 extractor, used by FastPitch/SpeedySpeech and Mixer-TTS |
+| `train-fastpitch` | The FastPitch/SpeedySpeech training engine (no extra deps beyond `[train]`) |
+| `train-mixer` | The Mixer-TTS training engine (no extra deps beyond `[train]`) |
 | `train-styletts2` | The StyleTTS2 training engine |
 | `train-resample` | Resampling for engines defined at a fixed sample rate (e.g. ZipVoice 24 kHz) |
 | `train-data` | Multi-format dataset loading for preprocessing (jsonl/parquet/HF repos with embedded audio bytes) |

--- a/docs/ovos_plugin.md
+++ b/docs/ovos_plugin.md
@@ -183,7 +183,7 @@ plugin = PhoonnxTTSPlugin(config={
 })
 ```
 
-## Key methods:
+## Key methods
 
 | Method | Description |
 |--------|-------------|

--- a/docs/phonemizers.md
+++ b/docs/phonemizers.md
@@ -48,6 +48,7 @@ matching [install extra](installation.md#language-extras).
 | `xpinyin` | XPinyin | Chinese |
 | `jieba` | Jieba (word segmentation, not a true phonemizer) | Chinese |
 | `mwl_phonemizer` | Mirandese phonemizer | Mirandese |
+| `vosk` | vosk-tts phoneme inventory (use with `Alphabet.VOSK`) | Russian |
 | `shami` | Levantine Arabic / English code-switching front-end (emits per-phoneme language IDs) | ar-LB / en |
 | `arbtok` | Dialect-aware Arabic on undiacritized text (o2i lattice; register via `phonemizer_model`) | Arabic |
 | `euskaphone` | Dialect-aware Basque (o2i lattice) | Basque |
@@ -78,6 +79,9 @@ The `Alphabet` enum controls the output representation of the phonemizer:
 | `eraab` | ERAAB (Persian) |
 | `cotovia` | Cotovia phoneme set (Galician) |
 | `buckwalter` | Buckwalter transliteration (Arabic) |
+| `graphemes` | Raw text characters |
+| `vosk` | vosk-tts phoneme inventory (Russian) |
+| `cangjie` | Cangjie input-method decomposition (Chinese) |
 
 ## Selecting a Phonemizer
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -139,7 +139,7 @@ is the **encoder**; the decoder is an auxiliary graph:
 ```
 
 ```python
-from phoonnx import TTSVoice
+from phoonnx.voice import TTSVoice
 voice = TTSVoice.load(model_path="encoder.onnx")  # config sits next to it
 ```
 

--- a/docs/training/engines/matcha.md
+++ b/docs/training/engines/matcha.md
@@ -48,7 +48,7 @@ Catalan Matxa voices ship in `phoonnx/voice_index/BSC.json`, mirrored under
 End-to-end (single ONNX, no vocoder):
 
 ```python
-from phoonnx import TTSVoice
+from phoonnx.voice import TTSVoice
 
 voice = TTSVoice.load(model_path="matxa_v2_graphemes_10_steps_wavenext.onnx")
 ```

--- a/docs/training/engines/shami.md
+++ b/docs/training/engines/shami.md
@@ -90,7 +90,8 @@ vendored symbol vocabulary.
 from phoonnx.voice import TTSVoice
 
 voice = TTSVoice.load("model.onnx", "config.json")
-audio = voice.synthesize("مَرحَبا، this is a test.")
+for chunk in voice.synthesize("مَرحَبا، this is a test."):
+    ...
 ```
 
 `TTSVoice` routes the model to `ShamiAdapter` and forwards the per-phoneme


### PR DESCRIPTION
## Summary

Full documentation QA pass over `README.md`, everything under `docs/`, and `VOICES.md`, verified against dev source (`phoonnx/`, `phoonnx_train/`, `pyproject.toml`). Every Python/bash snippet was extracted and either executed against a real downloaded voice (`OpenVoiceOS/phoonnx_pt-PT_miro_tugaphone`) or, where infeasible (multi-GB training runs, illustrative pseudocode), syntax- and API-checked against the source.

### Drift fixed

- **`VOICES.md`** regenerated via `phoonnx/model_manager.py`'s `generate_voices_markdown()` — was stale (2235/1239 vs actual 2238/1239).
- **README**: stale "17 synthesis engines" claim (actual: 14 registered inference adapters) fixed to 14; added a "Related projects" section linking `ovos-core`, `ovos-plugin-manager`, `ovos-tts-server`.
- **`docs/engines.md`**: the "Existing Engines" (training) table only listed VITS; added GlowTTS, Matcha, OptiSpeech, FastPitch/SpeedySpeech, ZipVoice, Mixer-TTS, StyleTTS2 (+ aligner/plbert/pitch), YourTTS — all actually registered in `phoonnx_train/engines/__init__.py`. Noted Chatterbox/F5-TTS/SuperTonic are inference-only for now.
- **`docs/configuration.md`** and **`docs/architecture.md`**: `Engine` enum has 17 members, not 16 — `supertonic` was missing from both the prose count and the reference table.
- **`docs/installation.md`**: `train-fastpitch` / `train-mixer` extras no longer pull `pyworld` (moved to a new `train-pyworld` extra in a prior refactor) — docs still described the old dependency; also documented the previously-undocumented `audiosr` extra (48kHz super-resolution).
- **`docs/phonemizers.md`**: added the `vosk` `PhonemeType` (Russian, vosk-tts inventory) and the `graphemes`/`vosk`/`cangjie` `Alphabet` values — all real, functional, but undocumented.
- **`docs/streaming.md`**, **`docs/training/engines/matcha.md`**: `from phoonnx import TTSVoice` doesn't work — `TTSVoice` is not re-exported from the package `__init__.py`. Fixed to `from phoonnx.voice import TTSVoice`.
- **`docs/cloning.md`**, **`docs/training/engines/shami.md`**: `audio = voice.synthesize(...)` is misleading — `synthesize()` is a generator yielding `AudioChunk`s per sentence, not a raw audio array (confirmed against `usage.md`, which documents this correctly, and against `TTSVoice.synthesize`'s actual signature). Fixed the assignments to `for chunk in voice.synthesize(...)`.
- Minor prose: dropped one piece of changelog-speak ("now accepts" → "accepts") and a trailing-colon heading in `docs/ovos_plugin.md`.

### Snippet run table (representative — every page's snippets were at minimum syntax+API checked)

| Page | Snippets | Result |
|---|---|---|
| README.md | quickstart Python | Ran against a real downloaded voice — OK |
| docs/quickstart.md | all 3 Python blocks | Ran end-to-end — OK |
| docs/usage.md | loading, streaming synthesis, alignments, low-level phonemize/tokenize/vocode, SynthesisConfig | Ran against a real voice — OK |
| docs/configuration.md | VoiceConfig/SynthesisConfig construction, provider check | Ran — OK |
| docs/phonemizers.md | `get_phonemizer` factory, overrides | Ran — OK |
| docs/voice_manager.md | TTSModelManager listing/downloading/loading, TTSModelInfo construction | Ran — OK |
| docs/vocoders.md | `list_vocoders`/`build_vocoder` | Ran — OK |
| docs/galician.md | CotoviaPhonemizer (IPA/Cotovia/stress variants), factory dispatch | Ran — OK |
| docs/alphabet_model.md | scriptconv `DEFAULT_GRAPH.convert` | Ran — OK |
| docs/ovos_plugin.md | `PhoonnxTTSPlugin` construction + `refresh_voices` | Ran — OK |
| docs/cli.md | `phoonnx-voices` CLI (update-cache/list-langs/list-voices/list-available/download) | Ran — OK, matches Click interface exactly |
| docs/streaming.md, docs/training/engines/matcha.md | `TTSVoice` import | Fixed (was broken import), now syntax+import verified |
| docs/cloning.md, docs/training/engines/shami.md | `voice.synthesize()` cloning examples | Fixed misleading return-type usage |
| docs/alignment.md (VISEME snippet), docs/training/engines/zipvoice.md (sampling-loop snippet) | pseudocode with `...`/undefined vars | Intentionally illustrative, not runnable — syntax-checked as pseudocode, left as-is |
| All other docs/*.md and docs/training/**/*.md Python blocks (85 blocks total across the repo) | — | AST-parsed + `phoonnx`/`phoonnx_train` imports resolved against the installed package; 0 remaining import/attribute failures |

### Code bugs found (NOT fixed here — findings only, per instructions)

None found. Everything checked against source was either already correct or was a docs-side discrepancy (fixed above). No phoonnx runtime bug was identified during this pass.

### Structure/QA

- No dead intra-repo links (checked every `](...)` link in README.md, VOICES.md, and all of docs/ against the filesystem).
- No references to the removed root `TRAINING.md`.
- Engine lists cross-checked against `phoonnx/engines/__init__.py` (14 registered) and `phoonnx_train/engines/__init__.py` (14 registered, incl. StyleTTS2 sub-engines) — `docs/engines.md`'s inference-adapter table was already complete (chatterbox, f5tts, zipvoice, supertonic, vits_streaming, yourtts all present); only the training-engine table was stale.
- `docs/README.md` index was already accurate — all listed pages exist, no missing per-engine guides.

### Test suite

Ran the non-training subset (`test_cli.py`, `test_config_detection*.py`, `test_engines.py`) directly relevant to the touched docs: **116 passed**. A full-suite run was attempted but was killed by OOM on this shared machine (contention from other concurrent agent sessions unrelated to this change, confirmed via `ps aux`) partway through the torch training tests — those are unaffected by a docs-only change and no test in the repo references `VOICES.md` or its voice/language counts.

---

This PR was authored by Claude Sonnet 5 under Fable orchestration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated engine and voice counts, architecture details, training-engine coverage, and related project links.
  - Added documentation for the SuperTonic engine, Vosk phonemizer, supported alphabet values, and optional audio super-resolution.
  - Added three Ukrainian Piper voices.
  - Updated voice-cloning and synthesis examples to handle streamed audio chunks.
  - Clarified installation extras and training configuration.
  - Corrected import examples and standardized documentation headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->