### PR TITLE
feat: NeuTTS/Akiti-TTS engine (autoregressive NeuCodec LM)

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -1,7 +1,7 @@
 ## Supported Voices
 
-**Total Voices:** 2238
-**Total Languages:** 1239
+**Total Voices:** 2247
+**Total Languages:** 1240
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
 
@@ -1964,6 +1964,15 @@
 | `facebook/mms-tts-tuf-Tunebo, Central` | `tuf` | `transformers` | `graphemes` |
 | `facebook/mms-tts-tuo-Tucano` | `tuo` | `transformers` | `graphemes` |
 | `facebook/mms-tts-tvw-Sedoa` | `tvw` | `transformers` | `graphemes` |
+| `neutts/akiti/twi/abena` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/akua` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/akwasi` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/kofi` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/kwabena` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/kwaku` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/kwame` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/yaa` | `tw` | `neutts` | `unicode` |
+| `neutts/akiti/twi/yaw` | `tw` | `neutts` | `unicode` |
 | `coqui/tw_akuapem-openbible-vits` | `tw-GH` | `coqui` | `graphemes` |
 | `coqui/tw_asante-openbible-vits` | `tw-GH` | `coqui` | `graphemes` |
 | `facebook/mms-tts-twb-Tawbuid` | `twb` | `transformers` | `graphemes` |

--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -27,6 +27,7 @@ turned into:
 |---|---|---|---|---|
 | **d-vector** | a **speaker encoder** maps the reference waveform to a fixed embedding that conditions synthesis | No | Yes | YourTTS, StyleTTS2, [Chatterbox](training/engines/chatterbox.md) |
 | **in-context** | the reference **audio + its transcription** are part of the model input; the model continues that voice | **Yes** | Per-phoneme (espeak/pinyin) | ZipVoice |
+| **in-context, pre-encoded** | the reference is **codec-encoded ahead of time** and shipped with the voice; the model continues those audio tokens | **Yes** (bundled) | Per-phoneme (espeak) | NeuTTS / Akiti-TTS |
 
 A cloning voice can still bundle a **default speaker**, so it works with *or* without a
 reference. When a reference is given it **overrides** the default
@@ -89,6 +90,32 @@ adds an **`exaggeration`** control (0.0–1.0) for expressiveness:
 ```python
 voice.synthesize("...", SynthesisConfig(speaker_reference="ref.wav", exaggeration=0.6))
 ```
+
+## Preset engine (NeuTTS / Akiti-TTS)
+
+[NeuTTS](engines.md) clones in-context, but the reference is **encoded once, offline**, and
+shipped with the voice rather than supplied per call. A preset is a reference
+transcription plus the NeuCodec tokens of its recording; the model is given both and
+continues the voice. Each bundled voice pins one preset, so no cloning arguments are
+needed:
+
+```python
+voice.synthesize("Meda wo ase paa.")
+```
+
+Switch presets per call through `extra_params`:
+
+```python
+SynthesisConfig(extra_params={"voice": "kofi", "temperature": 0.4, "seed": 0})
+```
+
+`speaker_reference` is **not** supported here: Neuphonic publishes NeuCodec's decoder as
+ONNX but not its encoder, so a fresh clip cannot be turned into reference tokens at
+runtime. Passing one raises rather than silently ignoring it.
+
+Sampling is tunable through `extra_params` — `temperature`, `top_p`, `top_k`,
+`repetition_penalty` and `max_new_tokens` (the autoregressive loop runs at 50 codec
+tokens per second of audio). `seed` makes a run reproducible.
 
 ## In-context engine (ZipVoice)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ config = VoiceConfig.from_dict(my_config_dict)
 `VoiceConfig.from_dict()` automatically detects the training engine from the config structure:
 
 - **Chatterbox** — an explicit `engine: "chatterbox"` (needs a BPE `tokenizer.json`)
+- **NeuTTS** — an explicit `engine: "neutts"` (the adapter loads its own BPE `tokenizer.json` and `voices.json` from `engine_params`)
 - **phoonnx** — presence of `phoonnx_version`
 - **Piper** — presence of `piper_version`, or a list-valued `phoneme_id_map` + `phoneme_type: "espeak"|"text"` (an explicitly declared non-piper engine wins over shape-sniffing)
 - **Mimic3** — presence of `phonemizer` + `phonemes` dict (requires an external `phonemes.txt`)
@@ -168,6 +169,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `f5tts` | DiT flow-matching (F5-TTS / Habibi) | [F5-TTS](training/engines/f5tts.md) |
 | `chatterbox` | Autoregressive codec-LM cloning | [Chatterbox](training/engines/chatterbox.md) |
 | `supertonic` | Multi-graph flow-matching, raw-text (no phonemizer) | [Engines](engines.md) |
+| `neutts` | Autoregressive NeuCodec LM, preset cloning @24 kHz | [Cloning](cloning.md) |
 
 ## Execution Providers
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -89,6 +89,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | Shami / HamsVITS | `phoonnx/engines/shami.py` | `engine in ("shami", "hams")` — VITS variant with per-phoneme `language_ids` for Levantine Arabic / English code-switching |
 | [Chatterbox](training/engines/chatterbox.md) | `phoonnx/engines/chatterbox.py` | `engine == "chatterbox"` — first **autoregressive** engine (codec-LM), d-vector [cloning](cloning.md) + exaggeration |
 | SuperTonic | `phoonnx/engines/supertonic.py` | `engine == "supertonic"` — multi-graph flow-matching engine (4 ONNX graphs via `aux_model_urls`), raw-text (no phonemizer), fixed per-speaker style instead of cloning |
+| NeuTTS (NeuTTS Air / VieNeu / Akiti) | `phoonnx/engines/neutts.py` | `engine == "neutts"` — autoregressive single-codebook codec-LM (Qwen3 backbone + NeuCodec decoder), raw text phonemized with espeak-ng, in-context [cloning](cloning.md) from pre-encoded voice presets, 24 kHz |
 
 ---
 

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -11,7 +11,7 @@ The catalog is not fetched from a handful of live endpoints. `merge_default_voic
 `OVOS`, `MMS`, `proxectonos`, `piper`, `phonikud`, `neurlang`, `mimic3`,
 `transformers_community`, `piper_community`, `optispeech`, `glowtts`, `mixertts`,
 `fastpitch`, `coqui_community`, `vits2`, `styletts2`, `f5tts`, `coqui_vits`, `BSC`,
-`shami`, `chatterbox`, `supertonic`.
+`shami`, `chatterbox`, `supertonic`, `neutts`.
 
 Each JSON entry becomes a `TTSModelInfo`. Model/config/vocoder files are only fetched from their URLs when a voice is actually downloaded or loaded.
 
@@ -165,7 +165,8 @@ relevant to specific engine families (see [engines.md](engines.md), [cloning.md]
 | `vocoder_type` | `str` \| `None` | Vocoder implementation (`vocos`, `wavenext`, `hifigan`, `melgan`, `raw`, `griffinlim`) |
 | `style_url` | `str` \| `None` | Per-voice StyleTTS2/Kokoro style embedding |
 | `speaker_encoder_url` / `speaker_encoder_type` | `str` \| `None` | Cloning speaker-encoder ONNX (reference audio → d-vector) |
-| `aux_model_urls` | `dict` \| `None` | Extra ONNX graphs/files for multi-graph engines (F5-TTS; SuperTonic's `duration_predictor`/`text_encoder`/`vocoder` graphs plus its `tts.json` config, `unicode_indexer.json` and per-speaker `style.json`), keyed by engine-param name |
+| `aux_model_urls` | `dict` \| `None` | Extra ONNX graphs/files for multi-graph engines (F5-TTS; SuperTonic's `duration_predictor`/`text_encoder`/`vocoder` graphs plus its `tts.json` config, `unicode_indexer.json` and per-speaker `style.json`; NeuTTS's NeuCodec decoder graph plus its `tokenizer.json` and `voices.json`), keyed by engine-param name |
+| `engine_options` | `dict` \| `None` | Plain per-voice engine settings that are not downloadable files, merged into `engine_params` as-is (e.g. NeuTTS's `voice` preset name) |
 | `display_name` | `str` \| `None` | Friendly name for UIs/CLIs; may contain `{engine}`/`{phoneme_type}` placeholders |
 | `vocab_override` | `dict` \| `None` | Custom token-to-ID mapping |
 

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -33,6 +33,7 @@ class Engine(str, Enum):
     F5TTS = "f5tts"  # F5-TTS / Habibi-TTS: DiT flow-matching, Euler ODE (iterative)
     CHATTERBOX = "chatterbox"  # autoregressive codec-LM, d-vector cloning + exaggeration
     SUPERTONIC = "supertonic"  # Supertone SuperTonic: 4-graph flow-matching, raw-text (no phonemizer)
+    NEUTTS = "neutts"  # NeuTTS Air / VieNeu / Akiti: Qwen3 codec-LM + NeuCodec decoder
 
 
 # Alphabet and PhonemeType are wire-format enums shared with scriptconv;
@@ -306,6 +307,27 @@ class VoiceConfig:
             diacritics = (lang_code or "").lower().startswith(("ar", "he"))
             config.setdefault("audio", {}).setdefault("sample_rate", 24000)
             config.setdefault("num_symbols", tokenizer._tok.get_vocab_size())
+
+        elif (engine == Engine.NEUTTS or
+                (isinstance(engine, str) and engine == "neutts") or
+                config.get("engine") == "neutts"):
+            # NeuTTS consumes raw text: the adapter owns the whole text -> id path
+            # (espeak-ng phonemization, prompt assembly, then the checkpoint's own BPE,
+            # all loaded from engine_params), so no phonemizer/tokenizer vocabulary is
+            # built here. Alphabet.GRAPHEMES routes TTSVoice.synthesize() through
+            # adapter.encode_text(). NeuCodec output is 24 kHz mono.
+            engine = Engine.NEUTTS
+            phoneme_type = phoneme_type or PhonemeType.UNICODE
+            alphabet = alphabet or Alphabet.GRAPHEMES
+            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
+            tokenizer = TTSTokenizer(
+                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
+                add_blank_char=False,
+                add_blank_word=False,
+                use_eos_bos=False,
+                blank_at_end=False,
+                blank_at_start=False,
+            )
 
         elif (engine == Engine.SUPERTONIC or
                 (isinstance(engine, str) and engine == "supertonic") or

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -140,6 +140,7 @@ def _register_builtins() -> None:
     from phoonnx.engines.f5tts import F5TTSAdapter
     from phoonnx.engines.chatterbox import ChatterboxAdapter
     from phoonnx.engines.supertonic import SuperTonicAdapter
+    from phoonnx.engines.neutts import NeuTTSAdapter
 
     # OptiSpeech shares VITS-like x/x_lengths/scales inputs with Matcha, but has
     # a distinctive metadata + wav/durations output signature — check it first.
@@ -160,6 +161,7 @@ def _register_builtins() -> None:
     register_engine("f5tts", F5TTSAdapter, detect_priority=30)
     register_engine("chatterbox", ChatterboxAdapter, detect_priority=29)
     register_engine("supertonic", SuperTonicAdapter, detect_priority=28)
+    register_engine("neutts", NeuTTSAdapter, detect_priority=27)
 
 
 _register_builtins()

--- a/phoonnx/engines/neutts.py
+++ b/phoonnx/engines/neutts.py
@@ -1,0 +1,482 @@
+"""NeuTTS inference adapter — autoregressive NeuCodec LM (NeuTTS Air / VieNeu / Akiti).
+
+The NeuTTS Air family (Neuphonic) pairs a Qwen3 causal LM with **NeuCodec**, a
+single-codebook 24 kHz neural codec. The LM is an ordinary text model whose vocabulary
+was extended with 65 536 ``<|speech_N|>`` tokens: give it phonemes, and it emits a flat
+stream of codec tokens that NeuCodec's decoder turns back into a waveform. There is no
+duration model, no vocoder and no speaker encoder.
+
+phoonnx's third autoregressive engine, after
+:class:`phoonnx.engines.chatterbox.ChatterboxAdapter` and
+:class:`phoonnx.engines.mosstts.MossTTSNanoAdapter`. Compared to MOSS-TTS-Nano it is the
+*simple* shape of the same idea: one token per step instead of a 16-token RVQ frame, so
+the decode loop is a plain KV-cached LM loop.
+
+Two ONNX graphs::
+
+    neutts_lm.onnx        Qwen3 backbone, KV-cached  (= the voice's ``session``)
+    neucodec_decoder.onnx codes[1, 1, N] -> waveform[..., T] @ 24 kHz
+
+``neutts_lm.onnx`` serves prefill *and* decode — the same graph with a different past
+length, exactly as Chatterbox's ``language_model`` does::
+
+    inputs   input_ids       int64 [1, S]        prompt tokens, or 1 token per step
+             attention_mask  int64 [1, P + S]    ones over past and current tokens
+             position_ids    int64 [1, S]        absolute positions, P .. P+S-1
+             past_key_<i>    fp32  [1, 4, P, 64] for i in 0..27
+             past_value_<i>  fp32  [1, 4, P, 64]
+    outputs  logits          fp32  [1, V]        last position only
+             present_key_<i> / present_value_<i>  fp32 [1, 4, P + S, 64]
+
+The KV geometry is read off the graph's own input signature, so a differently-sized
+sibling checkpoint needs no code change. See
+``scripts/conversion/neutts/export_neutts_onnx.py`` for the export.
+
+Prompt format
+~~~~~~~~~~~~~
+Reproduced from upstream's inference code, which is what the checkpoint was trained on::
+
+    <|TEXT_PROMPT_START|>{reference phones} {target phones}<|TEXT_PROMPT_END|>
+    <|SPEECH_GENERATION_START|>{<|speech_c|> for c in reference codes}
+
+Generation continues that speech-token run until ``<|SPEECH_GENERATION_END|>`` or EOS.
+Both phone strings come from espeak-ng, and the tokenizer is the checkpoint's own BPE, so
+text -> ids is byte-identical to training rather than re-derived here.
+
+Cloning is **in-context and pre-encoded**: a voice preset is a reference transcript plus
+the NeuCodec codes of its recording (a ``voices.json``, spec ``vieneu.voice.presets``),
+shipped as a per-voice asset. Neuphonic publishes NeuCodec's *decoder* as ONNX but not
+its encoder, so this adapter cannot encode a fresh reference clip — it clones from the
+presets only, and ``speaker_reference`` is not supported.
+"""
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+from quebra_frases import sentence_tokenize
+
+from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
+from phoonnx.util import LOG
+
+SAMPLE_RATE = 24000
+
+#: espeak-ng voice the family is phonemized with. Akiti-TTS phonemizes Asante Twi
+#: through Lingua Franca Nova: espeak-ng has no Twi voice, and ``lfn``'s five-vowel,
+#: near-one-to-one orthography is the closest reader for Twi spelling. This is what the
+#: checkpoint was trained on, so it is a property of the model, not a fallback.
+ESPEAK_VOICE = "lfn"
+
+# Special ids are read from the tokenizer, but the token *strings* are fixed by the
+# family's prompt format.
+TEXT_PROMPT_START = "<|TEXT_PROMPT_START|>"
+TEXT_PROMPT_END = "<|TEXT_PROMPT_END|>"
+SPEECH_GENERATION_START = "<|SPEECH_GENERATION_START|>"
+SPEECH_GENERATION_END = "<|SPEECH_GENERATION_END|>"
+SPEECH_TOKEN_TEMPLATE = "<|speech_{}|>"
+
+_SPEECH_TOKEN_RE = re.compile(r"^<\|speech_(\d+)\|>$")
+
+#: Reference codes fed as the generation prefix. Upstream truncates at 200 (~4 s): the
+#: prompt has to leave room for the target inside the LM's context.
+MAX_REFERENCE_CODES = 200
+
+#: Tokens the repetition penalty looks back over. Upstream runs the LM through
+#: llama.cpp, whose penalty is windowed (``last_n_tokens_size``, default 64) and spans
+#: the *prompt* as well as what has been generated. Penalising the whole generated run
+#: instead — the HuggingFace convention the other phoonnx codec-LMs use — is a different
+#: model, and it makes this one cut off early or babble.
+REPETITION_WINDOW = 64
+
+#: Punctuation ``phonemizer``'s ``preserve_punctuation=True`` keeps verbatim. espeak-ng
+#: drops punctuation from its phoneme output, so the marks are split out before the
+#: espeak call and spliced back after — the behaviour the training pipeline had.
+_PUNCTUATION = ';:,.!?¡¿—…"«»“”'
+_PUNCT_SPLIT = re.compile(f"([{re.escape(_PUNCTUATION)}]+)")
+
+
+def preserve_punctuation_phonemize(text: str, phonemize) -> str:
+    """espeak-phonemize *text* while keeping its punctuation in place.
+
+    ``phonemize`` is a ``str -> str`` callable (the voice's espeak phonemizer). Words and
+    punctuation runs are separated first, only the words go to espeak, and the marks are
+    re-inserted between the phonemized pieces — which is what ``phonemizer``'s
+    ``preserve_punctuation=True`` does, and therefore what the checkpoint saw at training
+    time. espeak-ng on its own silently deletes the marks.
+    """
+    out: List[str] = []
+    for part in _PUNCT_SPLIT.split(text):
+        if not part.strip():
+            continue
+        if _PUNCT_SPLIT.fullmatch(part):
+            out.append(part)
+        else:
+            phones = phonemize(part.strip())
+            if phones:
+                out.append(phones)
+    # marks attach to the preceding phones ("pˈaa." not "pˈaa ."), everything else is
+    # space-separated
+    joined = ""
+    for piece in out:
+        if joined and not _PUNCT_SPLIT.fullmatch(piece):
+            joined += " "
+        joined += piece
+    return joined
+
+
+def _softmax(x: np.ndarray) -> np.ndarray:
+    z = np.asarray(x, np.float64)
+    z = z - z.max()
+    e = np.exp(z)
+    return e / e.sum()
+
+
+def _apply_repetition_penalty(scores: np.ndarray, seen: np.ndarray, penalty: float) -> np.ndarray:
+    """Divide the score of tokens in ``seen`` by ``penalty`` (multiply when negative).
+
+    >1 discourages repeats. ``seen`` is the recent-token *window* the caller chose, not
+    the whole history — see :data:`REPETITION_WINDOW`. NeuTTS needs a fairly strong
+    penalty (upstream default 1.3) or it stalls on runs of silence tokens.
+    """
+    if penalty == 1.0 or seen.size == 0:
+        return scores
+    out = scores.copy()
+    idx = np.unique(seen[(seen >= 0) & (seen < out.shape[0])])
+    if idx.size:
+        s = out[idx]
+        out[idx] = np.where(s < 0, s * penalty, s / penalty)
+    return out
+
+
+def _sample(scores: np.ndarray, temperature: float, top_k: int, top_p: float,
+            rng: np.random.Generator) -> int:
+    """Top-k, then nucleus, then temperature — llama.cpp's sampler order (argmax if temp<=0).
+
+    The order matters and is not the HuggingFace one: llama.cpp truncates on the *raw*
+    distribution and only then applies temperature, so a low temperature sharpens the
+    surviving candidates rather than shrinking the candidate set. Upstream drives this
+    checkpoint through llama.cpp, so this reproduces the sampler it was tuned against.
+    """
+    s = np.asarray(scores, np.float32)
+    if temperature <= 0:
+        return int(np.argmax(s))
+    if 0 < top_k < s.shape[0]:
+        threshold = float(np.partition(s, -top_k)[-top_k])
+        s = np.where(s < threshold, -np.inf, s)
+    if 0 < top_p < 1:
+        order = np.argsort(s)[::-1]
+        cumulative = np.cumsum(_softmax(s[order]))
+        keep = np.ones(order.shape[0], bool)
+        # keep every token up to and including the one that crosses top_p
+        keep[1:] = cumulative[:-1] < top_p
+        masked = np.full_like(s, -np.inf)
+        masked[order[keep]] = s[order[keep]]
+        s = masked
+    probs = _softmax(s / float(temperature))
+    return int(rng.choice(probs.shape[0], p=probs))
+
+
+class NeuTTSAdapter(BaseOnnxAdapter):
+    """Adapter for the NeuTTS Air family (Qwen3 codec-LM + NeuCodec decoder)."""
+
+    #: hard ceiling on the AR loop; NeuCodec runs at 50 tokens/s, so 600 is ~12 s
+    MAX_NEW_TOKENS = 600
+    #: characters of target text per model call (upstream's chunk budget)
+    MAX_CHUNK_CHARS = 200
+
+    def __init__(self):
+        self.codec: Optional[onnxruntime.InferenceSession] = None
+        self.tokenizer = None
+        self.presets: Dict[str, Dict[str, Any]] = {}
+        self.default_preset: Optional[str] = None
+        self.speech_end_id: Optional[int] = None
+        self.eos_id: Optional[int] = None
+        self.speech_token_base: Optional[int] = None
+        self.num_layers = 0
+        self.num_kv_heads = 0
+        self.head_dim = 0
+        self._phonemizer = None
+        self._ref_phones: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # setup
+    # ------------------------------------------------------------------
+    def default_params(self) -> Dict[str, Any]:
+        """Upstream's CLI defaults."""
+        return {
+            "temperature": 0.4,
+            "top_p": 0.8,
+            "top_k": 50.0,
+            "repetition_penalty": 1.3,
+            "max_new_tokens": float(self.MAX_NEW_TOKENS),
+            "max_chunk_chars": float(self.MAX_CHUNK_CHARS),
+        }
+
+    def param_labels(self) -> Dict[str, str]:
+        return {
+            "temperature": "sampling temperature",
+            "top_p": "top-p (nucleus)",
+            "top_k": "top-k",
+            "repetition_penalty": "repetition penalty",
+            "max_new_tokens": "max codec tokens (50/s)",
+            "max_chunk_chars": "target characters per model call",
+            "voice": "voice preset name",
+        }
+
+    def configure(self, voice_config: Any) -> None:
+        """Load the NeuCodec decoder, the checkpoint's BPE and the voice presets from
+        ``engine_params``."""
+        ep = getattr(voice_config, "engine_params", None) or {}
+        if self.codec is None and ep.get("codec_decoder_path"):
+            self.codec = make_session(ep["codec_decoder_path"], providers=ep.get("providers"))
+        if self.tokenizer is None and ep.get("tokenizer_path"):
+            from tokenizers import Tokenizer
+            self.tokenizer = Tokenizer.from_file(str(ep["tokenizer_path"]))
+            self.speech_end_id = self.tokenizer.token_to_id(SPEECH_GENERATION_END)
+            self.speech_token_base = self.tokenizer.token_to_id(
+                SPEECH_TOKEN_TEMPLATE.format(0))
+            self.eos_id = self.tokenizer.token_to_id("<|endoftext|>")
+        if not self.presets and ep.get("voices_path"):
+            with open(ep["voices_path"], encoding="utf-8") as f:
+                voices = json.load(f)
+            self.presets = voices.get("presets") or {}
+            self.default_preset = voices.get("default_voice")
+
+    def _read_kv_shape(self, session: onnxruntime.InferenceSession) -> None:
+        for spec in session.get_inputs():
+            if spec.name.startswith("past_key_"):
+                self.num_layers += 1
+                if self.num_kv_heads == 0:
+                    self.num_kv_heads = int(spec.shape[1])
+                    self.head_dim = int(spec.shape[3])
+
+    # ------------------------------------------------------------------
+    # text
+    # ------------------------------------------------------------------
+    def _espeak(self, text: str) -> str:
+        """Phonemize with espeak-ng at the voice the checkpoint was trained with.
+
+        Deliberately *not* the phoonnx voice's own phonemizer: a NeuTTS voice is
+        ``Alphabet.GRAPHEMES``, whose phonemizer passes text through unchanged. Which
+        phonemes this model consumes is a property of the checkpoint, so espeak-ng is
+        addressed directly.
+        """
+        if self._phonemizer is None:
+            from scriptconv.phonemizers.mul import EspeakPhonemizer
+            self._phonemizer = EspeakPhonemizer()
+        return preserve_punctuation_phonemize(
+            text, lambda part: self._phonemizer.phonemize_string(part, ESPEAK_VOICE).strip())
+
+    def resolve_preset(self, voice: Any, syn_config: Any) -> Optional[Dict[str, Any]]:
+        """Pick the voice preset: an explicit per-call ``voice``, else the one this
+        phoonnx voice is pinned to, else ``voices.json``'s ``default_voice``."""
+        name = None
+        if syn_config is not None:
+            name = (syn_config.extra_params or {}).get("voice")
+        cfg = getattr(voice, "config", None)
+        if not name:
+            name = (getattr(cfg, "engine_params", None) or {}).get("voice")
+        if not name:
+            name = self.default_preset
+        if not name:
+            return None
+        if name not in self.presets:
+            raise ValueError(f"unknown NeuTTS voice preset {name!r}; "
+                             f"available: {sorted(self.presets)}")
+        return self.presets[name]
+
+    def reference_phones(self, name: str, preset: Dict[str, Any]) -> str:
+        """Phonemized reference transcript, cached per preset (it never changes)."""
+        if name not in self._ref_phones:
+            self._ref_phones[name] = self._espeak(preset.get("text", "")).strip()
+        return self._ref_phones[name]
+
+    def chunk_text(self, text: str, max_chars: int) -> List[str]:
+        """Pack whole sentences up to ``max_chars`` per model call.
+
+        The LM degrades on long prompts, so upstream splits before synthesizing.
+        Sentences come from the same ``quebra_frases`` splitter the rest of phoonnx uses;
+        an over-long single sentence is split on word boundaries rather than dropped.
+        """
+        text = (text or "").strip()
+        if not text:
+            return []
+        if len(text) <= max_chars:
+            return [text]
+        chunks: List[str] = []
+        current = ""
+        for sentence in sentence_tokenize(text) or [text]:
+            sentence = sentence.strip()
+            if not sentence:
+                continue
+            pieces = [sentence]
+            if len(sentence) > max_chars:
+                pieces, word_chunk = [], ""
+                for word in sentence.split():
+                    if word_chunk and len(word_chunk) + 1 + len(word) > max_chars:
+                        pieces.append(word_chunk)
+                        word_chunk = word
+                    else:
+                        word_chunk = f"{word_chunk} {word}".strip()
+                if word_chunk:
+                    pieces.append(word_chunk)
+            for piece in pieces:
+                if current and len(current) + 1 + len(piece) > max_chars:
+                    chunks.append(current)
+                    current = ""
+                current = f"{current} {piece}".strip()
+        if current:
+            chunks.append(current)
+        return chunks
+
+    def build_prompt(self, target_phones: str, reference_phones: str = "",
+                     reference_codes: Optional[List[int]] = None) -> str:
+        """The exact prompt string the checkpoint was fine-tuned on."""
+        text = f"{reference_phones} {target_phones}".strip() if reference_phones \
+            else target_phones.strip()
+        codes = "".join(SPEECH_TOKEN_TEMPLATE.format(int(c))
+                        for c in (reference_codes or [])[:MAX_REFERENCE_CODES])
+        return (f"{TEXT_PROMPT_START}{text}{TEXT_PROMPT_END}"
+                f"{SPEECH_GENERATION_START}{codes}")
+
+    def encode_text(self, text: str, voice: Any, syn_config: Any) -> List[List[int]]:
+        """Build one fully-formed prompt per model call and BPE-encode it.
+
+        The reference block is part of the prompt, so the whole string — reference phones,
+        target phones, special tokens and the pre-encoded reference codes — is tokenized
+        in one pass by the checkpoint's own BPE. Splicing separately-tokenized pieces
+        would not reproduce training-time ids at the joins.
+        """
+        if self.tokenizer is None:
+            raise RuntimeError("NeuTTS voice missing tokenizer_path in engine_params")
+        budget = int(self.MAX_CHUNK_CHARS)
+        if syn_config is not None:
+            budget = int((syn_config.extra_params or {}).get("max_chunk_chars", budget))
+        preset = self.resolve_preset(voice, syn_config)
+        ref_phones, ref_codes = "", None
+        if preset is not None:
+            name = next(k for k, v in self.presets.items() if v is preset)
+            ref_phones = self.reference_phones(name, preset)
+            ref_codes = preset.get("codes")
+        prompts = [self.build_prompt(self._espeak(chunk).strip(), ref_phones, ref_codes)
+                   for chunk in self.chunk_text(text, max(1, budget))]
+        return [list(self.tokenizer.encode(p, add_special_tokens=False).ids) for p in prompts]
+
+    # ------------------------------------------------------------------
+    # codec
+    # ------------------------------------------------------------------
+    def token_ids_to_codes(self, token_ids: List[int]) -> List[int]:
+        """Keep only ``<|speech_N|>`` tokens and map them back to NeuCodec indices."""
+        if self.speech_token_base is None:
+            raise RuntimeError("NeuTTS tokenizer has no <|speech_0|> token")
+        codes: List[int] = []
+        for tid in token_ids:
+            token = self.tokenizer.id_to_token(int(tid))
+            match = _SPEECH_TOKEN_RE.match(token or "")
+            if match:
+                codes.append(int(match.group(1)))
+        return codes
+
+    def decode_codes(self, codes: List[int]) -> np.ndarray:
+        """NeuCodec indices -> mono float32 waveform at 24 kHz."""
+        if not codes:
+            return np.zeros(0, np.float32)
+        arr = np.asarray(codes, np.int32).reshape(1, 1, -1)
+        name = self.codec.get_inputs()[0].name
+        audio = self.codec.run(None, {name: arr})[0]
+        return np.asarray(audio, np.float32).reshape(-1)
+
+    # ------------------------------------------------------------------
+    # autoregressive loop
+    # ------------------------------------------------------------------
+    def generate(self, session: onnxruntime.InferenceSession, prompt_ids: List[int],
+                 p: Dict[str, Any], rng: np.random.Generator) -> List[int]:
+        """Prefill the prompt, then sample codec tokens until the model stops."""
+        if not self.num_layers:
+            self._read_kv_shape(session)
+        out_names = [o.name for o in session.get_outputs()]
+        past_names = [f"past_{k}_{i}" for i in range(self.num_layers) for k in ("key", "value")]
+        present_names = [f"present_{k}_{i}" for i in range(self.num_layers) for k in ("key", "value")]
+
+        ids = np.asarray(prompt_ids, np.int64).reshape(1, -1)
+        length = ids.shape[1]
+        feed = {
+            "input_ids": ids,
+            "attention_mask": np.ones((1, length), np.int64),
+            "position_ids": np.arange(length, dtype=np.int64)[None, :],
+        }
+        empty = np.zeros((1, self.num_kv_heads, 0, self.head_dim), np.float32)
+        feed.update({n: empty for n in past_names})
+        named = dict(zip(out_names, session.run(None, feed)))
+
+        temperature = float(p.get("temperature", 0.4))
+        top_p = float(p.get("top_p", 0.8))
+        top_k = int(p.get("top_k", 50))
+        penalty = float(p.get("repetition_penalty", 1.3))
+        max_new = max(1, int(p.get("max_new_tokens", self.MAX_NEW_TOKENS)))
+
+        generated: List[int] = []
+        history = list(prompt_ids)
+        for step in range(max_new):
+            logits = np.asarray(named["logits"], np.float32).reshape(-1)
+            logits = _apply_repetition_penalty(
+                logits, np.asarray(history[-REPETITION_WINDOW:], np.int64), penalty)
+            token = _sample(logits, temperature, top_k, top_p, rng)
+            if token == self.speech_end_id or token == self.eos_id:
+                break
+            generated.append(token)
+            history.append(token)
+            if step == max_new - 1:
+                LOG.warning("NeuTTS hit the %d-token cap (%.1fs) without an end token",
+                            max_new, max_new / 50.0)
+                break
+            position = length + step
+            feed = {
+                "input_ids": np.asarray([[token]], np.int64),
+                "attention_mask": np.ones((1, position + 1), np.int64),
+                "position_ids": np.asarray([[position]], np.int64),
+                **{p_name: named[q] for p_name, q in zip(past_names, present_names)},
+            }
+            named = dict(zip(out_names, session.run(None, feed)))
+        return generated
+
+    # ------------------------------------------------------------------
+    # synthesis
+    # ------------------------------------------------------------------
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        if self.codec is None:
+            raise RuntimeError("NeuTTS voice missing codec_decoder_path in engine_params")
+        if self.tokenizer is None:
+            raise RuntimeError("NeuTTS voice missing tokenizer_path in engine_params")
+        if request.params.get("reference_audio") is not None:
+            raise RuntimeError(
+                "NeuTTS clones from pre-encoded voice presets, not from a reference clip: "
+                "NeuCodec's encoder is not published as ONNX. Select a preset with "
+                "extra_params={'voice': ...}")
+
+        p = {**self.default_params(), **request.params}
+        seed = p.get("seed")
+        rng = np.random.default_rng(None if seed is None else int(seed))
+        prompt_ids = [int(i) for i in np.asarray(request.phoneme_ids).reshape(-1)]
+        token_ids = self.generate(session, prompt_ids, p, rng)
+        codes = self.token_ids_to_codes(token_ids)
+        if not codes:
+            raise RuntimeError("NeuTTS generated no speech tokens — lower the temperature "
+                               "or pick another voice preset")
+        return AdapterSynthesisResult(audio=self.decode_codes(codes),
+                                      extras={"codes": len(codes)})
+
+    # required by the ABC but unused — synthesize() drives the AR loop.
+    def build_feed_dict(self, request, session):
+        raise NotImplementedError("NeuTTS is autoregressive — use synthesize()")
+
+    def parse_outputs(self, outputs, request, output_names=None):
+        raise NotImplementedError("NeuTTS is autoregressive — use synthesize()")
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        return bool(config and config.get("engine") == "neutts")

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -168,6 +168,12 @@ class TTSModelInfo:
     embed_tokens_url: Optional[str] = None
     conditional_decoder_url: Optional[str] = None
 
+    # Free-form engine settings that are plain values rather than downloadable files
+    # (``aux_model_urls`` covers the files). Merged into ``engine_params()`` as-is, so an
+    # index entry can pin a per-voice knob the adapter reads — e.g. NeuTTS voices, which
+    # all share one checkpoint and differ only by which ``voices.json`` preset they use.
+    engine_options: Optional[Dict[str, Any]] = field(default_factory=dict)
+
     # Optional BCP47 -> language-token map: how this voice's lang_code becomes the model's
     # language token. Dialect models (e.g. lahgtna) repurpose the base tokens, so a literal
     # token like "eg" is mapped here rather than derived from the (normalized) lang code.
@@ -507,7 +513,7 @@ class TTSModelInfo:
         Build the engine_params dict for synthesis, resolving the vocoder to
         its locally-downloaded path.  Empty for single-stage engines.
         """
-        params: Dict[str, Any] = {}
+        params: Dict[str, Any] = dict(self.engine_options or {})
         for key, aux_path in self.download_aux_models().items():
             params[key] = str(aux_path)
         style_path = self.download_style()
@@ -650,7 +656,7 @@ class TTSModelManager:
         "optispeech.json", "glowtts.json", "mixertts.json", "fastpitch.json",
         "coqui_community.json", "vits2.json", "styletts2.json", "f5tts.json",
         "coqui_vits.json", "BSC.json", "shami.json", "chatterbox.json",
-        "supertonic.json",
+        "supertonic.json", "neutts.json",
     )
 
     @classmethod

--- a/phoonnx/voice_index/neutts.json
+++ b/phoonnx/voice_index/neutts.json
@@ -1,0 +1,200 @@
+{
+    "neutts/akiti/twi/abena": {
+        "voice_id": "neutts/akiti/twi/abena",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "abena"
+        },
+        "display_name": "Akiti-TTS Twi (abena) - Akiti voice: abena"
+    },
+    "neutts/akiti/twi/akua": {
+        "voice_id": "neutts/akiti/twi/akua",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "akua"
+        },
+        "display_name": "Akiti-TTS Twi (akua) - Akiti voice: akua"
+    },
+    "neutts/akiti/twi/akwasi": {
+        "voice_id": "neutts/akiti/twi/akwasi",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "akwasi"
+        },
+        "display_name": "Akiti-TTS Twi (akwasi) - Akiti voice: akwasi"
+    },
+    "neutts/akiti/twi/kofi": {
+        "voice_id": "neutts/akiti/twi/kofi",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "kofi"
+        },
+        "display_name": "Akiti-TTS Twi (kofi) - Akiti voice: kofi"
+    },
+    "neutts/akiti/twi/kwabena": {
+        "voice_id": "neutts/akiti/twi/kwabena",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "kwabena"
+        },
+        "display_name": "Akiti-TTS Twi (kwabena) - Akiti voice: kwabena"
+    },
+    "neutts/akiti/twi/kwaku": {
+        "voice_id": "neutts/akiti/twi/kwaku",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "kwaku"
+        },
+        "display_name": "Akiti-TTS Twi (kwaku) - Akiti voice: kwaku"
+    },
+    "neutts/akiti/twi/kwame": {
+        "voice_id": "neutts/akiti/twi/kwame",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "kwame"
+        },
+        "display_name": "Akiti-TTS Twi (kwame) - Akiti voice: kwame"
+    },
+    "neutts/akiti/twi/yaa": {
+        "voice_id": "neutts/akiti/twi/yaa",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "yaa"
+        },
+        "display_name": "Akiti-TTS Twi (yaa) - Akiti voice: yaa"
+    },
+    "neutts/akiti/twi/yaw": {
+        "voice_id": "neutts/akiti/twi/yaw",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "neutts",
+        "lang": "tw",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
+            "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
+        },
+        "engine_options": {
+            "voice": "yaw"
+        },
+        "display_name": "Akiti-TTS Twi (yaw) - Akiti voice: yaw"
+    }
+}

--- a/phoonnx/voice_index/neutts.json
+++ b/phoonnx/voice_index/neutts.json
@@ -1,7 +1,7 @@
 {
     "neutts/akiti/twi/abena": {
         "voice_id": "neutts/akiti/twi/abena",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -12,6 +12,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -23,7 +24,7 @@
     },
     "neutts/akiti/twi/akua": {
         "voice_id": "neutts/akiti/twi/akua",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -34,6 +35,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -45,7 +47,7 @@
     },
     "neutts/akiti/twi/akwasi": {
         "voice_id": "neutts/akiti/twi/akwasi",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -56,6 +58,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -67,7 +70,7 @@
     },
     "neutts/akiti/twi/kofi": {
         "voice_id": "neutts/akiti/twi/kofi",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -78,6 +81,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -89,7 +93,7 @@
     },
     "neutts/akiti/twi/kwabena": {
         "voice_id": "neutts/akiti/twi/kwabena",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -100,6 +104,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -111,7 +116,7 @@
     },
     "neutts/akiti/twi/kwaku": {
         "voice_id": "neutts/akiti/twi/kwaku",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -122,6 +127,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -133,7 +139,7 @@
     },
     "neutts/akiti/twi/kwame": {
         "voice_id": "neutts/akiti/twi/kwame",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -144,6 +150,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -155,7 +162,7 @@
     },
     "neutts/akiti/twi/yaa": {
         "voice_id": "neutts/akiti/twi/yaa",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -166,6 +173,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"
@@ -177,7 +185,7 @@
     },
     "neutts/akiti/twi/yaw": {
         "voice_id": "neutts/akiti/twi/yaw",
-        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm_int8.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -188,6 +196,7 @@
         "engine": "neutts",
         "lang": "tw",
         "aux_model_urls": {
+            "lm_weights_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neutts_lm.onnx.data",
             "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/neucodec_decoder.onnx",
             "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/tokenizer.json",
             "voices_path": "https://huggingface.co/OpenVoiceOS/phoonnx-neutts/resolve/main/akiti-twi-onnx/voices.json"

--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -40,6 +40,26 @@ Converts coqui `tts_models/*/glow-tts` (GlowTTS / flow). GlowTTS already takes
 `input_lengths` as an explicit ONNX input, so it is dynamic without the mask fix;
 the same `voice_config_from_coqui` tokenization rules (sort + phonemizer) apply.
 
+## `neutts/`
+
+Exports a NeuTTS Air / VieNeu-TTS / Akiti-TTS backbone (a `Qwen3ForCausalLM` that emits
+NeuCodec audio tokens) to ONNX. Nothing is vendored — the checkpoint loads through
+`transformers`, and only the cache plumbing is wrapped so `torch.export` can carry it.
+
+One graph serves prefill *and* decode, with the KV cache as explicit inputs and outputs.
+A separate prefill graph would double ~0.3 B parameters on disk for an identical
+contract. Only the last position's logits are returned: the full `[1, S, 66938]` tensor
+is hundreds of MB of prefill output that sampling never reads.
+
+```bash
+python export_neutts_onnx.py --repo afrispeech/Akiti-TTS --out-dir ./onnx \
+    --quantize --check-parity
+```
+
+`--check-parity` re-runs the prompt through torch and prints the max absolute logit
+difference for the prefill call and for each decode step. The matching NeuCodec decoder
+is published by Neuphonic as ONNX and is used as-is, not re-exported.
+
 ## Licensing
 
 The vendored model code under each exporter is derived from

--- a/scripts/conversion/neutts/export_neutts_onnx.py
+++ b/scripts/conversion/neutts/export_neutts_onnx.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Export a NeuTTS Air / VieNeu-TTS / Akiti-TTS backbone to ONNX.
+
+The backbone is a plain ``Qwen3ForCausalLM`` that autoregressively emits NeuCodec
+audio tokens (``<|speech_N|>``). One graph serves the whole loop:
+
+``neutts_lm.onnx``
+    inputs
+        ``input_ids``       int64 ``[1, S]``      — ``S`` prompt tokens, or 1 per decode step
+        ``attention_mask``  int64 ``[1, P + S]``  — ones over past **and** current tokens
+        ``position_ids``    int64 ``[1, S]``      — absolute positions (``P .. P+S-1``)
+        ``past_key_<i>``    fp32  ``[1, 4, P, 64]`` for ``i`` in ``0..27``
+        ``past_value_<i>``  fp32  ``[1, 4, P, 64]``
+    outputs
+        ``logits``          fp32  ``[1, V]``      — **last position only**
+        ``present_key_<i>`` / ``present_value_<i>`` fp32 ``[1, 4, P + S, 64]``
+
+Prefill is ``P = 0`` with the full prompt; every decode step is ``S = 1`` with the
+returned cache. Emitting one graph rather than a separate prefill/decode pair keeps a
+single copy of the ~0.3 B weights on disk — the KV-cache contract is identical either
+way, and it is the same shape ``phoonnx.engines.chatterbox`` already drives.
+
+Only the last position's logits are returned: a full ``[1, S, 66938]`` tensor is ~250 MB
+of useless prefill output, and sampling only ever reads the final row.
+
+Usage::
+
+    python export_neutts_onnx.py --repo afrispeech/Akiti-TTS --out-dir ./onnx
+    python export_neutts_onnx.py --repo afrispeech/Akiti-TTS --out-dir ./onnx --quantize
+    python export_neutts_onnx.py --repo afrispeech/Akiti-TTS --out-dir ./onnx --check-parity
+
+Upstream weights keep their own license; see the model card of the source repo.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+class NeuTTSExportWrapper(torch.nn.Module):
+    """Flattens the HF cache API into positional tensors the ONNX graph can carry."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.num_layers = model.config.num_hidden_layers
+
+    def forward(self, input_ids, attention_mask, position_ids, past):
+        # ``past`` is one flat list of 2*L tensors rather than varargs: torch.export
+        # needs a fixed arity to attach per-input dynamic shapes to.
+        from transformers.cache_utils import DynamicCache
+
+        legacy = tuple(
+            (past[2 * i], past[2 * i + 1]) for i in range(self.num_layers)
+        )
+        cache = DynamicCache.from_legacy_cache(legacy)
+        out = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=cache,
+            use_cache=True,
+        )
+        present = out.past_key_values.to_legacy_cache()
+        flat = [t for layer in present for t in layer]
+        return (out.logits[:, -1, :], *flat)
+
+
+def _io_names(num_layers: int):
+    past = [n for i in range(num_layers) for n in (f"past_key_{i}", f"past_value_{i}")]
+    present = [n for i in range(num_layers) for n in (f"present_key_{i}", f"present_value_{i}")]
+    return past, present
+
+
+def _dummy_inputs(config, seq: int, past_len: int, dtype=torch.float32):
+    kv_heads = config.num_key_value_heads
+    head_dim = config.head_dim
+    input_ids = torch.randint(0, 300, (1, seq), dtype=torch.int64)
+    attention_mask = torch.ones((1, past_len + seq), dtype=torch.int64)
+    position_ids = torch.arange(past_len, past_len + seq, dtype=torch.int64)[None, :]
+    past = [
+        torch.zeros((1, kv_heads, past_len, head_dim), dtype=dtype)
+        for _ in range(2 * config.num_hidden_layers)
+    ]
+    return input_ids, attention_mask, position_ids, past
+
+
+def export(repo: str, out_dir: Path, opset: int = 17) -> Path:
+    from transformers import AutoModelForCausalLM
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    model = AutoModelForCausalLM.from_pretrained(repo, dtype=torch.float32)
+    model.eval()
+    config = model.config
+    wrapper = NeuTTSExportWrapper(model)
+
+    past_names, present_names = _io_names(config.num_hidden_layers)
+    input_names = ["input_ids", "attention_mask", "position_ids"] + past_names
+    output_names = ["logits"] + present_names
+
+    seq = torch.export.Dim("seq")
+    dynamic_shapes = {
+        "input_ids": {1: seq},
+        "attention_mask": {1: torch.export.Dim("total")},
+        "position_ids": {1: seq},
+        "past": [{2: torch.export.Dim("past")} for _ in past_names],
+    }
+
+    # A non-empty past in the export sample is what puts the cache-concat path (rather
+    # than the "no cache yet" branch) in the graph; the dynamic axes then let past=0
+    # work at prefill time.
+    ids, mask, pos, past = _dummy_inputs(config, seq=4, past_len=3)
+    path = out_dir / "neutts_lm.onnx"
+    torch.onnx.export(
+        wrapper,
+        (ids, mask, pos, past),
+        str(path),
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_shapes=dynamic_shapes,
+        opset_version=opset,
+        dynamo=True,
+    )
+    _write_meta(out_dir, repo, config)
+    return path
+
+
+def _write_meta(out_dir: Path, repo: str, config) -> None:
+    (out_dir / "neutts_onnx_meta.json").write_text(json.dumps({
+        "source_repo": repo,
+        "architecture": config.architectures[0],
+        "num_hidden_layers": config.num_hidden_layers,
+        "num_key_value_heads": config.num_key_value_heads,
+        "head_dim": config.head_dim,
+        "vocab_size": config.vocab_size,
+        "eos_token_id": config.eos_token_id,
+    }, indent=2) + "\n")
+
+
+def quantize(fp32_path: Path) -> Path:
+    """Dynamic int8 quantization of the MatMuls (the weights dominate this graph)."""
+    from onnxruntime.quantization import QuantType, quantize_dynamic
+
+    out = fp32_path.with_name(fp32_path.stem + "_int8.onnx")
+    quantize_dynamic(str(fp32_path), str(out), weight_type=QuantType.QInt8,
+                     extra_options={"MatMulConstBOnly": True})
+    return out
+
+
+def check_parity(repo: str, onnx_path: Path, seq: int = 24, steps: int = 8) -> dict:
+    """Compare ONNX against the torch model on a fixed prompt: the prefill logits and
+    every decode step, threading the ONNX cache through exactly as the engine does."""
+    import onnxruntime
+    from transformers import AutoModelForCausalLM
+
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_pretrained(repo, dtype=torch.float32).eval()
+    config = model.config
+    past_names, present_names = _io_names(config.num_hidden_layers)
+
+    sess = onnxruntime.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    out_names = [o.name for o in sess.get_outputs()]
+
+    ids = torch.randint(0, 60000, (1, seq), dtype=torch.int64)
+
+    # --- prefill
+    feed = {
+        "input_ids": ids.numpy(),
+        "attention_mask": np.ones((1, seq), np.int64),
+        "position_ids": np.arange(seq, dtype=np.int64)[None, :],
+    }
+    kv_shape = (1, config.num_key_value_heads, 0, config.head_dim)
+    feed.update({n: np.zeros(kv_shape, np.float32) for n in past_names})
+    onnx_out = dict(zip(out_names, sess.run(None, feed)))
+
+    with torch.no_grad():
+        ref = model(input_ids=ids, use_cache=True)
+    diffs = {"prefill": float(np.abs(onnx_out["logits"] - ref.logits[:, -1, :].numpy()).max())}
+
+    # --- decode steps, greedy so both stacks walk the same token path
+    past = {p: onnx_out[q] for p, q in zip(past_names, present_names)}
+    cache = ref.past_key_values
+    token = int(np.argmax(onnx_out["logits"]))
+    worst = 0.0
+    for step in range(steps):
+        pos = seq + step
+        feed = {
+            "input_ids": np.array([[token]], np.int64),
+            "attention_mask": np.ones((1, pos + 1), np.int64),
+            "position_ids": np.array([[pos]], np.int64),
+            **past,
+        }
+        onnx_out = dict(zip(out_names, sess.run(None, feed)))
+        with torch.no_grad():
+            ref = model(input_ids=torch.tensor([[token]]), past_key_values=cache, use_cache=True)
+        cache = ref.past_key_values
+        worst = max(worst, float(np.abs(onnx_out["logits"] - ref.logits[:, -1, :].numpy()).max()))
+        past = {p: onnx_out[q] for p, q in zip(past_names, present_names)}
+        token = int(np.argmax(onnx_out["logits"]))
+    diffs["decode"] = worst
+    return diffs
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default="afrispeech/Akiti-TTS",
+                    help="HF repo id or local directory holding the merged checkpoint")
+    ap.add_argument("--out-dir", type=Path, required=True)
+    ap.add_argument("--opset", type=int, default=18)
+    ap.add_argument("--quantize", action="store_true", help="also write an int8 graph")
+    ap.add_argument("--check-parity", action="store_true",
+                    help="compare the exported graph against torch and print max abs diff")
+    args = ap.parse_args()
+
+    path = export(args.repo, args.out_dir, args.opset)
+    print(f"wrote {path} ({os.path.getsize(path) / 1e6:.1f} MB)")
+    if args.quantize:
+        q = quantize(path)
+        print(f"wrote {q} ({os.path.getsize(q) / 1e6:.1f} MB)")
+    if args.check_parity:
+        for name, diff in check_parity(args.repo, path).items():
+            print(f"parity {name}: max abs diff {diff:.3e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_neutts.py
+++ b/tests/test_neutts.py
@@ -1,0 +1,476 @@
+"""NeuTTS adapter tests.
+
+Everything the adapter does around the model — phonemization with punctuation kept,
+prompt assembly, preset resolution, chunking, the KV-cached decode loop and the codec
+hand-off — is observable without the real weights, so the ONNX sessions here are fakes
+that record their feeds.
+"""
+import json
+
+import numpy as np
+import pytest
+
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.neutts import (
+    ESPEAK_VOICE, MAX_REFERENCE_CODES, SPEECH_GENERATION_START, SPEECH_TOKEN_TEMPLATE,
+    TEXT_PROMPT_END, TEXT_PROMPT_START, NeuTTSAdapter, _apply_repetition_penalty,
+    _sample, preserve_punctuation_phonemize,
+)
+
+LAYERS = 2
+KV_HEADS = 4
+HEAD_DIM = 8
+VOCAB = 64
+
+# fake vocabulary: 0..9 are text/special, 10.. are speech tokens
+SPEECH_BASE = 10
+END_ID = 5
+EOS_ID = 6
+
+
+def _req(prompt_ids=(1, 2, 3), **params):
+    ids = np.asarray(prompt_ids, np.int64).reshape(1, -1)
+    return AdapterSynthesisRequest(phoneme_ids=ids,
+                                   phoneme_lengths=np.array([ids.shape[1]], np.int64),
+                                   speaker_id=0, language_id=0, params=params)
+
+
+class _IO:
+    def __init__(self, name, shape=None):
+        self.name = name
+        self.shape = shape or []
+
+
+class _FakeSession:
+    """Minimal onnxruntime.InferenceSession stand-in: named IO + a feed log."""
+
+    def __init__(self, output_names, fn, input_specs=()):
+        self._outs = [_IO(n) for n in output_names]
+        self._ins = [_IO(n, s) for n, s in input_specs]
+        self._fn = fn
+        self.feeds = []
+
+    def get_outputs(self):
+        return self._outs
+
+    def get_inputs(self):
+        return self._ins
+
+    def run(self, _none, feed):
+        self.feeds.append(feed)
+        named = self._fn(feed, len(self.feeds) - 1)
+        return [named[o.name] for o in self._outs]
+
+
+class _FakeTokenizer:
+    """One id per character for plain text; speech/special tokens map to fixed ids."""
+
+    SPECIALS = {TEXT_PROMPT_START: 1, TEXT_PROMPT_END: 2, SPEECH_GENERATION_START: 3,
+                "<|SPEECH_GENERATION_END|>": END_ID, "<|endoftext|>": EOS_ID}
+
+    def token_to_id(self, token):
+        if token in self.SPECIALS:
+            return self.SPECIALS[token]
+        if token == SPEECH_TOKEN_TEMPLATE.format(0):
+            return SPEECH_BASE
+        return None
+
+    def id_to_token(self, tid):
+        for name, i in self.SPECIALS.items():
+            if i == tid:
+                return name
+        if tid >= SPEECH_BASE:
+            return SPEECH_TOKEN_TEMPLATE.format(tid - SPEECH_BASE)
+        return "x"
+
+    class _Enc:
+        def __init__(self, ids):
+            self.ids = ids
+
+    def encode(self, text, add_special_tokens=False):
+        # id 0 stands in for "some text token"; only the count matters to the tests
+        return self._Enc([0] * len(text))
+
+
+def _lm_names():
+    return ["logits"] + [f"present_{k}_{i}" for i in range(LAYERS) for k in ("key", "value")]
+
+
+def _lm_inputs():
+    specs = [("input_ids", [1, "seq"]), ("attention_mask", [1, "total"]),
+             ("position_ids", [1, "seq"])]
+    for i in range(LAYERS):
+        for k in ("key", "value"):
+            specs.append((f"past_{k}_{i}", [1, KV_HEADS, "past", HEAD_DIM]))
+    return specs
+
+
+def _lm_session(tokens):
+    """A fake LM that emits ``tokens`` one per step, then the end token."""
+    def fn(feed, i):
+        seq = feed["input_ids"].shape[1]
+        past = feed["past_key_0"].shape[2]
+        logits = np.full((1, VOCAB), -10.0, np.float32)
+        want = tokens[i] if i < len(tokens) else END_ID
+        logits[0, want] = 10.0
+        out = {"logits": logits}
+        for j in range(LAYERS):
+            out[f"present_key_{j}"] = np.zeros((1, KV_HEADS, past + seq, HEAD_DIM), np.float32)
+            out[f"present_value_{j}"] = np.zeros((1, KV_HEADS, past + seq, HEAD_DIM), np.float32)
+        return out
+    return _FakeSession(_lm_names(), fn, _lm_inputs())
+
+
+def _codec_session(samples_per_code=480):
+    def fn(feed, _i):
+        n = feed["codes"].shape[-1]
+        return {"audio": np.full((1, 1, n * samples_per_code), 0.25, np.float32)}
+    return _FakeSession(["audio"], fn, [("codes", [1, 1, "n"])])
+
+
+VOICES_JSON = {
+    "meta": {"spec": "vieneu.voice.presets"},
+    "default_voice": "ama",
+    "presets": {
+        "ama": {"text": "meda wo ase", "codes": list(range(300)), "description": "d"},
+        "kofi": {"text": "akwaaba", "codes": [7, 8, 9], "description": "d"},
+    },
+}
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    ad = NeuTTSAdapter()
+    voices = tmp_path / "voices.json"
+    voices.write_text(json.dumps(VOICES_JSON))
+
+    class VC:
+        engine_params = {"voices_path": str(voices)}
+
+    ad.configure(VC())
+    ad.tokenizer = _FakeTokenizer()
+    ad.speech_end_id = END_ID
+    ad.eos_id = EOS_ID
+    ad.speech_token_base = SPEECH_BASE
+    ad.codec = _codec_session()
+    # deterministic stand-in for espeak so the tests never shell out
+    ad._phonemizer = type("P", (), {
+        "phonemize_string": staticmethod(lambda t, lang: f"[{lang}:{t}]")})()
+    return ad
+
+
+# ----------------------------------------------------------------- registration
+def test_registered():
+    from phoonnx.engines import list_engines
+    assert "neutts" in list_engines()
+
+
+def test_detect():
+    assert NeuTTSAdapter.detect({"engine": "neutts"})
+    assert not NeuTTSAdapter.detect({"engine": "mosstts"})
+    assert not NeuTTSAdapter.detect(None)
+    assert not NeuTTSAdapter.detect({})
+
+
+def test_engine_enum_and_config_detection():
+    from phoonnx.config import Engine, VoiceConfig
+    from scriptconv.phonemizers.enums import Alphabet
+    assert Engine.NEUTTS.value == "neutts"
+    cfg = VoiceConfig.from_dict({"engine": "neutts"}, lang_code="tw")
+    assert cfg.engine == Engine.NEUTTS
+    # GRAPHEMES routes text -> ids through the adapter's own espeak + BPE path
+    assert cfg.alphabet == Alphabet.GRAPHEMES
+    assert cfg.sample_rate == 24000
+
+
+def test_default_params_match_upstream_cli_defaults():
+    p = NeuTTSAdapter().default_params()
+    assert p["temperature"] == 0.4
+    assert p["top_p"] == 0.8
+    assert p["repetition_penalty"] == 1.3
+    assert set(NeuTTSAdapter().param_labels()) >= set(p)
+
+
+# ------------------------------------------------------------------ phonemization
+def test_punctuation_is_preserved_around_phonemes():
+    out = preserve_punctuation_phonemize("meda wo ase paa.", lambda t: "P")
+    assert out == "P."
+
+
+def test_internal_punctuation_splits_the_espeak_calls():
+    seen = []
+
+    def fake(text):
+        seen.append(text)
+        return text.upper()
+
+    out = preserve_punctuation_phonemize("anopa yi, eye fe paa!", fake)
+    assert seen == ["anopa yi", "eye fe paa"]
+    assert out == "ANOPA YI, EYE FE PAA!"
+
+
+def test_unpunctuated_text_is_a_single_call():
+    seen = []
+    preserve_punctuation_phonemize("meda wo ase", lambda t: seen.append(t) or "P")
+    assert seen == ["meda wo ase"]
+
+
+def test_espeak_uses_the_voice_the_checkpoint_was_trained_with(adapter):
+    assert adapter._espeak("meda") == f"[{ESPEAK_VOICE}:meda]"
+    assert ESPEAK_VOICE == "lfn"
+
+
+# --------------------------------------------------------------------- presets
+def test_presets_and_default_are_read_from_voices_json(adapter):
+    assert sorted(adapter.presets) == ["ama", "kofi"]
+    assert adapter.default_preset == "ama"
+
+
+def test_preset_falls_back_to_the_json_default(adapter):
+    assert adapter.resolve_preset(None, None)["text"] == "meda wo ase"
+
+
+def test_voice_config_pins_a_preset(adapter):
+    voice = type("V", (), {"config": type("C", (), {"engine_params": {"voice": "kofi"}})})
+    assert adapter.resolve_preset(voice, None)["text"] == "akwaaba"
+
+
+def test_per_call_voice_wins_over_the_pinned_one(adapter):
+    voice = type("V", (), {"config": type("C", (), {"engine_params": {"voice": "kofi"}})})
+    syn = type("S", (), {"extra_params": {"voice": "ama"}})
+    assert adapter.resolve_preset(voice, syn)["text"] == "meda wo ase"
+
+
+def test_unknown_preset_is_rejected(adapter):
+    syn = type("S", (), {"extra_params": {"voice": "nobody"}})
+    with pytest.raises(ValueError, match="unknown NeuTTS voice preset"):
+        adapter.resolve_preset(None, syn)
+
+
+def test_reference_phones_are_cached(adapter):
+    calls = []
+    adapter._phonemizer = type("P", (), {
+        "phonemize_string": staticmethod(lambda t, lang: calls.append(t) or "P")})()
+    adapter.reference_phones("kofi", VOICES_JSON["presets"]["kofi"])
+    adapter.reference_phones("kofi", VOICES_JSON["presets"]["kofi"])
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------- prompt
+def test_prompt_layout_matches_the_training_format(adapter):
+    prompt = adapter.build_prompt("TGT", "REF", [1, 2])
+    assert prompt == (f"{TEXT_PROMPT_START}REF TGT{TEXT_PROMPT_END}"
+                      f"{SPEECH_GENERATION_START}<|speech_1|><|speech_2|>")
+
+
+def test_prompt_without_a_reference_omits_the_speech_prefix(adapter):
+    assert adapter.build_prompt("TGT") == (
+        f"{TEXT_PROMPT_START}TGT{TEXT_PROMPT_END}{SPEECH_GENERATION_START}")
+
+
+def test_reference_codes_are_truncated(adapter):
+    prompt = adapter.build_prompt("T", "R", list(range(500)))
+    assert prompt.count("<|speech_") == MAX_REFERENCE_CODES
+
+
+def test_encode_text_builds_one_prompt_per_chunk(adapter):
+    ids = adapter.encode_text("hello", None, None)
+    assert len(ids) == 1
+    assert len(ids[0]) > 0
+
+
+def test_encode_text_without_a_tokenizer_is_an_error(adapter):
+    adapter.tokenizer = None
+    with pytest.raises(RuntimeError, match="tokenizer_path"):
+        adapter.encode_text("hello", None, None)
+
+
+# --------------------------------------------------------------------- chunking
+def test_short_text_is_one_chunk(adapter):
+    assert adapter.chunk_text("Meda wo ase.", 200) == ["Meda wo ase."]
+
+
+def test_empty_text_yields_no_chunks(adapter):
+    assert adapter.chunk_text("   ", 200) == []
+
+
+def test_sentences_are_packed_up_to_the_budget(adapter):
+    text = "aaaa bbbb. cccc dddd. eeee ffff."
+    chunks = adapter.chunk_text(text, 22)
+    assert all(len(c) <= 22 for c in chunks)
+    assert "".join(chunks).replace(" ", "") == text.replace(" ", "")
+
+
+def test_an_over_long_sentence_is_split_not_dropped(adapter):
+    text = " ".join(["word"] * 40)
+    chunks = adapter.chunk_text(text, 30)
+    assert chunks and all(len(c) <= 30 for c in chunks)
+    assert sum(c.count("word") for c in chunks) == 40
+
+
+# ------------------------------------------------------------------- sampling
+def test_greedy_when_temperature_is_zero():
+    scores = np.array([1.0, 5.0, 2.0], np.float32)
+    assert _sample(scores, 0.0, 0, 0.0, np.random.default_rng(0)) == 1
+
+
+def test_top_k_of_one_is_deterministic():
+    scores = np.array([1.0, 5.0, 2.0], np.float32)
+    assert all(_sample(scores, 1.0, 1, 1.0, np.random.default_rng(s)) == 1
+               for s in range(5))
+
+
+def test_repetition_penalty_lowers_seen_positive_scores():
+    scores = np.array([2.0, 2.0], np.float32)
+    out = _apply_repetition_penalty(scores, np.array([0]), 2.0)
+    assert out[0] == pytest.approx(1.0)
+    assert out[1] == 2.0
+
+
+def test_repetition_penalty_raises_the_magnitude_of_negative_scores():
+    out = _apply_repetition_penalty(np.array([-2.0], np.float32), np.array([0]), 2.0)
+    assert out[0] == pytest.approx(-4.0)
+
+
+def test_repetition_penalty_of_one_is_a_no_op():
+    scores = np.array([2.0, -2.0], np.float32)
+    assert np.array_equal(_apply_repetition_penalty(scores, np.array([0, 1]), 1.0), scores)
+
+
+def test_repetition_penalty_ignores_out_of_range_tokens():
+    scores = np.array([2.0], np.float32)
+    assert np.array_equal(_apply_repetition_penalty(scores, np.array([9]), 2.0), scores)
+
+
+# --------------------------------------------------------------- decode loop
+def test_generate_stops_at_the_end_token(adapter):
+    session = _lm_session([SPEECH_BASE + 1, SPEECH_BASE + 2])
+    tokens = adapter.generate(session, [1, 2, 3], adapter.default_params(),
+                              np.random.default_rng(0))
+    assert tokens == [SPEECH_BASE + 1, SPEECH_BASE + 2]
+
+
+def test_generate_stops_at_eos(adapter):
+    session = _lm_session([SPEECH_BASE + 1, EOS_ID, SPEECH_BASE + 3])
+    tokens = adapter.generate(session, [1, 2, 3], adapter.default_params(),
+                              np.random.default_rng(0))
+    assert tokens == [SPEECH_BASE + 1]
+
+
+def test_generate_respects_the_token_cap(adapter):
+    session = _lm_session([SPEECH_BASE + i for i in range(50)])
+    p = {**adapter.default_params(), "max_new_tokens": 3}
+    assert len(adapter.generate(session, [1, 2], p, np.random.default_rng(0))) == 3
+
+
+def test_prefill_feeds_an_empty_cache_and_full_positions(adapter):
+    session = _lm_session([SPEECH_BASE + 1])
+    adapter.generate(session, [1, 2, 3, 4], adapter.default_params(), np.random.default_rng(0))
+    first = session.feeds[0]
+    assert first["input_ids"].shape == (1, 4)
+    assert first["attention_mask"].tolist() == [[1, 1, 1, 1]]
+    assert first["position_ids"].tolist() == [[0, 1, 2, 3]]
+    assert first["past_key_0"].shape == (1, KV_HEADS, 0, HEAD_DIM)
+
+
+def test_decode_steps_thread_the_cache_and_advance_positions(adapter):
+    session = _lm_session([SPEECH_BASE + 1, SPEECH_BASE + 2, SPEECH_BASE + 3])
+    adapter.generate(session, [1, 2, 3, 4], adapter.default_params(), np.random.default_rng(0))
+    step = session.feeds[1]
+    assert step["input_ids"].tolist() == [[SPEECH_BASE + 1]]
+    assert step["position_ids"].tolist() == [[4]]
+    assert step["attention_mask"].shape == (1, 5)
+    assert step["past_key_0"].shape == (1, KV_HEADS, 4, HEAD_DIM)
+    assert session.feeds[2]["past_key_0"].shape == (1, KV_HEADS, 5, HEAD_DIM)
+
+
+def test_kv_geometry_is_read_off_the_graph(adapter):
+    session = _lm_session([SPEECH_BASE + 1])
+    adapter.generate(session, [1], adapter.default_params(), np.random.default_rng(0))
+    assert (adapter.num_layers, adapter.num_kv_heads, adapter.head_dim) == (
+        LAYERS, KV_HEADS, HEAD_DIM)
+
+
+# ------------------------------------------------------------------- codec
+def test_speech_tokens_map_back_to_codec_indices(adapter):
+    assert adapter.token_ids_to_codes([SPEECH_BASE + 5, SPEECH_BASE + 9]) == [5, 9]
+
+
+def test_non_speech_tokens_are_dropped(adapter):
+    assert adapter.token_ids_to_codes([1, SPEECH_BASE + 4, END_ID]) == [4]
+
+
+def test_decode_codes_feeds_the_codec_a_3d_int32_tensor(adapter):
+    audio = adapter.decode_codes([1, 2, 3])
+    feed = adapter.codec.feeds[0]["codes"]
+    assert feed.shape == (1, 1, 3)
+    assert feed.dtype == np.int32
+    assert audio.ndim == 1 and audio.dtype == np.float32
+
+
+def test_decode_codes_of_nothing_is_empty(adapter):
+    assert adapter.decode_codes([]).shape == (0,)
+
+
+# --------------------------------------------------------------- synthesize
+def test_synthesize_returns_audio_and_a_code_count(adapter):
+    session = _lm_session([SPEECH_BASE + 1, SPEECH_BASE + 2])
+    result = adapter.synthesize(_req(), session)
+    assert result.extras["codes"] == 2
+    assert result.audio.shape[0] == 2 * 480
+
+
+def test_synthesize_without_a_codec_is_an_error(adapter):
+    adapter.codec = None
+    with pytest.raises(RuntimeError, match="codec_decoder_path"):
+        adapter.synthesize(_req(), _lm_session([SPEECH_BASE + 1]))
+
+
+def test_synthesize_rejects_a_reference_clip(adapter):
+    request = _req(reference_audio=(np.zeros(100, np.float32), 24000))
+    with pytest.raises(RuntimeError, match="pre-encoded voice presets"):
+        adapter.synthesize(request, _lm_session([SPEECH_BASE + 1]))
+
+
+def test_synthesize_without_speech_tokens_is_an_error(adapter):
+    with pytest.raises(RuntimeError, match="no speech tokens"):
+        adapter.synthesize(_req(), _lm_session([]))
+
+
+def test_the_seed_makes_synthesis_reproducible(adapter):
+    session = _lm_session([SPEECH_BASE + 1, SPEECH_BASE + 2])
+    a = adapter.synthesize(_req(seed=7), session).audio
+    b = adapter.synthesize(_req(seed=7), _lm_session([SPEECH_BASE + 1, SPEECH_BASE + 2])).audio
+    assert np.array_equal(a, b)
+
+
+def test_the_static_graph_entry_points_are_refused(adapter):
+    with pytest.raises(NotImplementedError):
+        adapter.build_feed_dict(_req(), None)
+    with pytest.raises(NotImplementedError):
+        adapter.parse_outputs([], _req())
+
+
+# --------------------------------------------------------------- voice index
+def test_voice_index_entries_are_well_formed():
+    import json as _json
+    from pathlib import Path
+    import phoonnx
+    path = Path(phoonnx.__file__).parent / "voice_index" / "neutts.json"
+    entries = _json.loads(path.read_text())
+    assert entries
+    for vid, entry in entries.items():
+        assert entry["voice_id"] == vid
+        assert entry["engine"] == "neutts"
+        assert entry["alphabet"] == "graphemes"
+        assert entry["lang"] == "tw"
+        assert entry["engine_options"]["voice"] == vid.rsplit("/", 1)[-1]
+        assert set(entry["aux_model_urls"]) == {
+            "codec_decoder_path", "tokenizer_path", "voices_path"}
+
+
+def test_engine_options_reach_engine_params(tmp_path):
+    from phoonnx.model_manager import TTSModelInfo
+    info = TTSModelInfo(voice_id="neutts/x", lang="tw", model_url="http://example/m.onnx",
+                        engine_options={"voice": "kofi"})
+    assert info.engine_params()["voice"] == "kofi"

--- a/tests/test_neutts.py
+++ b/tests/test_neutts.py
@@ -466,7 +466,10 @@ def test_voice_index_entries_are_well_formed():
         assert entry["lang"] == "tw"
         assert entry["engine_options"]["voice"] == vid.rsplit("/", 1)[-1]
         assert set(entry["aux_model_urls"]) == {
-            "codec_decoder_path", "tokenizer_path", "voices_path"}
+            "lm_weights_path", "codec_decoder_path", "tokenizer_path", "voices_path"}
+        # the fp32 graph's external weights must keep the filename the graph references
+        assert entry["aux_model_urls"]["lm_weights_path"].endswith("/neutts_lm.onnx.data")
+        assert entry["model_url"].endswith("/neutts_lm.onnx")
 
 
 def test_engine_options_reach_engine_params(tmp_path):


### PR DESCRIPTION
Adds **NeuTTS**, phoonnx's third autoregressive engine, and with it **Asante Twi** — the
first Ghanaian language in the catalog, via nine
[Akiti-TTS](https://github.com/AfriSpeech/akiti-tts) voices from AfriSpeech / Ghana NLP.

## Architecture

Akiti-TTS is a LoRA fine-tune of
[VieNeu-TTS-0.3B](https://huggingface.co/pnnbao-ump/VieNeu-TTS-0.3B), from Neuphonic's
NeuTTS Air family. A Qwen3 causal LM whose vocabulary carries 65 536 `<|speech_N|>`
tokens is given phonemes and emits a flat stream of NeuCodec tokens; NeuCodec's decoder
turns those into 24 kHz audio. No duration model, no vocoder, no speaker encoder.

It is the *simple* shape of what
[MOSS-TTS-Nano](https://github.com/TigreGotico/phoonnx/pull/321) does: one token per step
instead of a 16-token RVQ frame, so the decode loop is a plain KV-cached LM loop —
structurally the same as `chatterbox.py`'s.

## IO contracts

`neutts_lm.onnx` serves prefill **and** decode: the same graph with a different past
length.

```
inputs   input_ids       int64 [1, S]         prompt tokens, or 1 token per step
         attention_mask  int64 [1, P + S]     ones over past and current tokens
         position_ids    int64 [1, S]         absolute positions, P .. P+S-1
         past_key_<i>    fp32  [1, 4, P, 64]  i in 0..27
         past_value_<i>  fp32  [1, 4, P, 64]
outputs  logits          fp32  [1, 66938]     last position only
         present_key_<i> / present_value_<i>  fp32 [1, 4, P + S, 64]
```

`neucodec_decoder.onnx` (published by Neuphonic, used unmodified) takes `codes` int32
`[1, 1, N]` and returns `audio` float32 `[1, 1, 480 * (N - 1)]` at 24 kHz — 50 codec
tokens per second of audio.

Two deliberate export choices, both in
`scripts/conversion/neutts/export_neutts_onnx.py`:

- **One graph, not a prefill/decode pair.** The KV-cache contract is identical either
  way, so a second graph would only put a second copy of ~0.3 B parameters on disk.
- **Last-position logits only.** A full `[1, S, 66938]` prefill output is hundreds of MB
  that sampling never reads.

## Parity

`--check-parity` replays a fixed prompt through torch and compares:

| | fp32 ONNX max abs logit diff |
|---|---|
| prefill | **4.10e-05** |
| decode (8 steps, cache threaded as the engine does) | **2.96e-05** |

On a real Twi prompt the fp32 graph's top-5 next tokens match torch's exactly, in the
same order and to two decimal places. The int8 graph does **not**: it puts
`<|SPEECH_GENERATION_END|>` in the top 5 at the very first step, where fp32 does not. The
voice index therefore ships **fp32**; int8 is mirrored as an option, not the default.

## Correct by construction

Text → ids reproduces training rather than re-deriving it:

- **espeak-ng, `lfn` voice.** espeak-ng has no Twi voice; Lingua Franca Nova's
  five-vowel orthography reads Twi spelling closely, and it is what upstream trained
  with — a property of the model, not a fallback. Output verified identical to the
  `phonemizer` library call in upstream's code (which phoonnx does not depend on;
  `phonemizer` is GPL-3.0).
- **Punctuation.** espeak-ng deletes punctuation; the training pipeline kept it. Marks
  are split out before the espeak call and spliced back after.
- **One tokenizer pass.** The whole prompt — reference phones, target phones, special
  tokens and the pre-encoded reference codes — goes through the checkpoint's own BPE in
  one pass, so no join between separately-tokenized pieces can drift.
- **llama.cpp sampler semantics.** Upstream drives this checkpoint through llama.cpp, so
  the repetition penalty is windowed over the last 64 tokens of *prompt-plus-output*
  (not the whole run, the HuggingFace convention the other codec-LMs here use), and
  truncation happens on the raw distribution *before* temperature. Getting this wrong
  measurably makes the model cut off early or babble — both were observed and fixed
  during bring-up.

## Cloning

In-context, but **pre-encoded**: a preset is a reference transcript plus the NeuCodec
tokens of its recording, shipped with the voice via `engine_options`. Neuphonic publishes
NeuCodec's *decoder* as ONNX but not its encoder, so a fresh clip cannot be encoded at
runtime — `speaker_reference` raises rather than being silently ignored.

`engine_options` is the one new piece of general API: `aux_model_urls` covers files an
engine downloads, and this covers plain per-voice values that have no URL to hang on
(here, which preset a voice speaks with).

## Verification on real weights

All nine presets synthesize end-to-end through `TTSVoice.synthesize()` on the exported
fp32 graph. WAVs are at `/mnt/homelab/models/akiti-tts/samples/`.

The published index was also exercised for real — `TTSModelManager.merge_default_voices()`
→ `download_voice` → `synthesize()`, pulling the graph, the NeuCodec decoder, the
tokenizer and `voices.json` from the HF mirror over the wire, with `engine_options`
selecting the preset. Output at `akiti_from_index_kofi.wav`.

| voice | audio | gen | RTF |
|---|---|---|---|
| abena | 4.78 s | 23.16 s | 4.85 |
| akua | 5.80 s | 26.31 s | 4.54 |
| akwasi | 4.72 s | 21.40 s | 4.53 |
| kofi | 4.40 s | 26.27 s | 5.97 |
| kwabena | 0.24 s | 2.88 s | 11.99 |
| kwaku | 9.88 s | 71.04 s | 7.19 |
| kwame | 0.60 s | 4.31 s | 7.18 |
| yaa | 11.98 s | 108.91 s | 9.09 |
| yaw | 6.24 s | 61.01 s | 9.78 |

**RTF is bad and this is not shippable as a default voice.** Two things drive it:

1. **Stateless KV cache.** Every decode step copies all 28 layers of cache in and out of
   the graph — ~30 MB per step at 500 tokens. This is inherent to how phoonnx drives
   ONNX AR engines today; `chatterbox` and `mosstts` have the same shape. IO binding
   would fix it and is out of scope here.
2. **0.3 B parameters in fp32** on CPU. int8 measures ~25 % faster but costs quality
   (above), so the index ships fp32 and keeps int8 in the mirror as an option.

For reference, upstream's own CLI runs a Q4 GGUF through llama.cpp, which is a different
runtime, not a different model.

`kwabena` and `kwame` truncate at default sampling (`temperature=0.4`). Upstream's CLI
has the same failure mode and advises lowering the temperature; the engine raises a
message pointing at the same knob rather than returning near-silence unexplained. Worth
a follow-up look, but it reproduces upstream behaviour rather than diverging from it.

## Tests

47 new tests in `tests/test_neutts.py`, against fake ONNX sessions that record their
feeds — the KV-cache threading, position arithmetic and stop conditions are all
assertable without the 1 GB of real weights. Adversarial cases included: unknown preset,
reference clip passed to an engine that cannot encode one, over-long sentence,
generation that never yields a speech token, repetition penalty pointed at out-of-range
ids.

Full suite: **1578 passed, 18 failed**. Every failure is an `ImportError` for an optional
dependency that is not installed in this environment (`pycotovia`, `pyworld`) in
`test_pycotovia_gl.py`, `test_vendor_f0.py`, `test_fastpitch_training.py` and
`test_styletts2_aux_training.py` — none of them touch anything in this PR.

## Weights

Mirrored at
[OpenVoiceOS/phoonnx-neutts](https://huggingface.co/OpenVoiceOS/phoonnx-neutts), with the
voice index pointing at it. The card credits AfriSpeech / Ghana NLP (Akiti-TTS),
pnnbao-ump (VieNeu-TTS-0.3B) and Neuphonic (NeuTTS Air, NeuCodec).

### Licensing — upstream is inconsistent

Upstream states **two different licenses** for the same weights:

- the [HF model card](https://huggingface.co/afrispeech/Akiti-TTS) declares
  **CC BY-NC 4.0** (non-commercial);
- the [GitHub README](https://github.com/AfriSpeech/akiti-tts) says the weights are
  **Apache-2.0**.

This PR records both and resolves neither — that is AfriSpeech's call. The mirror's card
says to treat the stricter reading (**non-commercial**) as binding until they clarify.
The GitHub repo's *code* is MIT, which is not in dispute; `voices.json` comes from there.
`neucodec_decoder.onnx` is Apache-2.0.

**Nothing NC is vendored into this repository** — only URLs pointing at the mirror. But
reviewers should be aware that these voices may carry a non-commercial restriction, which
is unusual for the phoonnx catalog, and may want to raise the discrepancy upstream before
this is advertised anywhere.

---

Authored by Claude Opus under Fable orchestration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added NeuTTS text-to-speech engine support with 24 kHz audio output.
  - Added nine Akan/Twi voices, including Abena, Akua, Kofi, Yaa, and Yaw.
  - Added voice presets with reproducible in-context cloning and adjustable sampling controls.
  - Added automatic NeuTTS engine detection and configuration support.

- **Documentation**
  - Documented NeuTTS setup, cloning presets, voice catalog integration, and configuration options.
  - Added guidance for converting and validating NeuTTS models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->