### PR TITLE
fix: follow scriptconv mantoq→halabi notation rename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "langcodes",
     "ovos-number-parser>=0.4.0",
     "ovos-date-parser>=0.6.4a1",
-    "scriptconv[phonemizers]>=0.0.4a8",
+    "scriptconv[phonemizers]>=0.0.4a18",
     "unicode_rbnf",
     "click",
     "requests",

--- a/tests/test_ar.py
+++ b/tests/test_ar.py
@@ -203,7 +203,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
         self.assertNotIn(' ', result)
 
     # Phonemization Tests with IPA alphabet
-    @patch('scriptconv.phonemizers.ar.mantoq_to_ipa')
+    @patch('scriptconv.phonemizers.ar.halabi_to_ipa')
     @patch('scriptconv.phonemizers.ar.mantoq')
     def test_phonemize_string_ipa_basic(self, mock_mantoq, mock_bw2ipa):
         """Test phonemize_string with IPA alphabet."""
@@ -216,7 +216,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
         mock_bw2ipa.assert_called_once_with("marhaba")
         self.assertEqual(result, "marħaba")
 
-    @patch('scriptconv.phonemizers.ar.mantoq_to_ipa')
+    @patch('scriptconv.phonemizers.ar.halabi_to_ipa')
     @patch('scriptconv.phonemizers.ar.mantoq')
     def test_phonemize_string_ipa_with_separators(self, mock_mantoq, mock_bw2ipa):
         """Test IPA phonemization preserving word separators."""
@@ -229,7 +229,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
         mock_bw2ipa.assert_called_once_with("mar haba")
         self.assertEqual(result, "mar ħaba")
 
-    @patch('scriptconv.phonemizers.ar.mantoq_to_ipa')
+    @patch('scriptconv.phonemizers.ar.halabi_to_ipa')
     @patch('scriptconv.phonemizers.ar.mantoq')
     def test_phonemize_string_ipa_complex_phonemes(self, mock_mantoq, mock_bw2ipa):
         """Test IPA phonemization with complex Arabic phonemes."""
@@ -310,7 +310,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
         with self.assertRaises(ImportError):
             self.phonemizer_mantoq.phonemize_string("مرحبا", "ar")
 
-    @patch('scriptconv.phonemizers.ar.mantoq_to_ipa')
+    @patch('scriptconv.phonemizers.ar.halabi_to_ipa')
     @patch('scriptconv.phonemizers.ar.mantoq')
     def test_phonemize_string_bw2ipa_exception(self, mock_mantoq, mock_bw2ipa):
         """Test phonemize_string when bw2ipa raises an exception."""
@@ -322,7 +322,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
 
         self.assertIn("bw2ipa translation error", str(context.exception))
 
-    @patch('scriptconv.phonemizers.ar.mantoq_to_ipa')
+    @patch('scriptconv.phonemizers.ar.halabi_to_ipa')
     @patch('scriptconv.phonemizers.ar.mantoq')
     def test_phonemize_string_bw2ipa_import_error(self, mock_mantoq, mock_bw2ipa):
         """Test phonemize_string when bw2ipa has import issues."""
@@ -333,7 +333,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
             self.phonemizer_ipa.phonemize_string("مرحبا", "ar")
 
     # Data Format Validation Tests
-    @patch('scriptconv.phonemizers.ar.mantoq_to_ipa')
+    @patch('scriptconv.phonemizers.ar.halabi_to_ipa')
     @patch('scriptconv.phonemizers.ar.mantoq')
     def test_phonemize_string_bw2ipa_return_types(self, mock_mantoq, mock_bw2ipa):
         """Test phonemize_string when bw2ipa returns various types."""
@@ -366,7 +366,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
         ]
 
         with patch('scriptconv.phonemizers.ar.mantoq') as mock_mantoq, \
-                patch('scriptconv.phonemizers.ar.mantoq_to_ipa') as mock_bw2ipa:
+                patch('scriptconv.phonemizers.ar.halabi_to_ipa') as mock_bw2ipa:
             for arabic_text, description in arabic_test_cases:
                 with self.subTest(text=arabic_text, desc=description):
                     # Mock realistic phoneme output
@@ -508,7 +508,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
     def test_alphabet_specific_processing_paths(self):
         """Test that different alphabet settings trigger different processing paths."""
         with patch('scriptconv.phonemizers.ar.mantoq') as mock_mantoq, \
-                patch('scriptconv.phonemizers.ar.mantoq_to_ipa') as mock_bw2ipa:
+                patch('scriptconv.phonemizers.ar.halabi_to_ipa') as mock_bw2ipa:
             mock_mantoq.return_value = ("text", ['t', 'e', 's', 't'])
 
             # Test BUCKWALTER path (should not call bw2ipa)
@@ -539,7 +539,7 @@ class TestMantoqPhonemizer(unittest.TestCase):
         # Test IPA phonemizer
         self.assertEqual(self.phonemizer_ipa.alphabet, Alphabet.IPA)
         with patch('scriptconv.phonemizers.ar.mantoq') as mock_mantoq, \
-                patch('scriptconv.phonemizers.ar.mantoq_to_ipa') as mock_bw2ipa:
+                patch('scriptconv.phonemizers.ar.halabi_to_ipa') as mock_bw2ipa:
             mock_mantoq.return_value = ("text", [])
             mock_bw2ipa.return_value = ""
             self.phonemizer_ipa.phonemize_string("test", "ar")
@@ -578,7 +578,7 @@ class TestMantoqPhonemizerIntegration(unittest.TestCase):
     def test_full_pipeline_ipa_alphabet(self):
         """Test complete phonemization pipeline for IPA alphabet."""
         with patch('scriptconv.phonemizers.ar.mantoq') as mock_mantoq, \
-                patch('scriptconv.phonemizers.ar.mantoq_to_ipa') as mock_bw2ipa:
+                patch('scriptconv.phonemizers.ar.halabi_to_ipa') as mock_bw2ipa:
             # Simulate realistic mantoq output
             mock_mantoq.return_value = (
                 "مرحبا بالعالم",
@@ -607,7 +607,7 @@ class TestMantoqPhonemizerIntegration(unittest.TestCase):
 
         # Test bw2ipa error propagation  
         with patch('scriptconv.phonemizers.ar.mantoq') as mock_mantoq, \
-                patch('scriptconv.phonemizers.ar.mantoq_to_ipa') as mock_bw2ipa:
+                patch('scriptconv.phonemizers.ar.halabi_to_ipa') as mock_bw2ipa:
             mock_mantoq.return_value = ("text", ['t', 'e', 's', 't'])
             mock_bw2ipa.side_effect = RuntimeError("bw2ipa translation failed")
 


### PR DESCRIPTION
## Summary
- scriptconv 0.0.4a18 renamed the Arabic notation from `mantoq` to `halabi` — crediting the origin (Halabi Arabic-Phonetiser), not the wrapper: `Notation.MANTOQ` → `Notation.HALABI`, `scriptconv.notation.mantoq_to_ipa` → `halabi_to_ipa` (re-exported as `scriptconv.phonemizers.ar.halabi_to_ipa`). No deprecated alias was kept.
- phoonnx CI installs scriptconv prereleases via auto-generated uv constraints, so every CI run has been red since the rename shipped, with `AttributeError: type object 'Notation' has no attribute 'MANTOQ'` and `<module 'scriptconv.phonemizers.ar' ...> does not have the attribute 'mantoq_to_ipa'`.
- Updated `tests/test_ar.py` to mock `scriptconv.phonemizers.ar.halabi_to_ipa` instead of the removed `mantoq_to_ipa`.
- Bumped the scriptconv floor in `pyproject.toml` from `>=0.0.4a8` to `>=0.0.4a18` (prerelease floor pin house style) so an old scriptconv can't produce the inverse breakage.
- Not touched: phoonnx's own `PhonemeType.MANTOQ` (`scriptconv.phonemizers.enums.Phonemizer.MANTOQ`) — this is the name of the vendored mantoq G2P *engine* in scriptconv's phonemizer registry, unrelated to the notation enum that got renamed. It still exists upstream and is correct as-is.

## Test plan
- [x] `tests/test_ar.py` — 60 passed
- [x] `tests/test_mixertts.py`, `tests/test_fastpitch.py`, `tests/test_scriptconv_integration.py`, `tests/test_mantoq_num2words.py` — 77 passed
- Note: `tests/test_eu_phonemizer.py` fails independently of this change — the failure originates in the separate `ahotts-g2p` package (`Notation.MANTOQ` usage in its own `ahotts_g2p/notation.py`), not in phoonnx. That's a bug in the `ahotts-scriptconv` repo and needs a fix there, out of scope for this PR.

Authored by Claude Sonnet under Fable orchestration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with the latest language-processing components.
  - Strengthened validation of Arabic pronunciation and IPA conversion workflows, including error handling and alternate alphabet paths.

- **Tests**
  - Updated automated coverage to reflect current pronunciation-conversion behavior and maintain reliable results across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->