### PR TITLE
feat: Spark-TTS engine (BiCodec AR codec-LM)

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -1,6 +1,6 @@
 ## Supported Voices
 
-**Total Voices:** 2403
+**Total Voices:** 2407
 **Total Languages:** 1240
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
@@ -729,6 +729,8 @@
 | `piper_community/simoniz0r/en-US_eminem` | `en-US` | `piper` | `espeak` |
 | `piper_community/simoniz0r/en-US_patrick` | `en-US` | `piper` | `espeak` |
 | `piper_community/swqg-messiah/en-US_chitti` | `en-US` | `piper` | `espeak` |
+| `sparktts/female/en` | `en-US` | `sparktts` | `unicode` |
+| `sparktts/male/en` | `en-US` | `sparktts` | `unicode` |
 | `facebook/mms-tts-enb-Markweeta` | `enb` | `transformers` | `graphemes` |
 | `facebook/mms-tts-enx-Enxet` | `enx` | `transformers` | `graphemes` |
 | `bsc/es-styletts2` | `es` | `styletts2` | `espeak` |
@@ -2391,6 +2393,8 @@
 | `hf_community/BricksDisplay/vits-cmn` | `zh-CN` | `transformers` | `graphemes` |
 | `piper/zh_CN-huayan-medium` | `zh-CN` | `piper` | `espeak` |
 | `piper/zh_CN-huayan-x_low` | `zh-CN` | `piper` | `espeak` |
+| `sparktts/female/zh` | `zh-CN` | `sparktts` | `unicode` |
+| `sparktts/male/zh` | `zh-CN` | `sparktts` | `unicode` |
 | `piper_community/colafly/zh-TW_yt-chinese_female` | `zh-TW` | `piper` | `espeak` |
 | `facebook/mms-tts-zim-Mesme` | `zim` | `transformers` | `graphemes` |
 | `facebook/mms-tts-ziw-Zigula` | `ziw` | `transformers` | `graphemes` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ how to obtain or train it, and a synthesis example:
 [FastPitch](training/engines/fastpitch.md) ·
 [ZipVoice](training/engines/zipvoice.md) ·
 [Chatterbox](training/engines/chatterbox.md) ·
+[Spark-TTS](training/engines/sparktts.md) ·
 [F5-TTS](training/engines/f5tts.md) ·
 [Shami](training/engines/shami.md) ·
 [Pocket TTS](pockettts.md)

--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -25,8 +25,8 @@ turned into:
 
 | Paradigm | How it works | Needs the reference's text? | Language-agnostic? | Engines |
 |---|---|---|---|---|
-| **d-vector** | a **speaker encoder** maps the reference waveform to a fixed embedding that conditions synthesis | No | Yes | YourTTS, StyleTTS2, [Chatterbox](training/engines/chatterbox.md) |
-| **in-context** | the reference **audio + its transcription** are part of the model input; the model continues that voice | **Yes** | Per-phoneme (espeak/pinyin) | ZipVoice |
+| **d-vector** | a **speaker encoder** maps the reference waveform to a fixed embedding that conditions synthesis | No | Yes | YourTTS, StyleTTS2, [Chatterbox](training/engines/chatterbox.md), [Spark-TTS](training/engines/sparktts.md) |
+| **in-context** | the reference **audio + its transcription** are part of the model input; the model continues that voice | **Yes** | Per-phoneme (espeak/pinyin) | ZipVoice, [Spark-TTS](training/engines/sparktts.md) |
 | **in-context, pre-encoded** | the reference is **codec-encoded ahead of time** and shipped with the voice; the model continues those audio tokens | **Yes** (bundled) | Per-phoneme (espeak) | NeuTTS / Akiti-TTS |
 
 A cloning voice can still bundle a **default speaker**, so it works with *or* without a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `supertonic` | Multi-graph flow-matching, raw-text (no phonemizer) | [Engines](engines.md) |
 | `neutts` | Autoregressive NeuCodec LM, preset cloning @24 kHz | [Cloning](cloning.md) |
 | `pockettts` | Flow-matching codec LM with explicit stream state, raw-text (no phonemizer) | [Pocket TTS](pockettts.md) |
+| `sparktts` | Autoregressive codec-LM (Qwen2 + BiCodec), en/zh | [Spark-TTS](training/engines/sparktts.md) |
 
 ## Execution Providers
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -91,6 +91,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | SuperTonic | `phoonnx/engines/supertonic.py` | `engine == "supertonic"` — multi-graph flow-matching engine (4 ONNX graphs via `aux_model_urls`), raw-text (no phonemizer), fixed per-speaker style instead of cloning |
 | NeuTTS (NeuTTS Air / VieNeu / Akiti) | `phoonnx/engines/neutts.py` | `engine == "neutts"` — autoregressive single-codebook codec-LM (Qwen3 backbone + NeuCodec decoder), raw text phonemized with espeak-ng, in-context [cloning](cloning.md) from pre-encoded voice presets, 24 kHz |
 | [Pocket TTS](pockettts.md) | `phoonnx/engines/pockettts.py` | `engine == "pockettts"` — 5-graph flow-matching codec LM with explicit stream state, raw-text (no phonemizer), state-based voices and reference [cloning](cloning.md) |
+| [Spark-TTS](training/engines/sparktts.md) | `phoonnx/engines/sparktts.py` | `engine == "sparktts"` — autoregressive codec-LM (Qwen2 + BiCodec), raw-text, en/zh; preset 32-token speakers or zero-shot [cloning](cloning.md) |
 
 ---
 

--- a/docs/training/engines/sparktts.md
+++ b/docs/training/engines/sparktts.md
@@ -1,0 +1,136 @@
+# Spark-TTS Engine
+
+This page is for integrators who want Spark-TTS voices in phoonnx. After reading it you
+can use a preset speaker, clone a voice from a reference clip, and understand what each
+of the five ONNX graphs does.
+
+> Related: [adapter architecture](../../engines.md) ·
+> [configuration](../../configuration.md) · [voice cloning](../../cloning.md) ·
+> [Chatterbox — the sibling codec-LM engine](chatterbox.md)
+
+## What it is
+
+**Spark-TTS** (SparkAudio) is a decoder-only language model on a Qwen2.5-0.5B backbone.
+It does not predict audio. It predicts **BiCodec** tokens, and BiCodec turns those tokens
+into a waveform. BiCodec splits a voice into two streams:
+
+* **global tokens** — 32 tokens that hold the speaker: timbre, not content;
+* **semantic tokens** — one stream at 50 Hz that holds what is said.
+
+The language model reads a prompt made of control tokens, the text, and the 32 global
+tokens, and then writes the semantic stream. Spark-TTS is trained on English and
+Mandarin.
+
+## When to pick it
+
+Pick Spark-TTS when you want one small model to cover English and Mandarin with a
+speaker you can either freeze or clone. It is the second autoregressive codec-LM engine
+in phoonnx, after [Chatterbox](chatterbox.md). The difference that matters in practice:
+Chatterbox always needs a reference clip, while a Spark-TTS voice can ship its speaker as
+32 numbers and run with no reference at all.
+
+Spark-TTS is slower than the non-autoregressive engines. One token is one pass through
+the language model, and one second of speech is 50 tokens.
+
+## Architecture
+
+Five ONNX graphs. Only the first two are needed for a preset voice:
+
+```
+text ─► BPE ─► content ids ─┐
+speaker: 32 global tokens ──┤
+                            ▼
+              prompt = task + content + speaker
+                            │
+                            ▼
+     model.onnx (Qwen2, KV-cached) ──loop──► semantic tokens
+                            │
+                            ▼
+     bicodec_vocoder.onnx(semantic, global) ─► wav @ 16 kHz
+
+cloning only:
+  ref.wav@16k ─► |STFT| ─► speaker_encoder_tokenizer.onnx ─► 32 global tokens
+  ref.wav@16k ─► wav2vec2_model.onnx ─► bicodec_encoder_quantizer.onnx ─► semantic tokens
+```
+
+| Graph | Input | Output |
+| :--- | :--- | :--- |
+| `model.onnx` | `input_ids`, `attention_mask`, `position_ids`, `past_key_values.*` | `logits`, `present.*` |
+| `bicodec_vocoder.onnx` | `semantic_tokens` `[1,T]`, `global_tokens` `[1,1,32]` | waveform `[1,1,N]` |
+| `speaker_encoder_tokenizer.onnx` | `spec` `[1,513,T]` | `global_tokens` `[1,1,32]` |
+| `wav2vec2_model.onnx` | `wav` `[1,N]` | `feat` `[1,T,1024]` |
+| `bicodec_encoder_quantizer.onnx` | `feat` `[1,T,1024]` | `semantic_tokens` `[1,T]` |
+
+The KV-cache shape comes from the language model's own input signature, so no layer count
+is written into phoonnx. The three cloning graphs open on first use, so a preset voice
+never pays for the 860 MB wav2vec2 front end.
+
+The short-time Fourier transform in front of the speaker encoder runs in NumPy, not in a
+graph: ONNX has no complex dtype, so neither torch exporter can lower `torch.stft`. The
+mel filterbank projection is inside `speaker_encoder_tokenizer.onnx`, and the NumPy
+magnitude spectrogram matches torchaudio to 5e-7.
+
+## Speakers
+
+A Spark-TTS voice gets its speaker in one of two ways.
+
+**Preset.** The voice ships a small JSON with its 32 global tokens, so the speaker is
+fixed and every call sounds the same. The four bundled voices were minted with
+Spark-TTS's controllable mode (gender, moderate pitch, moderate speed) and then frozen.
+
+```python
+from phoonnx.model_manager import TTSModelManager
+
+manager = TTSModelManager()
+voice = manager.load_voice("sparktts/female/en")
+for chunk in voice.synthesize("Spark T T S speaks English and Mandarin."):
+    ...  # chunk.audio_float_array
+```
+
+**Zero-shot clone.** Give a reference clip and the speaker comes from the audio:
+
+```python
+from phoonnx.config import SynthesisConfig
+
+syn = SynthesisConfig(speaker_reference="reference.wav")
+for chunk in voice.synthesize("This sentence uses the cloned voice.", syn):
+    ...
+```
+
+Add `speaker_reference_text` — the transcription of the clip — for the in-context
+variant. The prompt then also carries the clip's own semantic tokens, so the model
+continues a real utterance instead of starting cold, which follows the voice more
+closely. This is the only path that needs the two extra cloning graphs.
+
+## Decoding parameters
+
+| Parameter | Default | Meaning |
+| :--- | :--- | :--- |
+| `temperature` | `0.8` | sampling temperature; `0` decodes greedily |
+| `top_k` | `50` | keep the 50 highest-scoring tokens |
+| `top_p` | `0.95` | nucleus: keep the smallest set covering 95 % of the mass |
+
+The warpers run in the order HuggingFace `generate` builds them — temperature, then
+top-k, then top-p — because that is the stack Spark-TTS's own inference code uses.
+Spark-TTS sets **no repetition penalty**: a penalty would suppress the repeated codec
+tokens that normal speech contains. This differs from [Chatterbox](chatterbox.md), whose
+own generation config does apply one.
+
+Text longer than 200 characters is split on sentence boundaries and synthesized one chunk
+per autoregressive pass, with a budget of 3000 tokens per pass (about 60 seconds of
+audio).
+
+## Weights and licensing
+
+The graphs live at
+[`OpenVoiceOS/phoonnx-spark-tts`](https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts).
+The language model is mirrored from `Fhrozen/Spark-TTS-0.5B-ONNX` after being verified
+against the SparkAudio torch weights; the four BiCodec and wav2vec2 graphs were exported
+from `SparkAudio/Spark-TTS-0.5B` at opset 17.
+
+Only the float32 language model is mirrored. The quantized exports published upstream
+(`q4`, `q4f16`, `int8`) disagree with the torch model by tens of logits and change greedy
+decoding, so they are not safe defaults.
+
+Spark-TTS 0.5B is released by SparkAudio under CC-BY-NC-SA-4.0; the upstream code is
+Apache-2.0. Check that licence before any commercial use.

--- a/docs/training/engines/sparktts.md
+++ b/docs/training/engines/sparktts.md
@@ -82,8 +82,9 @@ Spark-TTS's controllable mode (gender, moderate pitch, moderate speed) and then 
 from phoonnx.model_manager import TTSModelManager
 
 manager = TTSModelManager()
-voice = manager.load_voice("sparktts/female/en")
-for chunk in voice.synthesize("Spark T T S speaks English and Mandarin."):
+manager.merge_default_voices()
+voice = manager.voices["sparktts/female/en"].load()
+for chunk in voice.synthesize("Spark-TTS speaks English and Mandarin."):
     ...  # chunk.audio_float_array
 ```
 

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -11,7 +11,7 @@ The catalog is not fetched from a handful of live endpoints. `merge_default_voic
 `OVOS`, `MMS`, `proxectonos`, `piper`, `phonikud`, `neurlang`, `mimic3`,
 `transformers_community`, `piper_community`, `optispeech`, `glowtts`, `mixertts`,
 `fastpitch`, `coqui_community`, `vits2`, `styletts2`, `f5tts`, `coqui_vits`, `BSC`,
-`shami`, `chatterbox`, `supertonic`, `neutts`.
+`shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`.
 
 Each JSON entry becomes a `TTSModelInfo`. Model/config/vocoder files are only fetched from their URLs when a voice is actually downloaded or loaded.
 

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -35,6 +35,7 @@ class Engine(str, Enum):
     SUPERTONIC = "supertonic"  # Supertone SuperTonic: 4-graph flow-matching, raw-text (no phonemizer)
     NEUTTS = "neutts"  # NeuTTS Air / VieNeu / Akiti: Qwen3 codec-LM + NeuCodec decoder
     POCKETTTS = "pockettts"  # Kyutai Pocket TTS: 5-graph flow-matching codec LM, raw-text (no phonemizer)
+    SPARKTTS = "sparktts"  # Spark-TTS: Qwen2 codec-LM + BiCodec, preset or zero-shot speakers
 
 
 # Alphabet and PhonemeType are wire-format enums shared with scriptconv;
@@ -362,6 +363,26 @@ class VoiceConfig:
             phoneme_type = phoneme_type or PhonemeType.UNICODE
             alphabet = alphabet or Alphabet.GRAPHEMES
             config.setdefault("audio", {}).setdefault("sample_rate", 24000)
+            tokenizer = TTSTokenizer(
+                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
+                add_blank_char=False,
+                add_blank_word=False,
+                use_eos_bos=False,
+                blank_at_end=False,
+                blank_at_start=False,
+            )
+
+        elif (engine == Engine.SPARKTTS or
+                (isinstance(engine, str) and engine == "sparktts") or
+                config.get("engine") == "sparktts"):
+            # Spark-TTS consumes raw text: the adapter owns text -> id conversion with the
+            # model's own subword BPE (loaded from engine_params, like SuperTonic's
+            # indexer), so no phonemizer vocabulary is needed here. Alphabet.GRAPHEMES
+            # routes TTSVoice.synthesize() through adapter.encode_text().
+            engine = Engine.SPARKTTS
+            phoneme_type = phoneme_type or PhonemeType.UNICODE
+            alphabet = alphabet or Alphabet.GRAPHEMES
+            config.setdefault("audio", {}).setdefault("sample_rate", 16000)
             tokenizer = TTSTokenizer(
                 Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
                 add_blank_char=False,

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -142,6 +142,7 @@ def _register_builtins() -> None:
     from phoonnx.engines.supertonic import SuperTonicAdapter
     from phoonnx.engines.neutts import NeuTTSAdapter
     from phoonnx.engines.pockettts import PocketTTSAdapter
+    from phoonnx.engines.sparktts import SparkTTSAdapter
 
     # OptiSpeech shares VITS-like x/x_lengths/scales inputs with Matcha, but has
     # a distinctive metadata + wav/durations output signature — check it first.
@@ -164,6 +165,7 @@ def _register_builtins() -> None:
     register_engine("supertonic", SuperTonicAdapter, detect_priority=28)
     register_engine("neutts", NeuTTSAdapter, detect_priority=27)
     register_engine("pockettts", PocketTTSAdapter, detect_priority=26)
+    register_engine("sparktts", SparkTTSAdapter, detect_priority=25)
 
 
 _register_builtins()

--- a/phoonnx/engines/sparktts.py
+++ b/phoonnx/engines/sparktts.py
@@ -214,6 +214,7 @@ class SparkTTSAdapter(BaseOnnxAdapter):
         self.preset_global_tokens: Optional[np.ndarray] = None
         self.special: Dict[str, int] = {}
         self._params: Dict[str, Any] = {}
+        self._reference_text_ids: Optional[List[int]] = None
         self.past_names: List[str] = []
         self.num_kv_heads = 0
         self.head_dim = 0
@@ -280,9 +281,19 @@ class SparkTTSAdapter(BaseOnnxAdapter):
 
         Only the *content* is tokenized here. The control tokens and the speaker stream
         are added in :meth:`synthesize`, which is where the speaker is known.
+
+        A cloning reference's transcription is tokenized here too. It is text for this
+        model, so it goes through the same subword BPE as the content — not through the
+        shared phonemizer path, whose ``prompt_tokens`` are phoneme ids for the
+        phoneme-based in-context engines and mean nothing to Spark-TTS. The whole text is
+        encoded before the first chunk is synthesized, so one transcription is in place
+        for every chunk of the call.
         """
         if self.tokenizer is None:
             raise RuntimeError("Spark-TTS voice missing bpe_tokenizer_path in engine_params")
+        reference_text = getattr(syn_config, "speaker_reference_text", None)
+        self._reference_text_ids = (self.tokenizer.tokenize(reference_text)
+                                    if reference_text else None)
         return [self.tokenizer.tokenize(chunk) for chunk in chunk_text(text) if chunk.strip()]
 
     # ------------------------------------------------------------------
@@ -332,9 +343,8 @@ class SparkTTSAdapter(BaseOnnxAdapter):
         """Pick the speaker for this call: the reference clip if given, else the preset."""
         ref = request.params.get("reference_audio")
         if ref is not None:
-            wants_semantic = request.params.get("prompt_tokens") is not None
             return self.tokenize_reference(np.asarray(ref[0]), int(ref[1]),
-                                           with_semantic=wants_semantic)
+                                           with_semantic=bool(self._reference_text_ids))
         if self.preset_global_tokens is None:
             raise RuntimeError("Spark-TTS voice has neither a speaker_tokens_path preset "
                                "nor a speaker_reference clip to clone from")
@@ -403,7 +413,7 @@ class SparkTTSAdapter(BaseOnnxAdapter):
             raise RuntimeError("Spark-TTS voice missing bpe_tokenizer_path in engine_params")
 
         global_tokens, prompt_semantic = self._resolve_speaker(request)
-        prompt_text_ids = request.params.get("prompt_tokens")
+        prompt_text_ids = self._reference_text_ids
         prompt = self.build_prompt(
             np.asarray(request.phoneme_ids, np.int64).reshape(-1).tolist(),
             global_tokens, prompt_text_ids, prompt_semantic)

--- a/phoonnx/engines/sparktts.py
+++ b/phoonnx/engines/sparktts.py
@@ -215,6 +215,8 @@ class SparkTTSAdapter(BaseOnnxAdapter):
         self.special: Dict[str, int] = {}
         self._params: Dict[str, Any] = {}
         self._reference_text_ids: Optional[List[int]] = None
+        self._reference_cache_key: Optional[tuple] = None
+        self._reference_cache: Tuple[np.ndarray, Optional[np.ndarray]] = (None, None)
         self.past_names: List[str] = []
         self.num_kv_heads = 0
         self.head_dim = 0
@@ -261,6 +263,9 @@ class SparkTTSAdapter(BaseOnnxAdapter):
         if arr.size != N_GLOBAL_TOKENS:
             raise ValueError(f"Spark-TTS speaker tokens must be {N_GLOBAL_TOKENS} values, "
                              f"got {arr.size} from '{path}'")
+        if arr.min() < 0 or arr.max() >= GLOBAL_CODEBOOK:
+            raise ValueError(f"Spark-TTS speaker tokens must be in [0, {GLOBAL_CODEBOOK}) "
+                             f"in '{path}'")
         return arr
 
     def _read_kv_shape(self, session: onnxruntime.InferenceSession) -> None:
@@ -340,11 +345,20 @@ class SparkTTSAdapter(BaseOnnxAdapter):
 
     def _resolve_speaker(self, request: AdapterSynthesisRequest
                          ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
-        """Pick the speaker for this call: the reference clip if given, else the preset."""
+        """Pick the speaker for this call: the reference clip if given, else the preset.
+
+        Long text is synthesized one chunk per call, so the reference is encoded once and
+        reused for the rest of the chunks rather than re-run per sentence.
+        """
         ref = request.params.get("reference_audio")
         if ref is not None:
-            return self.tokenize_reference(np.asarray(ref[0]), int(ref[1]),
-                                           with_semantic=bool(self._reference_text_ids))
+            audio = np.asarray(ref[0], np.float32).reshape(-1)
+            key = (hash(audio.tobytes()), int(ref[1]), bool(self._reference_text_ids))
+            if self._reference_cache_key != key:
+                self._reference_cache = self.tokenize_reference(
+                    audio, int(ref[1]), with_semantic=bool(self._reference_text_ids))
+                self._reference_cache_key = key
+            return self._reference_cache
         if self.preset_global_tokens is None:
             raise RuntimeError("Spark-TTS voice has neither a speaker_tokens_path preset "
                                "nor a speaker_reference clip to clone from")

--- a/phoonnx/engines/sparktts.py
+++ b/phoonnx/engines/sparktts.py
@@ -1,0 +1,444 @@
+"""Spark-TTS inference adapter — autoregressive codec-LM TTS with BiCodec tokens.
+
+Spark-TTS (SparkAudio, ``SparkAudio/Spark-TTS-0.5B``) is a decoder-only language model
+on a Qwen2.5-0.5B backbone. It does not predict audio directly: it predicts *BiCodec*
+tokens, and BiCodec turns those tokens back into a waveform. BiCodec splits a voice into
+two streams:
+
+* **global tokens** — 32 tokens that carry the speaker (timbre, not content);
+* **semantic tokens** — one stream at 50 Hz that carries what is said.
+
+The language model reads a prompt made of control tokens, the text, and the 32 global
+tokens, and then writes the semantic stream. This is the same autoregressive family as
+:class:`phoonnx.engines.chatterbox.ChatterboxAdapter`, so it also drives the overridable
+``BaseOnnxAdapter.synthesize`` rather than the single-graph ``build_feed_dict`` path.
+
+Five ONNX graphs (HF: ``OpenVoiceOS/phoonnx-spark-tts``)::
+
+    model.onnx                      Qwen2 LM, KV-cached AR step (= the voice's ``session``)
+    bicodec_vocoder.onnx            semantic + global tokens -> waveform @ 16 kHz
+    wav2vec2_model.onnx             reference wav -> 1024-dim features        (cloning only)
+    bicodec_encoder_quantizer.onnx  features -> reference semantic tokens     (cloning only)
+    speaker_encoder_tokenizer.onnx  reference magnitude spectrogram -> global tokens (cloning only)
+
+plus ``tokenizer.json`` (the model's own subword BPE) and, for a preset voice, a small
+JSON that holds the 32 global tokens of that speaker.
+
+Voices come in two forms:
+
+* **preset** — the 32 global tokens ship with the voice as an asset, so the speaker is
+  fixed and no reference clip is needed;
+* **zero-shot clone** — ``SynthesisConfig.speaker_reference`` gives a reference clip, and
+  the three cloning graphs turn it into global tokens. Add
+  ``speaker_reference_text`` (the transcription of that clip) for the in-context variant,
+  which also feeds the clip's semantic tokens to the model and clones more closely.
+
+The short-time Fourier transform in front of the speaker encoder stays outside the ONNX
+graphs: ONNX has no complex dtype, so neither torch exporter can lower ``torch.stft``.
+The mel filterbank projection *is* inside ``speaker_encoder_tokenizer.onnx``; only the
+magnitude spectrogram is computed here, and it matches torchaudio to 5e-7.
+
+Prompt layout, sampler order and the audio front end follow SparkAudio's own inference
+code (Apache-2.0, ``SparkAudio/Spark-TTS``): the model is generated with HuggingFace
+``generate``, whose warpers apply temperature, then top-k, then top-p, with no
+repetition penalty.
+"""
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import onnxruntime
+from quebra_frases import sentence_tokenize
+
+from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
+from phoonnx.tokenizer import BPETokenizer
+from phoonnx.util import LOG
+
+SAMPLE_RATE = 16000
+"""Every BiCodec stage works at 16 kHz."""
+
+REF_SEGMENT_SAMPLES = 96000
+"""6 s of reference audio, rounded down to a multiple of the 320-sample latent hop."""
+
+N_FFT, WIN_LENGTH, HOP_LENGTH = 1024, 640, 320
+
+MAX_NEW_TOKENS = 3000
+"""Upstream's generation budget — about 60 s of audio at 50 tokens per second."""
+
+MAX_CHUNK_CHARS = 200
+"""Longest text handed to one autoregressive pass; longer input is split on sentences."""
+
+_SPECIAL_TOKENS = (
+    "<|task_tts|>", "<|start_content|>", "<|end_content|>",
+    "<|start_global_token|>", "<|end_global_token|>", "<|start_semantic_token|>",
+    "<|im_end|>", "<|bicodec_global_0|>", "<|bicodec_semantic_0|>",
+)
+
+N_GLOBAL_TOKENS = 32
+"""The speaker stream is always exactly 32 tokens."""
+
+GLOBAL_CODEBOOK, SEMANTIC_CODEBOOK = 4096, 8192
+
+
+def volume_normalize(audio: np.ndarray, coeff: float = 0.2) -> np.ndarray:
+    """Bring a clip to the loudness the BiCodec front end expects.
+
+    Ported from SparkAudio's ``audio_volume_normalize`` (Apache-2.0). The scale comes
+    from the mean of the loudest 10 % to 1 % of samples, which ignores both silence and
+    isolated peaks.
+    """
+    audio = np.asarray(audio, np.float32).reshape(-1)
+    temp = np.sort(np.abs(audio))
+    if temp.size == 0:
+        return audio
+    if temp[-1] < 0.1:
+        audio = audio / max(float(temp[-1]), 1e-3) * 0.1
+    temp = temp[temp > 0.01]
+    if temp.shape[0] <= 10:
+        return audio
+    volume = float(np.mean(temp[int(0.9 * temp.shape[0]):int(0.99 * temp.shape[0])]))
+    audio = audio * np.clip(coeff / volume, 0.1, 10)
+    peak = float(np.max(np.abs(audio)))
+    if peak > 1:
+        audio = audio / peak
+    return audio.astype(np.float32)
+
+
+def magnitude_spectrogram(wav: np.ndarray) -> np.ndarray:
+    """Magnitude STFT of ``wav``, shaped ``(1, 1 + n_fft // 2, frames)``.
+
+    Matches torchaudio ``Spectrogram(n_fft=1024, win_length=640, hop_length=320,
+    power=1, center=True, pad_mode="reflect")``, whose output the exported
+    ``speaker_encoder_tokenizer.onnx`` projects through the mel filterbank.
+    """
+    win = np.hanning(WIN_LENGTH + 1)[:-1].astype(np.float32)     # periodic Hann
+    pad = (N_FFT - WIN_LENGTH) // 2
+    win = np.pad(win, (pad, N_FFT - WIN_LENGTH - pad))
+    x = np.pad(np.asarray(wav, np.float32).reshape(-1),
+               (N_FFT // 2, N_FFT // 2), mode="reflect")
+    frames = 1 + (len(x) - N_FFT) // HOP_LENGTH
+    strided = np.lib.stride_tricks.as_strided(
+        x, shape=(frames, N_FFT), strides=(x.strides[0] * HOP_LENGTH, x.strides[0]))
+    spec = np.abs(np.fft.rfft(strided * win, n=N_FFT, axis=-1)).T
+    return spec[None].astype(np.float32)
+
+
+def resample(audio: np.ndarray, sr: int, target_sr: int = SAMPLE_RATE) -> np.ndarray:
+    """Resample a mono clip to ``target_sr``, preferring a polyphase filter."""
+    audio = np.asarray(audio, np.float32).reshape(-1)
+    if sr == target_sr:
+        return audio
+    try:
+        from math import gcd
+
+        from scipy.signal import resample_poly
+        g = gcd(sr, target_sr)
+        return resample_poly(audio, target_sr // g, sr // g).astype(np.float32)
+    except ImportError:
+        n = int(round(len(audio) * target_sr / sr))
+        return np.interp(np.linspace(0, len(audio) - 1, n),
+                         np.arange(len(audio)), audio).astype(np.float32)
+
+
+def reference_clip(wav: np.ndarray) -> np.ndarray:
+    """The fixed-length slice the speaker encoder reads, repeating a short clip."""
+    wav = np.asarray(wav, np.float32).reshape(-1)
+    if wav.size == 0:
+        raise ValueError("Spark-TTS reference clip is empty")
+    if wav.size < REF_SEGMENT_SAMPLES:
+        wav = np.tile(wav, REF_SEGMENT_SAMPLES // wav.size + 1)
+    return wav[:REF_SEGMENT_SAMPLES]
+
+
+def sample_token(logits: np.ndarray, temperature: float, top_k: int,
+                 top_p: float, rng: np.random.Generator) -> int:
+    """Draw one token the way HuggingFace ``generate`` does for this model.
+
+    The warpers run in the order HuggingFace builds them — temperature, then top-k, then
+    top-p — and Spark-TTS sets no repetition penalty. Order matters: applying top-p
+    before top-k gives a different nucleus, and a repetition penalty (which the sibling
+    Chatterbox engine does need) would suppress the repeated codec tokens that normal
+    speech contains.
+    """
+    x = np.asarray(logits, np.float64).reshape(-1)
+    if temperature > 0:
+        x = x / max(temperature, 1e-5)
+    else:
+        return int(x.argmax())
+    if top_k and 0 < top_k < x.size:
+        x = np.where(x < np.partition(x, -top_k)[-top_k], -np.inf, x)
+    x = x - x.max()
+    probs = np.exp(x)
+    probs /= probs.sum()
+    order = np.argsort(probs)[::-1]
+    cutoff = int(np.searchsorted(np.cumsum(probs[order]), top_p)) + 1
+    keep = order[:max(1, cutoff)]
+    p = probs[keep] / probs[keep].sum()
+    return int(rng.choice(keep, p=p))
+
+
+def chunk_text(text: str, max_len: int = MAX_CHUNK_CHARS) -> List[str]:
+    """Pack whole sentences into chunks of at most ``max_len`` characters.
+
+    One chunk is one autoregressive pass. Sentence boundaries come from
+    ``quebra_frases.sentence_tokenize``, the splitter the rest of phoonnx uses.
+    """
+    chunks: List[str] = []
+    for paragraph in (p.strip() for p in re.split(r"\n\s*\n+", text.strip())):
+        if not paragraph:
+            continue
+        current = ""
+        for sentence in sentence_tokenize(paragraph):
+            if len(current) + len(sentence) + 1 <= max_len:
+                current += (" " if current else "") + sentence
+            else:
+                if current:
+                    chunks.append(current.strip())
+                current = sentence
+        if current:
+            chunks.append(current.strip())
+    return chunks or ([text.strip()] if text.strip() else [])
+
+
+class SparkTTSAdapter(BaseOnnxAdapter):
+    """Adapter for Spark-TTS (Qwen2 codec-LM + BiCodec, preset or cloned speakers)."""
+
+    def __init__(self):
+        self.vocoder: Optional[onnxruntime.InferenceSession] = None
+        self.wav2vec2: Optional[onnxruntime.InferenceSession] = None
+        self.speaker_tokenizer: Optional[onnxruntime.InferenceSession] = None
+        self.semantic_tokenizer: Optional[onnxruntime.InferenceSession] = None
+        self.tokenizer: Optional[BPETokenizer] = None
+        self.preset_global_tokens: Optional[np.ndarray] = None
+        self.special: Dict[str, int] = {}
+        self._params: Dict[str, Any] = {}
+        self.past_names: List[str] = []
+        self.num_kv_heads = 0
+        self.head_dim = 0
+
+    def default_params(self) -> Dict[str, float]:
+        return {"temperature": 0.8, "top_k": 50.0, "top_p": 0.95}
+
+    def param_labels(self) -> Dict[str, str]:
+        return {"temperature": "Sampling temperature", "top_k": "Top-k",
+                "top_p": "Nucleus (top-p)"}
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def configure(self, voice_config: Any) -> None:
+        """Load the vocoder, the model's own BPE and the preset speaker tokens.
+
+        The three cloning graphs stay on disk until a call actually asks to clone. A
+        preset voice never touches them, and the wav2vec2 front end alone costs about a
+        gigabyte of memory to hold open.
+        """
+        ep = getattr(voice_config, "engine_params", None) or {}
+        self._params = dict(ep)
+
+        if self.vocoder is None and ep.get("vocoder_path"):
+            self.vocoder = make_session(ep["vocoder_path"], providers=ep.get("providers"))
+        if self.tokenizer is None and ep.get("bpe_tokenizer_path"):
+            self.tokenizer = BPETokenizer(ep["bpe_tokenizer_path"])
+            self.special = {t: self.tokenizer._tok.token_to_id(t) for t in _SPECIAL_TOKENS}
+            missing = [t for t, i in self.special.items() if i is None]
+            if missing:
+                raise ValueError(f"Spark-TTS tokenizer.json is missing {missing}")
+        if self.preset_global_tokens is None and ep.get("speaker_tokens_path"):
+            self.preset_global_tokens = self._load_speaker_tokens(ep["speaker_tokens_path"])
+
+    @staticmethod
+    def _load_speaker_tokens(path: str) -> np.ndarray:
+        """Read a preset speaker's 32 global tokens from its JSON asset."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        tokens = data["global_tokens"] if isinstance(data, dict) else data
+        arr = np.asarray(tokens, np.int64).reshape(-1)
+        if arr.size != N_GLOBAL_TOKENS:
+            raise ValueError(f"Spark-TTS speaker tokens must be {N_GLOBAL_TOKENS} values, "
+                             f"got {arr.size} from '{path}'")
+        return arr
+
+    def _read_kv_shape(self, session: onnxruntime.InferenceSession) -> None:
+        """Read the KV-cache layout from the LM's own input signature."""
+        for inp in session.get_inputs():
+            if inp.name.startswith("past_key_values"):
+                self.past_names.append(inp.name)
+                if not self.num_kv_heads:
+                    self.num_kv_heads = int(inp.shape[1])
+                    self.head_dim = int(inp.shape[3])
+
+    # ------------------------------------------------------------------
+    # Text
+    # ------------------------------------------------------------------
+
+    def encode_text(self, text: str, voice: Any, syn_config: Any) -> List[List[int]]:
+        """Turn text into one subword-id list per autoregressive pass.
+
+        Only the *content* is tokenized here. The control tokens and the speaker stream
+        are added in :meth:`synthesize`, which is where the speaker is known.
+        """
+        if self.tokenizer is None:
+            raise RuntimeError("Spark-TTS voice missing bpe_tokenizer_path in engine_params")
+        return [self.tokenizer.tokenize(chunk) for chunk in chunk_text(text) if chunk.strip()]
+
+    # ------------------------------------------------------------------
+    # Speaker
+    # ------------------------------------------------------------------
+
+    def _cloning_session(self, attribute: str, key: str) -> onnxruntime.InferenceSession:
+        """Open a cloning graph the first time a call needs it, then keep it."""
+        session = getattr(self, attribute)
+        if session is None:
+            path = self._params.get(key)
+            if not path:
+                raise RuntimeError(f"Spark-TTS voice cannot clone: no {key} in engine_params")
+            session = make_session(path, providers=self._params.get("providers"))
+            setattr(self, attribute, session)
+        return session
+
+    def tokenize_reference(self, audio: np.ndarray, sr: int,
+                           with_semantic: bool = False) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        """Turn a reference clip into its global tokens (and semantic tokens on request).
+
+        Returns ``(global_tokens, semantic_tokens)``; the second value is ``None`` unless
+        ``with_semantic`` is set, because only the in-context cloning path needs it.
+        """
+        self.speaker_tokenizer = self._cloning_session(
+            "speaker_tokenizer", "speaker_tokenizer_path")
+        wav = volume_normalize(resample(audio, sr))
+        spec = magnitude_spectrogram(reference_clip(wav))
+        global_tokens = np.asarray(
+            self.speaker_tokenizer.run(None, {"spec": spec})[0], np.int64).reshape(-1)
+
+        if not with_semantic:
+            return global_tokens, None
+        self.wav2vec2 = self._cloning_session("wav2vec2", "wav2vec2_path")
+        self.semantic_tokenizer = self._cloning_session(
+            "semantic_tokenizer", "semantic_tokenizer_path")
+        # wav2vec2 reads a zero-mean, unit-variance waveform (its feature extractor's
+        # do_normalize), and Spark-TTS mixes hidden states 11/14/16 inside the graph.
+        norm = (wav - wav.mean()) / np.sqrt(wav.var() + 1e-7)
+        feat = self.wav2vec2.run(None, {"wav": norm[None].astype(np.float32)})[0]
+        semantic = np.asarray(
+            self.semantic_tokenizer.run(None, {"feat": feat})[0], np.int64).reshape(-1)
+        return global_tokens, semantic
+
+    def _resolve_speaker(self, request: AdapterSynthesisRequest
+                         ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        """Pick the speaker for this call: the reference clip if given, else the preset."""
+        ref = request.params.get("reference_audio")
+        if ref is not None:
+            wants_semantic = request.params.get("prompt_tokens") is not None
+            return self.tokenize_reference(np.asarray(ref[0]), int(ref[1]),
+                                           with_semantic=wants_semantic)
+        if self.preset_global_tokens is None:
+            raise RuntimeError("Spark-TTS voice has neither a speaker_tokens_path preset "
+                               "nor a speaker_reference clip to clone from")
+        return self.preset_global_tokens, None
+
+    # ------------------------------------------------------------------
+    # Synthesis
+    # ------------------------------------------------------------------
+
+    def build_prompt(self, content_ids: List[int], global_tokens: np.ndarray,
+                     prompt_text_ids: Optional[List[int]] = None,
+                     prompt_semantic: Optional[np.ndarray] = None) -> np.ndarray:
+        """Assemble the control-token prompt Spark-TTS was trained on.
+
+        The bare form is ``task, content, speaker``. When a transcribed reference clip is
+        available the prompt also carries that transcription and the clip's own semantic
+        tokens, so the model continues a real utterance instead of starting cold.
+        """
+        s = self.special
+        global_ids = (s["<|bicodec_global_0|>"] + np.asarray(global_tokens, np.int64)).tolist()
+        ids: List[int] = [s["<|task_tts|>"], s["<|start_content|>"]]
+        ids += list(prompt_text_ids or [])
+        ids += list(content_ids)
+        ids += [s["<|end_content|>"], s["<|start_global_token|>"]]
+        ids += global_ids
+        ids += [s["<|end_global_token|>"]]
+        if prompt_text_ids and prompt_semantic is not None:
+            ids += [s["<|start_semantic_token|>"]]
+            ids += (s["<|bicodec_semantic_0|>"] + np.asarray(prompt_semantic, np.int64)).tolist()
+        return np.asarray(ids, np.int64)[None]
+
+    def _generate(self, session: onnxruntime.InferenceSession, prompt: np.ndarray,
+                  temperature: float, top_k: int, top_p: float,
+                  rng: np.random.Generator) -> List[int]:
+        """Run the KV-cached autoregressive loop and return the emitted token ids."""
+        if not self.past_names:
+            self._read_kv_shape(session)
+        names = [o.name for o in session.get_outputs()]
+        past = {n: np.zeros((1, self.num_kv_heads, 0, self.head_dim), np.float32)
+                for n in self.past_names}
+        prompt_len = prompt.shape[1]
+        feed = {"input_ids": prompt,
+                "attention_mask": np.ones((1, prompt_len), np.int64),
+                "position_ids": np.arange(prompt_len, dtype=np.int64)[None], **past}
+        eos = self.special["<|im_end|>"]
+        emitted: List[int] = []
+        for step in range(MAX_NEW_TOKENS):
+            outputs = dict(zip(names, session.run(None, feed)))
+            token = sample_token(outputs["logits"][0, -1], temperature, top_k, top_p, rng)
+            if token == eos:
+                break
+            emitted.append(token)
+            past = {n: outputs[n.replace("past_key_values", "present")]
+                    for n in self.past_names}
+            position = prompt_len + step
+            feed = {"input_ids": np.array([[token]], np.int64),
+                    "attention_mask": np.ones((1, position + 1), np.int64),
+                    "position_ids": np.array([[position]], np.int64), **past}
+        return emitted
+
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        if self.vocoder is None:
+            raise RuntimeError("Spark-TTS voice missing vocoder_path in engine_params")
+        if self.tokenizer is None:
+            raise RuntimeError("Spark-TTS voice missing bpe_tokenizer_path in engine_params")
+
+        global_tokens, prompt_semantic = self._resolve_speaker(request)
+        prompt_text_ids = request.params.get("prompt_tokens")
+        prompt = self.build_prompt(
+            np.asarray(request.phoneme_ids, np.int64).reshape(-1).tolist(),
+            global_tokens, prompt_text_ids, prompt_semantic)
+
+        p = request.params
+        rng = np.random.default_rng(p.get("seed"))
+        emitted = self._generate(session, prompt, float(p.get("temperature", 0.8)),
+                                 int(p.get("top_k", 50)), float(p.get("top_p", 0.95)), rng)
+
+        base = self.special["<|bicodec_semantic_0|>"]
+        semantic = [t - base for t in emitted if base <= t < base + SEMANTIC_CODEBOOK]
+        if not semantic:
+            LOG.warning("Spark-TTS produced no semantic tokens for this chunk")
+            return AdapterSynthesisResult(audio=np.zeros(0, np.float32))
+
+        wav = self.vocoder.run(None, {
+            "semantic_tokens": np.asarray([semantic], np.int64),
+            "global_tokens": np.asarray(global_tokens, np.int64).reshape(1, 1, -1),
+        })[0]
+        audio = np.asarray(wav, np.float32).reshape(-1)
+        return AdapterSynthesisResult(
+            audio=audio, extras={"semantic_token_count": len(semantic)})
+
+    # build_feed_dict / parse_outputs are required by the ABC but unused — synthesize()
+    # drives the autoregressive pipeline directly.
+    def build_feed_dict(self, request: AdapterSynthesisRequest,
+                        session: onnxruntime.InferenceSession) -> Dict[str, np.ndarray]:
+        raise NotImplementedError("Spark-TTS is autoregressive — use synthesize()")
+
+    def parse_outputs(self, outputs: List[np.ndarray],
+                      request: AdapterSynthesisRequest,
+                      output_names: Optional[List[str]] = None) -> AdapterSynthesisResult:
+        raise NotImplementedError("Spark-TTS is autoregressive — use synthesize()")
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        return bool(config and config.get("engine") == "sparktts")

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -656,7 +656,7 @@ class TTSModelManager:
         "optispeech.json", "glowtts.json", "mixertts.json", "fastpitch.json",
         "coqui_community.json", "vits2.json", "styletts2.json", "f5tts.json",
         "coqui_vits.json", "BSC.json", "shami.json", "chatterbox.json",
-        "supertonic.json", "neutts.json", "pockettts.json",
+        "supertonic.json", "neutts.json", "pockettts.json", "sparktts.json",
     )
 
     @classmethod

--- a/phoonnx/voice_index/sparktts.json
+++ b/phoonnx/voice_index/sparktts.json
@@ -1,0 +1,90 @@
+{
+    "sparktts/female/en": {
+        "voice_id": "sparktts/female/en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "sparktts",
+        "lang": "en-US",
+        "aux_model_urls": {
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_vocoder.onnx",
+            "wav2vec2_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/wav2vec2_model.onnx",
+            "speaker_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/speaker_encoder_tokenizer.onnx",
+            "semantic_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_encoder_quantizer.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/tokenizer.json",
+            "speaker_tokens_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/voices/female_en.json"
+        },
+        "display_name": "Spark-TTS female (English)"
+    },
+    "sparktts/male/en": {
+        "voice_id": "sparktts/male/en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "sparktts",
+        "lang": "en-US",
+        "aux_model_urls": {
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_vocoder.onnx",
+            "wav2vec2_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/wav2vec2_model.onnx",
+            "speaker_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/speaker_encoder_tokenizer.onnx",
+            "semantic_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_encoder_quantizer.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/tokenizer.json",
+            "speaker_tokens_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/voices/male_en.json"
+        },
+        "display_name": "Spark-TTS male (English)"
+    },
+    "sparktts/female/zh": {
+        "voice_id": "sparktts/female/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "sparktts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_vocoder.onnx",
+            "wav2vec2_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/wav2vec2_model.onnx",
+            "speaker_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/speaker_encoder_tokenizer.onnx",
+            "semantic_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_encoder_quantizer.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/tokenizer.json",
+            "speaker_tokens_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/voices/female_zh.json"
+        },
+        "display_name": "Spark-TTS female (Mandarin)"
+    },
+    "sparktts/male/zh": {
+        "voice_id": "sparktts/male/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "sparktts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_vocoder.onnx",
+            "wav2vec2_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/wav2vec2_model.onnx",
+            "speaker_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/speaker_encoder_tokenizer.onnx",
+            "semantic_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/bicodec_encoder_quantizer.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/tokenizer.json",
+            "speaker_tokens_path": "https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/resolve/main/voices/male_zh.json"
+        },
+        "display_name": "Spark-TTS male (Mandarin)"
+    }
+}

--- a/tests/test_sparktts.py
+++ b/tests/test_sparktts.py
@@ -8,6 +8,8 @@ from phoonnx.engines.base import AdapterSynthesisRequest
 from phoonnx.engines.sparktts import (
     N_GLOBAL_TOKENS,
     REF_SEGMENT_SAMPLES,
+    SAMPLE_RATE,
+    SEMANTIC_CODEBOOK,
     SparkTTSAdapter,
     chunk_text,
     magnitude_spectrogram,
@@ -335,3 +337,288 @@ def test_voice_index_entries():
 def test_voice_index_is_merged_by_the_manager():
     from phoonnx.model_manager import TTSModelManager
     assert any(p.name == "sparktts.json" for p in TTSModelManager.voice_index_files())
+
+
+# ----------------------------------------------------------------------
+# _generate() — the KV-cached autoregressive loop
+# ----------------------------------------------------------------------
+
+class _IOSpec:
+    """Mimics onnxruntime.NodeArg — just the ``.name``/``.shape`` the adapter reads."""
+
+    def __init__(self, name, shape):
+        self.name = name
+        self.shape = shape
+
+
+NUM_KV_HEADS, HEAD_DIM, NUM_LAYERS = 2, 4, 3
+VOCAB = 12000
+
+
+class _FakeLMSession:
+    """Fake Qwen2 KV-cached LM session with the real InferenceSession contract.
+
+    Implements ``get_inputs()``/``get_outputs()``/``run()`` with real numpy shapes so it
+    drives the adapter's own prefill/decode loop, the same way the neutts/pockettts fakes
+    drive their engines. ``tokens_to_emit`` is the fixed script of ids the "model" emits,
+    one per decode step; the fake never looks at ``input_ids`` to choose a token, but it
+    does assert the feed shapes it is handed are consistent with the KV-cache contract.
+    """
+
+    def __init__(self, tokens_to_emit, vocab=VOCAB):
+        self.tokens_to_emit = list(tokens_to_emit)
+        self.vocab = vocab
+        self.step = 0
+        self.calls = []  # recorded feed dicts, in call order
+
+    def get_inputs(self):
+        ins = [_IOSpec("input_ids", ["batch", "seq"]),
+              _IOSpec("attention_mask", ["batch", "seq"]),
+              _IOSpec("position_ids", ["batch", "seq"])]
+        for i in range(NUM_LAYERS):
+            ins.append(_IOSpec(f"past_key_values.{i}.key",
+                               ["batch", NUM_KV_HEADS, "past", HEAD_DIM]))
+        return ins
+
+    def get_outputs(self):
+        outs = [_IOSpec("logits", ["batch", "seq", self.vocab])]
+        for i in range(NUM_LAYERS):
+            outs.append(_IOSpec(f"present.{i}.key",
+                                ["batch", NUM_KV_HEADS, "total", HEAD_DIM]))
+        return outs
+
+    def run(self, output_names, feed):
+        self.calls.append({k: (v.copy() if isinstance(v, np.ndarray) else v)
+                           for k, v in feed.items()})
+        input_ids = feed["input_ids"]
+        seq = input_ids.shape[1]
+        past_len = feed[f"past_key_values.0.key"].shape[2]
+
+        # attention_mask / position_ids must match the running sequence length exactly
+        assert feed["attention_mask"].shape == (1, past_len + seq)
+        assert (feed["attention_mask"] == 1).all()
+        if past_len == 0:
+            assert feed["position_ids"].tolist() == [list(range(seq))]
+        else:
+            assert feed["position_ids"].tolist() == [[past_len]]
+            assert seq == 1  # decode steps feed exactly one new token
+
+        token = self.tokens_to_emit[min(self.step, len(self.tokens_to_emit) - 1)]
+        self.step += 1
+
+        logits = np.full((1, seq, self.vocab), -1e9, np.float32)
+        logits[0, -1, token] = 10.0  # sharp peak: argmax/greedy always resolves to `token`
+
+        new_past_len = past_len + seq
+        present = np.zeros((1, NUM_KV_HEADS, new_past_len, HEAD_DIM), np.float32)
+        # stamp a per-step, per-layer signature so growth/threading can be asserted
+        present[..., :] = new_past_len
+
+        outputs = [logits]
+        for i in range(NUM_LAYERS):
+            outputs.append(present.copy())
+        return outputs
+
+
+def _fake_lm_adapter():
+    ad = _adapter()
+    ad.past_names = [f"past_key_values.{i}.key" for i in range(NUM_LAYERS)]
+    ad.num_kv_heads = NUM_KV_HEADS
+    ad.head_dim = HEAD_DIM
+    return ad
+
+
+def test_generate_prefill_feed_has_zero_length_past():
+    ad = _fake_lm_adapter()
+    eos = SPECIAL["<|im_end|>"]
+    session = _FakeLMSession([100, 101, eos])
+    prompt = np.array([[1, 2, 3, 4]], np.int64)
+    ad._generate(session, prompt, temperature=0.0, top_k=50, top_p=0.95,
+                rng=np.random.default_rng(0))
+
+    first_feed = session.calls[0]
+    assert first_feed["input_ids"].shape == (1, 4)          # whole prompt, one shot
+    for name in ad.past_names:
+        assert first_feed[name].shape == (1, NUM_KV_HEADS, 0, HEAD_DIM)  # empty KV cache
+
+
+def test_generate_maps_present_to_past_key_values_and_grows_shapes_each_step():
+    ad = _fake_lm_adapter()
+    eos = SPECIAL["<|im_end|>"]
+    session = _FakeLMSession([100, 101, 102, eos])
+    prompt = np.array([[1, 2, 3]], np.int64)
+    ad._generate(session, prompt, temperature=0.0, top_k=50, top_p=0.95,
+                rng=np.random.default_rng(0))
+
+    # call 0: prefill (seq=3, past=0); calls 1..3: decode steps (seq=1, past growing)
+    assert len(session.calls) == 4
+    for i in range(NUM_LAYERS):
+        name = f"past_key_values.{i}.key"
+        # step 1 decode feed must carry step-0's `present.N` renamed to `past_key_values.N`
+        # (the value the fake stamped == the running length after the prefill step, i.e. 3)
+        assert session.calls[1][name].shape == (1, NUM_KV_HEADS, 3, HEAD_DIM)
+        assert (session.calls[1][name] == 3).all()
+        # each further decode step grows the cache by exactly one position
+        assert session.calls[2][name].shape == (1, NUM_KV_HEADS, 4, HEAD_DIM)
+        assert session.calls[3][name].shape == (1, NUM_KV_HEADS, 5, HEAD_DIM)
+
+
+def test_generate_decode_feed_shapes_and_position_ids_advance():
+    ad = _fake_lm_adapter()
+    eos = SPECIAL["<|im_end|>"]
+    session = _FakeLMSession([100, 101, eos])
+    prompt = np.array([[1, 2, 3, 4, 5]], np.int64)  # prompt_len = 5
+    ad._generate(session, prompt, temperature=0.0, top_k=50, top_p=0.95,
+                rng=np.random.default_rng(0))
+
+    decode_feeds = session.calls[1:]
+    for step, feed in enumerate(decode_feeds):
+        assert feed["input_ids"].shape == (1, 1)                 # decode feeds one token
+        assert feed["position_ids"].tolist() == [[5 + step]]     # prompt_len + step
+        assert feed["attention_mask"].shape == (1, 5 + step + 1)
+
+
+def test_generate_stops_on_eos_and_does_not_emit_it():
+    ad = _fake_lm_adapter()
+    eos = SPECIAL["<|im_end|>"]
+    session = _FakeLMSession([111, 222, eos, 333])  # 333 must never be reached
+    prompt = np.array([[1, 2]], np.int64)
+    emitted = ad._generate(session, prompt, temperature=0.0, top_k=50, top_p=0.95,
+                           rng=np.random.default_rng(0))
+
+    assert emitted == [111, 222]
+    assert len(session.calls) == 3  # prefill + 2 decode steps, stops before a 3rd decode
+
+
+def test_generate_respects_max_new_tokens_when_eos_never_comes():
+    from phoonnx.engines import sparktts as sparktts_mod
+    ad = _fake_lm_adapter()
+    session = _FakeLMSession([777])  # repeats forever, never emits eos
+    prompt = np.array([[1]], np.int64)
+    old_cap = sparktts_mod.MAX_NEW_TOKENS
+    sparktts_mod.MAX_NEW_TOKENS = 5
+    try:
+        emitted = ad._generate(session, prompt, temperature=0.0, top_k=50, top_p=0.95,
+                               rng=np.random.default_rng(0))
+    finally:
+        sparktts_mod.MAX_NEW_TOKENS = old_cap
+    assert emitted == [777] * 5
+
+
+def test_generate_reads_kv_shape_lazily_from_the_session_when_unset():
+    ad = _adapter()  # no past_names / num_kv_heads / head_dim pre-seeded
+    eos = SPECIAL["<|im_end|>"]
+    session = _FakeLMSession([100, eos])
+    prompt = np.array([[1, 2]], np.int64)
+    ad._generate(session, prompt, temperature=0.0, top_k=50, top_p=0.95,
+                rng=np.random.default_rng(0))
+    assert ad.past_names == [f"past_key_values.{i}.key" for i in range(NUM_LAYERS)]
+    assert ad.num_kv_heads == NUM_KV_HEADS
+    assert ad.head_dim == HEAD_DIM
+
+
+def test_generate_temperature_zero_is_deterministic_argmax_through_the_fake_session():
+    # two independent rng streams must produce the identical script, because temperature<=0
+    # takes the argmax branch in sample_token() and never touches the rng
+    eos = SPECIAL["<|im_end|>"]
+    tokens = [50, 3999, 0, eos]  # exercise low/high/edge vocab ids too
+    emitted_a = _fake_lm_adapter()._generate(
+        _FakeLMSession(tokens), np.array([[1, 2]], np.int64),
+        temperature=0.0, top_k=50, top_p=0.95, rng=np.random.default_rng(1))
+    emitted_b = _fake_lm_adapter()._generate(
+        _FakeLMSession(tokens), np.array([[1, 2]], np.int64),
+        temperature=-1.0, top_k=1, top_p=0.01, rng=np.random.default_rng(999))
+    assert emitted_a == emitted_b == [50, 3999, 0]
+
+
+# ----------------------------------------------------------------------
+# synthesize() — semantic-token -> vocoder handoff
+# ----------------------------------------------------------------------
+
+class _FakeVocoderSession:
+    """Records the exact feed dict it receives and returns a deterministic waveform."""
+
+    def __init__(self, n_samples=1600):
+        self.n_samples = n_samples
+        self.calls = []
+
+    def run(self, output_names, feed):
+        self.calls.append(feed)
+        return [np.linspace(-0.5, 0.5, self.n_samples, dtype=np.float32)[None]]
+
+
+def _synth_ready_adapter(lm_tokens, vocoder=None):
+    ad = _fake_lm_adapter()
+    ad.vocoder = vocoder or _FakeVocoderSession()
+    ad.tokenizer = object()
+    ad.preset_global_tokens = np.arange(N_GLOBAL_TOKENS, dtype=np.int64)
+    return ad, _FakeLMSession(lm_tokens)
+
+
+def test_synthesize_offsets_semantic_tokens_before_the_vocoder_call():
+    base = SPECIAL["<|bicodec_semantic_0|>"]
+    eos = SPECIAL["<|im_end|>"]
+    # raw emitted ids are base-offset; the vocoder must see them de-offset back to [0, 8192)
+    raw = [base + 5, base + 0, base + 8191, eos]
+    ad, session = _synth_ready_adapter(raw)
+    result = ad.synthesize(_req(), session)
+
+    vocoder_calls = ad.vocoder.calls
+    assert len(vocoder_calls) == 1
+    feed = vocoder_calls[0]
+    assert set(feed) == {"semantic_tokens", "global_tokens"}
+    assert feed["semantic_tokens"].dtype == np.int64
+    assert feed["semantic_tokens"].tolist() == [[5, 0, 8191]]
+    assert feed["global_tokens"].dtype == np.int64
+    assert feed["global_tokens"].shape == (1, 1, N_GLOBAL_TOKENS)
+    assert feed["global_tokens"].reshape(-1).tolist() == list(range(N_GLOBAL_TOKENS))
+    assert result.extras == {"semantic_token_count": 3}
+
+
+def test_synthesize_waveform_round_trips_into_an_audio_chunk():
+    from phoonnx.voice import AudioChunk
+
+    base = SPECIAL["<|bicodec_semantic_0|>"]
+    eos = SPECIAL["<|im_end|>"]
+    n_samples = 800
+    vocoder = _FakeVocoderSession(n_samples=n_samples)
+    ad, session = _synth_ready_adapter([base + 1, base + 2, eos], vocoder=vocoder)
+    result = ad.synthesize(_req(), session)
+
+    assert result.audio.dtype == np.float32
+    assert result.audio.shape == (n_samples,)
+    assert result.audio.min() >= -1.0 and result.audio.max() <= 1.0
+
+    chunk = AudioChunk(sample_rate=SAMPLE_RATE, sample_width=2, sample_channels=1,
+                       audio_float_array=result.audio)
+    assert chunk.audio_int16_array.dtype == np.int16
+    assert chunk.audio_int16_array.shape == (n_samples,)
+    assert len(chunk.audio_int16_bytes) == n_samples * 2
+
+
+def test_synthesize_filters_out_non_semantic_token_ids_before_the_vocoder():
+    # a malformed/garbage LM output: ids outside the semantic codebook window (control
+    # tokens, global-token ids, or plain out-of-range garbage) must never reach the vocoder
+    base = SPECIAL["<|bicodec_semantic_0|>"]
+    eos = SPECIAL["<|im_end|>"]
+    garbage_below = base - 1                       # just under the semantic window
+    garbage_above = base + SEMANTIC_CODEBOOK        # just at/over the semantic window
+    control_token = SPECIAL["<|start_content|>"]    # a real control id, not semantic at all
+    raw = [garbage_below, base + 42, garbage_above, control_token, eos]
+    ad, session = _synth_ready_adapter(raw)
+    result = ad.synthesize(_req(), session)
+
+    feed = ad.vocoder.calls[0]
+    assert feed["semantic_tokens"].tolist() == [[42]]   # only the one valid token survives
+    assert result.extras == {"semantic_token_count": 1}
+
+
+def test_synthesize_returns_silence_when_nothing_survives_the_filter_and_skips_the_vocoder():
+    base = SPECIAL["<|bicodec_semantic_0|>"]
+    eos = SPECIAL["<|im_end|>"]
+    ad, session = _synth_ready_adapter([SPECIAL["<|start_content|>"], eos])  # no semantic ids at all
+    result = ad.synthesize(_req(), session)
+
+    assert result.audio.shape == (0,)
+    assert result.audio.dtype == np.float32
+    assert ad.vocoder.calls == []  # vocoder must never be called with an empty token list

--- a/tests/test_sparktts.py
+++ b/tests/test_sparktts.py
@@ -237,6 +237,30 @@ def test_speaker_tokens_asset_accepts_a_bare_list(tmp_path):
     assert SparkTTSAdapter._load_speaker_tokens(str(path)).size == N_GLOBAL_TOKENS
 
 
+def test_speaker_tokens_asset_rejects_out_of_range_codes(tmp_path):
+    path = tmp_path / "v.json"
+    path.write_text(json.dumps({"global_tokens": [9999] * N_GLOBAL_TOKENS}))
+    with pytest.raises(ValueError):
+        SparkTTSAdapter._load_speaker_tokens(str(path))
+
+
+def test_reference_encoding_is_reused_across_chunks():
+    ad = _adapter()
+    calls = []
+
+    class _Sess:
+        def run(self, _, feed):
+            calls.append(1)
+            return [np.zeros((1, 1, N_GLOBAL_TOKENS), np.int64)]
+
+    ad.speaker_tokenizer = _Sess()
+    audio = np.sin(np.linspace(0, 200, 16000)).astype(np.float32)
+    req = _req(reference_audio=(audio, 16000))
+    ad._resolve_speaker(req)
+    ad._resolve_speaker(req)
+    assert len(calls) == 1
+
+
 def test_synthesize_requires_the_vocoder():
     with pytest.raises(RuntimeError):
         SparkTTSAdapter().synthesize(_req(), None)

--- a/tests/test_sparktts.py
+++ b/tests/test_sparktts.py
@@ -159,6 +159,26 @@ def test_encode_text_uses_the_models_own_bpe():
     assert ad.encode_text("hi!", None, None) == [[ord("h"), ord("i"), ord("!")]]
 
 
+def test_encode_text_tokenizes_the_reference_transcription_with_the_same_bpe():
+    # the transcription is text for this model, so it must not come from the shared
+    # phonemizer path (whose prompt_tokens are phoneme ids for ZipVoice-style engines)
+    ad = _adapter()
+
+    class _Bpe:
+        def tokenize(self, text):
+            return [ord(c) for c in text]
+
+    class _Syn:
+        speaker_reference_text = "ab"
+
+    ad.tokenizer = _Bpe()
+    ad.encode_text("hi", None, _Syn())
+    assert ad._reference_text_ids == [ord("a"), ord("b")]
+    # a later call without a transcription clears it, so a stale reference never leaks
+    ad.encode_text("hi", None, None)
+    assert ad._reference_text_ids is None
+
+
 def test_encode_text_without_a_tokenizer_is_an_error():
     with pytest.raises(RuntimeError):
         SparkTTSAdapter().encode_text("hi", None, None)

--- a/tests/test_sparktts.py
+++ b/tests/test_sparktts.py
@@ -1,0 +1,293 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.sparktts import (
+    N_GLOBAL_TOKENS,
+    REF_SEGMENT_SAMPLES,
+    SparkTTSAdapter,
+    chunk_text,
+    magnitude_spectrogram,
+    reference_clip,
+    sample_token,
+    volume_normalize,
+)
+
+SPECIAL = {
+    "<|task_tts|>": 1000,
+    "<|start_content|>": 1001,
+    "<|end_content|>": 1002,
+    "<|start_global_token|>": 1003,
+    "<|end_global_token|>": 1004,
+    "<|start_semantic_token|>": 1005,
+    "<|im_end|>": 1006,
+    "<|bicodec_global_0|>": 2000,
+    "<|bicodec_semantic_0|>": 3000,
+}
+
+
+def _req(**params):
+    return AdapterSynthesisRequest(phoneme_ids=np.array([[7, 8, 9]], np.int64),
+                                   phoneme_lengths=np.array([3], np.int64),
+                                   speaker_id=0, language_id=0, params=params)
+
+
+def _adapter():
+    ad = SparkTTSAdapter()
+    ad.special = dict(SPECIAL)
+    return ad
+
+
+def test_sparktts_registered():
+    from phoonnx.engines import list_engines
+    assert "sparktts" in list_engines()
+
+
+def test_sparktts_detect():
+    assert SparkTTSAdapter.detect({"engine": "sparktts"})
+    assert not SparkTTSAdapter.detect({"engine": "chatterbox"})
+    assert not SparkTTSAdapter.detect(None)
+
+
+def test_default_params_match_upstream():
+    # upstream SparkTTS.inference: temperature 0.8, top_k 50, top_p 0.95, no repetition penalty
+    assert SparkTTSAdapter().default_params() == {"temperature": 0.8, "top_k": 50.0, "top_p": 0.95}
+
+
+def test_engine_enum_and_config_alphabet():
+    from phoonnx.config import Alphabet, Engine, VoiceConfig
+    cfg = VoiceConfig.from_dict({"engine": "sparktts"}, engine=Engine.SPARKTTS, lang_code="en-US")
+    # graphemes routes text->ids through the adapter, never through a phonemizer
+    assert cfg.engine == Engine.SPARKTTS
+    assert cfg.alphabet == Alphabet.GRAPHEMES
+    assert cfg.sample_rate == 16000
+
+
+# ----------------------------------------------------------------------
+# sampler
+# ----------------------------------------------------------------------
+
+def test_sample_token_greedy_at_zero_temperature():
+    logits = np.array([1.0, 9.0, 2.0])
+    assert sample_token(logits, 0.0, 50, 0.95, np.random.default_rng(0)) == 1
+
+
+def test_sample_token_top_k_one_is_argmax():
+    logits = np.array([3.0, 1.0, 2.9])
+    rng = np.random.default_rng(0)
+    assert all(sample_token(logits, 1.0, 1, 1.0, rng) == 0 for _ in range(5))
+
+
+def test_sample_token_top_p_drops_the_tail():
+    # token 0 alone already covers > 0.9 of the mass, so nothing else can be drawn
+    logits = np.array([12.0, 0.0, -3.0, 0.5])
+    rng = np.random.default_rng(0)
+    assert all(sample_token(logits, 1.0, 50, 0.9, rng) == 0 for _ in range(5))
+
+
+def test_sample_token_top_k_applied_before_top_p():
+    # HF order is temperature -> top_k -> top_p. With k=2 the third token is gone even
+    # though a top_p-first nucleus of 0.99 would have kept it.
+    logits = np.array([2.0, 1.9, 1.8])
+    rng = np.random.default_rng(1)
+    assert {sample_token(logits, 1.0, 2, 0.99, rng) for _ in range(60)} == {0, 1}
+
+
+# ----------------------------------------------------------------------
+# audio front end
+# ----------------------------------------------------------------------
+
+def test_volume_normalize_scales_a_quiet_clip_up():
+    quiet = (np.sin(np.linspace(0, 100, 4000)) * 0.02).astype(np.float32)
+    out = volume_normalize(quiet)
+    assert np.abs(out).max() > np.abs(quiet).max()
+    assert np.abs(out).max() <= 1.0
+
+
+def test_volume_normalize_never_clips():
+    loud = (np.sin(np.linspace(0, 100, 4000)) * 4.0).astype(np.float32)
+    assert np.abs(volume_normalize(loud)).max() <= 1.0
+
+
+def test_reference_clip_repeats_short_and_truncates_long():
+    short = np.arange(1000, dtype=np.float32)
+    assert reference_clip(short).shape == (REF_SEGMENT_SAMPLES,)
+    long = np.zeros(REF_SEGMENT_SAMPLES * 2, np.float32)
+    assert reference_clip(long).shape == (REF_SEGMENT_SAMPLES,)
+
+
+def test_reference_clip_rejects_empty():
+    with pytest.raises(ValueError):
+        reference_clip(np.zeros(0, np.float32))
+
+
+def test_magnitude_spectrogram_layout():
+    wav = np.random.default_rng(0).standard_normal(16000).astype(np.float32)
+    spec = magnitude_spectrogram(wav)
+    # centred STFT: 1 + n // hop frames, 1 + n_fft // 2 bins, real and non-negative
+    assert spec.shape == (1, 513, 1 + 16000 // 320)
+    assert spec.dtype == np.float32
+    assert (spec >= 0).all()
+
+
+# ----------------------------------------------------------------------
+# text
+# ----------------------------------------------------------------------
+
+def test_chunk_text_packs_sentences_under_the_cap():
+    text = " ".join(["This is a sentence of a reasonable length."] * 20)
+    chunks = chunk_text(text, max_len=100)
+    assert len(chunks) > 1
+    assert all(len(c) <= 100 or " " not in c for c in chunks)
+
+
+def test_chunk_text_keeps_a_single_short_sentence_whole():
+    assert chunk_text("Hello there.") == ["Hello there."]
+
+
+def test_encode_text_uses_the_models_own_bpe():
+    ad = _adapter()
+
+    class _Bpe:
+        def tokenize(self, text):
+            return [ord(c) for c in text]
+
+    ad.tokenizer = _Bpe()
+    assert ad.encode_text("hi!", None, None) == [[ord("h"), ord("i"), ord("!")]]
+
+
+def test_encode_text_without_a_tokenizer_is_an_error():
+    with pytest.raises(RuntimeError):
+        SparkTTSAdapter().encode_text("hi", None, None)
+
+
+# ----------------------------------------------------------------------
+# prompt
+# ----------------------------------------------------------------------
+
+def test_build_prompt_bare_layout():
+    ad = _adapter()
+    globals_ = np.arange(N_GLOBAL_TOKENS, dtype=np.int64)
+    prompt = ad.build_prompt([7, 8], globals_)[0].tolist()
+    assert prompt[:2] == [1000, 1001]
+    assert prompt[2:4] == [7, 8]
+    assert prompt[4:6] == [1002, 1003]
+    assert prompt[6:6 + N_GLOBAL_TOKENS] == [2000 + i for i in range(N_GLOBAL_TOKENS)]
+    assert prompt[-1] == 1004
+    assert 1005 not in prompt          # no semantic section without a transcription
+
+
+def test_build_prompt_in_context_layout():
+    ad = _adapter()
+    globals_ = np.zeros(N_GLOBAL_TOKENS, np.int64)
+    prompt = ad.build_prompt([7], globals_, prompt_text_ids=[41, 42],
+                             prompt_semantic=np.array([5, 6]))[0].tolist()
+    # the reference transcription comes first, then the text to speak
+    assert prompt[2:5] == [41, 42, 7]
+    assert prompt[-3:] == [1005, 3005, 3006]
+
+
+def test_build_prompt_ignores_semantics_without_a_transcription():
+    ad = _adapter()
+    prompt = ad.build_prompt([7], np.zeros(N_GLOBAL_TOKENS, np.int64),
+                             prompt_semantic=np.array([5]))[0].tolist()
+    assert 1005 not in prompt
+
+
+# ----------------------------------------------------------------------
+# speaker resolution / guards
+# ----------------------------------------------------------------------
+
+def test_speaker_tokens_asset_must_hold_32_tokens(tmp_path):
+    good = tmp_path / "v.json"
+    good.write_text(json.dumps({"global_tokens": list(range(N_GLOBAL_TOKENS))}))
+    assert SparkTTSAdapter._load_speaker_tokens(str(good)).tolist() == list(range(N_GLOBAL_TOKENS))
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"global_tokens": [1, 2, 3]}))
+    with pytest.raises(ValueError):
+        SparkTTSAdapter._load_speaker_tokens(str(bad))
+
+
+def test_speaker_tokens_asset_accepts_a_bare_list(tmp_path):
+    path = tmp_path / "v.json"
+    path.write_text(json.dumps(list(range(N_GLOBAL_TOKENS))))
+    assert SparkTTSAdapter._load_speaker_tokens(str(path)).size == N_GLOBAL_TOKENS
+
+
+def test_synthesize_requires_the_vocoder():
+    with pytest.raises(RuntimeError):
+        SparkTTSAdapter().synthesize(_req(), None)
+
+
+def test_synthesize_requires_a_speaker():
+    ad = _adapter()
+    ad.vocoder = object()
+    ad.tokenizer = object()
+    with pytest.raises(RuntimeError):      # neither preset nor reference clip
+        ad.synthesize(_req(), None)
+
+
+def test_cloning_without_the_speaker_graph_is_an_error():
+    ad = _adapter()
+    with pytest.raises(RuntimeError):
+        ad.tokenize_reference(np.zeros(16000, np.float32), 16000)
+
+
+def test_in_context_cloning_needs_the_semantic_graphs():
+    ad = _adapter()
+
+    class _Sess:
+        def run(self, _, feed):
+            return [np.zeros((1, 1, N_GLOBAL_TOKENS), np.int64)]
+
+    ad.speaker_tokenizer = _Sess()
+    audio = np.sin(np.linspace(0, 200, 16000)).astype(np.float32)
+    # the speaker stream alone works without the wav2vec2 front end
+    globals_, semantic = ad.tokenize_reference(audio, 16000)
+    assert globals_.size == N_GLOBAL_TOKENS and semantic is None
+    with pytest.raises(RuntimeError):
+        ad.tokenize_reference(audio, 16000, with_semantic=True)
+
+
+def test_adapter_is_not_a_single_graph_engine():
+    ad = SparkTTSAdapter()
+    with pytest.raises(NotImplementedError):
+        ad.build_feed_dict(_req(), None)
+    with pytest.raises(NotImplementedError):
+        ad.parse_outputs([], _req())
+
+
+# ----------------------------------------------------------------------
+# voice index
+# ----------------------------------------------------------------------
+
+def test_voice_index_entries():
+    import phoonnx
+    from phoonnx.model_manager import TTSModelInfo
+
+    index = json.loads((Path(phoonnx.__file__).parent / "voice_index" /
+                        "sparktts.json").read_text())
+    assert set(index) == {"sparktts/female/en", "sparktts/male/en",
+                          "sparktts/female/zh", "sparktts/male/zh"}
+    for vid, entry in index.items():
+        info = TTSModelInfo(**entry)
+        assert info.engine == "sparktts"
+        assert info.alphabet == "graphemes"
+        aux = entry["aux_model_urls"]
+        # every graph the adapter loads in configure() must be published
+        assert set(aux) == {"vocoder_path", "wav2vec2_path", "speaker_tokenizer_path",
+                            "semantic_tokenizer_path", "bpe_tokenizer_path",
+                            "speaker_tokens_path"}
+        for url in list(aux.values()) + [entry["model_url"]]:
+            assert url.startswith("https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts/")
+        # each voice must point at its own speaker asset, not a shared one
+        gender, short = vid.split("/")[1:]
+        assert aux["speaker_tokens_path"].endswith(f"/voices/{gender}_{short}.json")
+
+
+def test_voice_index_is_merged_by_the_manager():
+    from phoonnx.model_manager import TTSModelManager
+    assert any(p.name == "sparktts.json" for p in TTSModelManager.voice_index_files())


### PR DESCRIPTION
Adds `sparktts`, an inference adapter for [Spark-TTS 0.5B](https://github.com/SparkAudio/Spark-TTS)
(SparkAudio), with four bundled voices in English and Mandarin, zero-shot cloning, docs
and tests.

## What it is

Spark-TTS is a decoder-only language model on a Qwen2.5-0.5B backbone. It does not
predict audio. It predicts **BiCodec** tokens, and BiCodec turns those into a waveform.
BiCodec keeps two streams: 32 **global** tokens that carry the speaker, and one
**semantic** stream at 50 Hz that carries what is said. The language model reads a prompt
of control tokens, the text and the 32 global tokens, then writes the semantic stream.

This is the second autoregressive codec-LM engine in phoonnx, after Chatterbox, and it
follows the same shape: it overrides `BaseOnnxAdapter.synthesize` and reads its KV-cache
layout from the language model's own input signature. What is new is that a voice can
carry its speaker as 32 numbers, so a preset voice runs with no reference clip at all.

## Architecture

```
text ─► BPE ─► content ids ─┐
speaker: 32 global tokens ──┤
                            ▼
              prompt = task + content + speaker
                            ▼
     model.onnx (Qwen2, KV-cached) ──loop──► semantic tokens
                            ▼
     bicodec_vocoder.onnx(semantic, global) ─► wav @ 16 kHz

cloning only:
  ref.wav@16k ─► |STFT| ─► speaker_encoder_tokenizer.onnx ─► 32 global tokens
  ref.wav@16k ─► wav2vec2_model.onnx ─► bicodec_encoder_quantizer.onnx ─► semantic tokens
```

### IO contracts

| Graph | Inputs | Outputs |
| :--- | :--- | :--- |
| `model.onnx` | `input_ids` `[1,S]`, `attention_mask` `[1,P+S]`, `position_ids` `[1,S]`, `past_key_values.{0..23}.{key,value}` `[1,2,P,64]` | `logits` `[1,S,166000]`, `present.{0..23}.{key,value}` |
| `bicodec_vocoder.onnx` | `semantic_tokens` `[1,T]` int64, `global_tokens` `[1,1,32]` int64 | `[1,1,N]` float32 @ 16 kHz |
| `speaker_encoder_tokenizer.onnx` | `spec` `[1,513,T]` float32 | `global_tokens` `[1,1,32]` int64 |
| `wav2vec2_model.onnx` | `wav` `[1,N]` float32 | `feat` `[1,T,1024]` float32 |
| `bicodec_encoder_quantizer.onnx` | `feat` `[1,T,1024]` float32 | `semantic_tokens` `[1,T]` int64 |

The three cloning graphs open on first use, so a preset voice never pays for the 860 MB
wav2vec2 front end.

The STFT in front of the speaker encoder stays outside the graphs: ONNX has no complex
dtype, so neither torch exporter can lower `torch.stft`. The mel filterbank projection
*is* inside `speaker_encoder_tokenizer.onnx`, so the runtime only reimplements a plain
real-valued magnitude spectrogram — and that matches torchaudio to 4.8e-7.

## Sampler

Verified against upstream rather than assumed. Spark-TTS generates with HuggingFace
`generate(do_sample=True, top_k=50, top_p=0.95, temperature=0.8, max_new_tokens=3000)`
and its `generation_config.json` sets no repetition penalty. So the adapter applies the
warpers in HuggingFace's build order — temperature, then top-k, then top-p — and applies
**no** repetition penalty. Chatterbox needs one; Spark-TTS does not, and adding one would
suppress the repeated codec tokens that normal speech contains.

## Parity against the torch model

The four BiCodec/wav2vec2 graphs were exported here at opset 17 from
`SparkAudio/Spark-TTS-0.5B`. The language model is mirrored from
`Fhrozen/Spark-TTS-0.5B-ONNX` and was verified against the SparkAudio torch weights on a
fixed control-mode prompt (18 tokens), over the real 165158-token vocabulary:

| Stage | Metric | Result |
| :--- | :--- | :--- |
| LM prefill (fp32) | max abs logit diff | **1.27e-3** |
| LM prefill (fp32) | argmax agreement | match |
| LM decode, 8 KV-cached steps (fp32) | max abs logit diff | **6.64e-4** |
| LM decode, 8 KV-cached steps (fp32) | greedy token agreement | **8/8** |
| Speaker tokenizer | token mismatches | **0/32** |
| Encoder + quantizer | token mismatches | **0/149** |
| BiCodec vocoder | max abs waveform diff | **1.15e-6** |
| Magnitude STFT (NumPy vs torchaudio) | max abs diff | **4.77e-7** |
| wav2vec2 features (real clip) | max relative diff | **1.80e-5** |
| wav2vec2 features (real clip) | RMS relative diff | **8.64e-6** |
| wav2vec2 → quantizer, end to end | semantic token mismatches | **0/199** |

The wav2vec2 stage is the only one with a visible absolute gap (1.07e-2 on hidden states
whose own scale is around 600), which is float32 accumulation order, not a conversion
error. Running the ONNX features through the quantizer gives byte-identical semantic
tokens, so nothing reaches the audio.

**The quantized language models published upstream are not usable and are not mirrored.**
Measured on the same prompt and vocabulary:

| Flavor | prefill max abs logit diff | decode max abs diff | greedy agreement |
| :--- | ---: | ---: | :--- |
| fp32 | 1.27e-3 | 6.64e-4 | 8/8 |
| q4 | 103.2 | 51.1 | 4/8 |
| q4f16 | 103.2 | 51.0 | 4/8 |
| int8 | 111.1 | 105.4 | 0/8 |

## ASR gate

Every sample was transcribed with `onnx-asr` (`whisper-base`, CPU) and scored against its
input text — WER for English, CER for Mandarin, both after normalization.

| Sample | Lang | Metric | Score | Reference | Hypothesis |
| :--- | :--- | :--- | ---: | :--- | :--- |
| `female_en` | en | WER | **0.0 %** | The morning train was delayed again, so she walked the last two kilometres to work. | The morning train was delayed again, so she walked the last two kilometres to work. |
| `male_en` | en | WER | **0.0 %** | The city council refused the demonstrators a permit because they feared violence. | The city council refused the demonstrators a permit because they feared violence. |
| `female_zh` | zh | CER | **6.2 %** | 今天天气很好，我们一起去公园散步吧。 | 今天天气很好我们一起去公人散步吧 |
| `male_zh` | zh | CER | **0.0 %** | 这是一个用于测试的中文句子。 | 这是一个用于测试的中文句子 |
| `clone_en` (zero-shot clone) | en | WER | **0.0 %** | This sentence is spoken in a cloned voice, taken from a short reference clip. | This sentence is spoken in a cloned voice, taken from a short reference clip. |

Worst case 6.2 %, well inside the 30 % gate. The single Mandarin error is one character
(园 heard as 人) from a `whisper-base` model, not an audible defect.

## Speed

CPU, 16 cores, float32 language model, excluding model load:

| Sample | Audio | Synthesis | RTF |
| :--- | ---: | ---: | ---: |
| `female_en` | 4.66 s | 49.1 s | 10.5 |
| `male_en` | 4.88 s | 29.6 s | 6.1 |
| `female_zh` | 3.48 s | 21.3 s | 6.1 |
| `male_zh` | 2.60 s | 15.7 s | 6.0 |
| `clone_en` | 4.26 s | 39.6 s | 9.3 |
| `mirror_male_zh` (from the published mirror) | 3.18 s | 18.6 s | 5.8 |

RTF around 6 is the steady state; the higher figures are runs that competed with other
work on the same box. This engine is slow by design: one token is one pass through the
language model, and one second of speech is 50 tokens.

## Voices

Four preset voices, minted with Spark-TTS's controllable mode (gender, moderate pitch,
moderate speed) and then frozen so each voice is stable across calls:

`sparktts/female/en`, `sparktts/male/en`, `sparktts/female/zh`, `sparktts/male/zh`.

Cloning uses the existing `SynthesisConfig.speaker_reference` API. Adding
`speaker_reference_text` selects the in-context variant, which also feeds the clip's own
semantic tokens to the model.

## Weights

Mirrored to [`OpenVoiceOS/phoonnx-spark-tts`](https://huggingface.co/OpenVoiceOS/phoonnx-spark-tts).
The card carries the IO table, the parity numbers and upstream attribution.

`sparktts/male/zh` was downloaded from that mirror through `TTSModelManager` on a clean
cache and synthesized end to end — 3.2 GB fetched, RTF 5.8. Its transcription scores
28.6 % CER, but every difference is a Simplified/Traditional glyph pair (这/這, 过/過,
载/載, 语/語): the two strings align character for character and read identically.

## Test suite

Run against the same environment twice, `origin/dev` first and this branch second, so the
numbers are comparable:

| Run | passed | failed | collection errors |
| :--- | ---: | ---: | ---: |
| `origin/dev` | 1305 | 90 | 9 |
| `feat/spark-tts` | 1337 | 90 | 9 |

Same failures and same collection errors before and after — they come from optional
dependencies missing in that environment, not from this change. The 32 extra passing
tests are the new Spark-TTS ones.

## Shared code

The diff is additive: a new engine module, a new voice index, tests, docs, and one enum
value plus registration lines. One rough edge is worked around rather than refactored:
`TTSVoice` builds `prompt_tokens` for a cloning transcription with the voice's
phonemizer, which suits the phoneme-based in-context engines but produces nothing usable
for a text-token model. The adapter therefore tokenizes the transcription itself in
`encode_text`, using the model's own BPE. A follow-up could let a text-token engine own
that step in the shared path.

## License

Spark-TTS 0.5B is released by SparkAudio under CC-BY-NC-SA-4.0; the upstream code is
Apache-2.0. The mirror redistributes converted weights under the same terms and adds no
license of its own. The docs page and the model card both say so.

---

Written by Claude Opus under Fable orchestration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spark-TTS as a supported text-to-speech engine.
  * Added English and Mandarin preset voices, including female and male options.
  * Added zero-shot voice cloning with optional reference audio and text.
  * Added audio processing, sampling, text chunking, and model configuration support.

* **Documentation**
  * Added Spark-TTS setup, configuration, engine, cloning, and training documentation.
  * Updated supported voice counts and bundled voice source listings.

* **Tests**
  * Added comprehensive coverage for Spark-TTS registration, synthesis, cloning, configuration, and audio handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->