### PR TITLE
fix: point supertonic voice index at the OpenVoiceOS mirror

### DIFF
--- a/phoonnx/voice_index/supertonic.json
+++ b/phoonnx/voice_index/supertonic.json
@@ -1,7 +1,7 @@
 {
     "supertonic/F1/en": {
         "voice_id": "supertonic/F1/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -12,18 +12,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/ko": {
         "voice_id": "supertonic/F1/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -34,18 +34,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/ja": {
         "voice_id": "supertonic/F1/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -56,18 +56,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/ar": {
         "voice_id": "supertonic/F1/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -78,18 +78,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/bg": {
         "voice_id": "supertonic/F1/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -100,18 +100,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/cs": {
         "voice_id": "supertonic/F1/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -122,18 +122,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/da": {
         "voice_id": "supertonic/F1/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -144,18 +144,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/de": {
         "voice_id": "supertonic/F1/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -166,18 +166,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/el": {
         "voice_id": "supertonic/F1/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -188,18 +188,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/es": {
         "voice_id": "supertonic/F1/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -210,18 +210,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/et": {
         "voice_id": "supertonic/F1/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -232,18 +232,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/fi": {
         "voice_id": "supertonic/F1/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -254,18 +254,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/fr": {
         "voice_id": "supertonic/F1/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -276,18 +276,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/hi": {
         "voice_id": "supertonic/F1/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -298,18 +298,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/hr": {
         "voice_id": "supertonic/F1/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -320,18 +320,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/hu": {
         "voice_id": "supertonic/F1/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -342,18 +342,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/id": {
         "voice_id": "supertonic/F1/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -364,18 +364,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/it": {
         "voice_id": "supertonic/F1/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -386,18 +386,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/lt": {
         "voice_id": "supertonic/F1/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -408,18 +408,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/lv": {
         "voice_id": "supertonic/F1/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -430,18 +430,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/nl": {
         "voice_id": "supertonic/F1/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -452,18 +452,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/pl": {
         "voice_id": "supertonic/F1/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -474,18 +474,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/pt": {
         "voice_id": "supertonic/F1/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -496,18 +496,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/ro": {
         "voice_id": "supertonic/F1/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -518,18 +518,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/ru": {
         "voice_id": "supertonic/F1/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -540,18 +540,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/sk": {
         "voice_id": "supertonic/F1/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -562,18 +562,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/sl": {
         "voice_id": "supertonic/F1/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -584,18 +584,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/sv": {
         "voice_id": "supertonic/F1/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -606,18 +606,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/tr": {
         "voice_id": "supertonic/F1/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -628,18 +628,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/uk": {
         "voice_id": "supertonic/F1/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -650,18 +650,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F1/vi": {
         "voice_id": "supertonic/F1/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -672,18 +672,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F1.json"
         },
         "display_name": "SuperTonic F1"
     },
     "supertonic/F2/en": {
         "voice_id": "supertonic/F2/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -694,18 +694,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/ko": {
         "voice_id": "supertonic/F2/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -716,18 +716,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/ja": {
         "voice_id": "supertonic/F2/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -738,18 +738,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/ar": {
         "voice_id": "supertonic/F2/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -760,18 +760,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/bg": {
         "voice_id": "supertonic/F2/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -782,18 +782,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/cs": {
         "voice_id": "supertonic/F2/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -804,18 +804,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/da": {
         "voice_id": "supertonic/F2/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -826,18 +826,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/de": {
         "voice_id": "supertonic/F2/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -848,18 +848,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/el": {
         "voice_id": "supertonic/F2/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -870,18 +870,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/es": {
         "voice_id": "supertonic/F2/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -892,18 +892,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/et": {
         "voice_id": "supertonic/F2/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -914,18 +914,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/fi": {
         "voice_id": "supertonic/F2/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -936,18 +936,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/fr": {
         "voice_id": "supertonic/F2/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -958,18 +958,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/hi": {
         "voice_id": "supertonic/F2/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -980,18 +980,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/hr": {
         "voice_id": "supertonic/F2/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1002,18 +1002,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/hu": {
         "voice_id": "supertonic/F2/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1024,18 +1024,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/id": {
         "voice_id": "supertonic/F2/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1046,18 +1046,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/it": {
         "voice_id": "supertonic/F2/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1068,18 +1068,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/lt": {
         "voice_id": "supertonic/F2/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1090,18 +1090,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/lv": {
         "voice_id": "supertonic/F2/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1112,18 +1112,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/nl": {
         "voice_id": "supertonic/F2/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1134,18 +1134,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/pl": {
         "voice_id": "supertonic/F2/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1156,18 +1156,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/pt": {
         "voice_id": "supertonic/F2/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1178,18 +1178,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/ro": {
         "voice_id": "supertonic/F2/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1200,18 +1200,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/ru": {
         "voice_id": "supertonic/F2/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1222,18 +1222,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/sk": {
         "voice_id": "supertonic/F2/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1244,18 +1244,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/sl": {
         "voice_id": "supertonic/F2/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1266,18 +1266,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/sv": {
         "voice_id": "supertonic/F2/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1288,18 +1288,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/tr": {
         "voice_id": "supertonic/F2/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1310,18 +1310,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/uk": {
         "voice_id": "supertonic/F2/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1332,18 +1332,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F2/vi": {
         "voice_id": "supertonic/F2/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1354,18 +1354,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F2.json"
         },
         "display_name": "SuperTonic F2"
     },
     "supertonic/F3/en": {
         "voice_id": "supertonic/F3/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1376,18 +1376,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/ko": {
         "voice_id": "supertonic/F3/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1398,18 +1398,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/ja": {
         "voice_id": "supertonic/F3/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1420,18 +1420,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/ar": {
         "voice_id": "supertonic/F3/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1442,18 +1442,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/bg": {
         "voice_id": "supertonic/F3/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1464,18 +1464,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/cs": {
         "voice_id": "supertonic/F3/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1486,18 +1486,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/da": {
         "voice_id": "supertonic/F3/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1508,18 +1508,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/de": {
         "voice_id": "supertonic/F3/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1530,18 +1530,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/el": {
         "voice_id": "supertonic/F3/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1552,18 +1552,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/es": {
         "voice_id": "supertonic/F3/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1574,18 +1574,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/et": {
         "voice_id": "supertonic/F3/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1596,18 +1596,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/fi": {
         "voice_id": "supertonic/F3/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1618,18 +1618,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/fr": {
         "voice_id": "supertonic/F3/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1640,18 +1640,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/hi": {
         "voice_id": "supertonic/F3/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1662,18 +1662,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/hr": {
         "voice_id": "supertonic/F3/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1684,18 +1684,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/hu": {
         "voice_id": "supertonic/F3/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1706,18 +1706,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/id": {
         "voice_id": "supertonic/F3/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1728,18 +1728,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/it": {
         "voice_id": "supertonic/F3/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1750,18 +1750,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/lt": {
         "voice_id": "supertonic/F3/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1772,18 +1772,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/lv": {
         "voice_id": "supertonic/F3/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1794,18 +1794,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/nl": {
         "voice_id": "supertonic/F3/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1816,18 +1816,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/pl": {
         "voice_id": "supertonic/F3/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1838,18 +1838,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/pt": {
         "voice_id": "supertonic/F3/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1860,18 +1860,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/ro": {
         "voice_id": "supertonic/F3/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1882,18 +1882,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/ru": {
         "voice_id": "supertonic/F3/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1904,18 +1904,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/sk": {
         "voice_id": "supertonic/F3/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1926,18 +1926,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/sl": {
         "voice_id": "supertonic/F3/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1948,18 +1948,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/sv": {
         "voice_id": "supertonic/F3/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1970,18 +1970,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/tr": {
         "voice_id": "supertonic/F3/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -1992,18 +1992,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/uk": {
         "voice_id": "supertonic/F3/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2014,18 +2014,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F3/vi": {
         "voice_id": "supertonic/F3/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2036,18 +2036,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F3.json"
         },
         "display_name": "SuperTonic F3"
     },
     "supertonic/F4/en": {
         "voice_id": "supertonic/F4/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2058,18 +2058,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/ko": {
         "voice_id": "supertonic/F4/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2080,18 +2080,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/ja": {
         "voice_id": "supertonic/F4/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2102,18 +2102,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/ar": {
         "voice_id": "supertonic/F4/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2124,18 +2124,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/bg": {
         "voice_id": "supertonic/F4/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2146,18 +2146,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/cs": {
         "voice_id": "supertonic/F4/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2168,18 +2168,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/da": {
         "voice_id": "supertonic/F4/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2190,18 +2190,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/de": {
         "voice_id": "supertonic/F4/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2212,18 +2212,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/el": {
         "voice_id": "supertonic/F4/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2234,18 +2234,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/es": {
         "voice_id": "supertonic/F4/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2256,18 +2256,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/et": {
         "voice_id": "supertonic/F4/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2278,18 +2278,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/fi": {
         "voice_id": "supertonic/F4/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2300,18 +2300,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/fr": {
         "voice_id": "supertonic/F4/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2322,18 +2322,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/hi": {
         "voice_id": "supertonic/F4/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2344,18 +2344,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/hr": {
         "voice_id": "supertonic/F4/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2366,18 +2366,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/hu": {
         "voice_id": "supertonic/F4/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2388,18 +2388,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/id": {
         "voice_id": "supertonic/F4/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2410,18 +2410,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/it": {
         "voice_id": "supertonic/F4/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2432,18 +2432,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/lt": {
         "voice_id": "supertonic/F4/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2454,18 +2454,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/lv": {
         "voice_id": "supertonic/F4/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2476,18 +2476,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/nl": {
         "voice_id": "supertonic/F4/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2498,18 +2498,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/pl": {
         "voice_id": "supertonic/F4/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2520,18 +2520,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/pt": {
         "voice_id": "supertonic/F4/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2542,18 +2542,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/ro": {
         "voice_id": "supertonic/F4/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2564,18 +2564,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/ru": {
         "voice_id": "supertonic/F4/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2586,18 +2586,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/sk": {
         "voice_id": "supertonic/F4/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2608,18 +2608,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/sl": {
         "voice_id": "supertonic/F4/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2630,18 +2630,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/sv": {
         "voice_id": "supertonic/F4/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2652,18 +2652,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/tr": {
         "voice_id": "supertonic/F4/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2674,18 +2674,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/uk": {
         "voice_id": "supertonic/F4/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2696,18 +2696,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F4/vi": {
         "voice_id": "supertonic/F4/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2718,18 +2718,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F4.json"
         },
         "display_name": "SuperTonic F4"
     },
     "supertonic/F5/en": {
         "voice_id": "supertonic/F5/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2740,18 +2740,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/ko": {
         "voice_id": "supertonic/F5/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2762,18 +2762,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/ja": {
         "voice_id": "supertonic/F5/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2784,18 +2784,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/ar": {
         "voice_id": "supertonic/F5/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2806,18 +2806,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/bg": {
         "voice_id": "supertonic/F5/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2828,18 +2828,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/cs": {
         "voice_id": "supertonic/F5/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2850,18 +2850,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/da": {
         "voice_id": "supertonic/F5/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2872,18 +2872,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/de": {
         "voice_id": "supertonic/F5/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2894,18 +2894,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/el": {
         "voice_id": "supertonic/F5/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2916,18 +2916,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/es": {
         "voice_id": "supertonic/F5/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2938,18 +2938,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/et": {
         "voice_id": "supertonic/F5/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2960,18 +2960,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/fi": {
         "voice_id": "supertonic/F5/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -2982,18 +2982,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/fr": {
         "voice_id": "supertonic/F5/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3004,18 +3004,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/hi": {
         "voice_id": "supertonic/F5/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3026,18 +3026,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/hr": {
         "voice_id": "supertonic/F5/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3048,18 +3048,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/hu": {
         "voice_id": "supertonic/F5/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3070,18 +3070,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/id": {
         "voice_id": "supertonic/F5/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3092,18 +3092,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/it": {
         "voice_id": "supertonic/F5/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3114,18 +3114,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/lt": {
         "voice_id": "supertonic/F5/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3136,18 +3136,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/lv": {
         "voice_id": "supertonic/F5/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3158,18 +3158,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/nl": {
         "voice_id": "supertonic/F5/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3180,18 +3180,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/pl": {
         "voice_id": "supertonic/F5/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3202,18 +3202,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/pt": {
         "voice_id": "supertonic/F5/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3224,18 +3224,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/ro": {
         "voice_id": "supertonic/F5/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3246,18 +3246,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/ru": {
         "voice_id": "supertonic/F5/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3268,18 +3268,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/sk": {
         "voice_id": "supertonic/F5/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3290,18 +3290,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/sl": {
         "voice_id": "supertonic/F5/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3312,18 +3312,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/sv": {
         "voice_id": "supertonic/F5/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3334,18 +3334,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/tr": {
         "voice_id": "supertonic/F5/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3356,18 +3356,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/uk": {
         "voice_id": "supertonic/F5/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3378,18 +3378,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/F5/vi": {
         "voice_id": "supertonic/F5/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3400,18 +3400,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/F5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/F5.json"
         },
         "display_name": "SuperTonic F5"
     },
     "supertonic/M1/en": {
         "voice_id": "supertonic/M1/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3422,18 +3422,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/ko": {
         "voice_id": "supertonic/M1/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3444,18 +3444,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/ja": {
         "voice_id": "supertonic/M1/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3466,18 +3466,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/ar": {
         "voice_id": "supertonic/M1/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3488,18 +3488,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/bg": {
         "voice_id": "supertonic/M1/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3510,18 +3510,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/cs": {
         "voice_id": "supertonic/M1/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3532,18 +3532,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/da": {
         "voice_id": "supertonic/M1/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3554,18 +3554,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/de": {
         "voice_id": "supertonic/M1/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3576,18 +3576,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/el": {
         "voice_id": "supertonic/M1/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3598,18 +3598,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/es": {
         "voice_id": "supertonic/M1/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3620,18 +3620,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/et": {
         "voice_id": "supertonic/M1/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3642,18 +3642,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/fi": {
         "voice_id": "supertonic/M1/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3664,18 +3664,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/fr": {
         "voice_id": "supertonic/M1/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3686,18 +3686,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/hi": {
         "voice_id": "supertonic/M1/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3708,18 +3708,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/hr": {
         "voice_id": "supertonic/M1/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3730,18 +3730,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/hu": {
         "voice_id": "supertonic/M1/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3752,18 +3752,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/id": {
         "voice_id": "supertonic/M1/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3774,18 +3774,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/it": {
         "voice_id": "supertonic/M1/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3796,18 +3796,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/lt": {
         "voice_id": "supertonic/M1/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3818,18 +3818,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/lv": {
         "voice_id": "supertonic/M1/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3840,18 +3840,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/nl": {
         "voice_id": "supertonic/M1/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3862,18 +3862,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/pl": {
         "voice_id": "supertonic/M1/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3884,18 +3884,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/pt": {
         "voice_id": "supertonic/M1/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3906,18 +3906,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/ro": {
         "voice_id": "supertonic/M1/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3928,18 +3928,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/ru": {
         "voice_id": "supertonic/M1/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3950,18 +3950,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/sk": {
         "voice_id": "supertonic/M1/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3972,18 +3972,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/sl": {
         "voice_id": "supertonic/M1/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -3994,18 +3994,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/sv": {
         "voice_id": "supertonic/M1/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4016,18 +4016,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/tr": {
         "voice_id": "supertonic/M1/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4038,18 +4038,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/uk": {
         "voice_id": "supertonic/M1/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4060,18 +4060,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M1/vi": {
         "voice_id": "supertonic/M1/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4082,18 +4082,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M1.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M1.json"
         },
         "display_name": "SuperTonic M1"
     },
     "supertonic/M2/en": {
         "voice_id": "supertonic/M2/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4104,18 +4104,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/ko": {
         "voice_id": "supertonic/M2/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4126,18 +4126,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/ja": {
         "voice_id": "supertonic/M2/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4148,18 +4148,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/ar": {
         "voice_id": "supertonic/M2/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4170,18 +4170,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/bg": {
         "voice_id": "supertonic/M2/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4192,18 +4192,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/cs": {
         "voice_id": "supertonic/M2/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4214,18 +4214,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/da": {
         "voice_id": "supertonic/M2/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4236,18 +4236,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/de": {
         "voice_id": "supertonic/M2/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4258,18 +4258,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/el": {
         "voice_id": "supertonic/M2/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4280,18 +4280,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/es": {
         "voice_id": "supertonic/M2/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4302,18 +4302,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/et": {
         "voice_id": "supertonic/M2/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4324,18 +4324,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/fi": {
         "voice_id": "supertonic/M2/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4346,18 +4346,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/fr": {
         "voice_id": "supertonic/M2/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4368,18 +4368,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/hi": {
         "voice_id": "supertonic/M2/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4390,18 +4390,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/hr": {
         "voice_id": "supertonic/M2/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4412,18 +4412,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/hu": {
         "voice_id": "supertonic/M2/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4434,18 +4434,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/id": {
         "voice_id": "supertonic/M2/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4456,18 +4456,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/it": {
         "voice_id": "supertonic/M2/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4478,18 +4478,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/lt": {
         "voice_id": "supertonic/M2/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4500,18 +4500,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/lv": {
         "voice_id": "supertonic/M2/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4522,18 +4522,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/nl": {
         "voice_id": "supertonic/M2/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4544,18 +4544,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/pl": {
         "voice_id": "supertonic/M2/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4566,18 +4566,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/pt": {
         "voice_id": "supertonic/M2/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4588,18 +4588,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/ro": {
         "voice_id": "supertonic/M2/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4610,18 +4610,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/ru": {
         "voice_id": "supertonic/M2/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4632,18 +4632,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/sk": {
         "voice_id": "supertonic/M2/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4654,18 +4654,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/sl": {
         "voice_id": "supertonic/M2/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4676,18 +4676,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/sv": {
         "voice_id": "supertonic/M2/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4698,18 +4698,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/tr": {
         "voice_id": "supertonic/M2/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4720,18 +4720,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/uk": {
         "voice_id": "supertonic/M2/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4742,18 +4742,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M2/vi": {
         "voice_id": "supertonic/M2/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4764,18 +4764,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M2.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M2.json"
         },
         "display_name": "SuperTonic M2"
     },
     "supertonic/M3/en": {
         "voice_id": "supertonic/M3/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4786,18 +4786,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/ko": {
         "voice_id": "supertonic/M3/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4808,18 +4808,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/ja": {
         "voice_id": "supertonic/M3/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4830,18 +4830,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/ar": {
         "voice_id": "supertonic/M3/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4852,18 +4852,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/bg": {
         "voice_id": "supertonic/M3/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4874,18 +4874,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/cs": {
         "voice_id": "supertonic/M3/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4896,18 +4896,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/da": {
         "voice_id": "supertonic/M3/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4918,18 +4918,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/de": {
         "voice_id": "supertonic/M3/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4940,18 +4940,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/el": {
         "voice_id": "supertonic/M3/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4962,18 +4962,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/es": {
         "voice_id": "supertonic/M3/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -4984,18 +4984,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/et": {
         "voice_id": "supertonic/M3/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5006,18 +5006,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/fi": {
         "voice_id": "supertonic/M3/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5028,18 +5028,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/fr": {
         "voice_id": "supertonic/M3/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5050,18 +5050,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/hi": {
         "voice_id": "supertonic/M3/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5072,18 +5072,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/hr": {
         "voice_id": "supertonic/M3/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5094,18 +5094,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/hu": {
         "voice_id": "supertonic/M3/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5116,18 +5116,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/id": {
         "voice_id": "supertonic/M3/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5138,18 +5138,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/it": {
         "voice_id": "supertonic/M3/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5160,18 +5160,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/lt": {
         "voice_id": "supertonic/M3/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5182,18 +5182,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/lv": {
         "voice_id": "supertonic/M3/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5204,18 +5204,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/nl": {
         "voice_id": "supertonic/M3/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5226,18 +5226,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/pl": {
         "voice_id": "supertonic/M3/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5248,18 +5248,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/pt": {
         "voice_id": "supertonic/M3/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5270,18 +5270,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/ro": {
         "voice_id": "supertonic/M3/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5292,18 +5292,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/ru": {
         "voice_id": "supertonic/M3/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5314,18 +5314,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/sk": {
         "voice_id": "supertonic/M3/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5336,18 +5336,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/sl": {
         "voice_id": "supertonic/M3/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5358,18 +5358,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/sv": {
         "voice_id": "supertonic/M3/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5380,18 +5380,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/tr": {
         "voice_id": "supertonic/M3/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5402,18 +5402,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/uk": {
         "voice_id": "supertonic/M3/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5424,18 +5424,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M3/vi": {
         "voice_id": "supertonic/M3/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5446,18 +5446,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M3.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M3.json"
         },
         "display_name": "SuperTonic M3"
     },
     "supertonic/M4/en": {
         "voice_id": "supertonic/M4/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5468,18 +5468,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/ko": {
         "voice_id": "supertonic/M4/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5490,18 +5490,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/ja": {
         "voice_id": "supertonic/M4/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5512,18 +5512,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/ar": {
         "voice_id": "supertonic/M4/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5534,18 +5534,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/bg": {
         "voice_id": "supertonic/M4/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5556,18 +5556,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/cs": {
         "voice_id": "supertonic/M4/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5578,18 +5578,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/da": {
         "voice_id": "supertonic/M4/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5600,18 +5600,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/de": {
         "voice_id": "supertonic/M4/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5622,18 +5622,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/el": {
         "voice_id": "supertonic/M4/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5644,18 +5644,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/es": {
         "voice_id": "supertonic/M4/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5666,18 +5666,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/et": {
         "voice_id": "supertonic/M4/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5688,18 +5688,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/fi": {
         "voice_id": "supertonic/M4/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5710,18 +5710,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/fr": {
         "voice_id": "supertonic/M4/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5732,18 +5732,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/hi": {
         "voice_id": "supertonic/M4/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5754,18 +5754,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/hr": {
         "voice_id": "supertonic/M4/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5776,18 +5776,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/hu": {
         "voice_id": "supertonic/M4/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5798,18 +5798,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/id": {
         "voice_id": "supertonic/M4/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5820,18 +5820,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/it": {
         "voice_id": "supertonic/M4/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5842,18 +5842,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/lt": {
         "voice_id": "supertonic/M4/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5864,18 +5864,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/lv": {
         "voice_id": "supertonic/M4/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5886,18 +5886,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/nl": {
         "voice_id": "supertonic/M4/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5908,18 +5908,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/pl": {
         "voice_id": "supertonic/M4/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5930,18 +5930,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/pt": {
         "voice_id": "supertonic/M4/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5952,18 +5952,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/ro": {
         "voice_id": "supertonic/M4/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5974,18 +5974,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/ru": {
         "voice_id": "supertonic/M4/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -5996,18 +5996,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/sk": {
         "voice_id": "supertonic/M4/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6018,18 +6018,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/sl": {
         "voice_id": "supertonic/M4/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6040,18 +6040,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/sv": {
         "voice_id": "supertonic/M4/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6062,18 +6062,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/tr": {
         "voice_id": "supertonic/M4/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6084,18 +6084,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/uk": {
         "voice_id": "supertonic/M4/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6106,18 +6106,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M4/vi": {
         "voice_id": "supertonic/M4/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6128,18 +6128,18 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M4.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M4.json"
         },
         "display_name": "SuperTonic M4"
     },
     "supertonic/M5/en": {
         "voice_id": "supertonic/M5/en",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6150,18 +6150,18 @@
         "engine": "supertonic",
         "lang": "en",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/ko": {
         "voice_id": "supertonic/M5/ko",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6172,18 +6172,18 @@
         "engine": "supertonic",
         "lang": "ko",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/ja": {
         "voice_id": "supertonic/M5/ja",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6194,18 +6194,18 @@
         "engine": "supertonic",
         "lang": "ja",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/ar": {
         "voice_id": "supertonic/M5/ar",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6216,18 +6216,18 @@
         "engine": "supertonic",
         "lang": "ar",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/bg": {
         "voice_id": "supertonic/M5/bg",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6238,18 +6238,18 @@
         "engine": "supertonic",
         "lang": "bg",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/cs": {
         "voice_id": "supertonic/M5/cs",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6260,18 +6260,18 @@
         "engine": "supertonic",
         "lang": "cs",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/da": {
         "voice_id": "supertonic/M5/da",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6282,18 +6282,18 @@
         "engine": "supertonic",
         "lang": "da",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/de": {
         "voice_id": "supertonic/M5/de",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6304,18 +6304,18 @@
         "engine": "supertonic",
         "lang": "de",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/el": {
         "voice_id": "supertonic/M5/el",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6326,18 +6326,18 @@
         "engine": "supertonic",
         "lang": "el",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/es": {
         "voice_id": "supertonic/M5/es",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6348,18 +6348,18 @@
         "engine": "supertonic",
         "lang": "es",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/et": {
         "voice_id": "supertonic/M5/et",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6370,18 +6370,18 @@
         "engine": "supertonic",
         "lang": "et",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/fi": {
         "voice_id": "supertonic/M5/fi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6392,18 +6392,18 @@
         "engine": "supertonic",
         "lang": "fi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/fr": {
         "voice_id": "supertonic/M5/fr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6414,18 +6414,18 @@
         "engine": "supertonic",
         "lang": "fr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/hi": {
         "voice_id": "supertonic/M5/hi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6436,18 +6436,18 @@
         "engine": "supertonic",
         "lang": "hi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/hr": {
         "voice_id": "supertonic/M5/hr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6458,18 +6458,18 @@
         "engine": "supertonic",
         "lang": "hr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/hu": {
         "voice_id": "supertonic/M5/hu",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6480,18 +6480,18 @@
         "engine": "supertonic",
         "lang": "hu",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/id": {
         "voice_id": "supertonic/M5/id",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6502,18 +6502,18 @@
         "engine": "supertonic",
         "lang": "id",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/it": {
         "voice_id": "supertonic/M5/it",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6524,18 +6524,18 @@
         "engine": "supertonic",
         "lang": "it",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/lt": {
         "voice_id": "supertonic/M5/lt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6546,18 +6546,18 @@
         "engine": "supertonic",
         "lang": "lt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/lv": {
         "voice_id": "supertonic/M5/lv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6568,18 +6568,18 @@
         "engine": "supertonic",
         "lang": "lv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/nl": {
         "voice_id": "supertonic/M5/nl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6590,18 +6590,18 @@
         "engine": "supertonic",
         "lang": "nl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/pl": {
         "voice_id": "supertonic/M5/pl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6612,18 +6612,18 @@
         "engine": "supertonic",
         "lang": "pl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/pt": {
         "voice_id": "supertonic/M5/pt",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6634,18 +6634,18 @@
         "engine": "supertonic",
         "lang": "pt",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/ro": {
         "voice_id": "supertonic/M5/ro",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6656,18 +6656,18 @@
         "engine": "supertonic",
         "lang": "ro",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/ru": {
         "voice_id": "supertonic/M5/ru",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6678,18 +6678,18 @@
         "engine": "supertonic",
         "lang": "ru",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/sk": {
         "voice_id": "supertonic/M5/sk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6700,18 +6700,18 @@
         "engine": "supertonic",
         "lang": "sk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/sl": {
         "voice_id": "supertonic/M5/sl",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6722,18 +6722,18 @@
         "engine": "supertonic",
         "lang": "sl",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/sv": {
         "voice_id": "supertonic/M5/sv",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6744,18 +6744,18 @@
         "engine": "supertonic",
         "lang": "sv",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/tr": {
         "voice_id": "supertonic/M5/tr",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6766,18 +6766,18 @@
         "engine": "supertonic",
         "lang": "tr",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/uk": {
         "voice_id": "supertonic/M5/uk",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6788,18 +6788,18 @@
         "engine": "supertonic",
         "lang": "uk",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     },
     "supertonic/M5/vi": {
         "voice_id": "supertonic/M5/vi",
-        "model_url": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vector_estimator.onnx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vector_estimator.onnx",
         "config_url": null,
         "vocab_url": null,
         "tokens_url": null,
@@ -6810,12 +6810,12 @@
         "engine": "supertonic",
         "lang": "vi",
         "aux_model_urls": {
-            "duration_predictor_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx",
-            "text_encoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/text_encoder.onnx",
-            "vocoder_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/vocoder.onnx",
-            "unicode_indexer_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/unicode_indexer.json",
-            "tts_config_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/tts.json",
-            "style_path": "https://huggingface.co/Supertone/supertonic-3/resolve/main/voice_styles/M5.json"
+            "duration_predictor_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/duration_predictor.onnx",
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/text_encoder.onnx",
+            "vocoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/vocoder.onnx",
+            "unicode_indexer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/unicode_indexer.json",
+            "tts_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/onnx/tts.json",
+            "style_path": "https://huggingface.co/OpenVoiceOS/phoonnx-supertonic/resolve/main/voice_styles/M5.json"
         },
         "display_name": "SuperTonic M5"
     }


### PR DESCRIPTION
## Summary
- Adds a new HF model repo, [OpenVoiceOS/phoonnx-supertonic](https://huggingface.co/OpenVoiceOS/phoonnx-supertonic), mirroring the 16 assets from `Supertone/supertonic-3` that `phoonnx/voice_index/supertonic.json` references (4 shared ONNX graphs, 2 shared config/indexer files, 10 per-speaker style JSONs; ~401 MB total).
- Repoints all 310 `supertonic/*` voice entries in `phoonnx/voice_index/supertonic.json` from `Supertone/supertonic-3` to the new `OpenVoiceOS/phoonnx-supertonic` mirror (2170 URL occurrences, pure find/replace, no other index files touched).
- Rationale: house policy is that phoonnx vendors/mirrors all model weights it uses under the OpenVoiceOS org on Hugging Face, so voices keep working independent of upstream repo availability/renames. `Supertone/supertonic-3` weights are OpenRAIL-M licensed; the mirror carries the same license plus Supertone attribution and a phoonnx GitHub link.
- Added to the `OpenVoiceOS/phoonnx-community-mirror` HF collection.

## Test plan
- [x] Sampled 8 rewritten URLs (across 3 random voice entries, covering all 4 ONNX graphs + tts.json + unicode_indexer.json + 2 style JSONs) — all resolve HTTP 200 against the new mirror.
- [x] `pytest tests/test_supertonic.py` — 43 passed.

Authorship: implemented by Claude (Sonnet 5) under Fable orchestration.