### PR TITLE
feat: OuteTTS engine

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -1,7 +1,7 @@
 ## Supported Voices
 
-**Total Voices:** 2422
-**Total Languages:** 1240
+**Total Voices:** 2445
+**Total Languages:** 1242
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
 
@@ -98,6 +98,7 @@
 | `hf_community/wasmdashai/vits-ar-sa-A` | `ar-SA` | `transformers` | `graphemes` |
 | `hf_community/wasmdashai/vits-ar-sa-huba-v2` | `ar-SA` | `transformers` | `graphemes` |
 | `namaa/ar-sa-v2` | `ar-SA` | `f5tts` | `graphemes` |
+| `outetts/1B/ar` | `ar-SA` | `outetts` | `unicode` |
 | `chatterbox/lahgtna/sd` | `ar-SD` | `chatterbox` | `unicode` |
 | `chatterbox/lahgtna/sy` | `ar-SY` | `chatterbox` | `unicode` |
 | `chatterbox/lahgtna/tn` | `ar-TN` | `chatterbox` | `unicode` |
@@ -143,6 +144,7 @@
 | `facebook/mms-tts-bdu-Oroko` | `bdu` | `transformers` | `graphemes` |
 | `facebook/mms-tts-bdv-Bodo Parja` | `bdv` | `transformers` | `graphemes` |
 | `coqui-be-common-voice-glow-tts` | `be-BY` | `glowtts` | `graphemes` |
+| `outetts/1B/be` | `be-BY` | `outetts` | `unicode` |
 | `facebook/mms-tts-beh-Biali` | `beh` | `transformers` | `graphemes` |
 | `facebook/mms-tts-bem-Bemba` | `bem` | `transformers` | `graphemes` |
 | `facebook/mms-tts-bep-Behoa` | `bep` | `transformers` | `graphemes` |
@@ -195,6 +197,7 @@
 | `coqui/bn-custom-vits-male` | `bn` | `coqui` | `graphemes` |
 | `facebook/mms-tts-ben-Bengali` | `bn` | `transformers` | `graphemes` |
 | `mimic3/bn/multi_low` | `bn` | `mimic3` | `espeak` |
+| `outetts/1B/bn` | `bn-BD` | `outetts` | `unicode` |
 | `facebook/mms-tts-bng-Benga` | `bng` | `transformers` | `graphemes` |
 | `facebook/mms-tts-bno-Bantoanon` | `bno` | `transformers` | `graphemes` |
 | `facebook/mms-tts-bnp-Bola` | `bnp` | `transformers` | `graphemes` |
@@ -424,6 +427,7 @@
 | `mimic3/de_DE/thorsten_low` | `de-DE` | `mimic3` | `gruut` |
 | `OpenVoiceOS/pipertts_de-DE_dii` | `de-DE` | `piper` | `espeak` |
 | `OpenVoiceOS/pipertts_de-DE_miro` | `de-DE` | `piper` | `espeak` |
+| `outetts/0.6B/de` | `de-DE` | `outetts` | `unicode` |
 | `piper/de_DE-eva_k-x_low` | `de-DE` | `piper` | `espeak` |
 | `piper/de_DE-karlsson-low` | `de-DE` | `piper` | `espeak` |
 | `piper/de_DE-kerstin-low` | `de-DE` | `piper` | `espeak` |
@@ -668,6 +672,7 @@
 | `mimic3/en_US/m-ailabs_low` | `en-US` | `mimic3` | `gruut` |
 | `mimic3/en_US/vctk_low` | `en-US` | `mimic3` | `gruut` |
 | `OpenVoiceOS/pipertts_en-US_miro` | `en-US` | `piper` | `espeak` |
+| `outetts/0.6B/en` | `en-US` | `outetts` | `unicode` |
 | `piper/en_US-amy-low` | `en-US` | `piper` | `espeak` |
 | `piper/en_US-amy-medium` | `en-US` | `piper` | `espeak` |
 | `piper/en_US-arctic-medium` | `en-US` | `piper` | `espeak` |
@@ -730,8 +735,8 @@
 | `piper_community/simoniz0r/en-US_eminem` | `en-US` | `piper` | `espeak` |
 | `piper_community/simoniz0r/en-US_patrick` | `en-US` | `piper` | `espeak` |
 | `piper_community/swqg-messiah/en-US_chitti` | `en-US` | `piper` | `espeak` |
-| `qwen3tts/ryan/en` | `en-US` | `qwen3tts` | `unicode` |
 | `qwen3tts/aiden/en` | `en-US` | `qwen3tts` | `unicode` |
+| `qwen3tts/ryan/en` | `en-US` | `qwen3tts` | `unicode` |
 | `sparktts/female/en` | `en-US` | `sparktts` | `unicode` |
 | `sparktts/male/en` | `en-US` | `sparktts` | `unicode` |
 | `facebook/mms-tts-enb-Markweeta` | `enb` | `transformers` | `graphemes` |
@@ -795,6 +800,7 @@
 | `mimic3/es_ES/m-ailabs_low` | `es-ES` | `mimic3` | `espeak` |
 | `OpenVoiceOS/phoonnx_es-ES_dii_espeak` | `es-ES` | `phoonnx` | `espeak` |
 | `OpenVoiceOS/pipertts_es-ES_miro` | `es-ES` | `piper` | `espeak` |
+| `outetts/0.6B/es` | `es-ES` | `outetts` | `unicode` |
 | `piper/es_ES-carlfm-x_low` | `es-ES` | `piper` | `espeak` |
 | `piper/es_ES-davefx-medium` | `es-ES` | `piper` | `espeak` |
 | `piper/es_ES-mls_10246-low` | `es-ES` | `piper` | `espeak` |
@@ -845,6 +851,7 @@
 | `hf_community/SadeghK/persian-text-to-speech/epoch=5719-step=2609600-ganji` | `fa` | `piper` | `espeak` |
 | `hf_community/SadeghK/persian-text-to-speech/epoch=6363-step=2694608-ganji-adabi` | `fa` | `piper` | `espeak` |
 | `mimic3/fa/haaniye_low` | `fa` | `mimic3` | `espeak` |
+| `outetts/1B/fa` | `fa-IR` | `outetts` | `unicode` |
 | `piper/fa_IR-amir-medium` | `fa-IR` | `piper` | `espeak` |
 | `piper/fa_IR-ganji-medium` | `fa-IR` | `piper` | `espeak` |
 | `piper/fa_IR-ganji_adabi-medium` | `fa-IR` | `piper` | `espeak` |
@@ -929,6 +936,7 @@
 | `mimic3/fr_FR/siwis_low` | `fr-FR` | `mimic3` | `gruut` |
 | `mimic3/fr_FR/tom_low` | `fr-FR` | `mimic3` | `gruut` |
 | `OpenVoiceOS/pipertts_fr-FR_miro` | `fr-FR` | `piper` | `espeak` |
+| `outetts/0.6B/fr` | `fr-FR` | `outetts` | `unicode` |
 | `piper/fr_FR-gilles-low` | `fr-FR` | `piper` | `espeak` |
 | `piper/fr_FR-mls-medium` | `fr-FR` | `piper` | `espeak` |
 | `piper/fr_FR-mls_1840-low` | `fr-FR` | `piper` | `espeak` |
@@ -1083,6 +1091,7 @@
 | `coqui/hu-css10-vits` | `hu-HU` | `coqui` | `graphemes` |
 | `facebook/mms-tts-hun-Hungarian` | `hu-HU` | `transformers` | `graphemes` |
 | `mimic3/hu_HU/diana-majlinger_low` | `hu-HU` | `mimic3` | `espeak` |
+| `outetts/0.6B/hu` | `hu-HU` | `outetts` | `unicode` |
 | `piper/hu_HU-anna-medium` | `hu-HU` | `piper` | `espeak` |
 | `piper/hu_HU-berta-medium` | `hu-HU` | `piper` | `espeak` |
 | `piper/hu_HU-imre-medium` | `hu-HU` | `piper` | `espeak` |
@@ -1191,6 +1200,7 @@
 | `mimic3/it_IT/riccardo-fasol_low` | `it-IT` | `mimic3` | `gruut` |
 | `OpenVoiceOS/pipertts_it-IT_dii` | `it-IT` | `piper` | `espeak` |
 | `OpenVoiceOS/pipertts_it-IT_miro` | `it-IT` | `piper` | `espeak` |
+| `outetts/0.6B/it` | `it-IT` | `outetts` | `unicode` |
 | `piper/it_IT-paola-medium` | `it-IT` | `piper` | `espeak` |
 | `piper/it_IT-riccardo-x_low` | `it-IT` | `piper` | `espeak` |
 | `piper_community/Einrich99/it-IT_ugo` | `it-IT` | `piper` | `espeak` |
@@ -1222,6 +1232,7 @@
 | `kokoro/jf_nezumi` | `ja-JP` | `styletts2` | `misaki_ja` |
 | `kokoro/jf_tebukuro` | `ja-JP` | `styletts2` | `misaki_ja` |
 | `kokoro/jm_kumo` | `ja-JP` | `styletts2` | `misaki_ja` |
+| `outetts/0.6B/ja` | `ja-JP` | `outetts` | `unicode` |
 | `qwen3tts/ono_anna/ja` | `ja-JP` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-jac-Jakalteko` | `jac` | `transformers` | `graphemes` |
 | `facebook/mms-tts-jam-Jamaican English Creole` | `jam` | `transformers` | `graphemes` |
@@ -1236,6 +1247,7 @@
 | `facebook/mms-tts-jav-Javanese` | `jv-ID` | `transformers` | `graphemes` |
 | `mimic3/jv_ID/google-gmu_low` | `jv-ID` | `mimic3` | `epitran` |
 | `facebook/mms-tts-jvn-Javanese, Suriname` | `jvn` | `transformers` | `graphemes` |
+| `outetts/0.6B/ka` | `ka-GE` | `outetts` | `unicode` |
 | `piper/ka_GE-natia-medium` | `ka-GE` | `piper` | `espeak` |
 | `facebook/mms-tts-kaa-Karakalpak` | `kaa` | `transformers` | `graphemes` |
 | `facebook/mms-tts-kab-Amazigh` | `kab` | `transformers` | `graphemes` |
@@ -1319,6 +1331,7 @@
 | `piper_neurlang/ko-KO_kss-korean` | `ko-KO` | `piper` | `goruut` |
 | `chatterbox/multilingual/ko` | `ko-KR` | `chatterbox` | `unicode` |
 | `facebook/mms-tts-kor-Korean` | `ko-KR` | `transformers` | `graphemes` |
+| `outetts/0.6B/ko` | `ko-KR` | `outetts` | `unicode` |
 | `qwen3tts/sohee/ko` | `ko-KR` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-kog-Kogi` | `kog` | `transformers` | `graphemes` |
 | `facebook/mms-tts-kpq-Korupun-Sela` | `kpq` | `transformers` | `graphemes` |
@@ -1424,6 +1437,7 @@
 | `supertonic/M4/lt` | `lt` | `supertonic` | `unicode` |
 | `supertonic/M5/lt` | `lt` | `supertonic` | `unicode` |
 | `coqui/lt-cv-vits` | `lt-LT` | `coqui` | `graphemes` |
+| `outetts/1B/lt` | `lt-LT` | `outetts` | `unicode` |
 | `facebook/mms-tts-luc-Aringa` | `luc` | `transformers` | `graphemes` |
 | `supertonic/F1/lv` | `lv` | `supertonic` | `unicode` |
 | `supertonic/F2/lv` | `lv` | `supertonic` | `unicode` |
@@ -1438,6 +1452,7 @@
 | `coqui/lv-cv-vits` | `lv-LV` | `coqui` | `graphemes` |
 | `facebook/mms-tts-lav-Latvian` | `lv-LV` | `transformers` | `graphemes` |
 | `hf_community/RaivisDejus/Piper-lv_LV-Aivars-medium` | `lv-LV` | `piper` | `espeak` |
+| `outetts/0.6B/lv` | `lv-LV` | `outetts` | `unicode` |
 | `piper/lv_LV-aivars-medium` | `lv-LV` | `piper` | `espeak` |
 | `piper_community/RaivisDejus/lv-LV_Aivars` | `lv-LV` | `piper` | `espeak` |
 | `facebook/mms-tts-lwo-Luwo` | `lwo` | `transformers` | `graphemes` |
@@ -1645,6 +1660,7 @@
 | `chatterbox/multilingual/nl` | `nl-NL` | `chatterbox` | `unicode` |
 | `OpenVoiceOS/pipertts_nl-NL_dii` | `nl-NL` | `piper` | `espeak` |
 | `OpenVoiceOS/pipertts_nl-NL_miro` | `nl-NL` | `piper` | `espeak` |
+| `outetts/0.6B/nl` | `nl-NL` | `outetts` | `unicode` |
 | `piper/nl_NL-mls-medium` | `nl-NL` | `piper` | `espeak` |
 | `piper/nl_NL-mls_5809-low` | `nl-NL` | `piper` | `espeak` |
 | `piper/nl_NL-mls_7432-low` | `nl-NL` | `piper` | `espeak` |
@@ -1736,6 +1752,7 @@
 | `hf_community/WitoldG/polish_piper_models/pl_PL-meski_wg_glos-medium` | `pl-PL` | `piper` | `espeak` |
 | `hf_community/WitoldG/polish_piper_models/pl_PL-zenski_wg_glos-medium` | `pl-PL` | `piper` | `espeak` |
 | `mimic3/pl_PL/m-ailabs_low` | `pl-PL` | `mimic3` | `espeak` |
+| `outetts/0.6B/pl` | `pl-PL` | `outetts` | `unicode` |
 | `piper/pl_PL-darkman-medium` | `pl-PL` | `piper` | `espeak` |
 | `piper/pl_PL-gosia-medium` | `pl-PL` | `piper` | `espeak` |
 | `piper/pl_PL-mc_speech-medium` | `pl-PL` | `piper` | `espeak` |
@@ -1816,6 +1833,7 @@
 | `OpenVoiceOS/phoonnx_pt-PT_miro_unicode` | `pt-PT` | `phoonnx` | `unicode` |
 | `OpenVoiceOS/pipertts_pt-PT_dii` | `pt-PT` | `piper` | `espeak` |
 | `OpenVoiceOS/pipertts_pt-PT_miro` | `pt-PT` | `piper` | `espeak` |
+| `outetts/1B/pt` | `pt-PT` | `outetts` | `unicode` |
 | `piper/pt_PT-tugão-medium` | `pt-PT` | `piper` | `espeak` |
 | `facebook/mms-tts-ptu-Bambam` | `ptu` | `transformers` | `graphemes` |
 | `facebook/mms-tts-pui-Puinave` | `pui` | `transformers` | `graphemes` |
@@ -1907,6 +1925,7 @@
 | `larynx/ru-ru-minaev-glow_tts` | `ru-RU` | `glowtts` | `gruut` |
 | `larynx/ru-ru-nikolaev-glow_tts` | `ru-RU` | `glowtts` | `gruut` |
 | `mimic3/ru_RU/multi_low` | `ru-RU` | `mimic3` | `gruut` |
+| `outetts/0.6B/ru` | `ru-RU` | `outetts` | `unicode` |
 | `piper/ru_RU-denis-medium` | `ru-RU` | `piper` | `espeak` |
 | `piper/ru_RU-dmitri-medium` | `ru-RU` | `piper` | `espeak` |
 | `piper/ru_RU-irina-medium` | `ru-RU` | `piper` | `espeak` |
@@ -2027,6 +2046,7 @@
 | `larynx/sw-biblia_takatifu-glow_tts` | `sw` | `glowtts` | `gruut` |
 | `mimic3/sw/lanfrica_low` | `sw` | `mimic3` | `gruut` |
 | `piper/sw_CD-lanfrica-medium` | `sw-CD` | `piper` | `espeak` |
+| `outetts/1B/sw` | `sw-KE` | `outetts` | `unicode` |
 | `facebook/mms-tts-swh-Swahili` | `swh` | `transformers` | `graphemes` |
 | `facebook/mms-tts-sxb-Suba` | `sxb` | `transformers` | `graphemes` |
 | `facebook/mms-tts-sxn-Sangir` | `sxn` | `transformers` | `graphemes` |
@@ -2036,6 +2056,7 @@
 | `facebook/mms-tts-tam-Tamil` | `ta` | `transformers` | `graphemes` |
 | `hf_community/ylacombe/mms-tam-finetuned-monospeaker` | `ta` | `transformers` | `graphemes` |
 | `chatterbox/multilingual/ta` | `ta-IN` | `chatterbox` | `unicode` |
+| `outetts/1B/ta` | `ta-IN` | `outetts` | `unicode` |
 | `facebook/mms-tts-tac-Tarahumara, Western` | `tac` | `transformers` | `graphemes` |
 | `facebook/mms-tts-taj-Tamang, Eastern` | `taj` | `transformers` | `graphemes` |
 | `facebook/mms-tts-tao-Yami` | `tao` | `transformers` | `graphemes` |
@@ -2176,6 +2197,7 @@
 | `coqui-uk-mai-glow-tts` | `uk-UA` | `glowtts` | `graphemes` |
 | `coqui/uk-mai-vits` | `uk-UA` | `coqui` | `graphemes` |
 | `facebook/mms-tts-ukr-Ukrainian` | `uk-UA` | `transformers` | `graphemes` |
+| `outetts/1B/uk` | `uk-UA` | `outetts` | `unicode` |
 | `piper/uk_UA-lada-x_low` | `uk-UA` | `piper` | `espeak` |
 | `piper/uk_UA-mykyta-high` | `uk-UA` | `piper` | `espeak` |
 | `piper/uk_UA-oleksa-high` | `uk-UA` | `piper` | `espeak` |
@@ -2401,13 +2423,14 @@
 | `kokoro/zm_yunyang` | `zh` | `styletts2` | `misaki_zh` |
 | `chatterbox/multilingual/zh` | `zh-CN` | `chatterbox` | `unicode` |
 | `hf_community/BricksDisplay/vits-cmn` | `zh-CN` | `transformers` | `graphemes` |
+| `outetts/0.6B/zh` | `zh-CN` | `outetts` | `unicode` |
 | `piper/zh_CN-huayan-medium` | `zh-CN` | `piper` | `espeak` |
 | `piper/zh_CN-huayan-x_low` | `zh-CN` | `piper` | `espeak` |
-| `qwen3tts/vivian/zh` | `zh-CN` | `qwen3tts` | `unicode` |
-| `qwen3tts/serena/zh` | `zh-CN` | `qwen3tts` | `unicode` |
-| `qwen3tts/uncle_fu/zh` | `zh-CN` | `qwen3tts` | `unicode` |
 | `qwen3tts/dylan/zh` | `zh-CN` | `qwen3tts` | `unicode` |
 | `qwen3tts/eric/zh` | `zh-CN` | `qwen3tts` | `unicode` |
+| `qwen3tts/serena/zh` | `zh-CN` | `qwen3tts` | `unicode` |
+| `qwen3tts/uncle_fu/zh` | `zh-CN` | `qwen3tts` | `unicode` |
+| `qwen3tts/vivian/zh` | `zh-CN` | `qwen3tts` | `unicode` |
 | `sparktts/female/zh` | `zh-CN` | `sparktts` | `unicode` |
 | `sparktts/male/zh` | `zh-CN` | `sparktts` | `unicode` |
 | `piper_community/colafly/zh-TW_yt-chinese_female` | `zh-TW` | `piper` | `espeak` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,8 @@ how to obtain or train it, and a synthesis example:
 [Qwen3-TTS](training/engines/qwen3tts.md) ·
 [F5-TTS](training/engines/f5tts.md) ·
 [Shami](training/engines/shami.md) ·
-[Pocket TTS](pockettts.md)
+[Pocket TTS](pockettts.md) ·
+[OuteTTS](training/engines/outetts.md)
 
 ## Language notes
 

--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -27,7 +27,7 @@ turned into:
 |---|---|---|---|---|
 | **d-vector** | a **speaker encoder** maps the reference waveform to a fixed embedding that conditions synthesis | No | Yes | YourTTS, StyleTTS2, [Chatterbox](training/engines/chatterbox.md), [Spark-TTS](training/engines/sparktts.md) |
 | **in-context** | the reference **audio + its transcription** are part of the model input; the model continues that voice | **Yes** | Per-phoneme (espeak/pinyin) | ZipVoice, [Spark-TTS](training/engines/sparktts.md) |
-| **in-context, pre-encoded** | the reference is **codec-encoded ahead of time** and shipped with the voice; the model continues those audio tokens | **Yes** (bundled) | Per-phoneme (espeak) | NeuTTS / Akiti-TTS |
+| **in-context, pre-encoded** | the reference is **codec-encoded ahead of time** and shipped with the voice; the model continues those audio tokens | **Yes** (bundled) | Per-phoneme (espeak) | NeuTTS / Akiti-TTS, [OuteTTS](training/engines/outetts.md) |
 
 A cloning voice can still bundle a **default speaker**, so it works with *or* without a
 reference. When a reference is given it **overrides** the default

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,7 +174,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `pockettts` | Flow-matching codec LM with explicit stream state, raw-text (no phonemizer) | [Pocket TTS](pockettts.md) |
 | `sparktts` | Autoregressive codec-LM (Qwen2 + BiCodec), en/zh | [Spark-TTS](training/engines/sparktts.md) |
 | `qwen3tts` | Two-stage codec LM (talker + code predictor), 10 languages | [Qwen3-TTS](training/engines/qwen3tts.md) |
-| `outetts` | Autoregressive codec-LM (Qwen3 + DAC.speech), raw-text, 14 languages | [OuteTTS](training/engines/outetts.md) |
+| `outetts` | Autoregressive codec-LM (Qwen3 or Llama-3.2 + DAC.speech), raw-text, 23 languages | [OuteTTS](training/engines/outetts.md) |
 
 ## Execution Providers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,6 +174,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `pockettts` | Flow-matching codec LM with explicit stream state, raw-text (no phonemizer) | [Pocket TTS](pockettts.md) |
 | `sparktts` | Autoregressive codec-LM (Qwen2 + BiCodec), en/zh | [Spark-TTS](training/engines/sparktts.md) |
 | `qwen3tts` | Two-stage codec LM (talker + code predictor), 10 languages | [Qwen3-TTS](training/engines/qwen3tts.md) |
+| `outetts` | Autoregressive codec-LM (Qwen3 + DAC.speech), raw-text, 14 languages | [OuteTTS](training/engines/outetts.md) |
 
 ## Execution Providers
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -93,6 +93,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | [Pocket TTS](pockettts.md) | `phoonnx/engines/pockettts.py` | `engine == "pockettts"` — 5-graph flow-matching codec LM with explicit stream state, raw-text (no phonemizer), state-based voices and reference [cloning](cloning.md) |
 | [Spark-TTS](training/engines/sparktts.md) | `phoonnx/engines/sparktts.py` | `engine == "sparktts"` — autoregressive codec-LM (Qwen2 + BiCodec), raw-text, en/zh; preset 32-token speakers or zero-shot [cloning](cloning.md) |
 | [Qwen3-TTS](training/engines/qwen3tts.md) | `phoonnx/engines/qwen3tts.py` | `engine == "qwen3tts"` — two autoregressive stages (28-layer talker + 5-layer code predictor) writing 16 code groups per 12.5 Hz frame, raw-text, 10 languages, nine fixed timbres, 24 kHz |
+| [OuteTTS](training/engines/outetts.md) | `phoonnx/engines/outetts.py` | `engine == "outetts"` — autoregressive two-codebook codec-LM (Qwen3 backbone + DAC.speech decoder), raw text in 14 languages, in-context [cloning](cloning.md) from pre-encoded speaker profiles, 24 kHz |
 
 ---
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -93,7 +93,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | [Pocket TTS](pockettts.md) | `phoonnx/engines/pockettts.py` | `engine == "pockettts"` — 5-graph flow-matching codec LM with explicit stream state, raw-text (no phonemizer), state-based voices and reference [cloning](cloning.md) |
 | [Spark-TTS](training/engines/sparktts.md) | `phoonnx/engines/sparktts.py` | `engine == "sparktts"` — autoregressive codec-LM (Qwen2 + BiCodec), raw-text, en/zh; preset 32-token speakers or zero-shot [cloning](cloning.md) |
 | [Qwen3-TTS](training/engines/qwen3tts.md) | `phoonnx/engines/qwen3tts.py` | `engine == "qwen3tts"` — two autoregressive stages (28-layer talker + 5-layer code predictor) writing 16 code groups per 12.5 Hz frame, raw-text, 10 languages, nine fixed timbres, 24 kHz |
-| [OuteTTS](training/engines/outetts.md) | `phoonnx/engines/outetts.py` | `engine == "outetts"` — autoregressive two-codebook codec-LM (Qwen3 backbone + DAC.speech decoder), raw text in 14 languages, in-context [cloning](cloning.md) from pre-encoded speaker profiles, 24 kHz |
+| [OuteTTS](training/engines/outetts.md) | `phoonnx/engines/outetts.py` | `engine == "outetts"` — autoregressive two-codebook codec-LM (Qwen3 backbone + DAC.speech decoder), raw text in 23 languages, in-context [cloning](cloning.md) from pre-encoded speaker profiles, 24 kHz |
 
 ---
 

--- a/docs/training/engines/outetts.md
+++ b/docs/training/engines/outetts.md
@@ -1,0 +1,175 @@
+# OuteTTS Engine
+
+This page is for integrators who want OuteTTS voices in phoonnx. After reading it you can
+pick a language, understand what the two ONNX graphs do, and know why phoonnx ships the
+0.6B model and not the 1B.
+
+> Related: [adapter architecture](../../engines.md) ·
+> [configuration](../../configuration.md) · [voice cloning](../../cloning.md) ·
+> [NeuTTS — the sibling codec-LM engine](../../../phoonnx/engines/neutts.py)
+
+## What it is
+
+**OuteTTS 1.0** (OuteAI) is a decoder-only language model that predicts audio codec
+tokens. The vocabulary of an ordinary text model was extended with the two codebooks of
+**DAC.speech.v1.0**, a 24 kHz codec by IBM Research that runs at 1.5 kbps. The model
+reads text and writes interleaved `<|c1_N|><|c2_N|>` pairs; the codec decoder turns that
+pair stream into a waveform.
+
+There is no phonemizer, no duration model and no vocoder. The model consumes raw text in
+the language's own script, which is why one checkpoint covers 14 languages.
+
+Two checkpoints share the interface:
+
+| Checkpoint | Backbone | Languages | License |
+| :--- | :--- | :--- | :--- |
+| `OuteTTS-1.0-0.6B` | Qwen3-0.6B | 14 | Apache-2.0 |
+| `Llama-OuteTTS-1.0-1B` | Llama-3.2-1B | 23 | CC-BY-NC-SA-4.0 |
+
+phoonnx indexes the **0.6B only**. See [Weights and licensing](#weights-and-licensing).
+
+## When to pick it
+
+Pick OuteTTS when you want one small model to speak many languages from raw text, with no
+per-language phonemizer to install. It is the fourth autoregressive codec-LM engine in
+phoonnx, after Chatterbox, NeuTTS and Spark-TTS.
+
+Do not pick it when you need speed. One codec frame is two passes through the language
+model, and one second of speech is about 47 frames, so one second of audio costs about 94
+model calls. On a modern desktop CPU that is a real-time factor around 20 to 30. The
+non-autoregressive engines are two orders of magnitude faster.
+
+## Languages
+
+English, Chinese, Dutch, French, Georgian, German, Hungarian, Italian, Japanese, Korean,
+Latvian, Polish, Russian, Spanish.
+
+The model can also produce speech in languages it was not trained on, with variable
+quality. The voice index lists only the trained set.
+
+## Architecture
+
+```
+text ─► normalize ─► chunk (10-30 words)
+                          │
+speaker profile ──────────┤   transcript + per-word DAC codes
+                          ▼
+      prompt = <|im_start|> <|text_start|>...<|text_end|>
+               <|audio_start|> <word blocks> <|word_start|>
+                          │
+                          ▼
+   model.onnx (Qwen3, KV-cached) ──loop──► <|c1_N|><|c2_N|> ...
+                          │
+                          ▼
+   decoder_model.onnx(audio_codes[1,2,T]) ─► wav @ 24 kHz
+                          │
+                          ▼
+              fade, then loudness normalize to -18 LUFS
+```
+
+| Graph | Input | Output |
+| :--- | :--- | :--- |
+| `model.onnx` | `input_ids`, `attention_mask`, `position_ids`, `past_key_values.<i>.<key\|value>` | `logits` `[1,S,V]`, `present.<i>.<key\|value>` |
+| `decoder_model.onnx` | `audio_codes` `[1,2,T]` int64 | `audio_values` `[1,1,T*512]` |
+
+The KV-cache shape (layers, heads, head dim) comes from the language model's own input
+signature, so no layer count is written into phoonnx.
+
+Two details differ from the other codec-LM engines:
+
+* `logits` covers **every** position, not only the last one, so the decode step reads
+  `logits[0, -1]`.
+* The waveform is **loudness normalized** to -18 LUFS with a -1 dBFS peak ceiling, and
+  every decoder chunk is faded in and out over 15 ms. Upstream does this inside its codec
+  wrapper, so it is part of the model's output level, not a phoonnx preference. phoonnx
+  reimplements ITU-R BS.1770-4 in NumPy rather than adding `pyloudnorm` as a dependency.
+
+## Speakers
+
+An OuteTTS voice needs a **speaker profile** or it invents random vocal characteristics.
+A profile is an in-context audio prompt: a transcript whose words each carry a duration,
+three prosody buckets (energy, spectral centroid, pitch) and their DAC codes. The
+profile's transcript is glued in front of your text, and its codes are the start of the
+generated stream, so the model continues a real utterance.
+
+The bundled voices all use OuteAI's `en-female-1-neutral` profile. The model carries the
+speaker across languages, so this English profile leaves an English accent on the other
+13 languages. For production in one language, build a profile from a clip in that
+language.
+
+Select a profile per call when a voice ships more than one:
+
+```python
+from phoonnx.config import SynthesisConfig
+from phoonnx.model_manager import TTSModelManager
+
+manager = TTSModelManager()
+manager.merge_default_voices()
+voice = manager.voices["outetts/0.6B/de"].load()
+syn = SynthesisConfig(extra_params={"voice": "en-female-1-neutral"})
+for chunk in voice.synthesize("Der alte Leuchtturm steht an der Küste.", syn):
+    ...  # chunk.audio_float_array, 24 kHz mono
+```
+
+phoonnx **cannot build a profile from a reference clip**. That needs Whisper word
+alignment plus the DAC encoder and a prosody analysis pass; `speaker_reference` therefore
+raises. Build the profile with the upstream `outetts` package and ship the JSON.
+
+## Decoding parameters
+
+| Parameter | Default | Meaning |
+| :--- | :--- | :--- |
+| `temperature` | `0.4` | sampling temperature; `0` decodes greedily |
+| `top_k` | `40` | keep the 40 highest-scoring tokens |
+| `top_p` | `0.9` | nucleus: keep the smallest set covering 90 % of the mass |
+| `min_p` | `0.05` | drop every token below 5 % of the top token's probability |
+| `repetition_penalty` | `1.1` | applied over the **last 64 tokens** only |
+| `max_new_tokens` | `4096` | hard stop, about 44 seconds |
+| `max_chunk_words` | `30` | words per autoregressive pass |
+
+The warpers run in the order HuggingFace `generate` builds them — temperature, then
+top-k, top-p and min-p — because `outetts` drives this checkpoint through the HuggingFace
+backend by default. This is **not** the order NeuTTS uses: NeuTTS runs on llama.cpp,
+which truncates the raw distribution and applies temperature last.
+
+The repetition penalty is windowed. Upstream ships a patched
+`RepetitionPenaltyLogitsProcessor` that looks back only 64 tokens instead of over the
+whole context, because the unwindowed penalty destroys long generations for this model.
+The window spans the prompt as well as what has been generated.
+
+Text is split into chunks of 10 to 30 words on sentence boundaries and synthesized one
+chunk per pass. Upstream segments Chinese and Japanese with MeCab; phoonnx counts CJK per
+character instead, which is a tighter bound and needs no extra dependency. This changes
+only where a long passage is cut, never the tokens inside a chunk.
+
+## Weights and licensing
+
+The graphs live at
+[`OpenVoiceOS/phoonnx-outetts`](https://huggingface.co/OpenVoiceOS/phoonnx-outetts),
+mirrored unchanged from OuteAI and IBM Research.
+
+**Only the float32 0.6B is indexed.** Two findings drove that:
+
+* Every quantized 0.6B export published upstream (`fp16`, `int8`, `uint8`, `q4`, `q4f16`,
+  `bnb4`, `quantized`) changes greedy decoding against the torch weights. The float32
+  export matches it exactly.
+* The float32 **1B** export also disagrees with its torch weights — by 12 logits at the
+  end of a 1843-token prompt, with a correlation of 0.48 at that position, and greedy
+  decoding diverges. The 0.6B export at the same prompt length differs by 3.8e-05. The 1B
+  is mirrored for reference but is not indexed.
+
+That costs the nine languages only the 1B covers: Arabic, Belarusian, Bengali,
+Lithuanian, Persian, Portuguese, Swahili, Tamil and Ukrainian. They come back as soon as
+a 1B export that verifies against its weights exists.
+
+Licenses differ per artifact:
+
+| Artifact | License |
+| :--- | :--- |
+| `OuteTTS-1.0-0.6B` | Apache-2.0 |
+| `Llama-OuteTTS-1.0-1B` | CC-BY-NC-SA-4.0 — **no commercial use** |
+| `DAC.speech.v1.0` (IBM Research) | CDLA-Permissive-2.0 |
+| speaker profiles (from the `outetts` package) | Apache-2.0 |
+
+Model authorship and research credit belong to OuteAI. Do not clone a voice without the
+speaker's permission.

--- a/docs/training/engines/outetts.md
+++ b/docs/training/engines/outetts.md
@@ -26,7 +26,8 @@ Two checkpoints share the interface:
 | `OuteTTS-1.0-0.6B` | Qwen3-0.6B | 14 | Apache-2.0 |
 | `Llama-OuteTTS-1.0-1B` | Llama-3.2-1B | 23 | CC-BY-NC-SA-4.0 |
 
-phoonnx indexes the **0.6B only**. See [Weights and licensing](#weights-and-licensing).
+phoonnx indexes both: the 0.6B for the 14 languages it was trained on, and the 1B for the
+nine only it covers. See [Weights and licensing](#weights-and-licensing).
 
 ## When to pick it
 
@@ -41,8 +42,14 @@ non-autoregressive engines are two orders of magnitude faster.
 
 ## Languages
 
-English, Chinese, Dutch, French, Georgian, German, Hungarian, Italian, Japanese, Korean,
-Latvian, Polish, Russian, Spanish.
+**On the 0.6B (Apache-2.0), 14:** English, Chinese, Dutch, French, Georgian, German,
+Hungarian, Italian, Japanese, Korean, Latvian, Polish, Russian, Spanish.
+
+**On the 1B (CC-BY-NC-SA-4.0), 9 more:** Arabic, Belarusian, Bengali, Lithuanian,
+Persian, Portuguese, Swahili, Tamil, Ukrainian.
+
+A voice id says which model it uses — `outetts/0.6B/de`, `outetts/1B/sw` — so nothing you
+reach by default carries the 1B's non-commercial clause.
 
 The model can also produce speech in languages it was not trained on, with variable
 quality. The voice index lists only the trained set.
@@ -148,26 +155,25 @@ The graphs live at
 [`OpenVoiceOS/phoonnx-outetts`](https://huggingface.co/OpenVoiceOS/phoonnx-outetts),
 mirrored unchanged from OuteAI and IBM Research.
 
-**Only the float32 0.6B is indexed.** Two findings drove that:
+**Only float32 graphs are indexed.** Every quantized 0.6B export published upstream
+(`fp16`, `int8`, `uint8`, `q4`, `q4f16`, `bnb4`, `quantized`) changes greedy decoding
+against the torch weights, so none is a safe default.
 
-* Every quantized 0.6B export published upstream (`fp16`, `int8`, `uint8`, `q4`, `q4f16`,
-  `bnb4`, `quantized`) changes greedy decoding against the torch weights. The float32
-  export matches it exactly.
-* The float32 **1B** export also disagrees with its torch weights — by 12 logits at the
-  end of a 1843-token prompt, with a correlation of 0.48 at that position, and greedy
-  decoding diverges. The 0.6B export at the same prompt length differs by 3.8e-05. The 1B
-  is mirrored for reference but is not indexed.
-
-That costs the nine languages only the 1B covers: Arabic, Belarusian, Bengali,
-Lithuanian, Persian, Portuguese, Swahili, Tamil and Ukrainian. They come back as soon as
-a 1B export that verifies against its weights exists.
+**The 1B graph in the mirror is phoonnx's own export, not OuteAI's.** OuteAI's published
+float32 1B ONNX does not reproduce its torch weights: 12 logits of error at the end of a
+1843-token prompt, a logit correlation of **0.48** there, and greedy decoding diverges.
+The gap is already 0.08 at 32 tokens, so it is the export, not accumulation.
+`scripts/conversion/outetts/export_outetts_onnx.py` re-exports the same KV-cache contract
+from `OuteAI/Llama-OuteTTS-1.0-1B` and matches it to **1.8e-05** with **64/64** greedy
+agreement, so the nine 1B-only languages are usable. The script also reproduces the 0.6B
+to 1.6e-05, which is how it is verified against a graph that was already known good.
 
 Licenses differ per artifact:
 
 | Artifact | License |
 | :--- | :--- |
 | `OuteTTS-1.0-0.6B` | Apache-2.0 |
-| `Llama-OuteTTS-1.0-1B` | CC-BY-NC-SA-4.0 — **no commercial use** |
+| `Llama-OuteTTS-1.0-1B` | CC-BY-NC-SA-4.0 — **no commercial use** (only the nine `outetts/1B/*` voices) |
 | `DAC.speech.v1.0` (IBM Research) | CDLA-Permissive-2.0 |
 | speaker profiles (from the `outetts` package) | Apache-2.0 |
 

--- a/docs/training/engines/outetts.md
+++ b/docs/training/engines/outetts.md
@@ -84,8 +84,11 @@ signature, so no layer count is written into phoonnx.
 
 Two details differ from the other codec-LM engines:
 
-* `logits` covers **every** position, not only the last one, so the decode step reads
-  `logits[0, -1]`.
+* `logits` shape differs by graph. OuteAI's own 0.6B ONNX exports return **every**
+  position, `[1, S, V]`. phoonnx's own re-export of the 1B (see
+  [Weights and licensing](#weights-and-licensing)) returns only the **last** position,
+  `[1, 1, V]`, to avoid materializing a full-sequence tensor the sampler never reads. The
+  engine reads only `logits[0, -1]` either way, so both graphs work unchanged.
 * The waveform is **loudness normalized** to -18 LUFS with a -1 dBFS peak ceiling, and
   every decoder chunk is faded in and out over 15 ms. Upstream does this inside its codec
   wrapper, so it is part of the model's output level, not a phoonnx preference. phoonnx
@@ -121,6 +124,20 @@ for chunk in voice.synthesize("Der alte Leuchtturm steht an der Küste.", syn):
 phoonnx **cannot build a profile from a reference clip**. That needs Whisper word
 alignment plus the DAC encoder and a prosody analysis pass; `speaker_reference` therefore
 raises. Build the profile with the upstream `outetts` package and ship the JSON.
+
+## Known quality caveats
+
+The bundled voices all share the same English speaker profile, so every non-English
+voice carries an audible English accent. This is strongest in Polish.
+
+Sampling can occasionally make the model repeat or loop part of the sentence. This has
+been observed in Ukrainian. Greedy decoding (`temperature=0`) does not loop, but it is
+not the default.
+
+ASR coverage used to check word error rate during integration was limited for several
+languages: Arabic, Belarusian, Bengali, Persian, Swahili and Tamil had no capable
+`onnx-asr` model to check against, and Georgian had none at all. Those voices are
+therefore less verified than the European ones.
 
 ## Decoding parameters
 

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -11,7 +11,8 @@ The catalog is not fetched from a handful of live endpoints. `merge_default_voic
 `OVOS`, `MMS`, `proxectonos`, `piper`, `phonikud`, `neurlang`, `mimic3`,
 `transformers_community`, `piper_community`, `optispeech`, `glowtts`, `mixertts`,
 `fastpitch`, `coqui_community`, `vits2`, `styletts2`, `f5tts`, `coqui_vits`, `BSC`,
-`shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`, `qwen3tts`.
+`shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`, `qwen3tts`,
+`outetts`.
 
 Each JSON entry becomes a `TTSModelInfo`. Model/config/vocoder files are only fetched from their URLs when a voice is actually downloaded or loaded.
 

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -37,6 +37,7 @@ class Engine(str, Enum):
     POCKETTTS = "pockettts"  # Kyutai Pocket TTS: 5-graph flow-matching codec LM, raw-text (no phonemizer)
     SPARKTTS = "sparktts"  # Spark-TTS: Qwen2 codec-LM + BiCodec, preset or zero-shot speakers
     QWEN3TTS = "qwen3tts"  # Qwen3-TTS: talker + code predictor, 16 code groups, 12.5 Hz codec
+    OUTETTS = "outetts"  # OuteTTS 1.0: Llama/Qwen codec-LM + DAC.speech decoder, 23 languages
 
 
 # Alphabet and PhonemeType are wire-format enums shared with scriptconv;
@@ -401,6 +402,26 @@ class VoiceConfig:
             # so no phonemizer vocabulary is needed here. Alphabet.GRAPHEMES routes
             # TTSVoice.synthesize() through adapter.encode_text().
             engine = Engine.QWEN3TTS
+            phoneme_type = phoneme_type or PhonemeType.UNICODE
+            alphabet = alphabet or Alphabet.GRAPHEMES
+            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
+            tokenizer = TTSTokenizer(
+                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
+                add_blank_char=False,
+                add_blank_word=False,
+                use_eos_bos=False,
+                blank_at_end=False,
+                blank_at_start=False,
+            )
+
+        elif (engine == Engine.OUTETTS or
+                (isinstance(engine, str) and engine == "outetts") or
+                config.get("engine") == "outetts"):
+            # OuteTTS consumes raw text: the adapter owns text -> id conversion with the
+            # checkpoint's own tokenizer (loaded from engine_params), so no phonemizer
+            # vocabulary is needed here. Alphabet.GRAPHEMES routes
+            # TTSVoice.synthesize() through adapter.encode_text().
+            engine = Engine.OUTETTS
             phoneme_type = phoneme_type or PhonemeType.UNICODE
             alphabet = alphabet or Alphabet.GRAPHEMES
             config.setdefault("audio", {}).setdefault("sample_rate", 24000)

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -144,6 +144,7 @@ def _register_builtins() -> None:
     from phoonnx.engines.pockettts import PocketTTSAdapter
     from phoonnx.engines.sparktts import SparkTTSAdapter
     from phoonnx.engines.qwen3tts import Qwen3TTSAdapter
+    from phoonnx.engines.outetts import OuteTTSAdapter
 
     # OptiSpeech shares VITS-like x/x_lengths/scales inputs with Matcha, but has
     # a distinctive metadata + wav/durations output signature — check it first.
@@ -168,6 +169,7 @@ def _register_builtins() -> None:
     register_engine("pockettts", PocketTTSAdapter, detect_priority=26)
     register_engine("sparktts", SparkTTSAdapter, detect_priority=25)
     register_engine("qwen3tts", Qwen3TTSAdapter, detect_priority=24)
+    register_engine("outetts", OuteTTSAdapter, detect_priority=23)
 
 
 _register_builtins()

--- a/phoonnx/engines/outetts.py
+++ b/phoonnx/engines/outetts.py
@@ -9,12 +9,12 @@ duration model, no vocoder and no phonemizer — the LM consumes raw text.
 Two checkpoints share one interface (upstream's "interface v3")::
 
     OuteTTS-1.0-0.6B        Qwen3-0.6B backbone, Apache-2.0, 14 languages
-    Llama-OuteTTS-1.0-1B    Llama-3.2-1B backbone, CC-BY-NC-SA-4.0, 23+ languages
+    Llama-OuteTTS-1.0-1B    Llama-3.2-1B backbone, CC-BY-NC-SA-4.0, 23 languages
 
-phoonnx defaults to the 0.6B: it is the permissively licensed one and the one that
-runs comfortably on CPU. The 1B is indexed as well because it is the only member of
-the family that covers the low-resource languages (Bengali, Persian, Swahili, Tamil,
-Lithuanian, Ukrainian, ...) — see ``VOICES.md`` for the license note.
+The 14 languages the 0.6B was trained on resolve to the 0.6B: it is the permissively
+licensed one and the one that runs comfortably on CPU. The nine languages only the 1B
+covers (Arabic, Belarusian, Bengali, Lithuanian, Persian, Portuguese, Swahili, Tamil,
+Ukrainian) resolve to the 1B — see ``VOICES.md`` for the license note.
 
 Two ONNX graphs::
 
@@ -29,12 +29,15 @@ length, exactly as :class:`phoonnx.engines.neutts.NeuTTSAdapter` does::
              position_ids              int64 [1, S]        absolute positions P .. P+S-1
              past_key_values.<i>.key   fp32  [1, H, P, D]  for i in 0 .. L-1
              past_key_values.<i>.value fp32  [1, H, P, D]
-    outputs  logits                    fp32  [1, S, V]     **all** positions
+    outputs  logits                    fp32  [1, S, V]     all positions
              present.<i>.key / present.<i>.value  fp32 [1, H, P + S, D]
 
 Unlike NeuTTS's export, ``logits`` carries the whole sequence, so the decode step reads
-``logits[0, -1]``. The KV geometry (L, H, D) is read off the graph's own input
-signature, so the 0.6B and the 1B need no code change.
+``logits[0, -1]``. That indexing is also what makes a leaner export work: phoonnx's own
+1B graph (``scripts/conversion/outetts/export_outetts_onnx.py``) returns ``[1, 1, V]``,
+the final row alone, rather than a ~1 GB prefill tensor the sampler never looks at. The
+KV geometry (L, H, D) is read off the graph's own input signature, so the 0.6B and the
+1B need no code change.
 
 Prompt format
 ~~~~~~~~~~~~~

--- a/phoonnx/engines/outetts.py
+++ b/phoonnx/engines/outetts.py
@@ -1,0 +1,734 @@
+"""OuteTTS 1.0 inference adapter — Llama/Qwen codec-LM + DAC.speech decoder.
+
+OuteTTS 1.0 (OuteAI) is a causal language model whose vocabulary was extended with
+the two codebooks of **DAC.speech.v1.0**, a 24 kHz residual-vector-quantized codec at
+1.5 kbps. The model reads a text prompt and emits interleaved ``<|c1_N|><|c2_N|>``
+pairs; the codec decoder turns that pair stream back into a waveform. There is no
+duration model, no vocoder and no phonemizer — the LM consumes raw text.
+
+Two checkpoints share one interface (upstream's "interface v3")::
+
+    OuteTTS-1.0-0.6B        Qwen3-0.6B backbone, Apache-2.0, 14 languages
+    Llama-OuteTTS-1.0-1B    Llama-3.2-1B backbone, CC-BY-NC-SA-4.0, 23+ languages
+
+phoonnx defaults to the 0.6B: it is the permissively licensed one and the one that
+runs comfortably on CPU. The 1B is indexed as well because it is the only member of
+the family that covers the low-resource languages (Bengali, Persian, Swahili, Tamil,
+Lithuanian, Ukrainian, ...) — see ``VOICES.md`` for the license note.
+
+Two ONNX graphs::
+
+    model.onnx          the codec-LM, KV-cached  (= the voice's ``session``)
+    decoder_model.onnx  audio_codes[1, 2, N] -> audio_values[1, 1, T] @ 24 kHz
+
+``model.onnx`` serves prefill *and* decode — the same graph with a different past
+length, exactly as :class:`phoonnx.engines.neutts.NeuTTSAdapter` does::
+
+    inputs   input_ids                 int64 [1, S]        prompt, or 1 token per step
+             attention_mask            int64 [1, P + S]    ones over past and current
+             position_ids              int64 [1, S]        absolute positions P .. P+S-1
+             past_key_values.<i>.key   fp32  [1, H, P, D]  for i in 0 .. L-1
+             past_key_values.<i>.value fp32  [1, H, P, D]
+    outputs  logits                    fp32  [1, S, V]     **all** positions
+             present.<i>.key / present.<i>.value  fp32 [1, H, P + S, D]
+
+Unlike NeuTTS's export, ``logits`` carries the whole sequence, so the decode step reads
+``logits[0, -1]``. The KV geometry (L, H, D) is read off the graph's own input
+signature, so the 0.6B and the 1B need no code change.
+
+Prompt format
+~~~~~~~~~~~~~
+Reproduced from ``outetts.version.v3.prompt_processor.PromptProcessor``::
+
+    <|im_start|>
+    <|text_start|>{speaker text}{separator}{target text}<|text_end|>
+    <|audio_start|>
+    <|word_start|>{word}<|features|><|t_0.20|><|energy_N|><|spectral_centroid_N|>
+        <|pitch_N|><|code|><|c1_a|><|c2_a|>...<|word_end|>
+    ... one line per speaker word ...
+    <|word_start|>
+
+Generation continues that stream until ``<|audio_end|>`` or ``<|im_end|>``.
+
+Cloning is **in-context and pre-encoded**: a speaker profile is a JSON transcript whose
+words each carry a duration, three prosody buckets and their DAC codes (upstream's
+``speaker`` dict, ``interface_version: 3``). Building a profile from a fresh clip needs
+Whisper word-alignment plus the DAC *encoder*; this adapter clones from published
+profiles only, so ``speaker_reference`` is not supported.
+
+Sampling follows upstream's **HuggingFace** stack — ``outetts``'s default backend is
+``Backend.HF`` — which is a different order from the llama.cpp one NeuTTS uses:
+windowed repetition penalty, then temperature, then top-k, top-p and min-p over the
+*tempered* distribution. See :func:`_sample`.
+"""
+import copy
+import json
+import math
+import re
+import unicodedata
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import onnxruntime
+
+from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
+from phoonnx.util import LOG
+
+SAMPLE_RATE = 24000
+
+#: DAC.speech.v1.0 hop length; 24000 / 512 = 46.875 code frames per second.
+CODEC_HOP_LENGTH = 512
+FRAMES_PER_SECOND = SAMPLE_RATE / CODEC_HOP_LENGTH
+
+# Special token strings — fixed by the family's prompt format
+# (``outetts.version.v3.tokens.SpecialTokens``). The *ids* are read from the
+# checkpoint's own tokenizer, so a sibling export needs no table here.
+BOS = "<|im_start|>"
+EOS = "<|im_end|>"
+TEXT_START = "<|text_start|>"
+TEXT_END = "<|text_end|>"
+AUDIO_START = "<|audio_start|>"
+AUDIO_END = "<|audio_end|>"
+WORD_START = "<|word_start|>"
+WORD_END = "<|word_end|>"
+FEATURES = "<|features|>"
+CODE = "<|code|>"
+TIME = "<|t_{:.2f}|>"
+C1 = "<|c1_{}|>"
+C2 = "<|c2_{}|>"
+
+#: Both DAC codebooks hold 1024 entries; upstream maps 1025 ids per codebook (the extra
+#: slot exists in the vocabulary but is never emitted by the encoder).
+CODEBOOK_TOKENS = 1025
+
+#: Tokens the repetition penalty looks back over. Upstream ships a *patched*
+#: ``RepetitionPenaltyLogitsProcessor`` that windows the penalty to the last 64 tokens
+#: instead of HuggingFace's whole-context default, because the unwindowed penalty
+#: destroys long generations for this model. The window spans the prompt too.
+REPETITION_WINDOW = 64
+
+#: Word-count bounds of upstream's ``chunk_text``.
+CHUNK_MIN_WORDS = 10
+CHUNK_MAX_WORDS = 30
+
+_SENTENCE_END = re.compile(r"([.!?。！？︕︖]+\s*)")
+_C1_RE = re.compile(r"^<\|c1_(\d+)\|>$")
+_C2_RE = re.compile(r"^<\|c2_(\d+)\|>$")
+
+
+# ----------------------------------------------------------------------------------
+# text
+# ----------------------------------------------------------------------------------
+def _is_cjk(text: str) -> bool:
+    """True when *text* contains Hiragana, Katakana or Han — upstream's language probe."""
+    return any("぀" <= c <= "ゟ" or "゠" <= c <= "ヿ"
+               or "一" <= c <= "鿿" for c in text)
+
+
+def text_normalizations(text: str) -> str:
+    """Upstream's ``PromptProcessor.text_normalizations``.
+
+    Upstream runs ``ftfy.fix_text`` first to repair mojibake. phoonnx does not carry
+    ``ftfy``, and NFKC — which upstream applies straight after — covers the
+    compatibility folding that actually changes tokenization here. Text that reaches
+    phoonnx has not been through a broken decode, so the mojibake repair has nothing
+    to do; the rest of the pipeline is reproduced exactly.
+    """
+    if not isinstance(text, str):
+        return "" if text is None else str(text)
+    text = unicodedata.normalize("NFKC", text)
+    text = text.replace("…", "...")
+    text = re.sub(r"\.{2,}", "...", text)
+    text = re.sub(r"[“”„‟«»]", '"', text)
+    text = re.sub(r"[‘’‛‹›`´]", "'", text)
+    text = re.sub(r"[–—―−‐]", "-", text)
+    text = re.sub(r"-{2,}", "-", text)
+    text = re.sub(r"[\x00-\x1F\x7F-\x9F­​-‍﻿]", "", text)
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r"\s+([,.?!:;])", r"\1", text)
+    text = re.sub(r"([,.?!:;])(?=[^\s,.?!:;])", r"\1 ", text)
+    text = re.sub(r"(\w)\s+'\s*(\w)", r"\1'\2", text)
+    text = re.sub(r"(\w)\s+'\s*([,.?!:;\s]|$)", r"\1'\2", text)
+    text = re.sub(r"(\w)\s*'\s*([tsdmreSNTDMRE])\b", r"\1'\2", text, flags=re.IGNORECASE)
+    text = re.sub(r"([?!])\1+", r"\1", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.replace('"', "").strip()
+
+
+def _tokenize_words(text: str) -> List[str]:
+    """Split *text* into the units ``chunk_text`` counts.
+
+    Upstream sends CJK text through MeCab (``-Owakati``) and everything else through
+    ``str.split``. MeCab is a Japanese-only morphological analyser and a heavyweight
+    optional dependency, so CJK is split per character here instead. That changes only
+    *where* a long passage is cut into chunks, never the tokens inside a chunk, and a
+    character is a tighter bound than a MeCab word — so a chunk stays under the model's
+    budget either way.
+    """
+    if not text.strip():
+        return []
+    if _is_cjk(text):
+        return [c for c in text if not c.isspace()]
+    return text.split()
+
+
+def split_into_sentences(text: str) -> List[str]:
+    """Split on sentence-final punctuation, keeping the marks attached."""
+    parts = _SENTENCE_END.split(text)
+    sentences = []
+    for i in range(0, len(parts), 2):
+        current = parts[i]
+        if i + 1 < len(parts):
+            current += parts[i + 1]
+        if current.strip():
+            sentences.append(current.strip())
+    return sentences
+
+
+def chunk_text(text: str, min_words: int = CHUNK_MIN_WORDS,
+               max_words: int = CHUNK_MAX_WORDS) -> List[str]:
+    """Pack sentences into chunks of ``min_words``..``max_words`` — upstream's default
+    ``GenerationType.CHUNKED`` behaviour.
+
+    The LM degrades on long prompts, so upstream synthesizes chunk by chunk and
+    concatenates the code streams. An over-long sentence is cut at ``max_words``.
+    """
+    text = re.sub(r"\s+", " ", unicodedata.normalize("NFKC", text)).strip()
+    if not text:
+        return []
+
+    def join(tokens: List[str]) -> str:
+        return "".join(tokens) if _is_cjk("".join(tokens)) else " ".join(tokens)
+
+    chunks: List[str] = []
+    current = ""
+    count = 0
+    for sentence in split_into_sentences(text) or [text]:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        tokens = _tokenize_words(sentence)
+        n = len(tokens)
+
+        if n > max_words:
+            if current:
+                chunks.append(current)
+                current, count = "", 0
+            part: List[str] = []
+            for token in tokens:
+                part.append(token)
+                if len(part) >= max_words:
+                    chunks.append(join(part))
+                    part = []
+            if part:
+                chunks.append(join(part))
+            continue
+
+        if count + n <= max_words:
+            current = f"{current} {sentence}" if current else sentence
+            count += n
+        elif count >= min_words:
+            chunks.append(current)
+            current, count = sentence, n
+        else:
+            space_left = max_words - count
+            head, tail = tokens[:space_left], tokens[space_left:]
+            if current:
+                joined = join(head)
+                chunks.append(current + ("" if _is_cjk(joined) else " ") + joined)
+            else:
+                chunks.append(join(head))
+            current = join(tail)
+            count = len(tail)
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+# ----------------------------------------------------------------------------------
+# sampling — HuggingFace order (upstream's default backend)
+# ----------------------------------------------------------------------------------
+def _softmax(x: np.ndarray) -> np.ndarray:
+    z = np.asarray(x, np.float64)
+    z = z - z.max()
+    e = np.exp(z)
+    return e / e.sum()
+
+
+def _apply_repetition_penalty(scores: np.ndarray, seen: np.ndarray,
+                              penalty: float) -> np.ndarray:
+    """Divide positive scores of tokens in *seen* by *penalty*, multiply negative ones.
+
+    ``seen`` is the recent-token window the caller chose, not the whole history —
+    see :data:`REPETITION_WINDOW`.
+    """
+    if penalty == 1.0 or seen.size == 0:
+        return scores
+    out = scores.copy()
+    idx = np.unique(seen[(seen >= 0) & (seen < out.shape[0])])
+    if idx.size:
+        s = out[idx]
+        out[idx] = np.where(s <= 0, s * penalty, s / penalty)
+    return out
+
+
+def _sample(scores: np.ndarray, temperature: float, top_k: int, top_p: float,
+            min_p: float, rng: np.random.Generator) -> int:
+    """Temperature, then top-k, then top-p, then min-p — HuggingFace's warper order.
+
+    ``outetts``'s default backend is ``Backend.HF``, so this reproduces the sampler the
+    published defaults (``generation_config.json``) were tuned against. The order is
+    *not* llama.cpp's: temperature is applied **first**, so the truncations below all
+    operate on the already-tempered distribution. ``min_p`` has no llama.cpp-order
+    equivalent in phoonnx's other codec-LMs — it drops every token whose probability is
+    below ``min_p`` times the top token's.
+    """
+    s = np.asarray(scores, np.float32)
+    if temperature <= 0:
+        return int(np.argmax(s))
+    s = s / float(temperature)
+    if 0 < top_k < s.shape[0]:
+        threshold = float(np.partition(s, -top_k)[-top_k])
+        s = np.where(s < threshold, -np.inf, s)
+    if 0 < top_p < 1:
+        order = np.argsort(s)[::-1]
+        cumulative = np.cumsum(_softmax(s[order]))
+        keep = np.ones(order.shape[0], bool)
+        # keep every token up to and including the one that crosses top_p
+        keep[1:] = cumulative[:-1] < top_p
+        masked = np.full_like(s, -np.inf)
+        masked[order[keep]] = s[order[keep]]
+        s = masked
+    if 0 < min_p < 1:
+        probs = _softmax(s)
+        s = np.where(probs < min_p * probs.max(), -np.inf, s)
+    return int(rng.choice(s.shape[0], p=_softmax(s)))
+
+
+# ----------------------------------------------------------------------------------
+# loudness — ITU-R BS.1770-4, as pyloudnorm implements it
+# ----------------------------------------------------------------------------------
+def _biquad(kind: str, rate: int) -> Tuple[np.ndarray, np.ndarray]:
+    """K-weighting stage coefficients, ``pyloudnorm.IIRfilter`` designs them per rate."""
+    if kind == "high_shelf":
+        gain, q, fc = 4.0, 0.7071752369554196, 1681.9744509555319
+    else:
+        gain, q, fc = 0.0, 0.5003270373238773, 38.13547087602444
+    a = 10 ** (gain / 40.0)
+    w0 = 2.0 * math.pi * (fc / rate)
+    alpha = math.sin(w0) / (2.0 * q)
+    cos = math.cos(w0)
+    if kind == "high_shelf":
+        root = math.sqrt(a)
+        b = np.array([a * ((a + 1) + (a - 1) * cos + 2 * root * alpha),
+                      -2 * a * ((a - 1) + (a + 1) * cos),
+                      a * ((a + 1) + (a - 1) * cos - 2 * root * alpha)])
+        den = np.array([(a + 1) - (a - 1) * cos + 2 * root * alpha,
+                        2 * ((a - 1) - (a + 1) * cos),
+                        (a + 1) - (a - 1) * cos - 2 * root * alpha])
+    else:
+        b = np.array([(1 + cos) / 2, -(1 + cos), (1 + cos) / 2])
+        den = np.array([1 + alpha, -2 * cos, 1 - alpha])
+    return b / den[0], den / den[0]
+
+
+def integrated_loudness(audio: np.ndarray, rate: int = SAMPLE_RATE,
+                        block_size: float = 0.400) -> float:
+    """Gated integrated loudness of mono *audio* in LUFS (ITU-R BS.1770-4).
+
+    Reimplemented in numpy/scipy rather than pulled in as a dependency: it is two
+    biquads and a two-stage gate, and ``pyloudnorm`` would be a new hard requirement
+    for every phoonnx install. Returns ``-inf`` for silence, which
+    :func:`normalize_loudness` passes through unchanged.
+    """
+    from scipy.signal import lfilter
+    x = np.asarray(audio, np.float64).reshape(-1)
+    for kind in ("high_shelf", "high_pass"):
+        b, a = _biquad(kind, rate)
+        x = lfilter(b, a, x)
+
+    step = 0.25  # 75 % overlap
+    duration = x.shape[0] / rate
+    num_blocks = int(round((duration - block_size) / (block_size * step)) + 1)
+    if num_blocks < 1:
+        return -np.inf
+    z = np.empty(num_blocks)
+    for j in range(num_blocks):
+        lo = int(block_size * (j * step) * rate)
+        hi = int(block_size * (j * step + 1) * rate)
+        z[j] = np.sum(np.square(x[lo:hi])) / (block_size * rate)
+    with np.errstate(divide="ignore"):
+        loudness = -0.691 + 10.0 * np.log10(z)
+
+    gated = z[loudness > -70.0]
+    if gated.size == 0:
+        return -np.inf
+    with np.errstate(divide="ignore"):
+        relative = -0.691 + 10.0 * np.log10(gated.mean()) - 10.0
+    gated = z[(loudness > -70.0) & (loudness > relative)]
+    if gated.size == 0:
+        return -np.inf
+    return float(-0.691 + 10.0 * np.log10(gated.mean()))
+
+
+def normalize_loudness(audio: np.ndarray, target: float = -18.0,
+                       peak_limit: float = -1.0, rate: int = SAMPLE_RATE,
+                       block_size: float = 0.400) -> np.ndarray:
+    """Upstream's ``process_audio_tensor``: loudness-normalize, then peak-limit.
+
+    Every OuteTTS waveform goes through this on the way out of the codec, so it is part
+    of the model's output level, not a phoonnx-side taste decision. Clips shorter than
+    one gating block are zero-padded for the measurement and trimmed back after, as
+    upstream does.
+    """
+    x = np.asarray(audio, np.float64).reshape(-1)
+    original = x.shape[0]
+    if original == 0:
+        return np.zeros(0, np.float32)
+    minimum = int(block_size * rate)
+    measured = integrated_loudness(
+        np.pad(x, (0, max(0, minimum - original))), rate, block_size)
+    if np.isfinite(measured):
+        x = x * (10 ** ((target - measured) / 20.0))
+    peak = float(np.max(np.abs(x)))
+    threshold = 10 ** (peak_limit / 20.0)
+    if peak > threshold:
+        x = x * threshold / peak
+    return np.asarray(x[:original], np.float32)
+
+
+class OuteTTSAdapter(BaseOnnxAdapter):
+    """Adapter for OuteTTS 1.0 (codec-LM + DAC.speech decoder)."""
+
+    #: hard ceiling on the AR loop; DAC runs at ~46.9 frames/s and each frame is two
+    #: tokens, so 4096 tokens is ~44 s of speech.
+    MAX_NEW_TOKENS = 4096
+    #: code frames per DAC decoder call (upstream's ``dac_decoding_chunk``)
+    DECODE_CHUNK = 2048
+    #: crossfade applied to every decoder chunk, in seconds (upstream's ``apply_fade``)
+    FADE_SECONDS = 0.015
+
+    def __init__(self):
+        self.codec: Optional[onnxruntime.InferenceSession] = None
+        self.tokenizer = None
+        self.speakers: Dict[str, Dict[str, Any]] = {}
+        self.default_speaker: Optional[str] = None
+        self.audio_end_id: Optional[int] = None
+        self.eos_id: Optional[int] = None
+        self.word_start_id: Optional[int] = None
+        self.c1: Dict[int, int] = {}
+        self.c2: Dict[int, int] = {}
+        self.num_layers = 0
+        self.num_kv_heads = 0
+        self.head_dim = 0
+
+    # ------------------------------------------------------------------
+    # setup
+    # ------------------------------------------------------------------
+    def default_params(self) -> Dict[str, Any]:
+        """Upstream's ``SamplerConfig`` / ``generation_config.json`` defaults."""
+        return {
+            "temperature": 0.4,
+            "top_p": 0.9,
+            "top_k": 40.0,
+            "min_p": 0.05,
+            "repetition_penalty": 1.1,
+            "max_new_tokens": float(self.MAX_NEW_TOKENS),
+            "max_chunk_words": float(CHUNK_MAX_WORDS),
+        }
+
+    def param_labels(self) -> Dict[str, str]:
+        return {
+            "temperature": "sampling temperature",
+            "top_p": "top-p (nucleus)",
+            "top_k": "top-k",
+            "min_p": "min-p (relative probability floor)",
+            "repetition_penalty": "repetition penalty (64-token window)",
+            "max_new_tokens": "max codec tokens (~94/s)",
+            "max_chunk_words": "target words per model call",
+            "voice": "speaker profile name",
+        }
+
+    def configure(self, voice_config: Any) -> None:
+        """Load the DAC decoder, the checkpoint's tokenizer and the speaker profiles."""
+        ep = getattr(voice_config, "engine_params", None) or {}
+        if self.codec is None and ep.get("codec_decoder_path"):
+            self.codec = make_session(ep["codec_decoder_path"], providers=ep.get("providers"))
+        if self.tokenizer is None and ep.get("tokenizer_path"):
+            from tokenizers import Tokenizer
+            self.tokenizer = Tokenizer.from_file(str(ep["tokenizer_path"]))
+            self._build_token_maps()
+        if not self.speakers and ep.get("speakers_path"):
+            with open(ep["speakers_path"], encoding="utf-8") as f:
+                data = json.load(f)
+            # a bare upstream profile is a single speaker; phoonnx also accepts a
+            # ``{"default_voice": ..., "speakers": {...}}`` bundle
+            if "words" in data:
+                name = data.get("name") or "default"
+                self.speakers = {name: data}
+                self.default_speaker = name
+            else:
+                self.speakers = data.get("speakers") or {}
+                self.default_speaker = data.get("default_voice")
+
+    def _build_token_maps(self) -> None:
+        """Map ``<|c1_N|>`` / ``<|c2_N|>`` token ids back to codebook indices.
+
+        Built from the tokenizer rather than from an offset table: the two checkpoints
+        have different vocabularies, and nothing guarantees the codec tokens are
+        contiguous in either.
+        """
+        for template, table in ((C1, self.c1), (C2, self.c2)):
+            for i in range(CODEBOOK_TOKENS):
+                tid = self.tokenizer.token_to_id(template.format(i))
+                if tid is not None:
+                    table[int(tid)] = i
+        self.audio_end_id = self.tokenizer.token_to_id(AUDIO_END)
+        self.eos_id = self.tokenizer.token_to_id(EOS)
+        self.word_start_id = self.tokenizer.token_to_id(WORD_START)
+
+    def _read_kv_shape(self, session: onnxruntime.InferenceSession) -> None:
+        for spec in session.get_inputs():
+            if spec.name.startswith("past_key_values.") and spec.name.endswith(".key"):
+                self.num_layers += 1
+                if self.num_kv_heads == 0:
+                    self.num_kv_heads = int(spec.shape[1])
+                    self.head_dim = int(spec.shape[3])
+
+    # ------------------------------------------------------------------
+    # prompt
+    # ------------------------------------------------------------------
+    def resolve_speaker(self, voice: Any, syn_config: Any) -> Optional[Dict[str, Any]]:
+        """Pick the speaker profile: an explicit per-call ``voice``, else the one this
+        phoonnx voice is pinned to, else the bundle's ``default_voice``."""
+        name = None
+        if syn_config is not None:
+            name = (syn_config.extra_params or {}).get("voice")
+        if not name:
+            cfg = getattr(voice, "config", None)
+            name = (getattr(cfg, "engine_params", None) or {}).get("voice")
+        if not name:
+            name = self.default_speaker
+        if not name:
+            return None
+        if name not in self.speakers:
+            raise ValueError(f"unknown OuteTTS speaker profile {name!r}; "
+                             f"available: {sorted(self.speakers)}")
+        return self.speakers[name]
+
+    @staticmethod
+    def _separator(text: str) -> str:
+        """Sentence separator for the speaker transcript's script."""
+        if any("぀" <= c <= "ゟ" or "゠" <= c <= "ヿ"
+               or "一" <= c <= "鿿" for c in text):
+            return "。"
+        return ". "
+
+    def merge_speaker_text(self, target: str, speaker_text: str) -> Tuple[str, str]:
+        """Glue the speaker's transcript in front of the target text.
+
+        The profile's audio *is* the start of the utterance, so its transcript has to
+        lead the prompt; the separator that joins them is also appended to the profile's
+        last word, so the codes and the text stay aligned.
+        """
+        speaker_text = speaker_text.strip()
+        separator = self._separator(speaker_text)
+        ends = ["。", "？", "！", "?", "!"] if separator == "。" \
+            else [".", "?", "!"]
+        joiner = ""
+        if speaker_text:
+            if speaker_text[-1] not in ends:
+                joiner = separator
+            elif separator != "。":
+                joiner = " "
+        return speaker_text + joiner + target.strip(), joiner.strip()
+
+    @staticmethod
+    def _feature_tokens(features: Dict[str, Any]) -> str:
+        return "".join(f"<|{key}_{features.get(key, 0)}|>"
+                       for key in ("energy", "spectral_centroid", "pitch"))
+
+    def create_codes(self, words: List[Dict[str, Any]]) -> str:
+        """Render the speaker profile's words as the model's in-context audio prompt."""
+        lines = []
+        for word in words:
+            body = word["word"] + FEATURES + TIME.format(float(word["duration"]))
+            body += self._feature_tokens(word.get("features") or {})
+            pairs = "".join(C1.format(a) + C2.format(b)
+                            for a, b in zip(word["c1"], word["c2"]))
+            lines.append(WORD_START + body + CODE + pairs + WORD_END)
+        return "\n".join(lines)
+
+    def build_prompt(self, text: str, speaker: Optional[Dict[str, Any]] = None) -> str:
+        """The exact completion prompt upstream's ``get_completion_prompt`` produces.
+
+        The speaker dict is deep-copied first: upstream appends the separator to the
+        profile's last word *in place*, which corrupts the profile for every later call
+        in the same process.
+        """
+        text = text_normalizations(text)
+        codes = ""
+        if speaker is not None:
+            speaker = copy.deepcopy(speaker)
+            text, separator = self.merge_speaker_text(text, speaker["text"])
+            speaker["words"][-1]["word"] += separator
+            codes = self.create_codes(speaker["words"])
+        prompt = f"{BOS}\n{TEXT_START}{text}{TEXT_END}\n{AUDIO_START}\n"
+        if speaker is not None:
+            prompt += codes + "\n" + WORD_START
+        return prompt
+
+    def encode_text(self, text: str, voice: Any, syn_config: Any) -> List[List[int]]:
+        """Build one fully-formed prompt per model call and tokenize it.
+
+        The speaker block is part of the prompt, so the whole string is tokenized in one
+        pass by the checkpoint's own tokenizer: splicing separately-tokenized pieces
+        would not reproduce training-time ids at the joins.
+        """
+        if self.tokenizer is None:
+            raise RuntimeError("OuteTTS voice missing tokenizer_path in engine_params")
+        budget = CHUNK_MAX_WORDS
+        if syn_config is not None:
+            budget = int((syn_config.extra_params or {}).get("max_chunk_words", budget))
+        speaker = self.resolve_speaker(voice, syn_config)
+        prompts = [self.build_prompt(chunk, speaker)
+                   for chunk in chunk_text(text, max_words=max(1, budget))]
+        return [list(self.tokenizer.encode(p, add_special_tokens=False).ids)
+                for p in prompts]
+
+    # ------------------------------------------------------------------
+    # codec
+    # ------------------------------------------------------------------
+    def token_ids_to_codes(self, token_ids: List[int]) -> List[List[int]]:
+        """Split the generated stream into the two DAC codebooks.
+
+        The two runs are truncated to a common length: the model can stop mid-frame,
+        having emitted a ``c1`` without its ``c2``.
+        """
+        first = [self.c1[t] for t in token_ids if t in self.c1]
+        second = [self.c2[t] for t in token_ids if t in self.c2]
+        n = min(len(first), len(second))
+        return [first[:n], second[:n]]
+
+    def _fade(self, audio: np.ndarray) -> np.ndarray:
+        """Fade a decoder chunk in and out, as upstream does before concatenating."""
+        total = audio.shape[0]
+        length = min(int(SAMPLE_RATE * self.FADE_SECONDS), total // 2)
+        if length <= 0:
+            return audio
+        audio = audio.copy()
+        audio[:length] *= np.linspace(0.0, 1.0, length, dtype=audio.dtype)
+        audio[total - length:] *= np.linspace(1.0, 0.0, length, dtype=audio.dtype)
+        return audio
+
+    def decode_codes(self, codes: List[List[int]]) -> np.ndarray:
+        """Two DAC codebooks -> mono float32 waveform at 24 kHz."""
+        if not codes or not codes[0]:
+            return np.zeros(0, np.float32)
+        arr = np.asarray(codes, np.int64).reshape(1, 2, -1)
+        name = self.codec.get_inputs()[0].name
+        pieces = []
+        for start in range(0, arr.shape[-1], self.DECODE_CHUNK):
+            chunk = arr[..., start:start + self.DECODE_CHUNK]
+            audio = self.codec.run(None, {name: chunk})[0]
+            pieces.append(self._fade(np.asarray(audio, np.float32).reshape(-1)))
+        return normalize_loudness(np.concatenate(pieces))
+
+    # ------------------------------------------------------------------
+    # autoregressive loop
+    # ------------------------------------------------------------------
+    def generate(self, session: onnxruntime.InferenceSession, prompt_ids: List[int],
+                 p: Dict[str, Any], rng: np.random.Generator) -> List[int]:
+        """Prefill the prompt, then sample codec tokens until the model stops."""
+        if not self.num_layers:
+            self._read_kv_shape(session)
+        out_names = [o.name for o in session.get_outputs()]
+        past_names = [f"past_key_values.{i}.{k}"
+                      for i in range(self.num_layers) for k in ("key", "value")]
+        present_names = [f"present.{i}.{k}"
+                         for i in range(self.num_layers) for k in ("key", "value")]
+
+        ids = np.asarray(prompt_ids, np.int64).reshape(1, -1)
+        length = ids.shape[1]
+        feed = {
+            "input_ids": ids,
+            "attention_mask": np.ones((1, length), np.int64),
+            "position_ids": np.arange(length, dtype=np.int64)[None, :],
+        }
+        empty = np.zeros((1, self.num_kv_heads, 0, self.head_dim), np.float32)
+        feed.update({n: empty for n in past_names})
+        named = dict(zip(out_names, session.run(None, feed)))
+
+        temperature = float(p.get("temperature", 0.4))
+        top_p = float(p.get("top_p", 0.9))
+        top_k = int(p.get("top_k", 40))
+        min_p = float(p.get("min_p", 0.05))
+        penalty = float(p.get("repetition_penalty", 1.1))
+        max_new = max(1, int(p.get("max_new_tokens", self.MAX_NEW_TOKENS)))
+
+        generated: List[int] = []
+        history = list(prompt_ids)
+        for step in range(max_new):
+            # the export returns logits for every position, so the next-token
+            # distribution is the last row — not the whole tensor as in NeuTTS
+            logits = np.asarray(named["logits"], np.float32)[0, -1]
+            logits = _apply_repetition_penalty(
+                logits, np.asarray(history[-REPETITION_WINDOW:], np.int64), penalty)
+            token = _sample(logits, temperature, top_k, top_p, min_p, rng)
+            if token == self.audio_end_id or token == self.eos_id:
+                break
+            generated.append(token)
+            history.append(token)
+            if step == max_new - 1:
+                LOG.warning("OuteTTS hit the %d-token cap (~%.1fs) without an end token",
+                            max_new, max_new / (2 * FRAMES_PER_SECOND))
+                break
+            position = length + step
+            feed = {
+                "input_ids": np.asarray([[token]], np.int64),
+                "attention_mask": np.ones((1, position + 1), np.int64),
+                "position_ids": np.asarray([[position]], np.int64),
+                **{name: named[q] for name, q in zip(past_names, present_names)},
+            }
+            named = dict(zip(out_names, session.run(None, feed)))
+        return generated
+
+    # ------------------------------------------------------------------
+    # synthesis
+    # ------------------------------------------------------------------
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        if self.codec is None:
+            raise RuntimeError("OuteTTS voice missing codec_decoder_path in engine_params")
+        if self.tokenizer is None:
+            raise RuntimeError("OuteTTS voice missing tokenizer_path in engine_params")
+        if request.params.get("reference_audio") is not None:
+            raise RuntimeError(
+                "OuteTTS clones from pre-encoded speaker profiles, not from a reference "
+                "clip: building one needs Whisper word alignment and the DAC encoder. "
+                "Select a profile with extra_params={'voice': ...}")
+
+        p = {**self.default_params(), **request.params}
+        seed = p.get("seed")
+        rng = np.random.default_rng(None if seed is None else int(seed))
+        prompt_ids = [int(i) for i in np.asarray(request.phoneme_ids).reshape(-1)]
+        token_ids = self.generate(session, prompt_ids, p, rng)
+        codes = self.token_ids_to_codes(token_ids)
+        if not codes[0]:
+            raise RuntimeError("OuteTTS generated no codec tokens — lower the temperature "
+                               "or pick another speaker profile")
+        return AdapterSynthesisResult(audio=self.decode_codes(codes),
+                                      extras={"frames": len(codes[0])})
+
+    # required by the ABC but unused — synthesize() drives the AR loop.
+    def build_feed_dict(self, request, session):
+        raise NotImplementedError("OuteTTS is autoregressive — use synthesize()")
+
+    def parse_outputs(self, outputs, request, output_names=None):
+        raise NotImplementedError("OuteTTS is autoregressive — use synthesize()")
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        return bool(config and config.get("engine") == "outetts")

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -658,6 +658,7 @@ class TTSModelManager:
         "coqui_vits.json", "BSC.json", "shami.json", "chatterbox.json",
         "supertonic.json", "neutts.json", "pockettts.json", "sparktts.json",
         "qwen3tts.json",
+        "outetts.json",
     )
 
     @classmethod

--- a/phoonnx/voice_index/outetts.json
+++ b/phoonnx/voice_index/outetts.json
@@ -264,5 +264,176 @@
             "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
         },
         "display_name": "OuteTTS 1.0 0.6B — Spanish"
+    },
+    "outetts/1B/ar": {
+        "voice_id": "outetts/1B/ar",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "ar-SA",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Arabic"
+    },
+    "outetts/1B/be": {
+        "voice_id": "outetts/1B/be",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "be-BY",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Belarusian"
+    },
+    "outetts/1B/bn": {
+        "voice_id": "outetts/1B/bn",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "bn-BD",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Bengali"
+    },
+    "outetts/1B/fa": {
+        "voice_id": "outetts/1B/fa",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "fa-IR",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Persian"
+    },
+    "outetts/1B/lt": {
+        "voice_id": "outetts/1B/lt",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "lt-LT",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Lithuanian"
+    },
+    "outetts/1B/pt": {
+        "voice_id": "outetts/1B/pt",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "pt-PT",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Portuguese"
+    },
+    "outetts/1B/sw": {
+        "voice_id": "outetts/1B/sw",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "sw-KE",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Swahili"
+    },
+    "outetts/1B/ta": {
+        "voice_id": "outetts/1B/ta",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "ta-IN",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Tamil"
+    },
+    "outetts/1B/uk": {
+        "voice_id": "outetts/1B/uk",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "uk-UA",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 1B — Ukrainian"
     }
 }

--- a/phoonnx/voice_index/outetts.json
+++ b/phoonnx/voice_index/outetts.json
@@ -1,0 +1,268 @@
+{
+    "outetts/0.6B/en": {
+        "voice_id": "outetts/0.6B/en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "en-US",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — English"
+    },
+    "outetts/0.6B/zh": {
+        "voice_id": "outetts/0.6B/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Chinese"
+    },
+    "outetts/0.6B/nl": {
+        "voice_id": "outetts/0.6B/nl",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "nl-NL",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Dutch"
+    },
+    "outetts/0.6B/fr": {
+        "voice_id": "outetts/0.6B/fr",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "fr-FR",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — French"
+    },
+    "outetts/0.6B/ka": {
+        "voice_id": "outetts/0.6B/ka",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "ka-GE",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Georgian"
+    },
+    "outetts/0.6B/de": {
+        "voice_id": "outetts/0.6B/de",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "de-DE",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — German"
+    },
+    "outetts/0.6B/hu": {
+        "voice_id": "outetts/0.6B/hu",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "hu-HU",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Hungarian"
+    },
+    "outetts/0.6B/it": {
+        "voice_id": "outetts/0.6B/it",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "it-IT",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Italian"
+    },
+    "outetts/0.6B/ja": {
+        "voice_id": "outetts/0.6B/ja",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "ja-JP",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Japanese"
+    },
+    "outetts/0.6B/ko": {
+        "voice_id": "outetts/0.6B/ko",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "ko-KR",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Korean"
+    },
+    "outetts/0.6B/lv": {
+        "voice_id": "outetts/0.6B/lv",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "lv-LV",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Latvian"
+    },
+    "outetts/0.6B/pl": {
+        "voice_id": "outetts/0.6B/pl",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "pl-PL",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Polish"
+    },
+    "outetts/0.6B/ru": {
+        "voice_id": "outetts/0.6B/ru",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "ru-RU",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Russian"
+    },
+    "outetts/0.6B/es": {
+        "voice_id": "outetts/0.6B/es",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "outetts",
+        "lang": "es-ES",
+        "aux_model_urls": {
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/dac/decoder_model.onnx",
+            "tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/tokenizer.json",
+            "speakers_path": "https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/speakers/en-female-1-neutral.json"
+        },
+        "display_name": "OuteTTS 1.0 0.6B — Spanish"
+    }
+}

--- a/scripts/conversion/outetts/export_outetts_onnx.py
+++ b/scripts/conversion/outetts/export_outetts_onnx.py
@@ -38,6 +38,10 @@ Usage::
     python export_outetts_onnx.py --repo OuteAI/OuteTTS-1.0-0.6B --out-dir ./onnx \\
         --check-parity
 
+``--check-parity`` prints the diagnostic (prefill/decode max abs diff, greedy agreement)
+and then exits non-zero if greedy agreement is below 100% or either max diff exceeds
+1e-4, so a broken re-export fails CI instead of scrolling past in a log.
+
 Upstream weights keep their own license: ``OuteTTS-1.0-0.6B`` is Apache-2.0, and
 ``Llama-OuteTTS-1.0-1B`` is CC-BY-NC-SA-4.0 (no commercial use).
 """
@@ -46,6 +50,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -290,15 +295,23 @@ def main() -> None:
     ap.add_argument("--opset", type=int, default=18)
     ap.add_argument("--filename", default="model.onnx")
     ap.add_argument("--check-parity", action="store_true",
-                    help="compare the exported graph against torch and print max abs diff")
+                    help="compare the exported graph against torch, print max abs diff, "
+                         "and exit non-zero if greedy_agreement < 100%% or a max diff "
+                         "exceeds the 1e-4 tolerance")
     args = ap.parse_args()
 
     path = export(args.repo, args.out_dir, args.opset, args.filename)
     print(f"wrote {path} ({os.path.getsize(path) / 1e6:.1f} MB + sidecar)")
     if args.check_parity:
-        for name, value in check_parity(args.repo, path).items():
+        tolerance = 1e-4
+        diffs = check_parity(args.repo, path)
+        for name, value in diffs.items():
             print(f"parity {name}: {value:.3e}" if name != "greedy_agreement"
                   else f"parity {name}: {value:.0%}")
+        if diffs["greedy_agreement"] < 1.0 or diffs["prefill"] > tolerance \
+                or diffs["decode"] > tolerance:
+            print(f"parity check FAILED (tolerance={tolerance:.0e})")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/conversion/outetts/export_outetts_onnx.py
+++ b/scripts/conversion/outetts/export_outetts_onnx.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Export an OuteTTS 1.0 backbone to ONNX with the KV-cache contract phoonnx drives.
+
+OuteTTS 1.0 ships two checkpoints — ``OuteTTS-1.0-0.6B`` (Qwen3) and
+``Llama-OuteTTS-1.0-1B`` (Llama-3.2). Both are plain causal LMs that emit DAC.speech
+codec tokens (``<|c1_N|>``/``<|c2_N|>``). One graph serves prefill *and* decode::
+
+    model.onnx
+        inputs
+            ``input_ids``                 int64 ``[1, S]``      prompt, or 1 token/step
+            ``attention_mask``            int64 ``[1, P + S]``  ones over past + current
+            ``position_ids``              int64 ``[1, S]``      absolute, ``P .. P+S-1``
+            ``past_key_values.<i>.key``   fp32  ``[1, H, P, D]`` for ``i`` in ``0..L-1``
+            ``past_key_values.<i>.value`` fp32  ``[1, H, P, D]``
+        outputs
+            ``logits``                    fp32  ``[1, 1, V]``   last position only
+            ``present.<i>.key`` / ``present.<i>.value``  fp32 ``[1, H, P + S, D]``
+
+The names match OuteAI's own ONNX exports, so ``phoonnx.engines.outetts`` drives a graph
+from this script and one from ``OuteAI/*-ONNX`` with the same code.
+
+``logits`` carries only the final row. OuteAI's exports return every position, which is a
+~1 GB tensor on a 1843-token prefill that the sampler never reads;
+``OuteTTSAdapter.generate`` indexes ``logits[0, -1]``, which is correct either way.
+
+Why re-export the 1B
+~~~~~~~~~~~~~~~~~~~~
+``OuteAI/Llama-OuteTTS-1.0-1B-ONNX`` does not reproduce its own torch weights. Measured
+against ``OuteAI/Llama-OuteTTS-1.0-1B`` in float32 on a real 1843-token OuteTTS prompt,
+the published float32 graph is off by **12 logits** at the last position with a logit
+correlation of **0.48**, and greedy decoding diverges. The gap is already there at 32
+tokens, so it is the export and not accumulation. The 0.6B export, by contrast, matches
+to 3.8e-05 — so this script exists for the 1B and is verified on both.
+
+Usage::
+
+    python export_outetts_onnx.py --repo OuteAI/Llama-OuteTTS-1.0-1B --out-dir ./onnx
+    python export_outetts_onnx.py --repo OuteAI/OuteTTS-1.0-0.6B --out-dir ./onnx \\
+        --check-parity
+
+Upstream weights keep their own license: ``OuteTTS-1.0-0.6B`` is Apache-2.0, and
+``Llama-OuteTTS-1.0-1B`` is CC-BY-NC-SA-4.0 (no commercial use).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+class OuteTTSExportWrapper(torch.nn.Module):
+    """Flattens the HuggingFace cache API into positional tensors an ONNX graph carries."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.num_layers = model.config.num_hidden_layers
+
+    def forward(self, input_ids, attention_mask, position_ids, past):
+        # ``past`` is one flat list of 2*L tensors rather than varargs: torch.export
+        # needs a fixed arity to attach per-input dynamic shapes to.
+        from transformers.cache_utils import DynamicCache
+
+        legacy = tuple((past[2 * i], past[2 * i + 1]) for i in range(self.num_layers))
+        cache = DynamicCache.from_legacy_cache(legacy)
+        out = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=cache,
+            use_cache=True,
+        )
+        present = out.past_key_values.to_legacy_cache()
+        flat = [t for layer in present for t in layer]
+        # keep the sequence axis so ``logits[0, -1]`` reads the same row here as it does
+        # on an OuteAI export that returns every position
+        return (out.logits[:, -1:, :], *flat)
+
+
+def _load_fp32(repo: str):
+    """Load *repo* in float32 across transformers versions.
+
+    The keyword was renamed ``torch_dtype`` -> ``dtype`` in transformers 4.56; both
+    spellings exist in the wild, so pick whichever this install accepts rather than
+    pinning the caller to one version.
+    """
+    import inspect
+
+    from transformers import AutoModelForCausalLM
+
+    keyword = "dtype" if "dtype" in inspect.signature(
+        AutoModelForCausalLM.from_pretrained).parameters else "torch_dtype"
+    return AutoModelForCausalLM.from_pretrained(repo, **{keyword: torch.float32}).eval()
+
+
+def _io_names(num_layers: int):
+    past = [f"past_key_values.{i}.{k}"
+            for i in range(num_layers) for k in ("key", "value")]
+    present = [f"present.{i}.{k}"
+               for i in range(num_layers) for k in ("key", "value")]
+    return past, present
+
+
+def _kv_geometry(config):
+    """(heads, head_dim) of one KV cache entry.
+
+    ``head_dim`` is explicit on Qwen3 and on recent Llama configs, and derived from the
+    hidden size on older ones.
+    """
+    head_dim = getattr(config, "head_dim", None) or \
+        config.hidden_size // config.num_attention_heads
+    return config.num_key_value_heads, head_dim
+
+
+def _dummy_inputs(config, seq: int, past_len: int, dtype=torch.float32):
+    kv_heads, head_dim = _kv_geometry(config)
+    input_ids = torch.randint(0, 300, (1, seq), dtype=torch.int64)
+    attention_mask = torch.ones((1, past_len + seq), dtype=torch.int64)
+    position_ids = torch.arange(past_len, past_len + seq, dtype=torch.int64)[None, :]
+    past = [
+        torch.zeros((1, kv_heads, past_len, head_dim), dtype=dtype)
+        for _ in range(2 * config.num_hidden_layers)
+    ]
+    return input_ids, attention_mask, position_ids, past
+
+
+def export(repo: str, out_dir: Path, opset: int = 18,
+           filename: str = "model.onnx") -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    model = _load_fp32(repo)
+    config = model.config
+    wrapper = OuteTTSExportWrapper(model)
+
+    past_names, present_names = _io_names(config.num_hidden_layers)
+    input_names = ["input_ids", "attention_mask", "position_ids"] + past_names
+    output_names = ["logits"] + present_names
+
+    seq = torch.export.Dim("seq")
+    dynamic_shapes = {
+        "input_ids": {1: seq},
+        "attention_mask": {1: torch.export.Dim("total")},
+        "position_ids": {1: seq},
+        "past": [{2: torch.export.Dim("past")} for _ in past_names],
+    }
+
+    # A non-empty past in the export sample is what puts the cache-concat path (rather
+    # than the "no cache yet" branch) in the graph; the dynamic axes then let past=0
+    # work at prefill time.
+    ids, mask, pos, past = _dummy_inputs(config, seq=4, past_len=3)
+    path = out_dir / filename
+    # 1.2 B float32 parameters do not fit in a protobuf, so the weights always go to the
+    # ``model.onnx_data`` sidecar; phoonnx's model manager fetches that sidecar by name.
+    torch.onnx.export(
+        wrapper,
+        (ids, mask, pos, past),
+        str(path),
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_shapes=dynamic_shapes,
+        opset_version=opset,
+        dynamo=True,
+        external_data=True,
+    )
+    _rename_external_data(path)
+    _write_meta(out_dir, repo, config)
+    return path
+
+
+def _rename_external_data(path: Path) -> Path:
+    """Move the weight sidecar to ``<graph name>_data`` and repoint the graph at it.
+
+    ``torch.onnx.export`` writes ``model.onnx.data``. phoonnx's model manager derives the
+    sidecar URL from the graph URL by appending ``_data``
+    (:meth:`phoonnx.model_manager.TTSModelInfo._fetch_onnx`), which is also the
+    convention every OuteAI/optimum export uses, so a graph exported here has to say
+    ``model.onnx_data`` or a downloaded voice will not find its weights.
+
+    Only the protobuf is rewritten — the multi-GB sidecar is renamed on disk, never
+    loaded — so this costs no memory.
+    """
+    import onnx
+
+    target = path.name + "_data"
+    written = path.with_name(path.name + ".data")
+    if not written.exists():
+        return path
+
+    model = onnx.load(str(path), load_external_data=False)
+
+    def repoint(graph):
+        for tensor in graph.initializer:
+            for entry in tensor.external_data:
+                if entry.key == "location":
+                    entry.value = target
+        for node in graph.node:
+            for attr in node.attribute:
+                if attr.HasField("g"):
+                    repoint(attr.g)
+                for sub in attr.graphs:
+                    repoint(sub)
+
+    repoint(model.graph)
+    onnx.save(model, str(path), save_as_external_data=False)
+    written.rename(path.with_name(target))
+    return path
+
+
+def _write_meta(out_dir: Path, repo: str, config) -> None:
+    kv_heads, head_dim = _kv_geometry(config)
+    (out_dir / "outetts_onnx_meta.json").write_text(json.dumps({
+        "source_repo": repo,
+        "architecture": config.architectures[0],
+        "num_hidden_layers": config.num_hidden_layers,
+        "num_key_value_heads": kv_heads,
+        "head_dim": head_dim,
+        "vocab_size": config.vocab_size,
+        "eos_token_id": config.eos_token_id,
+    }, indent=2) + "\n")
+
+
+def check_parity(repo: str, onnx_path: Path, seq: int = 64, steps: int = 16) -> dict:
+    """Compare ONNX against torch on a fixed prompt: the prefill logits and every decode
+    step, threading the ONNX cache through exactly as the engine does."""
+    import onnxruntime
+
+    torch.manual_seed(0)
+    model = _load_fp32(repo)
+    config = model.config
+    kv_heads, head_dim = _kv_geometry(config)
+    past_names, present_names = _io_names(config.num_hidden_layers)
+
+    sess = onnxruntime.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    out_names = [o.name for o in sess.get_outputs()]
+
+    ids = torch.randint(0, config.vocab_size, (1, seq), dtype=torch.int64)
+
+    feed = {
+        "input_ids": ids.numpy(),
+        "attention_mask": np.ones((1, seq), np.int64),
+        "position_ids": np.arange(seq, dtype=np.int64)[None, :],
+    }
+    feed.update({n: np.zeros((1, kv_heads, 0, head_dim), np.float32) for n in past_names})
+    onnx_out = dict(zip(out_names, sess.run(None, feed)))
+
+    with torch.no_grad():
+        ref = model(input_ids=ids, use_cache=True)
+    reference = ref.logits[:, -1, :].numpy()
+    got = np.asarray(onnx_out["logits"]).reshape(1, -1)
+    diffs = {"prefill": float(np.abs(got - reference).max())}
+
+    past = {p: onnx_out[q] for p, q in zip(past_names, present_names)}
+    cache = ref.past_key_values
+    token = int(np.argmax(got))
+    worst = 0.0
+    agree = 0
+    for step in range(steps):
+        pos = seq + step
+        feed = {
+            "input_ids": np.array([[token]], np.int64),
+            "attention_mask": np.ones((1, pos + 1), np.int64),
+            "position_ids": np.array([[pos]], np.int64),
+            **past,
+        }
+        onnx_out = dict(zip(out_names, sess.run(None, feed)))
+        with torch.no_grad():
+            ref = model(input_ids=torch.tensor([[token]]), past_key_values=cache,
+                        use_cache=True)
+        cache = ref.past_key_values
+        reference = ref.logits[:, -1, :].numpy()
+        got = np.asarray(onnx_out["logits"]).reshape(1, -1)
+        worst = max(worst, float(np.abs(got - reference).max()))
+        agree += int(np.argmax(got) == np.argmax(reference))
+        past = {p: onnx_out[q] for p, q in zip(past_names, present_names)}
+        token = int(np.argmax(got))
+    diffs["decode"] = worst
+    diffs["greedy_agreement"] = agree / steps
+    return diffs
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default="OuteAI/Llama-OuteTTS-1.0-1B",
+                    help="HF repo id or local directory holding the checkpoint")
+    ap.add_argument("--out-dir", type=Path, required=True)
+    ap.add_argument("--opset", type=int, default=18)
+    ap.add_argument("--filename", default="model.onnx")
+    ap.add_argument("--check-parity", action="store_true",
+                    help="compare the exported graph against torch and print max abs diff")
+    args = ap.parse_args()
+
+    path = export(args.repo, args.out_dir, args.opset, args.filename)
+    print(f"wrote {path} ({os.path.getsize(path) / 1e6:.1f} MB + sidecar)")
+    if args.check_parity:
+        for name, value in check_parity(args.repo, path).items():
+            print(f"parity {name}: {value:.3e}" if name != "greedy_agreement"
+                  else f"parity {name}: {value:.0%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_outetts.py
+++ b/tests/test_outetts.py
@@ -1,0 +1,829 @@
+"""OuteTTS 1.0 adapter tests.
+
+Everything the adapter does around the model — text normalization, chunking, prompt
+assembly, speaker resolution, the KV-cached decode loop, the DAC hand-off and the
+loudness stage — is observable without the real weights, so the ONNX sessions here are
+fakes that record their feeds.
+"""
+import copy
+import json
+
+import numpy as np
+import pytest
+
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.outetts import (
+    AUDIO_END, AUDIO_START, BOS, C1, C2, CODE, CODEBOOK_TOKENS, EOS, FEATURES,
+    REPETITION_WINDOW, SAMPLE_RATE, TEXT_END, TEXT_START, WORD_END, WORD_START,
+    OuteTTSAdapter, _apply_repetition_penalty, _sample, chunk_text,
+    integrated_loudness, normalize_loudness, split_into_sentences, text_normalizations,
+)
+
+LAYERS = 2
+KV_HEADS = 4
+HEAD_DIM = 8
+VOCAB = 64
+
+# fake vocabulary: 0..7 are text/special, 8..(8+N) c1, then c2
+C1_BASE = 8
+C2_BASE = 8 + 8
+AUDIO_END_ID = 5
+EOS_ID = 6
+WORD_START_ID = 7
+N_CODES = 8  # codebook size in the fake tokenizer
+
+
+SPEAKER = {
+    "text": "Hello there",
+    "global_features": {"energy": 13, "spectral_centroid": 20, "pitch": 28},
+    "interface_version": "3",
+    "words": [
+        {"word": "Hello", "duration": 0.2, "c1": [1, 2], "c2": [3, 4],
+         "features": {"energy": 10, "spectral_centroid": 15, "pitch": 45}},
+        {"word": "there", "duration": 0.35, "c1": [5], "c2": [6],
+         "features": {"energy": 11, "spectral_centroid": 16, "pitch": 46}},
+    ],
+}
+
+
+def _req(prompt_ids=(1, 2, 3), **params):
+    ids = np.asarray(prompt_ids, np.int64).reshape(1, -1)
+    return AdapterSynthesisRequest(phoneme_ids=ids,
+                                   phoneme_lengths=np.array([ids.shape[1]], np.int64),
+                                   speaker_id=0, language_id=0, params=params)
+
+
+class _IO:
+    def __init__(self, name, shape=None, type_="tensor(float)"):
+        self.name = name
+        self.shape = shape or []
+        self.type = type_
+
+
+class _FakeSession:
+    """Minimal onnxruntime.InferenceSession stand-in: named IO + a feed log."""
+
+    def __init__(self, output_names, fn, input_specs=()):
+        self._outs = [_IO(n) for n in output_names]
+        self._ins = [_IO(n, s) for n, s in input_specs]
+        self._fn = fn
+        self.feeds = []
+
+    def get_outputs(self):
+        return self._outs
+
+    def get_inputs(self):
+        return self._ins
+
+    def run(self, _none, feed):
+        self.feeds.append(feed)
+        named = self._fn(feed, len(self.feeds) - 1)
+        return [named[o.name] for o in self._outs]
+
+
+class _FakeTokenizer:
+    """One id per character for plain text; codec/special tokens map to fixed ids."""
+
+    SPECIALS = {AUDIO_END: AUDIO_END_ID, EOS: EOS_ID, WORD_START: WORD_START_ID}
+
+    def token_to_id(self, token):
+        if token in self.SPECIALS:
+            return self.SPECIALS[token]
+        for template, base in ((C1, C1_BASE), (C2, C2_BASE)):
+            for i in range(N_CODES):
+                if token == template.format(i):
+                    return base + i
+        return None
+
+    class _Enc:
+        def __init__(self, ids):
+            self.ids = ids
+
+    def encode(self, text, add_special_tokens=False):
+        # id 0 stands in for "some text token"; only the count matters to the tests
+        return self._Enc([0] * len(text))
+
+
+def _lm_names():
+    return ["logits"] + [f"present.{i}.{k}" for i in range(LAYERS) for k in ("key", "value")]
+
+
+def _lm_inputs():
+    specs = [("input_ids", [1, "seq"]), ("attention_mask", [1, "total"]),
+             ("position_ids", [1, "seq"])]
+    for i in range(LAYERS):
+        for k in ("key", "value"):
+            specs.append((f"past_key_values.{i}.{k}", [1, KV_HEADS, "past", HEAD_DIM]))
+    return specs
+
+
+def _lm_session(tokens, end_token=AUDIO_END_ID):
+    """A fake LM that emits ``tokens`` one per step, then ``end_token``.
+
+    Its KV outputs carry a per-layer fingerprint and grow by the number of tokens fed,
+    so the decode loop's present -> past wiring and cache growth are both observable.
+    """
+    def fn(feed, i):
+        seq = feed["input_ids"].shape[1]
+        past = feed["past_key_values.0.key"].shape[2]
+        # logits for every position; only the last row is the next-token distribution
+        logits = np.full((1, seq, VOCAB), -10.0, np.float32)
+        want = tokens[i] if i < len(tokens) else end_token
+        logits[0, -1, want] = 10.0
+        out = {"logits": logits}
+        for j in range(LAYERS):
+            for k in ("key", "value"):
+                block = np.full((1, KV_HEADS, past + seq, HEAD_DIM),
+                                float(j) + (0.5 if k == "value" else 0.0), np.float32)
+                out[f"present.{j}.{k}"] = block
+        return out
+    return _FakeSession(_lm_names(), fn, _lm_inputs())
+
+
+def _adapter(tokens=(C1_BASE + 1, C2_BASE + 2), speakers=None):
+    a = OuteTTSAdapter()
+    a.tokenizer = _FakeTokenizer()
+    a._build_token_maps()
+    a.speakers = speakers if speakers is not None else {"spk": copy.deepcopy(SPEAKER)}
+    a.default_speaker = "spk" if speakers is None else None
+    return a
+
+
+# ----------------------------------------------------------------------------------
+# text normalization
+# ----------------------------------------------------------------------------------
+def test_normalization_collapses_ellipsis_and_dashes():
+    assert text_normalizations("a… b—c −d") == "a... b-c -d"
+
+
+def test_normalization_unifies_quotes_and_drops_double_quotes():
+    # curly singles become ASCII apostrophes; double quotes are removed entirely, and
+    # the trailing-apostrophe rule then pulls the closing quote onto the word
+    assert text_normalizations("“le ‘mot’ ”") == "le'mot'"
+
+
+def test_normalization_repairs_split_contractions():
+    assert text_normalizations("can 't stop") == "can't stop"
+
+
+def test_normalization_spaces_after_punctuation():
+    assert text_normalizations("hi ,there.Now") == "hi, there. Now"
+
+
+def test_normalization_collapses_repeated_terminators():
+    assert text_normalizations("what?!!! really???") == "what?! really?"
+
+
+def test_normalization_strips_control_and_zero_width():
+    assert text_normalizations("a​b\x07c") == "abc"
+
+
+def test_normalization_handles_non_strings():
+    assert text_normalizations(None) == ""
+    assert text_normalizations(7) == "7"
+
+
+# ----------------------------------------------------------------------------------
+# chunking
+# ----------------------------------------------------------------------------------
+def test_split_into_sentences_keeps_terminators():
+    assert split_into_sentences("One. Two! Three?") == ["One.", "Two!", "Three?"]
+
+
+def test_chunk_text_returns_short_text_whole():
+    assert chunk_text("Just a few words here.") == ["Just a few words here."]
+
+
+def test_chunk_text_never_exceeds_max_words():
+    text = " ".join(f"word{i}" for i in range(100)) + "."
+    chunks = chunk_text(text, max_words=10)
+    assert chunks and all(len(c.split()) <= 10 for c in chunks)
+    assert " ".join(chunks) == text
+
+
+def test_chunk_text_preserves_every_word():
+    text = ". ".join(" ".join(f"w{i}{j}" for j in range(12)) for i in range(4)) + "."
+    joined = " ".join(chunk_text(text, max_words=15))
+    for token in text.replace(".", " ").split():
+        assert token in joined
+
+
+def test_chunk_text_packs_short_sentences_together():
+    text = "One two three. Four five six. Seven eight nine."
+    assert chunk_text(text, min_words=3, max_words=30) == [text]
+
+
+def test_chunk_text_splits_when_max_reached():
+    text = "One two three four five. Six seven eight nine ten."
+    chunks = chunk_text(text, min_words=5, max_words=5)
+    assert len(chunks) == 2
+
+
+def test_chunk_text_empty_input():
+    assert chunk_text("   ") == []
+
+
+def test_chunk_text_cjk_splits_on_characters():
+    # no MeCab in phoonnx: CJK is counted per character, which is a tighter bound
+    chunks = chunk_text("你好世界你好世界你好世界。", max_words=4)
+    assert chunks
+    assert all(len(c) <= 4 for c in chunks)
+
+
+# ----------------------------------------------------------------------------------
+# speaker text merging
+# ----------------------------------------------------------------------------------
+def test_merge_adds_period_when_speaker_text_unterminated():
+    merged, sep = OuteTTSAdapter().merge_speaker_text("World", "Hello")
+    assert merged == "Hello. World"
+    assert sep == "."
+
+
+def test_merge_adds_only_a_space_when_already_terminated():
+    merged, sep = OuteTTSAdapter().merge_speaker_text("World", "Hello!")
+    assert merged == "Hello! World"
+    assert sep == ""
+
+
+def test_merge_uses_ideographic_period_for_cjk():
+    merged, sep = OuteTTSAdapter().merge_speaker_text("世界", "你好")
+    assert merged == "你好。世界"
+    assert sep == "。"
+
+
+def test_merge_with_empty_speaker_text():
+    merged, sep = OuteTTSAdapter().merge_speaker_text("World", "")
+    assert merged == "World"
+    assert sep == ""
+
+
+# ----------------------------------------------------------------------------------
+# prompt assembly
+# ----------------------------------------------------------------------------------
+def test_prompt_without_speaker_is_bare_text_block():
+    prompt = OuteTTSAdapter().build_prompt("Hello world")
+    assert prompt == f"{BOS}\n{TEXT_START}Hello world{TEXT_END}\n{AUDIO_START}\n"
+
+
+def test_prompt_with_speaker_ends_on_an_open_word():
+    a = _adapter()
+    prompt = a.build_prompt("World", copy.deepcopy(SPEAKER))
+    assert prompt.startswith(f"{BOS}\n{TEXT_START}Hello there. World{TEXT_END}\n{AUDIO_START}\n")
+    assert prompt.endswith("\n" + WORD_START)
+
+
+def test_prompt_word_block_has_the_exact_upstream_layout():
+    a = _adapter()
+    prompt = a.build_prompt("World", copy.deepcopy(SPEAKER))
+    expected = (WORD_START + "Hello" + FEATURES + "<|t_0.20|>"
+                + "<|energy_10|><|spectral_centroid_15|><|pitch_45|>"
+                + CODE + C1.format(1) + C2.format(3) + C1.format(2) + C2.format(4)
+                + WORD_END)
+    assert expected in prompt
+
+
+def test_prompt_appends_the_separator_to_the_last_speaker_word():
+    a = _adapter()
+    prompt = a.build_prompt("World", copy.deepcopy(SPEAKER))
+    assert WORD_START + "there." + FEATURES in prompt
+
+
+def test_build_prompt_does_not_mutate_the_profile():
+    """Upstream appends the separator in place, corrupting the profile for later calls."""
+    a = _adapter()
+    profile = copy.deepcopy(SPEAKER)
+    a.build_prompt("One", profile)
+    a.build_prompt("Two", profile)
+    assert profile["words"][-1]["word"] == "there"
+
+
+def test_repeated_prompts_are_identical():
+    a = _adapter()
+    first = a.build_prompt("One", a.speakers["spk"])
+    second = a.build_prompt("One", a.speakers["spk"])
+    assert first == second
+
+
+def test_prompt_normalizes_the_target_text():
+    a = OuteTTSAdapter()
+    assert "..." in a.build_prompt("wait…")
+    assert "…" not in a.build_prompt("wait…")
+
+
+# ----------------------------------------------------------------------------------
+# speaker resolution
+# ----------------------------------------------------------------------------------
+class _Cfg:
+    def __init__(self, **params):
+        self.engine_params = params
+
+
+class _Voice:
+    def __init__(self, **params):
+        self.config = _Cfg(**params)
+
+
+class _Syn:
+    def __init__(self, **extra):
+        self.extra_params = extra
+
+
+def test_per_call_voice_wins_over_the_pinned_one():
+    a = _adapter(speakers={"a": SPEAKER, "b": SPEAKER})
+    a.default_speaker = "a"
+    picked = a.resolve_speaker(_Voice(voice="a"), _Syn(voice="b"))
+    assert picked is a.speakers["b"]
+
+
+def test_pinned_voice_wins_over_the_bundle_default():
+    a = _adapter(speakers={"a": SPEAKER, "b": SPEAKER})
+    a.default_speaker = "a"
+    assert a.resolve_speaker(_Voice(voice="b"), _Syn()) is a.speakers["b"]
+
+
+def test_bundle_default_is_the_last_resort():
+    a = _adapter(speakers={"a": SPEAKER})
+    a.default_speaker = "a"
+    assert a.resolve_speaker(_Voice(), None) is a.speakers["a"]
+
+
+def test_unknown_speaker_name_raises_and_lists_the_options():
+    a = _adapter(speakers={"a": SPEAKER})
+    with pytest.raises(ValueError, match="nope"):
+        a.resolve_speaker(_Voice(), _Syn(voice="nope"))
+
+
+def test_no_speaker_configured_returns_none():
+    a = _adapter(speakers={})
+    assert a.resolve_speaker(_Voice(), None) is None
+
+
+# ----------------------------------------------------------------------------------
+# configure / token maps
+# ----------------------------------------------------------------------------------
+def test_configure_loads_a_bare_upstream_profile(tmp_path):
+    path = tmp_path / "spk.json"
+    path.write_text(json.dumps(SPEAKER), encoding="utf-8")
+    a = OuteTTSAdapter()
+    a.configure(_Cfg(speakers_path=str(path)))
+    assert a.default_speaker == "default"
+    assert a.speakers["default"]["text"] == "Hello there"
+
+
+def test_configure_loads_a_phoonnx_bundle(tmp_path):
+    path = tmp_path / "voices.json"
+    path.write_text(json.dumps({"default_voice": "b", "speakers": {"a": SPEAKER,
+                                                                  "b": SPEAKER}}),
+                    encoding="utf-8")
+    a = OuteTTSAdapter()
+    a.configure(_Cfg(speakers_path=str(path)))
+    assert a.default_speaker == "b"
+    assert sorted(a.speakers) == ["a", "b"]
+
+
+def test_token_maps_cover_both_codebooks_and_specials():
+    a = _adapter()
+    assert a.c1 == {C1_BASE + i: i for i in range(N_CODES)}
+    assert a.c2 == {C2_BASE + i: i for i in range(N_CODES)}
+    assert (a.audio_end_id, a.eos_id, a.word_start_id) == (AUDIO_END_ID, EOS_ID,
+                                                           WORD_START_ID)
+
+
+def test_token_maps_skip_ids_the_tokenizer_does_not_have():
+    a = _adapter()
+    # the fake tokenizer only knows N_CODES entries out of CODEBOOK_TOKENS
+    assert len(a.c1) < CODEBOOK_TOKENS
+
+
+# ----------------------------------------------------------------------------------
+# encode_text
+# ----------------------------------------------------------------------------------
+def test_encode_text_returns_one_id_list_per_chunk():
+    a = _adapter()
+    text = ". ".join(" ".join(f"w{i}{j}" for j in range(12)) for i in range(3)) + "."
+    ids = a.encode_text(text, _Voice(), _Syn(max_chunk_words=12))
+    assert len(ids) >= 3
+    assert all(isinstance(seq, list) and seq for seq in ids)
+
+
+def test_encode_text_honours_the_per_call_word_budget():
+    a = _adapter()
+    text = " ".join(f"w{i}" for i in range(60)) + "."
+    few = a.encode_text(text, _Voice(), _Syn(max_chunk_words=30))
+    many = a.encode_text(text, _Voice(), _Syn(max_chunk_words=5))
+    assert len(many) > len(few)
+
+
+def test_encode_text_without_a_tokenizer_raises():
+    a = OuteTTSAdapter()
+    with pytest.raises(RuntimeError, match="tokenizer_path"):
+        a.encode_text("hi", _Voice(), None)
+
+
+# ----------------------------------------------------------------------------------
+# sampling
+# ----------------------------------------------------------------------------------
+def test_repetition_penalty_divides_positive_and_multiplies_negative():
+    scores = np.array([2.0, -2.0, 5.0], np.float32)
+    out = _apply_repetition_penalty(scores, np.array([0, 1]), 2.0)
+    assert out[0] == pytest.approx(1.0)
+    assert out[1] == pytest.approx(-4.0)
+    assert out[2] == pytest.approx(5.0)
+
+
+def test_repetition_penalty_of_one_is_a_no_op():
+    scores = np.array([2.0, -2.0], np.float32)
+    assert np.array_equal(_apply_repetition_penalty(scores, np.array([0, 1]), 1.0), scores)
+
+
+def test_repetition_penalty_ignores_out_of_range_ids():
+    scores = np.array([2.0, 3.0], np.float32)
+    out = _apply_repetition_penalty(scores, np.array([-1, 99]), 2.0)
+    assert np.array_equal(out, scores)
+
+
+def test_zero_temperature_is_argmax():
+    scores = np.array([0.0, 3.0, 1.0], np.float32)
+    assert _sample(scores, 0.0, 0, 1.0, 0.0, None) == 1
+
+
+def test_top_k_restricts_the_candidate_set():
+    scores = np.array([5.0, 4.0, -20.0, -30.0], np.float32)
+    rng = np.random.default_rng(0)
+    picked = {_sample(scores, 1.0, 2, 1.0, 0.0, rng) for _ in range(200)}
+    assert picked == {0, 1}
+
+
+def test_top_p_keeps_the_token_that_crosses_the_threshold():
+    # probabilities are ~0.525 / 0.475 / ~0: the second token is what crosses 0.6
+    scores = np.array([10.0, 9.9, -30.0], np.float32)
+    rng = np.random.default_rng(0)
+    assert {_sample(scores, 1.0, 0, 0.6, 0.0, rng) for _ in range(200)} == {0, 1}
+    assert {_sample(scores, 1.0, 0, 0.4, 0.0, rng) for _ in range(200)} == {0}
+
+
+def test_min_p_drops_tokens_far_below_the_top():
+    scores = np.array([10.0, 4.0, 0.0], np.float32)
+    rng = np.random.default_rng(0)
+    picked = {_sample(scores, 1.0, 0, 1.0, 0.5, rng) for _ in range(200)}
+    assert picked == {0}
+
+
+def test_temperature_is_applied_before_truncation():
+    """HuggingFace's order, not llama.cpp's.
+
+    With temperature first, a low temperature sharpens the distribution *before* top-p
+    looks at it, so nucleus sampling keeps fewer tokens. Under llama.cpp's order top-p
+    would see the raw distribution and the candidate set would not depend on
+    temperature at all.
+    """
+    scores = np.array([2.0, 1.0, 0.0], np.float32)
+    rng = np.random.default_rng(0)
+    cold = {_sample(scores, 0.1, 0, 0.9, 0.0, rng) for _ in range(300)}
+    hot = {_sample(scores, 5.0, 0, 0.9, 0.0, rng) for _ in range(300)}
+    assert cold == {0}
+    assert len(hot) > len(cold)
+
+
+def test_sampling_is_reproducible_for_a_seed():
+    scores = np.array([1.0, 1.0, 1.0], np.float32)
+    first = [_sample(scores, 1.0, 0, 1.0, 0.0, np.random.default_rng(7)) for _ in range(5)]
+    second = [_sample(scores, 1.0, 0, 1.0, 0.0, np.random.default_rng(7)) for _ in range(5)]
+    assert first == second
+
+
+# ----------------------------------------------------------------------------------
+# the KV-cached decode loop
+# ----------------------------------------------------------------------------------
+def test_prefill_feeds_empty_caches_and_absolute_positions():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1])
+    a.generate(session, [1, 2, 3, 4], a.default_params(), np.random.default_rng(0))
+    first = session.feeds[0]
+    assert first["input_ids"].tolist() == [[1, 2, 3, 4]]
+    assert first["attention_mask"].shape == (1, 4)
+    assert first["position_ids"].tolist() == [[0, 1, 2, 3]]
+    assert first["past_key_values.0.key"].shape == (1, KV_HEADS, 0, HEAD_DIM)
+
+
+def test_decode_steps_feed_one_token_with_the_next_absolute_position():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1, C2_BASE + 2, C1_BASE + 3])
+    a.generate(session, [1, 2, 3], a.default_params(), np.random.default_rng(0))
+    steps = session.feeds[1:]
+    assert [f["input_ids"].tolist() for f in steps[:3]] == [[[C1_BASE + 1]],
+                                                            [[C2_BASE + 2]],
+                                                            [[C1_BASE + 3]]]
+    assert [f["position_ids"].tolist() for f in steps[:3]] == [[[3]], [[4]], [[5]]]
+
+
+def test_attention_mask_covers_past_plus_current_token():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1, C2_BASE + 2])
+    a.generate(session, [1, 2, 3], a.default_params(), np.random.default_rng(0))
+    assert [f["attention_mask"].shape[1] for f in session.feeds] == [3, 4, 5]
+
+
+def test_present_caches_are_fed_back_as_past():
+    """present.<i>.<k> at step n must arrive as past_key_values.<i>.<k> at step n+1."""
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1, C2_BASE + 2])
+    a.generate(session, [1, 2, 3], a.default_params(), np.random.default_rng(0))
+    for i in range(LAYERS):
+        # the fake session fingerprints each layer/kind, so a crossed wire is visible
+        assert session.feeds[1][f"past_key_values.{i}.key"][0, 0, 0, 0] == float(i)
+        assert session.feeds[1][f"past_key_values.{i}.value"][0, 0, 0, 0] == float(i) + 0.5
+
+
+def test_kv_cache_grows_by_one_token_per_step():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1, C2_BASE + 2, C1_BASE + 3])
+    a.generate(session, [1, 2, 3], a.default_params(), np.random.default_rng(0))
+    grew = [f["past_key_values.0.key"].shape[2] for f in session.feeds[1:]]
+    assert grew == [3, 4, 5]
+
+
+def test_kv_geometry_is_read_off_the_graph():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1])
+    a.generate(session, [1], a.default_params(), np.random.default_rng(0))
+    assert (a.num_layers, a.num_kv_heads, a.head_dim) == (LAYERS, KV_HEADS, HEAD_DIM)
+
+
+def test_audio_end_stops_generation_and_is_not_emitted():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1, C2_BASE + 2])
+    out = a.generate(session, [1, 2], a.default_params(), np.random.default_rng(0))
+    assert out == [C1_BASE + 1, C2_BASE + 2]
+
+
+def test_eos_also_stops_generation():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1], end_token=EOS_ID)
+    out = a.generate(session, [1, 2], a.default_params(), np.random.default_rng(0))
+    assert out == [C1_BASE + 1]
+
+
+def test_length_cap_stops_a_model_that_never_ends():
+    a = _adapter()
+    session = _lm_session([C1_BASE + 1] * 50)
+    params = {**a.default_params(), "max_new_tokens": 5}
+    out = a.generate(session, [1, 2], params, np.random.default_rng(0))
+    assert len(out) == 5
+
+
+def test_only_the_last_logit_row_drives_the_next_token():
+    """The export returns logits for every prefill position, not just the last one."""
+    a = _adapter()
+
+    def fn(feed, i):
+        seq = feed["input_ids"].shape[1]
+        past = feed["past_key_values.0.key"].shape[2]
+        logits = np.full((1, seq, VOCAB), -10.0, np.float32)
+        # every earlier row votes for a different token than the last one
+        logits[0, :, C2_BASE + 7] = 50.0
+        logits[0, -1, :] = -10.0
+        logits[0, -1, C1_BASE + 1 if i == 0 else AUDIO_END_ID] = 10.0
+        out = {"logits": logits}
+        for j in range(LAYERS):
+            for k in ("key", "value"):
+                out[f"present.{j}.{k}"] = np.zeros((1, KV_HEADS, past + seq, HEAD_DIM),
+                                                   np.float32)
+        return out
+
+    session = _FakeSession(_lm_names(), fn, _lm_inputs())
+    assert a.generate(session, [1, 2, 3], a.default_params(),
+                      np.random.default_rng(0)) == [C1_BASE + 1]
+
+
+def test_repetition_penalty_window_spans_the_prompt():
+    """Upstream's patched processor penalises prompt tokens too, within the window."""
+    a = _adapter()
+    seen = {}
+
+    def fn(feed, i):
+        seq = feed["input_ids"].shape[1]
+        past = feed["past_key_values.0.key"].shape[2]
+        logits = np.zeros((1, seq, VOCAB), np.float32)
+        logits[0, -1, AUDIO_END_ID] = 1.0
+        logits[0, -1, 1] = 1.0  # token 1 is in the prompt
+        out = {"logits": logits}
+        for j in range(LAYERS):
+            for k in ("key", "value"):
+                out[f"present.{j}.{k}"] = np.zeros((1, KV_HEADS, past + seq, HEAD_DIM),
+                                                   np.float32)
+        return out
+
+    session = _FakeSession(_lm_names(), fn, _lm_inputs())
+    params = {**a.default_params(), "temperature": 0.0, "repetition_penalty": 2.0}
+    # token 1 sits in the prompt, so its score is halved and AUDIO_END wins outright
+    assert a.generate(session, [1, 1, 1], params, np.random.default_rng(0)) == []
+    assert REPETITION_WINDOW == 64
+
+
+# ----------------------------------------------------------------------------------
+# codec hand-off
+# ----------------------------------------------------------------------------------
+def test_token_ids_to_codes_splits_the_two_codebooks():
+    a = _adapter()
+    ids = [C1_BASE + 1, C2_BASE + 2, C1_BASE + 3, C2_BASE + 4]
+    assert a.token_ids_to_codes(ids) == [[1, 3], [2, 4]]
+
+
+def test_token_ids_to_codes_drops_a_trailing_half_frame():
+    a = _adapter()
+    ids = [C1_BASE + 1, C2_BASE + 2, C1_BASE + 3]
+    assert a.token_ids_to_codes(ids) == [[1], [2]]
+
+
+def test_token_ids_to_codes_ignores_non_codec_tokens():
+    a = _adapter()
+    ids = [WORD_START_ID, C1_BASE + 1, 0, C2_BASE + 2, WORD_START_ID]
+    assert a.token_ids_to_codes(ids) == [[1], [2]]
+
+
+def _codec_session(record):
+    def fn(feed, _i):
+        codes = feed["audio_codes"]
+        record.append(codes.shape)
+        n = codes.shape[-1]
+        return {"audio_values": np.ones((1, 1, n * 512), np.float32)}
+    return _FakeSession(["audio_values"], fn, [("audio_codes", [1, 2, "t"])])
+
+
+def test_decode_codes_feeds_a_two_codebook_int64_tensor():
+    a = _adapter()
+    shapes = []
+    a.codec = _codec_session(shapes)
+    a.decode_codes([[1, 2, 3], [4, 5, 6]])
+    assert shapes == [(1, 2, 3)]
+
+
+def test_decode_codes_chunks_long_streams():
+    a = _adapter()
+    shapes = []
+    a.codec = _codec_session(shapes)
+    n = a.DECODE_CHUNK + 10
+    a.decode_codes([list(range(n)), list(range(n))])
+    assert [s[-1] for s in shapes] == [a.DECODE_CHUNK, 10]
+
+
+def test_decode_codes_returns_mono_float32():
+    a = _adapter()
+    a.codec = _codec_session([])
+    audio = a.decode_codes([[1, 2], [3, 4]])
+    assert audio.dtype == np.float32
+    assert audio.ndim == 1
+    assert audio.shape[0] == 2 * 512
+
+
+def test_decode_codes_of_an_empty_stream_is_silence():
+    a = _adapter()
+    a.codec = _codec_session([])
+    assert a.decode_codes([[], []]).shape == (0,)
+
+
+def test_decode_chunks_are_faded_in_and_out():
+    a = _adapter()
+    a.codec = _codec_session([])
+    audio = a.decode_codes([[1] * 100, [1] * 100])
+    fade = int(SAMPLE_RATE * a.FADE_SECONDS)
+    assert abs(audio[0]) < abs(audio[fade])
+    assert abs(audio[-1]) < abs(audio[-fade])
+
+
+# ----------------------------------------------------------------------------------
+# loudness
+# ----------------------------------------------------------------------------------
+def _sine(seconds=3.0, amplitude=0.5, freq=1000.0):
+    t = np.arange(int(SAMPLE_RATE * seconds)) / SAMPLE_RATE
+    return (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+def test_integrated_loudness_tracks_amplitude_by_the_decibel():
+    loud = integrated_loudness(_sine(amplitude=0.5))
+    quiet = integrated_loudness(_sine(amplitude=0.25))
+    assert loud - quiet == pytest.approx(6.02, abs=0.05)
+
+
+def test_integrated_loudness_of_silence_is_minus_infinity():
+    assert integrated_loudness(np.zeros(SAMPLE_RATE, np.float32)) == -np.inf
+
+
+def test_integrated_loudness_of_a_too_short_clip_is_minus_infinity():
+    assert integrated_loudness(_sine(seconds=0.1)) == -np.inf
+
+
+def test_normalize_loudness_hits_the_target():
+    out = normalize_loudness(_sine(amplitude=0.2), target=-18.0)
+    assert integrated_loudness(out) == pytest.approx(-18.0, abs=0.1)
+
+
+def test_normalize_loudness_respects_the_peak_ceiling():
+    out = normalize_loudness(_sine(amplitude=0.01), target=0.0, peak_limit=-1.0)
+    assert np.max(np.abs(out)) == pytest.approx(10 ** (-1.0 / 20.0), rel=1e-6)
+
+
+def test_normalize_loudness_keeps_the_original_length():
+    short = _sine(seconds=0.05)
+    assert normalize_loudness(short).shape == short.shape
+
+
+def test_normalize_loudness_passes_silence_through():
+    out = normalize_loudness(np.zeros(SAMPLE_RATE, np.float32))
+    assert np.all(out == 0.0)
+
+
+def test_normalize_loudness_of_an_empty_array():
+    assert normalize_loudness(np.zeros(0, np.float32)).shape == (0,)
+
+
+# ----------------------------------------------------------------------------------
+# synthesize
+# ----------------------------------------------------------------------------------
+def test_synthesize_runs_the_loop_and_the_codec():
+    a = _adapter()
+    a.codec = _codec_session([])
+    session = _lm_session([C1_BASE + 1, C2_BASE + 2, C1_BASE + 3, C2_BASE + 4])
+    result = a.synthesize(_req((1, 2, 3), temperature=0.0, seed=1), session)
+    assert result.extras["frames"] == 2
+    assert result.audio.shape[0] == 2 * 512
+
+
+def test_synthesize_without_a_codec_raises():
+    a = _adapter()
+    with pytest.raises(RuntimeError, match="codec_decoder_path"):
+        a.synthesize(_req(), _lm_session([]))
+
+
+def test_synthesize_without_a_tokenizer_raises():
+    a = OuteTTSAdapter()
+    a.codec = _codec_session([])
+    with pytest.raises(RuntimeError, match="tokenizer_path"):
+        a.synthesize(_req(), _lm_session([]))
+
+
+def test_synthesize_rejects_a_reference_clip():
+    a = _adapter()
+    a.codec = _codec_session([])
+    with pytest.raises(RuntimeError, match="speaker profiles"):
+        a.synthesize(_req(reference_audio=np.zeros(10)), _lm_session([]))
+
+
+def test_synthesize_without_any_codec_tokens_raises():
+    a = _adapter()
+    a.codec = _codec_session([])
+    session = _lm_session([])  # ends immediately
+    with pytest.raises(RuntimeError, match="no codec tokens"):
+        a.synthesize(_req(temperature=0.0), session)
+
+
+def test_synthesize_is_deterministic_for_a_seed():
+    def run():
+        a = _adapter()
+        a.codec = _codec_session([])
+        return a.synthesize(_req((1, 2, 3), seed=42),
+                            _lm_session([C1_BASE + 1, C2_BASE + 2])).audio
+    assert np.array_equal(run(), run())
+
+
+# ----------------------------------------------------------------------------------
+# registration
+# ----------------------------------------------------------------------------------
+def test_detect_matches_only_a_declared_outetts_voice():
+    assert OuteTTSAdapter.detect(config={"engine": "outetts"})
+    assert not OuteTTSAdapter.detect(config={"engine": "neutts"})
+    assert not OuteTTSAdapter.detect(config=None)
+
+
+def test_engine_is_registered_and_probed_after_its_siblings():
+    from phoonnx.engines import get_adapter, list_engines
+    assert "outetts" in list_engines()
+    assert isinstance(get_adapter("outetts"), OuteTTSAdapter)
+
+
+def test_config_selects_the_adapter_for_an_outetts_voice():
+    from phoonnx.engines import detect_engine
+    assert isinstance(detect_engine(config={"engine": "outetts"}), OuteTTSAdapter)
+
+
+def test_default_params_match_the_published_generation_config():
+    p = OuteTTSAdapter().default_params()
+    assert p["temperature"] == 0.4
+    assert p["top_k"] == 40.0
+    assert p["top_p"] == 0.9
+    assert p["min_p"] == 0.05
+    assert p["repetition_penalty"] == 1.1
+
+
+def test_every_default_param_has_a_label():
+    a = OuteTTSAdapter()
+    assert set(a.default_params()) <= set(a.param_labels())
+
+
+def test_the_abc_hooks_refuse_the_feed_dict_path():
+    a = OuteTTSAdapter()
+    with pytest.raises(NotImplementedError):
+        a.build_feed_dict(_req(), None)
+    with pytest.raises(NotImplementedError):
+        a.parse_outputs([], _req())

--- a/tests/test_outetts.py
+++ b/tests/test_outetts.py
@@ -596,6 +596,34 @@ def test_only_the_last_logit_row_drives_the_next_token():
                       np.random.default_rng(0)) == [C1_BASE + 1]
 
 
+def test_a_last_row_only_export_drives_the_same_loop():
+    """phoonnx's own 1B export returns ``logits[1, 1, V]``, not every position.
+
+    ``scripts/conversion/outetts/export_outetts_onnx.py`` drops the prefill rows the
+    sampler never reads. ``logits[0, -1]`` is the last row either way, so one adapter
+    drives both that graph and OuteAI's full-sequence exports.
+    """
+    a = _adapter()
+
+    def fn(feed, i):
+        seq = feed["input_ids"].shape[1]
+        past = feed["past_key_values.0.key"].shape[2]
+        logits = np.full((1, 1, VOCAB), -10.0, np.float32)
+        logits[0, 0, C1_BASE + 1 if i == 0 else AUDIO_END_ID] = 10.0
+        out = {"logits": logits}
+        for j in range(LAYERS):
+            for k in ("key", "value"):
+                out[f"present.{j}.{k}"] = np.zeros((1, KV_HEADS, past + seq, HEAD_DIM),
+                                                   np.float32)
+        return out
+
+    session = _FakeSession(_lm_names(), fn, _lm_inputs())
+    assert a.generate(session, [1, 2, 3], a.default_params(),
+                      np.random.default_rng(0)) == [C1_BASE + 1]
+    # the prefill still fed the whole prompt, only the returned logits are narrower
+    assert session.feeds[0]["input_ids"].shape == (1, 3)
+
+
 def test_repetition_penalty_window_spans_the_prompt():
     """Upstream's patched processor penalises prompt tokens too, within the window."""
     a = _adapter()


### PR DESCRIPTION
Adds `phoonnx.engines.outetts`, an adapter for **OuteTTS 1.0** (OuteAI), and indexes 23
voices — one per trained language of the family. It also adds
`scripts/conversion/outetts/export_outetts_onnx.py`, because OuteAI's published 1B ONNX
export does not reproduce its own torch weights and had to be replaced.

## Architecture

OuteTTS 1.0 is a causal language model whose vocabulary carries the two codebooks of
**DAC.speech.v1.0** (IBM Research), a 24 kHz codec at 1.5 kbps. The model reads raw text
and writes interleaved `<|c1_N|><|c2_N|>` pairs; the codec decoder turns that pair stream
into a waveform. There is no phonemizer, no duration model and no vocoder, which is how
one checkpoint covers 14 languages.

The adapter is `Alphabet.GRAPHEMES`, so `TTSVoice.synthesize()` routes through
`encode_text()` and the adapter owns text → ids with the checkpoint's own tokenizer.

### IO contracts

| Graph | Input | Output |
| :--- | :--- | :--- |
| `model.onnx` | `input_ids` `[1,S]`, `attention_mask` `[1,P+S]`, `position_ids` `[1,S]`, `past_key_values.<i>.<key\|value>` `[1,H,P,D]` | `logits` `[1,S,V]`, `present.<i>.<key\|value>` `[1,H,P+S,D]` |
| `decoder_model.onnx` | `audio_codes` `[1,2,T]` int64 | `audio_values` `[1,1,T*512]` @ 24 kHz |

For the 0.6B: L=28, H=8, D=128, V=157760. For the 1B: L=16, H=8, D=64, V=134400. The KV
geometry is read off the graph's own input signature, so the two checkpoints share one
code path.

Two things differ from the other codec-LM engines in phoonnx:

* `logits` covers **every** position on OuteAI's exports, so the decode step reads
  `logits[0, -1]` — NeuTTS's export returns the last row only. phoonnx's own 1B graph
  returns `[1, 1, V]`, the final row alone, instead of a ~1 GB prefill tensor the sampler
  never reads; `logits[0, -1]` is correct for both, and a test pins that.
* The waveform is loudness-normalized to **-18 LUFS** with a -1 dBFS ceiling, and every
  decoder chunk is faded 15 ms in and out. Upstream does this inside its codec wrapper,
  so it is part of the model's output level. ITU-R BS.1770-4 is reimplemented in
  NumPy/SciPy rather than adding `pyloudnorm` as a hard dependency.

### Prompt format

Reproduced from `outetts.version.v3.prompt_processor`:

```
<|im_start|>
<|text_start|>{speaker transcript}{separator}{target text}<|text_end|>
<|audio_start|>
<|word_start|>{word}<|features|><|t_0.20|><|energy_N|><|spectral_centroid_N|><|pitch_N|><|code|><|c1_a|><|c2_a|>...<|word_end|>
...
<|word_start|>
```

A speaker profile is an in-context audio prompt: a transcript whose words each carry a
duration, three prosody buckets and their DAC codes. `speaker_reference` is **not**
supported — building a profile needs Whisper word alignment plus the DAC encoder.

Upstream mutates the profile in place (it appends the separator to the last word), which
corrupts it for every later call in the same process. The adapter deep-copies first;
there is a regression test for it.

### Sampler semantics

`outetts`'s default backend is `Backend.HF`, so this follows **HuggingFace's** warper
order — repetition penalty, then temperature, then top-k, top-p, min-p — not the
llama.cpp order NeuTTS uses. Verified against `transformers` 4.52's
`_get_logits_processor`. The repetition penalty is upstream's *patched* windowed one:
64 tokens, spanning the prompt.

Defaults match `generation_config.json`: `temperature 0.4`, `top_k 40`, `top_p 0.9`,
`min_p 0.05`, `repetition_penalty 1.1`.

## Numeric parity

Official ONNX vs upstream torch weights, fixed 1843-token prompt, CPU float32, 64 greedy
decode steps. "greedy" is with no penalty; "greedy+pen" repeats it with the windowed
penalty at 1.1 and therefore also verifies the adapter's penalty implementation against
upstream's patched processor.

### OuteTTS-1.0-0.6B (Qwen3, Apache-2.0)

| Export | max abs logit diff | mean | greedy | greedy+pen |
| :--- | ---: | ---: | ---: | ---: |
| `model.onnx` (fp32) | **3.77e-05** | 8.35e-06 | **64/64** | **64/64** |
| `model_fp16.onnx` | 0.036 | 9.2e-03 | 63/64 | 63/64 |
| `model_quantized` / `model_uint8` | 5.72 | 0.81 | 62/64 | 32/64 |
| `model_q4` | 3.97 | 0.66 | 33/64 | 61/64 |
| `model_q4f16` | 3.85 | 0.66 | 33/64 | 61/64 |
| `model_bnb4` | 4.16 | 0.74 | 34/64 | 53/64 |
| `model_int8` | 5.85 | 1.12 | 32/64 | 52/64 |

The float32 export reproduces its torch weights exactly and is the only one shipped.
Every quantized export changes greedy decoding.

### Llama-OuteTTS-1.0-1B (Llama-3.2, CC-BY-NC-SA-4.0)

OuteAI's published exports fail:

| Export | max abs logit diff | mean | greedy | greedy+pen |
| :--- | ---: | ---: | ---: | ---: |
| `model.onnx` (fp32) | 12 | 1.64 | 61/64 | 27/64 |
| every quantized export | 11.5 - 16.3 | 1.48 - 1.95 | 13-62/64 | 4-19/64 |

The **float32** export does not reproduce its torch weights. Diagnostics on the real
prompt: position 0 differs by 2.5e-05, position 921 by 1.31, position 1842 by 12 with a
logit correlation of **0.48**; prefill argmax agrees on 1580/1843 positions. On random
tokens the gap is there from length 32 (0.08) and never closes (corr 0.96-0.98 at
512-2048). That signature is the export, not accumulation — the 0.6B at the same prompt
length differs by 3.8e-05.

**So the 1B is re-exported from torch**, with the same KV-cache contract, by the new
`scripts/conversion/outetts/export_outetts_onnx.py`:

| Export | max abs logit diff | mean | corr | greedy | greedy+pen |
| :--- | ---: | ---: | ---: | ---: | ---: |
| OuteAI `model.onnx` (fp32) | 12 | 1.64 | 0.48 | 61/64 | 27/64 |
| **this PR's re-export** (fp32) | **1.78e-05** | **3.74e-06** | **1.00000000** | **64/64** | **64/64** |

Same prompt, same harness, same rigor as the 0.6B row. The script's own quick check on a
random 64-token prompt reports prefill 1.96e-05, worst decode step 2.24e-05 and 100 %
greedy agreement while threading the ONNX cache exactly as the engine does. Running the
script against the **0.6B** reproduces that checkpoint to 1.57e-05 with 100 % greedy
agreement, which is how the exporter is validated against a graph already known good.

No quantized variant is shipped for either size.

> One harness note, since it changes the numbers: `outetts` monkey-patches
> `RepetitionPenaltyLogitsProcessor` to a **64-token window**. A torch reference built
> without that patch penalises the whole 1843-token context and cannot agree with any
> correct ONNX loop — the "greedy+pen" column installs the patched processor, so it
> verifies the adapter's penalty against what the checkpoint is really sampled with.

### DAC.speech.v1.0 decoder

`decoder_model.onnx` vs `descript-audio-codec` with IBM's `weights_24khz_1.5kbps_v1.0.pth`,
300 random code frames: **max abs 4.23e-06, RMS 1.24e-07, corr 1.00000000, SNR 121.3 dB**.

## Per-language WER / CER and RTF

One sentence per language, seed 0, defaults. ASR is `nemo-canary-1b-v2` where it has the
language and `whisper-base` otherwise — both CPU onnx-asr. RTF is wall/audio on a 24-core
CPU under concurrent load, so treat it as an upper bound.

### 0.6B — the 14 languages it was trained on

| Lang | ASR model | WER % | CER % | audio s | RTF |
| :--- | :--- | ---: | ---: | ---: | ---: |
| en | nemo-canary-1b-v2 | 0.0 | 0.0 | 4.33 | 35.8 |
| es | nemo-canary-1b-v2 | 0.0 | 0.0 | 4.81 | 23.0 |
| fr | nemo-canary-1b-v2 | 0.0 | 0.0 | 4.05 | 27.9 |
| de | nemo-canary-1b-v2 | 0.0 | 0.0 | 4.40 | 36.9 |
| it | nemo-canary-1b-v2 | 0.0 | 0.0 | 4.32 | 39.4 |
| ru | nemo-canary-1b-v2 | 0.0 | 0.0 | 4.72 | 31.4 |
| ko | whisper-base | 0.0 | 0.0 | 3.61 | 31.0 |
| ja | whisper-base | 18.2 | 18.2 | 4.71 | 26.1 |
| nl | nemo-canary-1b-v2 | 55.6 | 22.2 | 3.76 | 30.0 |
| hu | nemo-canary-1b-v2 | 55.6 | 22.0 | 3.81 | 27.7 |
| lv | nemo-canary-1b-v2 | 75.0 | 33.3 | 3.80 | 34.2 |
| pl | nemo-canary-1b-v2 | 87.5 | 35.6 | 4.12 | 29.1 |
| zh | whisper-base | 105.6 | 105.6 | 4.65 | 30.1 |
| ka | whisper-base | 100.0 | 100.0 | 4.52 | 26.9 |

### 1B — the nine languages only it covers (this PR's re-export)

| Lang | ASR model | WER % | CER % | audio s | RTF |
| :--- | :--- | ---: | ---: | ---: | ---: |
| pt | nemo-canary-1b-v2 | 0.0 | 0.0 | 4.77 | 36.7 |
| lt | nemo-canary-1b-v2 | 25.0 | 4.3 | 4.32 | 41.1 |
| ta | whisper-base | 47.6 | 41.4 | 6.15 | 59.3 |
| ar | whisper-base | 62.5 | 23.7 | 5.84 | 36.2 |
| be | whisper-base | 75.0 | 25.0 | 4.56 | 38.9 |
| sw | whisper-base | 81.8 | 13.0 | 4.97 | 40.7 |
| uk | nemo-canary-1b-v2 | 88.9 | 73.3 | 7.68 | 34.7 |
| fa | whisper-base | 91.7 | 41.0 | 5.28 | 43.7 |
| bn | whisper-base | 100.0 | 142.3 | 4.92 | 48.9 |

**ASR coverage for the nine, stated per language.** Only **pt, lt and uk** have a capable
onnx-asr model (`nemo-canary-1b-v2`). For **ar, be, bn, fa, sw and ta** onnx-asr offers
nothing but `whisper-base`, so those six rows are **not a measurement of the TTS**:

* **bn** — *no usable coverage*. `whisper-base` returned **Arabic script** for Bengali
  audio; it did not identify the language. CER 142 % is the ASR failing, nothing else.
* **be** — *no usable coverage*. `whisper-base` transcribed Belarusian as Russian
  ("пересекая раку"), which is what it does with Belarusian in general.
* **sw** — CER **13 %** against WER 81.8 %: `whisper-base` ran the words together
  ("Darajela Zamanilamawe"). The phone sequence is largely right; the WER is tokenization.
* **ar, fa, ta** — `whisper-base` is weak in all three; the hypotheses are recognizable
  but degraded, so read the CER, not the WER.

**Ukrainian is a genuine finding, not an ASR artifact.** At seed 0 the model produced
7.68 s for a ~5 s sentence and canary transcribed the sentence twice — the decode loop
repeated the whole utterance. Re-running separates it:

| uk run | audio s | WER % |
| :--- | ---: | ---: |
| seed 0 (table) | 7.68 | 88.9 |
| greedy (temp 0) | 4.96 | 55.6 |
| seed 7 | 4.81 | 77.8 |
| seed 3 | 8.08 | 155.6 |

Greedy never loops; two of three sampled seeds do. So Ukrainian under the English speaker
profile is both weak *and* prone to a whole-sentence repeat under sampling. Same root
cause as Polish below — a cross-lingual speaker profile — and the same fix.

**ASR coverage for the 14, stated per language.** onnx-asr has no model for Georgian, and its only
Chinese/Japanese/Korean option is `whisper-base`. So:

* **ka** — *no usable onnx-asr coverage*. `whisper-base` returned Latin-script nonsense
  ("Dresdili tsé anatepsta hairi subtire"), which is a property of the ASR model, not a
  measurement of the TTS. The 100 % is uninformative; treat Georgian as unmeasured.
* **zh** — measured with `whisper-base` only. The hypothesis recovers the tail correctly
  (`公園散步吧`) and loses the head, so part of the 105 % is the ASR model.
* **ja, ko** — `whisper-base` only, but the hypotheses are clean, so the numbers stand.

**Investigation of the four >30 % European cases.** The confound is the speaker profile:
OuteAI ships exactly one for interface v3, `en-female-1-neutral`, and the model carries
the speaker's accent across languages — upstream's own card says to build a profile in
the target language. Re-running Polish and Dutch with other decode settings separates
sampling noise from a systematic accent:

| Lang | seed 0 (table) | greedy (temp 0) | seed 7 |
| :--- | ---: | ---: | ---: |
| nl | 55.6 | 55.6 | **11.1** |
| pl | 87.5 | 100.0 | 62.5 |

Dutch reaches 11 % on another seed, so its number is sampling variance on a single
sentence. Polish stays bad on every setting, including greedy — that is the English
profile leaving an accent Polish ASR will not accept, not a bug in the adapter. Both are
expected behaviour for this checkpoint with a cross-lingual profile; a per-language
profile is the fix and is a follow-up, not a blocker.

RTF is 23-39 on the 0.6B and 35-59 on the 1B: one codec frame is **two** LM passes and
one second of audio is ~47 frames, so ~94 model calls per second of speech. This is the
slowest engine in phoonnx and the docs say so.

## Mirror

* [`OpenVoiceOS/phoonnx-outetts`](https://huggingface.co/OpenVoiceOS/phoonnx-outetts) —
  0.6B and 1B graphs, both tokenizers, the DAC encoder/decoder and the speaker profile.
  Everything is redistributed unchanged **except `1B/model.onnx`**, which is this PR's
  re-export; the defective OuteAI file it replaced is gone from the repo. The model card
  documents the 0.48-correlation defect in the official export and the numbers for the
  replacement, since that is useful public information for anyone else consuming
  `OuteAI/Llama-OuteTTS-1.0-1B-ONNX`.
* Added to the
  [phoonnx community mirror](https://huggingface.co/collections/OpenVoiceOS/phoonnx-community-mirror-6a2204d302e0e7497870cd68)
  collection.
* The voice index points only at the mirror.

Verified end to end from the published mirror through `TTSModelManager`:

```
model_url https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/0.6B/model.onnx
OK samples=123832 dur=5.16s wall=179.4s RTF=34.76

model_url https://huggingface.co/OpenVoiceOS/phoonnx-outetts/resolve/main/1B/model.onnx
OK samples=119352 dur=4.97s wall=294.2s RTF=59.17
```

The 1B round-trip is the one that matters for the re-export: `torch.onnx.export` writes
`model.onnx.data`, but the model manager fetches `<graph url>_data`, so the exporter
renames the sidecar and repoints the graph at it. This confirms a fresh download resolves
its 5 GB of weights.

Sample WAVs for all 23 languages, both mirror round-trips and the Polish/Dutch/Ukrainian
investigation runs are on the homelab share at `models/outetts/samples/`.

## Licensing

| Artifact | License |
| :--- | :--- |
| `OuteTTS-1.0-0.6B` (indexed) | Apache-2.0 |
| `Llama-OuteTTS-1.0-1B` (nine `outetts/1B/*` voices) | CC-BY-NC-SA-4.0 — **no commercial use** |
| `DAC.speech.v1.0` (IBM Research) | CDLA-Permissive-2.0 |
| speaker profile (`outetts` package) | Apache-2.0 |

Every language the Apache-2.0 checkpoint covers resolves to the Apache-2.0 checkpoint.
The non-commercial 1B is reachable only through the nine `outetts/1B/*` ids, which is
visible in the voice id itself, in `VOICES.md` and on the model card. Re-exporting the
weights does not change their license. Model authorship and research credit belong to
OuteAI; the codec is IBM Research's.

## Tests

`tests/test_outetts.py`, 87 tests, all passing (112 with `tests/test_engines.py`). Real assertions on fake sessions that
record their feeds:

* text normalization (7), chunking incl. CJK (8), speaker-text merging (4)
* prompt assembly, exact upstream layout, and the deep-copy that stops the in-place
  mutation (7)
* speaker resolution precedence, `configure()` for both profile shapes, token maps (9)
* sampler: penalty sign handling, min-p, and a test that pins **temperature before
  truncation** so an accidental switch to llama.cpp order fails (9)
* the KV loop: prefill shapes, one-token decode steps, absolute positions, attention-mask
  growth, `present.<i>.<k>` → `past_key_values.<i>.<k>` wiring with per-layer
  fingerprints, cache growth, geometry read off the graph, last-logit-row selection,
  EOS/audio-end stop, length cap, prompt-spanning penalty window (12)
* codec hand-off: codebook split, half-frame truncation, decoder chunking, fades (8)
* loudness: 6.02 dB per halving, silence, target hit, peak ceiling (7)
* synthesize paths, error messages, determinism, registration (15)
* the last-row-only logits shape phoonnx's own 1B export emits, driving the same loop (1)

## Changes

* `phoonnx/engines/outetts.py` — new
* `phoonnx/engines/__init__.py` — register at `detect_priority=23`
* `phoonnx/config.py` — `Engine.OUTETTS` + the graphemes/24 kHz branch
* `phoonnx/voice_index/outetts.json` — new, 23 voices (14 on the 0.6B, 9 on the 1B)
* `scripts/conversion/outetts/export_outetts_onnx.py` — new, the 1B/0.6B ONNX exporter
* `phoonnx/model_manager.py` — index order
* `VOICES.md` — regenerated (2407 → 2430)
* `docs/training/engines/outetts.md` — new; linked from the engine catalog, the
  configuration table, the voice-manager list and the cloning table
* `tests/test_outetts.py` — new

Purely additive: no existing engine, index or shared helper is touched.

## Follow-ups

* Per-language speaker profiles. One English profile for 14 languages is the single
  largest quality lever here, and it needs the DAC **encoder** (already mirrored) plus
  word alignment.
* Worth reporting the broken official 1B export upstream to OuteAI.
* `pyloudnorm`-compatible loudness now lives in `outetts.py`. If a second engine needs
  BS.1770 it should move to a shared helper — flagging rather than pre-emptively moving
  shared code.

Authored by Claude Opus under Fable orchestration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OuteTTS as a supported text-to-speech engine with 24 kHz audio output.
  * Added 22 OuteTTS voices across multiple languages and model sizes.
  * Added speaker profile selection, text chunking, codec-based generation, and loudness normalization.
  * Added documentation covering setup, configuration, cloning support, supported languages, and model usage.

* **Documentation**
  * Expanded the supported voice catalog to 2,445 voices and 1,242 languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->