### PR TITLE
feat: Qwen3-TTS engine

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -1,6 +1,6 @@
 ## Supported Voices
 
-**Total Voices:** 2407
+**Total Voices:** 2422
 **Total Languages:** 1240
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
@@ -441,6 +441,7 @@
 | `piper_community/systemofapwne/de-DE_glados_high` | `de-DE` | `piper` | `espeak` |
 | `piper_community/systemofapwne/de-DE_glados_low` | `de-DE` | `piper` | `espeak` |
 | `piper_community/systemofapwne/de-DE_glados_medium` | `de-DE` | `piper` | `espeak` |
+| `qwen3tts/ryan/de` | `de-DE` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-ded-Dedua` | `ded` | `transformers` | `graphemes` |
 | `facebook/mms-tts-des-Desano` | `des` | `transformers` | `graphemes` |
 | `facebook/mms-tts-dga-Dagaare, Southern` | `dga` | `transformers` | `graphemes` |
@@ -729,6 +730,8 @@
 | `piper_community/simoniz0r/en-US_eminem` | `en-US` | `piper` | `espeak` |
 | `piper_community/simoniz0r/en-US_patrick` | `en-US` | `piper` | `espeak` |
 | `piper_community/swqg-messiah/en-US_chitti` | `en-US` | `piper` | `espeak` |
+| `qwen3tts/ryan/en` | `en-US` | `qwen3tts` | `unicode` |
+| `qwen3tts/aiden/en` | `en-US` | `qwen3tts` | `unicode` |
 | `sparktts/female/en` | `en-US` | `sparktts` | `unicode` |
 | `sparktts/male/en` | `en-US` | `sparktts` | `unicode` |
 | `facebook/mms-tts-enb-Markweeta` | `enb` | `transformers` | `graphemes` |
@@ -798,6 +801,7 @@
 | `piper/es_ES-mls_9972-low` | `es-ES` | `piper` | `espeak` |
 | `piper/es_ES-sharvard-medium` | `es-ES` | `piper` | `espeak` |
 | `piper_community/friyin/es-ES_friyin` | `es-ES` | `piper` | `espeak` |
+| `qwen3tts/ryan/es` | `es-ES` | `qwen3tts` | `unicode` |
 | `piper/es_MX-ald-medium` | `es-MX` | `piper` | `espeak` |
 | `piper/es_MX-claude-high` | `es-MX` | `piper` | `espeak` |
 | `piper_community/HirCoir/es-MX_Laura` | `es-MX` | `piper` | `espeak` |
@@ -932,6 +936,7 @@
 | `piper/fr_FR-siwis-medium` | `fr-FR` | `piper` | `espeak` |
 | `piper/fr_FR-tom-medium` | `fr-FR` | `piper` | `espeak` |
 | `piper/fr_FR-upmc-medium` | `fr-FR` | `piper` | `espeak` |
+| `qwen3tts/ryan/fr` | `fr-FR` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-frd-Fordata` | `frd` | `transformers` | `graphemes` |
 | `coqui/ga-cv-vits` | `ga-IE` | `coqui` | `graphemes` |
 | `facebook/mms-tts-gag-script_cyrillic-Gagauz` | `gag-Cyrl` | `transformers` | `graphemes` |
@@ -1193,6 +1198,7 @@
 | `piper_community/kirys79/it-IT_Giorgio` | `it-IT` | `piper` | `espeak` |
 | `piper_community/kirys79/it-IT_Leonardo` | `it-IT` | `piper` | `espeak` |
 | `piper_community/paolapersico1/it-IT_paola` | `it-IT` | `piper` | `espeak` |
+| `qwen3tts/ryan/it` | `it-IT` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-itl-Itelmen` | `itl` | `transformers` | `graphemes` |
 | `facebook/mms-tts-itv-Itawit` | `itv` | `transformers` | `graphemes` |
 | `facebook/mms-tts-ixl-dialect_sangasparchajul-Ixil` | `ixl-x-sangaspa-rchajul` | `transformers` | `graphemes` |
@@ -1216,6 +1222,7 @@
 | `kokoro/jf_nezumi` | `ja-JP` | `styletts2` | `misaki_ja` |
 | `kokoro/jf_tebukuro` | `ja-JP` | `styletts2` | `misaki_ja` |
 | `kokoro/jm_kumo` | `ja-JP` | `styletts2` | `misaki_ja` |
+| `qwen3tts/ono_anna/ja` | `ja-JP` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-jac-Jakalteko` | `jac` | `transformers` | `graphemes` |
 | `facebook/mms-tts-jam-Jamaican English Creole` | `jam` | `transformers` | `graphemes` |
 | `facebook/mms-tts-jbu-Jukun Takum` | `jbu` | `transformers` | `graphemes` |
@@ -1312,6 +1319,7 @@
 | `piper_neurlang/ko-KO_kss-korean` | `ko-KO` | `piper` | `goruut` |
 | `chatterbox/multilingual/ko` | `ko-KR` | `chatterbox` | `unicode` |
 | `facebook/mms-tts-kor-Korean` | `ko-KR` | `transformers` | `graphemes` |
+| `qwen3tts/sohee/ko` | `ko-KR` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-kog-Kogi` | `kog` | `transformers` | `graphemes` |
 | `facebook/mms-tts-kpq-Korupun-Sela` | `kpq` | `transformers` | `graphemes` |
 | `facebook/mms-tts-kps-Tehit` | `kps` | `transformers` | `graphemes` |
@@ -1801,6 +1809,7 @@
 | `piper/pt_BR-faber-medium` | `pt-BR` | `piper` | `espeak` |
 | `piper/pt_BR-jeff-medium` | `pt-BR` | `piper` | `espeak` |
 | `piper_community/srxz/pt-BR_sage` | `pt-BR` | `piper` | `espeak` |
+| `qwen3tts/ryan/pt` | `pt-BR` | `qwen3tts` | `unicode` |
 | `chatterbox/multilingual/pt` | `pt-PT` | `chatterbox` | `unicode` |
 | `OpenVoiceOS/phoonnx_pt-PT_dii_tugaphone` | `pt-PT` | `phoonnx` | `tugaphone` |
 | `OpenVoiceOS/phoonnx_pt-PT_miro_tugaphone` | `pt-PT` | `phoonnx` | `tugaphone` |
@@ -1903,6 +1912,7 @@
 | `piper/ru_RU-irina-medium` | `ru-RU` | `piper` | `espeak` |
 | `piper/ru_RU-ruslan-medium` | `ru-RU` | `piper` | `espeak` |
 | `piper_community/superkeka/ru-RU_luka` | `ru-RU` | `piper` | `espeak` |
+| `qwen3tts/ryan/ru` | `ru-RU` | `qwen3tts` | `unicode` |
 | `facebook/mms-tts-rub-Gungu` | `rub` | `transformers` | `graphemes` |
 | `facebook/mms-tts-ruf-Luguru` | `ruf` | `transformers` | `graphemes` |
 | `facebook/mms-tts-rug-Roviana` | `rug` | `transformers` | `graphemes` |
@@ -2393,6 +2403,11 @@
 | `hf_community/BricksDisplay/vits-cmn` | `zh-CN` | `transformers` | `graphemes` |
 | `piper/zh_CN-huayan-medium` | `zh-CN` | `piper` | `espeak` |
 | `piper/zh_CN-huayan-x_low` | `zh-CN` | `piper` | `espeak` |
+| `qwen3tts/vivian/zh` | `zh-CN` | `qwen3tts` | `unicode` |
+| `qwen3tts/serena/zh` | `zh-CN` | `qwen3tts` | `unicode` |
+| `qwen3tts/uncle_fu/zh` | `zh-CN` | `qwen3tts` | `unicode` |
+| `qwen3tts/dylan/zh` | `zh-CN` | `qwen3tts` | `unicode` |
+| `qwen3tts/eric/zh` | `zh-CN` | `qwen3tts` | `unicode` |
 | `sparktts/female/zh` | `zh-CN` | `sparktts` | `unicode` |
 | `sparktts/male/zh` | `zh-CN` | `sparktts` | `unicode` |
 | `piper_community/colafly/zh-TW_yt-chinese_female` | `zh-TW` | `piper` | `espeak` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ how to obtain or train it, and a synthesis example:
 [ZipVoice](training/engines/zipvoice.md) ·
 [Chatterbox](training/engines/chatterbox.md) ·
 [Spark-TTS](training/engines/sparktts.md) ·
+[Qwen3-TTS](training/engines/qwen3tts.md) ·
 [F5-TTS](training/engines/f5tts.md) ·
 [Shami](training/engines/shami.md) ·
 [Pocket TTS](pockettts.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `neutts` | Autoregressive NeuCodec LM, preset cloning @24 kHz | [Cloning](cloning.md) |
 | `pockettts` | Flow-matching codec LM with explicit stream state, raw-text (no phonemizer) | [Pocket TTS](pockettts.md) |
 | `sparktts` | Autoregressive codec-LM (Qwen2 + BiCodec), en/zh | [Spark-TTS](training/engines/sparktts.md) |
+| `qwen3tts` | Two-stage codec LM (talker + code predictor), 10 languages | [Qwen3-TTS](training/engines/qwen3tts.md) |
 
 ## Execution Providers
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -92,6 +92,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | NeuTTS (NeuTTS Air / VieNeu / Akiti) | `phoonnx/engines/neutts.py` | `engine == "neutts"` — autoregressive single-codebook codec-LM (Qwen3 backbone + NeuCodec decoder), raw text phonemized with espeak-ng, in-context [cloning](cloning.md) from pre-encoded voice presets, 24 kHz |
 | [Pocket TTS](pockettts.md) | `phoonnx/engines/pockettts.py` | `engine == "pockettts"` — 5-graph flow-matching codec LM with explicit stream state, raw-text (no phonemizer), state-based voices and reference [cloning](cloning.md) |
 | [Spark-TTS](training/engines/sparktts.md) | `phoonnx/engines/sparktts.py` | `engine == "sparktts"` — autoregressive codec-LM (Qwen2 + BiCodec), raw-text, en/zh; preset 32-token speakers or zero-shot [cloning](cloning.md) |
+| [Qwen3-TTS](training/engines/qwen3tts.md) | `phoonnx/engines/qwen3tts.py` | `engine == "qwen3tts"` — two autoregressive stages (28-layer talker + 5-layer code predictor) writing 16 code groups per 12.5 Hz frame, raw-text, 10 languages, nine fixed timbres, 24 kHz |
 
 ---
 

--- a/docs/training/engines/qwen3tts.md
+++ b/docs/training/engines/qwen3tts.md
@@ -64,10 +64,13 @@ asks for.
 Voice ids follow `qwen3tts/<timbre>/<language>`:
 
 ```python
-from phoonnx.voice import TTSVoice
+from phoonnx.model_manager import TTSModelManager
 
-voice = TTSVoice.load("qwen3tts/ryan/en")
-audio = voice.synthesize("The quick brown fox jumps over the lazy dog.")
+manager = TTSModelManager()
+manager.merge_default_voices()
+voice = manager.voices["qwen3tts/ryan/en"].load()
+for chunk in voice.synthesize("The quick brown fox jumps over the lazy dog."):
+    ...  # chunk.audio_float_array
 ```
 
 ## Graphs

--- a/docs/training/engines/qwen3tts.md
+++ b/docs/training/engines/qwen3tts.md
@@ -103,11 +103,15 @@ Defaults come from the checkpoint's own `generation_config.json`:
 | `subtalker_top_k` | 50 | code-predictor top-k |
 | `subtalker_top_p` | 1.0 | code-predictor nucleus |
 
-Two more parameters are accepted per call: `do_sample` (set it to `False` for a
-deterministic result that matches the upstream PyTorch model token for token) and `seed`.
+Two more parameters are accepted per call: `do_sample` and `seed`. `do_sample=False`
+gives a deterministic result that matches the upstream PyTorch model token for token,
+which is what the parity checker uses. Do not use it for synthesis: greedy decoding makes
+this model loop and talk forever on some inputs, which is why upstream samples by
+default.
 
-Sampling is stochastic, and a rare draw makes the model keep talking past the text. If
-you need a bounded result, set `do_sample=False` or cap `max_new_tokens`.
+Sampling is stochastic, and a rare draw also makes the model keep talking past the text.
+Cap `max_new_tokens` when you need a bounded result: at 12.5 frames per second, 250
+frames is 20 seconds of audio.
 
 ## Licence
 

--- a/docs/training/engines/qwen3tts.md
+++ b/docs/training/engines/qwen3tts.md
@@ -1,0 +1,116 @@
+# Qwen3-TTS Engine
+
+This page is for integrators who want Qwen3-TTS voices in phoonnx. After reading it you
+can pick a timbre and a language, and you know what each of the seven ONNX graphs does
+and what one second of audio costs.
+
+> Related: [adapter architecture](../../engines.md) ·
+> [configuration](../../configuration.md) ·
+> [Spark-TTS — the sibling codec-LM engine](sparktts.md)
+
+## What it is
+
+**Qwen3-TTS** (Alibaba Qwen) predicts the tokens of a 12.5 Hz neural codec and turns them
+into a waveform at 24 kHz. It has two stacked autoregressive models, not one:
+
+* the **talker** — 28 decoder layers that emit one token per audio frame. That token is
+  code group 0, and the talker's hidden state conditions the second model;
+* the **code predictor** — 5 decoder layers that read the talker's hidden state and write
+  the other 15 code groups of the *same* frame, one group per step.
+
+One 80 ms frame therefore costs one talker step and 15 code-predictor steps. The 16
+groups of a frame are summed into a single embedding and fed back to the talker together
+with the next slice of the text.
+
+The talker reads embeddings, never token ids: at every prompt position a text hidden
+state and a codec hidden state are added together. The prompt holds the assistant role
+tokens, a language block, the speaker, the whole text against codec padding, and finally
+the codec BOS that starts the audio.
+
+phoonnx ships the **0.6B CustomVoice** checkpoint. It has nine trained timbres and no
+speaker encoder, so a voice is a name, not a reference clip, and this engine does not do
+[cloning](../../cloning.md).
+
+## When to pick it
+
+Pick Qwen3-TTS when one model has to cover many languages with a fixed, high-quality
+voice. It speaks Chinese, English, Japanese, Korean, German, French, Russian, Portuguese,
+Spanish and Italian, which is the widest language set of any codec-LM engine in phoonnx.
+
+Do not pick it when you need to clone a speaker — use [Spark-TTS](sparktts.md) or
+[Chatterbox](chatterbox.md) — or when you need real-time synthesis on a small CPU. Two
+autoregressive stages cost far more than a single-pass engine: measured on six cores,
+one second of audio takes about five seconds of CPU time.
+
+## Voices
+
+| Voice | Timbre | Native language |
+| --- | --- | --- |
+| `vivian` | bright young female | Chinese |
+| `serena` | warm gentle young female | Chinese |
+| `uncle_fu` | seasoned male, mellow | Chinese |
+| `dylan` | youthful male | Chinese (Beijing) |
+| `eric` | lively male | Chinese (Sichuan) |
+| `ryan` | dynamic male | English |
+| `aiden` | sunny American male | English |
+| `ono_anna` | playful female | Japanese |
+| `sohee` | warm female | Korean |
+
+Any timbre speaks any of the ten languages; the table gives the language each timbre was
+recorded in, which is where it sounds best. `dylan` and `eric` are dialect voices: they
+always speak their dialect when the language is Chinese or unset, whatever the caller
+asks for.
+
+Voice ids follow `qwen3tts/<timbre>/<language>`:
+
+```python
+from phoonnx.voice import TTSVoice
+
+voice = TTSVoice.load("qwen3tts/ryan/en")
+audio = voice.synthesize("The quick brown fox jumps over the lazy dog.")
+```
+
+## Graphs
+
+| File | What it does |
+| --- | --- |
+| `talker.onnx` | the 28-layer talker, one KV-cached step per frame (the voice's `model_url`) |
+| `text_embed.onnx` | text ids to projected text hidden states |
+| `codec_embed.onnx` | talker codec ids to hidden states |
+| `code_predictor_prefill.onnx` | talker hidden plus code group 0, gives code group 1 |
+| `code_predictor_step.onnx` | code group n gives code group n+1 |
+| `sub_codec_embed.onnx` | code-group token to its group's embedding |
+| `codec_decoder.onnx` | 16 code groups per frame to 24 kHz audio |
+
+Every group has its own embedding table and its own output head, so the step graph takes
+the group index as an input and gathers both from a stacked weight. The graphs are
+float32 and total about 4.4 GB, which is what a voice downloads once.
+
+The mirror is [`OpenVoiceOS/phoonnx-qwen3-tts`](https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts).
+The export script is `scripts/conversion/qwen3tts/export_qwen3tts_onnx.py`.
+
+## Control parameters
+
+Defaults come from the checkpoint's own `generation_config.json`:
+
+| Parameter | Default | What it does |
+| --- | --- | --- |
+| `temperature` | 0.9 | talker sampling temperature |
+| `top_k` | 50 | talker top-k |
+| `top_p` | 1.0 | talker nucleus |
+| `repetition_penalty` | 1.05 | penalty over the code-group-0 tokens already emitted |
+| `subtalker_temperature` | 0.9 | code-predictor temperature |
+| `subtalker_top_k` | 50 | code-predictor top-k |
+| `subtalker_top_p` | 1.0 | code-predictor nucleus |
+
+Two more parameters are accepted per call: `do_sample` (set it to `False` for a
+deterministic result that matches the upstream PyTorch model token for token) and `seed`.
+
+Sampling is stochastic, and a rare draw makes the model keep talking past the text. If
+you need a bounded result, set `do_sample=False` or cap `max_new_tokens`.
+
+## Licence
+
+Apache-2.0, the licence of the upstream model. The weights, the architecture and the nine
+timbres are the work of the Alibaba Qwen team; cite the Qwen3-TTS technical report
+(arXiv 2601.15621) when you use them.

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -11,7 +11,7 @@ The catalog is not fetched from a handful of live endpoints. `merge_default_voic
 `OVOS`, `MMS`, `proxectonos`, `piper`, `phonikud`, `neurlang`, `mimic3`,
 `transformers_community`, `piper_community`, `optispeech`, `glowtts`, `mixertts`,
 `fastpitch`, `coqui_community`, `vits2`, `styletts2`, `f5tts`, `coqui_vits`, `BSC`,
-`shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`.
+`shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`, `qwen3tts`.
 
 Each JSON entry becomes a `TTSModelInfo`. Model/config/vocoder files are only fetched from their URLs when a voice is actually downloaded or loaded.
 

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -36,6 +36,7 @@ class Engine(str, Enum):
     NEUTTS = "neutts"  # NeuTTS Air / VieNeu / Akiti: Qwen3 codec-LM + NeuCodec decoder
     POCKETTTS = "pockettts"  # Kyutai Pocket TTS: 5-graph flow-matching codec LM, raw-text (no phonemizer)
     SPARKTTS = "sparktts"  # Spark-TTS: Qwen2 codec-LM + BiCodec, preset or zero-shot speakers
+    QWEN3TTS = "qwen3tts"  # Qwen3-TTS: talker + code predictor, 16 code groups, 12.5 Hz codec
 
 
 # Alphabet and PhonemeType are wire-format enums shared with scriptconv;
@@ -383,6 +384,26 @@ class VoiceConfig:
             phoneme_type = phoneme_type or PhonemeType.UNICODE
             alphabet = alphabet or Alphabet.GRAPHEMES
             config.setdefault("audio", {}).setdefault("sample_rate", 16000)
+            tokenizer = TTSTokenizer(
+                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
+                add_blank_char=False,
+                add_blank_word=False,
+                use_eos_bos=False,
+                blank_at_end=False,
+                blank_at_start=False,
+            )
+
+        elif (engine == Engine.QWEN3TTS or
+                (isinstance(engine, str) and engine == "qwen3tts") or
+                config.get("engine") == "qwen3tts"):
+            # Qwen3-TTS consumes raw text: the adapter owns text -> id conversion with
+            # the model's own subword BPE (loaded from engine_params, like Spark-TTS),
+            # so no phonemizer vocabulary is needed here. Alphabet.GRAPHEMES routes
+            # TTSVoice.synthesize() through adapter.encode_text().
+            engine = Engine.QWEN3TTS
+            phoneme_type = phoneme_type or PhonemeType.UNICODE
+            alphabet = alphabet or Alphabet.GRAPHEMES
+            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
             tokenizer = TTSTokenizer(
                 Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
                 add_blank_char=False,

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -143,6 +143,7 @@ def _register_builtins() -> None:
     from phoonnx.engines.neutts import NeuTTSAdapter
     from phoonnx.engines.pockettts import PocketTTSAdapter
     from phoonnx.engines.sparktts import SparkTTSAdapter
+    from phoonnx.engines.qwen3tts import Qwen3TTSAdapter
 
     # OptiSpeech shares VITS-like x/x_lengths/scales inputs with Matcha, but has
     # a distinctive metadata + wav/durations output signature — check it first.
@@ -166,6 +167,7 @@ def _register_builtins() -> None:
     register_engine("neutts", NeuTTSAdapter, detect_priority=27)
     register_engine("pockettts", PocketTTSAdapter, detect_priority=26)
     register_engine("sparktts", SparkTTSAdapter, detect_priority=25)
+    register_engine("qwen3tts", Qwen3TTSAdapter, detect_priority=24)
 
 
 _register_builtins()

--- a/phoonnx/engines/qwen3tts.py
+++ b/phoonnx/engines/qwen3tts.py
@@ -43,6 +43,10 @@ The sampler order follows HuggingFace ``generate``, the stack upstream uses: a
 repetition penalty over the tokens emitted so far, then the minimum-new-tokens floor
 that blocks an immediate end of speech, then the suppressed control-token range, and
 only then temperature, top-k and top-p. Reordering these changes which tokens survive.
+The minimum-new-tokens floor is just the ``MIN_NEW_TOKENS`` step check below, not
+HuggingFace's ``MinNewTokensLengthLogitsProcessor`` class; the two are behaviorally
+identical here because every call starts from an empty cache (``step`` is always
+tokens-generated-so-far, never an offset into a pre-filled prompt).
 """
 import re
 from typing import Any, Dict, List, Optional, Tuple

--- a/phoonnx/engines/qwen3tts.py
+++ b/phoonnx/engines/qwen3tts.py
@@ -1,0 +1,545 @@
+"""Qwen3-TTS inference adapter — two-stage codec LM with 16 code groups.
+
+Qwen3-TTS (Alibaba Qwen, Apache-2.0, ``QwenLM/Qwen3-TTS``) predicts the tokens of a
+12.5 Hz neural codec and turns them into a waveform at 24 kHz. It has two stacked
+autoregressive models, not one:
+
+* the **talker** — 28 decoder layers that emit one token per audio frame. That token
+  is code group 0, and its hidden state conditions the second model;
+* the **code predictor** (upstream calls it the sub-talker) — 5 decoder layers that
+  read the talker's hidden state and write the other 15 code groups of the *same*
+  frame, one group per step.
+
+So one 80 ms frame costs one talker step plus 15 code-predictor steps. The 16 groups
+of a frame are then fed back to the talker as a single summed embedding, together
+with the next slice of the text. This engine drives the overridable
+``BaseOnnxAdapter.synthesize`` rather than the single-graph ``build_feed_dict`` path,
+like the sibling :class:`phoonnx.engines.sparktts.SparkTTSAdapter`.
+
+Seven ONNX graphs (HF: ``OpenVoiceOS/phoonnx-qwen3-tts``)::
+
+    talker.onnx                 28-layer KV-cached talker step (= the voice's ``session``)
+    text_embed.onnx             text ids -> projected text hidden (1024)
+    codec_embed.onnx            codec ids -> codec hidden (1024)
+    code_predictor_prefill.onnx [talker hidden, group-0 embed] -> group-1 logits + KV
+    code_predictor_step.onnx    group-n embed -> group-(n+1) logits + KV
+    sub_codec_embed.onnx        code-group token -> its group's embedding
+    codec_decoder.onnx          (1, 16, T) codes -> waveform @ 24 kHz
+
+plus ``tokenizer.json`` (the model's own Qwen2 subword BPE).
+
+The talker reads *embeddings*, never ids: at every position a text hidden state and a
+codec hidden state are summed. ``build_prompt`` reproduces the layout upstream builds
+in ``Qwen3TTSForConditionalGeneration.generate`` for non-streaming input — the
+assistant role tokens, a language "think" block, the speaker embedding, then the whole
+text against codec padding, and finally the codec BOS that starts the audio.
+
+Voices are the nine timbres the CustomVoice checkpoint was trained with; a voice is
+one entry in ``spk_id``, so no reference clip and no speaker encoder are involved.
+Two of them are Chinese dialect voices, and upstream overrides the language tag for
+those, which :func:`resolve_language_id` reproduces.
+
+The sampler order follows HuggingFace ``generate``, the stack upstream uses: a
+repetition penalty over the tokens emitted so far, then the minimum-new-tokens floor
+that blocks an immediate end of speech, then the suppressed control-token range, and
+only then temperature, top-k and top-p. Reordering these changes which tokens survive.
+"""
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import onnxruntime
+from quebra_frases import sentence_tokenize
+
+from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
+from phoonnx.tokenizer import BPETokenizer
+from phoonnx.util import LOG
+
+SAMPLE_RATE = 24000
+"""The codec decoder writes 24 kHz audio."""
+
+FRAME_RATE = 12.5
+"""Code frames per second; one frame is 1920 samples."""
+
+UPSAMPLE = 1920
+"""Waveform samples produced per code frame."""
+
+NUM_CODE_GROUPS = 16
+"""Codebooks per frame: group 0 from the talker, groups 1-15 from the code predictor."""
+
+TALKER_LAYERS, TALKER_KV_HEADS, TALKER_HEAD_DIM = 28, 8, 128
+PREDICTOR_LAYERS, PREDICTOR_KV_HEADS, PREDICTOR_HEAD_DIM = 5, 8, 128
+
+TALKER_VOCAB = 3072
+"""Talker codebook plus the control tokens above it."""
+
+SUPPRESS_FROM = TALKER_VOCAB - 1024
+"""Upstream suppresses every token from here up, except the end-of-speech token."""
+
+MIN_NEW_TOKENS = 2
+"""Upstream forbids ending speech before this many frames."""
+
+MAX_NEW_TOKENS = 4096
+"""Upstream generation budget — about 5.5 minutes of audio at 12.5 frames per second."""
+
+MAX_CHUNK_CHARS = 300
+"""Longest text handed to one autoregressive pass; longer input is split on sentences."""
+
+DECODE_CHUNK, DECODE_LEFT_CONTEXT = 300, 25
+"""Frames per codec-decoder call and the left context each call re-reads."""
+
+# Text-side control tokens (ids in the Qwen2 text vocabulary).
+TTS_PAD_TOKEN, TTS_BOS_TOKEN, TTS_EOS_TOKEN = 151671, 151672, 151673
+
+# Codec-side control tokens (ids in the talker vocabulary).
+CODEC_PAD, CODEC_BOS, CODEC_EOS = 2148, 2149, 2150
+CODEC_THINK, CODEC_NOTHINK = 2154, 2155
+CODEC_THINK_BOS, CODEC_THINK_EOS = 2156, 2157
+
+ROLE_PREFIX_TOKENS = 3
+"""``<|im_start|>assistant\\n`` — the part of the prompt that stays outside the sum."""
+
+TAIL_TOKENS = 5
+"""``<|im_end|>\\n<|im_start|>assistant\\n`` — the closing part, never spoken."""
+
+LANGUAGE_IDS: Dict[str, int] = {
+    "chinese": 2055, "english": 2050, "german": 2053, "italian": 2070,
+    "portuguese": 2071, "spanish": 2054, "japanese": 2058, "korean": 2064,
+    "french": 2061, "russian": 2069,
+    "beijing_dialect": 2074, "sichuan_dialect": 2062,
+}
+"""Talker tokens that name the language of the utterance."""
+
+LANG_CODE_TO_NAME: Dict[str, str] = {
+    "zh": "chinese", "en": "english", "de": "german", "it": "italian",
+    "pt": "portuguese", "es": "spanish", "ja": "japanese", "ko": "korean",
+    "fr": "french", "ru": "russian",
+}
+"""BCP-47 primary subtag -> the language name the talker was trained with."""
+
+SPEAKER_IDS: Dict[str, int] = {
+    "vivian": 3065, "serena": 3066, "uncle_fu": 3010, "dylan": 2878, "eric": 2875,
+    "ryan": 3061, "aiden": 2861, "ono_anna": 2873, "sohee": 2864,
+}
+"""The nine timbres of the CustomVoice checkpoint."""
+
+SPEAKER_DIALECT: Dict[str, str] = {"eric": "sichuan_dialect", "dylan": "beijing_dialect"}
+"""Voices that override the Chinese language tag with a dialect tag."""
+
+
+def resolve_language_name(lang: Optional[str]) -> str:
+    """Map a language tag or name to the name the talker knows.
+
+    Accepts what a voice config carries (``"en-US"``), what upstream's API takes
+    (``"English"``) and the ``"auto"`` sentinel, which drops the language block from
+    the prompt and lets the model infer the language from the text.
+    """
+    if not lang:
+        return "auto"
+    name = str(lang).strip().lower().replace("-", "_")
+    if name in LANGUAGE_IDS or name == "auto":
+        return name
+    primary = name.split("_")[0]
+    return LANG_CODE_TO_NAME.get(primary, "auto")
+
+
+def resolve_language_id(language: str, speaker: str) -> Optional[int]:
+    """The language token for this call, or ``None`` for the no-language prompt.
+
+    A dialect voice wins over the requested language whenever that language is
+    Chinese or unset, which is what upstream does: Dylan always speaks Beijing
+    Mandarin and Eric always speaks Sichuanese, whatever tag the caller passed.
+    """
+    speaker = speaker.lower()
+    language = resolve_language_name(language)
+    if language in ("chinese", "auto") and speaker in SPEAKER_DIALECT:
+        return LANGUAGE_IDS[SPEAKER_DIALECT[speaker]]
+    if language == "auto":
+        return None
+    return LANGUAGE_IDS[language]
+
+
+def chunk_text(text: str, max_len: int = MAX_CHUNK_CHARS) -> List[str]:
+    """Pack whole sentences into chunks of at most ``max_len`` characters.
+
+    One chunk is one autoregressive pass. Sentence boundaries come from
+    ``quebra_frases.sentence_tokenize``, the splitter the rest of phoonnx uses.
+    """
+    chunks: List[str] = []
+    for paragraph in (p.strip() for p in re.split(r"\n\s*\n+", text.strip())):
+        if not paragraph:
+            continue
+        current = ""
+        for sentence in sentence_tokenize(paragraph):
+            if len(current) + len(sentence) + 1 <= max_len:
+                current += (" " if current else "") + sentence
+            else:
+                if current:
+                    chunks.append(current.strip())
+                current = sentence
+        if current:
+            chunks.append(current.strip())
+    return chunks or ([text.strip()] if text.strip() else [])
+
+
+def apply_logits_processors(logits: np.ndarray, generated: List[int],
+                            repetition_penalty: float, step: int) -> np.ndarray:
+    """Apply the processors HuggingFace ``generate`` builds for this model, in order.
+
+    The order is the one upstream gets: repetition penalty, then the minimum-new-tokens
+    floor, then the suppressed token range. Suppression comes last, so it cannot be
+    undone by the penalty; the end-of-speech token is the one id inside the suppressed
+    range that survives.
+    """
+    x = np.asarray(logits, np.float64).reshape(-1).copy()
+    if repetition_penalty != 1.0 and generated:
+        seen = np.unique(np.asarray(generated, np.int64))
+        scores = x[seen]
+        x[seen] = np.where(scores < 0, scores * repetition_penalty,
+                           scores / repetition_penalty)
+    eos = x[CODEC_EOS]
+    x[SUPPRESS_FROM:] = -np.inf
+    x[CODEC_EOS] = -np.inf if step < MIN_NEW_TOKENS else eos
+    return x
+
+
+def sample_token(logits: np.ndarray, temperature: float, top_k: int, top_p: float,
+                 rng: np.random.Generator, do_sample: bool = True) -> int:
+    """Draw one token the way HuggingFace ``generate`` does for this model.
+
+    The warpers run in the order HuggingFace builds them — temperature, then top-k,
+    then top-p. The repetition penalty is *not* here: it is a processor, and
+    :func:`apply_logits_processors` has already run it on the talker's logits. The
+    code predictor has no processors at all, so it calls this function directly.
+    """
+    x = np.asarray(logits, np.float64).reshape(-1)
+    if not do_sample or temperature <= 0:
+        return int(np.argmax(x))
+    x = x / max(temperature, 1e-5)
+    if top_k and 0 < top_k < x.size:
+        x = np.where(x < np.partition(x, -top_k)[-top_k], -np.inf, x)
+    x = x - x.max()
+    probs = np.exp(x)
+    probs /= probs.sum()
+    if top_p >= 1.0:
+        return int(rng.choice(probs.size, p=probs))
+    order = np.argsort(probs)[::-1]
+    cutoff = int(np.searchsorted(np.cumsum(probs[order]), top_p)) + 1
+    keep = order[:max(1, cutoff)]
+    p = probs[keep] / probs[keep].sum()
+    return int(rng.choice(keep, p=p))
+
+
+def empty_cache(layers: int, heads: int, head_dim: int) -> Dict[str, np.ndarray]:
+    """A zero-length KV cache for a fresh autoregressive pass."""
+    return {f"past_key_values.{i}.{kind}": np.zeros((1, heads, 0, head_dim), np.float32)
+            for i in range(layers) for kind in ("key", "value")}
+
+
+def roll_cache(outputs: Dict[str, np.ndarray], layers: int) -> Dict[str, np.ndarray]:
+    """Map this step's ``present`` tensors onto the next step's ``past`` inputs."""
+    return {f"past_key_values.{i}.{kind}": outputs[f"present.{i}.{kind}"]
+            for i in range(layers) for kind in ("key", "value")}
+
+
+class Qwen3TTSAdapter(BaseOnnxAdapter):
+    """Adapter for Qwen3-TTS (talker + code predictor + 12.5 Hz codec decoder)."""
+
+    def __init__(self):
+        self.text_embed: Optional[onnxruntime.InferenceSession] = None
+        self.codec_embed: Optional[onnxruntime.InferenceSession] = None
+        self.predictor_prefill: Optional[onnxruntime.InferenceSession] = None
+        self.predictor_step: Optional[onnxruntime.InferenceSession] = None
+        self.sub_codec_embed: Optional[onnxruntime.InferenceSession] = None
+        self.decoder: Optional[onnxruntime.InferenceSession] = None
+        self.tokenizer: Optional[BPETokenizer] = None
+        self.speaker: str = ""
+        self.language: str = "auto"
+        self._params: Dict[str, Any] = {}
+        self._sub_tables = np.arange(NUM_CODE_GROUPS - 1, dtype=np.int64)
+
+    def default_params(self) -> Dict[str, float]:
+        # upstream generation_config.json for the CustomVoice checkpoints
+        return {"temperature": 0.9, "top_k": 50.0, "top_p": 1.0,
+                "repetition_penalty": 1.05, "subtalker_temperature": 0.9,
+                "subtalker_top_k": 50.0, "subtalker_top_p": 1.0}
+
+    def param_labels(self) -> Dict[str, str]:
+        return {"temperature": "Sampling temperature", "top_k": "Top-k",
+                "top_p": "Nucleus (top-p)", "repetition_penalty": "Repetition penalty",
+                "subtalker_temperature": "Code-predictor temperature",
+                "subtalker_top_k": "Code-predictor top-k",
+                "subtalker_top_p": "Code-predictor nucleus (top-p)"}
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def configure(self, voice_config: Any) -> None:
+        """Open the six side graphs and the model's own subword BPE.
+
+        The speaker comes from the voice, not from a reference clip: this checkpoint
+        has nine trained timbres and no speaker encoder. The language comes from the
+        voice's ``lang_code`` unless ``engine_params`` names one explicitly.
+        """
+        ep = getattr(voice_config, "engine_params", None) or {}
+        self._params = dict(ep)
+        providers = ep.get("providers")
+
+        for attribute, key in (("text_embed", "text_embed_path"),
+                               ("codec_embed", "codec_embed_path"),
+                               ("predictor_prefill", "code_predictor_prefill_path"),
+                               ("predictor_step", "code_predictor_step_path"),
+                               ("sub_codec_embed", "sub_codec_embed_path"),
+                               ("decoder", "codec_decoder_path")):
+            if getattr(self, attribute) is None and ep.get(key):
+                setattr(self, attribute, make_session(ep[key], providers=providers))
+
+        if self.tokenizer is None and ep.get("bpe_tokenizer_path"):
+            self.tokenizer = BPETokenizer(ep["bpe_tokenizer_path"])
+
+        speaker = str(ep.get("speaker", "")).lower()
+        if speaker and speaker not in SPEAKER_IDS:
+            raise ValueError(f"Qwen3-TTS has no speaker '{speaker}'; "
+                             f"known speakers: {sorted(SPEAKER_IDS)}")
+        self.speaker = speaker
+        self.language = resolve_language_name(
+            ep.get("language") or getattr(voice_config, "lang_code", None))
+
+    # ------------------------------------------------------------------
+    # Text
+    # ------------------------------------------------------------------
+
+    def encode_text(self, text: str, voice: Any, syn_config: Any) -> List[List[int]]:
+        """Turn text into one subword-id list per autoregressive pass.
+
+        The chat wrapper is added here because the prompt builder needs to know where
+        the role prefix ends and the spoken text begins, and it locates both by a fixed
+        token count rather than by searching the sequence.
+        """
+        if self.tokenizer is None:
+            raise RuntimeError("Qwen3-TTS voice missing bpe_tokenizer_path in engine_params")
+        return [self.tokenizer.tokenize(
+            f"<|im_start|>assistant\n{chunk}<|im_end|>\n<|im_start|>assistant\n")
+            for chunk in chunk_text(text) if chunk.strip()]
+
+    # ------------------------------------------------------------------
+    # Prompt
+    # ------------------------------------------------------------------
+
+    def _text_hidden(self, ids) -> np.ndarray:
+        return self.text_embed.run(
+            None, {"input_ids": np.asarray(ids, np.int64).reshape(1, -1)})[0]
+
+    def _codec_hidden(self, ids) -> np.ndarray:
+        return self.codec_embed.run(
+            None, {"input_ids": np.asarray(ids, np.int64).reshape(1, -1)})[0]
+
+    def build_prompt(self, input_ids: np.ndarray, speaker: str,
+                     language: str) -> Tuple[np.ndarray, np.ndarray]:
+        """Assemble the summed text/codec embedding sequence the talker was trained on.
+
+        Returns ``(prompt, tts_pad)``. The second value is the text-side padding hidden
+        state, which every generated frame adds once the text has run out.
+
+        The layout, position by position:
+
+        1. the three role tokens, text side only;
+        2. the language "think" block, the speaker, and codec padding, each summed with
+           text padding, closing with the text BOS;
+        3. the whole text summed with codec padding, closing with the text EOS;
+        4. text padding summed with the codec BOS, which is where audio starts.
+        """
+        speaker = speaker.lower()
+        if speaker not in SPEAKER_IDS:
+            raise ValueError(f"Qwen3-TTS has no speaker '{speaker}'; "
+                             f"known speakers: {sorted(SPEAKER_IDS)}")
+        input_ids = np.asarray(input_ids, np.int64).reshape(1, -1)
+        if input_ids.shape[1] <= ROLE_PREFIX_TOKENS + TAIL_TOKENS:
+            raise ValueError("Qwen3-TTS prompt has no text between the chat markers")
+
+        text_hidden = self._text_hidden(input_ids)
+        specials = self._text_hidden([TTS_BOS_TOKEN, TTS_EOS_TOKEN, TTS_PAD_TOKEN])
+        tts_bos, tts_eos, tts_pad = specials[:, 0:1], specials[:, 1:2], specials[:, 2:3]
+
+        language_id = resolve_language_id(language, speaker)
+        if language_id is None:
+            think = [CODEC_NOTHINK, CODEC_THINK_BOS, CODEC_THINK_EOS]
+        else:
+            think = [CODEC_THINK, CODEC_THINK_BOS, language_id, CODEC_THINK_EOS]
+        codec_prefix = np.concatenate([
+            self._codec_hidden(think),
+            self._codec_hidden([SPEAKER_IDS[speaker]]),
+            self._codec_hidden([CODEC_PAD, CODEC_BOS]),
+        ], axis=1)
+
+        role = text_hidden[:, :ROLE_PREFIX_TOKENS]
+        head = np.concatenate(
+            [np.repeat(tts_pad, codec_prefix.shape[1] - 2, axis=1), tts_bos],
+            axis=1) + codec_prefix[:, :-1]
+
+        body_text = text_hidden[:, ROLE_PREFIX_TOKENS:-TAIL_TOKENS]
+        body = (np.concatenate([body_text, tts_eos], axis=1)
+                + self._codec_hidden([CODEC_PAD] * (body_text.shape[1] + 1)))
+        tail = tts_pad + self._codec_hidden([CODEC_BOS])
+
+        prompt = np.concatenate([role, head, body, tail], axis=1)
+        return prompt.astype(np.float32), tts_pad.astype(np.float32)
+
+    # ------------------------------------------------------------------
+    # Code predictor
+    # ------------------------------------------------------------------
+
+    def _sub_embed(self, tokens, tables) -> np.ndarray:
+        return self.sub_codec_embed.run(None, {
+            "input_ids": np.asarray(tokens, np.int64).reshape(-1),
+            "tables": np.asarray(tables, np.int64).reshape(-1)})[0]
+
+    def predict_code_groups(self, talker_hidden: np.ndarray, group0_hidden: np.ndarray,
+                            rng: np.random.Generator, temperature: float, top_k: int,
+                            top_p: float, do_sample: bool) -> List[int]:
+        """Run the code predictor over code groups 1..15 of one frame.
+
+        The prefill reads two positions — the talker's hidden state and the embedding
+        of the group-0 token — and every later step reads the previous group's token
+        through that group's own embedding table and its own output head, which is why
+        the step graph takes the group index as an input.
+        """
+        feed = {"inputs_embeds": np.concatenate(
+            [talker_hidden, group0_hidden], axis=1).astype(np.float32)}
+        names = [o.name for o in self.predictor_prefill.get_outputs()]
+        out = dict(zip(names, self.predictor_prefill.run(None, feed)))
+        past = roll_cache(out, PREDICTOR_LAYERS)
+        tokens = [sample_token(out["logits"][0], temperature, top_k, top_p, rng, do_sample)]
+
+        step_names = [o.name for o in self.predictor_step.get_outputs()]
+        for group in range(1, NUM_CODE_GROUPS - 1):
+            feed = {"inputs_embeds": self._sub_embed(tokens[-1], group - 1).astype(np.float32),
+                    "step": np.asarray(group, np.int64),
+                    "position_ids": np.asarray([[group + 1]], np.int64), **past}
+            out = dict(zip(step_names, self.predictor_step.run(None, feed)))
+            past = roll_cache(out, PREDICTOR_LAYERS)
+            tokens.append(sample_token(out["logits"][0], temperature, top_k, top_p,
+                                       rng, do_sample))
+        return tokens
+
+    # ------------------------------------------------------------------
+    # Talker
+    # ------------------------------------------------------------------
+
+    def generate_codes(self, session: onnxruntime.InferenceSession, prompt: np.ndarray,
+                       tts_pad: np.ndarray, params: Dict[str, Any],
+                       rng: np.random.Generator) -> np.ndarray:
+        """Run both autoregressive loops and return the ``(frames, 16)`` code matrix."""
+        do_sample = bool(params.get("do_sample", True))
+        temperature = float(params.get("temperature", 0.9))
+        top_k = int(params.get("top_k", 50))
+        top_p = float(params.get("top_p", 1.0))
+        repetition_penalty = float(params.get("repetition_penalty", 1.05))
+        sub_temperature = float(params.get("subtalker_temperature", 0.9))
+        sub_top_k = int(params.get("subtalker_top_k", 50))
+        sub_top_p = float(params.get("subtalker_top_p", 1.0))
+        max_new = int(params.get("max_new_tokens", MAX_NEW_TOKENS))
+
+        names = [o.name for o in session.get_outputs()]
+        past = empty_cache(TALKER_LAYERS, TALKER_KV_HEADS, TALKER_HEAD_DIM)
+        step_embeds, position, codes, generated = prompt, 0, [], []
+
+        for step in range(max_new):
+            width = step_embeds.shape[1]
+            feed = {"inputs_embeds": step_embeds,
+                    "position_ids": np.arange(position, position + width,
+                                              dtype=np.int64)[None], **past}
+            out = dict(zip(names, session.run(None, feed)))
+            position += width
+            past = roll_cache(out, TALKER_LAYERS)
+
+            scores = apply_logits_processors(
+                out["logits"][0, -1], generated, repetition_penalty, step)
+            token = sample_token(scores, temperature, top_k, top_p, rng, do_sample)
+            generated.append(token)
+            if token == CODEC_EOS:
+                break
+
+            group0_hidden = self._codec_hidden([token])
+            groups = self.predict_code_groups(
+                out["last_hidden"], group0_hidden, rng, sub_temperature,
+                sub_top_k, sub_top_p, do_sample)
+            codes.append([token] + groups)
+
+            sub_hidden = self._sub_embed(groups, self._sub_tables)
+            step_embeds = (group0_hidden + sub_hidden.sum(axis=1, keepdims=True)
+                           + tts_pad).astype(np.float32)
+
+        return np.asarray(codes, np.int64).reshape(-1, NUM_CODE_GROUPS)
+
+    # ------------------------------------------------------------------
+    # Codec decoder
+    # ------------------------------------------------------------------
+
+    def decode_codes(self, codes: np.ndarray) -> np.ndarray:
+        """Turn a code matrix into a waveform, one bounded chunk at a time.
+
+        The decoder's attention window is 72 frames, so upstream decodes in chunks with
+        a left context that is thrown away afterwards. Decoding a long utterance in one
+        call would allocate an attention mask of the whole length for no gain.
+        """
+        codes = np.asarray(codes, np.int64).reshape(-1, NUM_CODE_GROUPS).T[None]
+        total = codes.shape[-1]
+        parts, start = [], 0
+        while start < total:
+            end = min(start + DECODE_CHUNK, total)
+            context = DECODE_LEFT_CONTEXT if start - DECODE_LEFT_CONTEXT > 0 else start
+            chunk = np.ascontiguousarray(codes[..., start - context:end])
+            wav = self.decoder.run(None, {"codes": chunk})[0]
+            parts.append(wav[..., context * UPSAMPLE:])
+            start = end
+        return np.concatenate(parts, axis=-1).reshape(-1).astype(np.float32)
+
+    # ------------------------------------------------------------------
+    # Synthesis
+    # ------------------------------------------------------------------
+
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        for attribute, key in (("text_embed", "text_embed_path"),
+                               ("codec_embed", "codec_embed_path"),
+                               ("predictor_prefill", "code_predictor_prefill_path"),
+                               ("predictor_step", "code_predictor_step_path"),
+                               ("sub_codec_embed", "sub_codec_embed_path"),
+                               ("decoder", "codec_decoder_path")):
+            if getattr(self, attribute) is None:
+                raise RuntimeError(f"Qwen3-TTS voice missing {key} in engine_params")
+
+        params = request.params
+        speaker = str(params.get("speaker") or self.speaker)
+        language = str(params.get("language") or self.language)
+        prompt, tts_pad = self.build_prompt(request.phoneme_ids, speaker, language)
+
+        rng = np.random.default_rng(params.get("seed"))
+        codes = self.generate_codes(session, prompt, tts_pad, params, rng)
+        if codes.size == 0:
+            LOG.warning("Qwen3-TTS produced no code frames for this chunk")
+            return AdapterSynthesisResult(audio=np.zeros(0, np.float32))
+
+        audio = self.decode_codes(codes)
+        return AdapterSynthesisResult(
+            audio=audio, extras={"frame_count": int(codes.shape[0]),
+                                 "speaker": speaker, "language": language})
+
+    # build_feed_dict / parse_outputs are required by the ABC but unused — synthesize()
+    # drives the two autoregressive loops directly.
+    def build_feed_dict(self, request: AdapterSynthesisRequest,
+                        session: onnxruntime.InferenceSession) -> Dict[str, np.ndarray]:
+        raise NotImplementedError("Qwen3-TTS is autoregressive — use synthesize()")
+
+    def parse_outputs(self, outputs: List[np.ndarray],
+                      request: AdapterSynthesisRequest,
+                      output_names: Optional[List[str]] = None) -> AdapterSynthesisResult:
+        raise NotImplementedError("Qwen3-TTS is autoregressive — use synthesize()")
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        return bool(config and config.get("engine") == "qwen3tts")

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -657,6 +657,7 @@ class TTSModelManager:
         "coqui_community.json", "vits2.json", "styletts2.json", "f5tts.json",
         "coqui_vits.json", "BSC.json", "shami.json", "chatterbox.json",
         "supertonic.json", "neutts.json", "pockettts.json", "sparktts.json",
+        "qwen3tts.json",
     )
 
     @classmethod

--- a/phoonnx/voice_index/qwen3tts.json
+++ b/phoonnx/voice_index/qwen3tts.json
@@ -1,0 +1,407 @@
+{
+    "qwen3tts/vivian/zh": {
+        "voice_id": "qwen3tts/vivian/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Vivian (bright young female)",
+        "engine_options": {
+            "speaker": "vivian",
+            "language": "zh-CN"
+        }
+    },
+    "qwen3tts/serena/zh": {
+        "voice_id": "qwen3tts/serena/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Serena (warm gentle young female)",
+        "engine_options": {
+            "speaker": "serena",
+            "language": "zh-CN"
+        }
+    },
+    "qwen3tts/uncle_fu/zh": {
+        "voice_id": "qwen3tts/uncle_fu/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Uncle Fu (seasoned male, mellow)",
+        "engine_options": {
+            "speaker": "uncle_fu",
+            "language": "zh-CN"
+        }
+    },
+    "qwen3tts/dylan/zh": {
+        "voice_id": "qwen3tts/dylan/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Dylan (youthful Beijing male)",
+        "engine_options": {
+            "speaker": "dylan",
+            "language": "zh-CN"
+        }
+    },
+    "qwen3tts/eric/zh": {
+        "voice_id": "qwen3tts/eric/zh",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "zh-CN",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Eric (lively Chengdu male)",
+        "engine_options": {
+            "speaker": "eric",
+            "language": "zh-CN"
+        }
+    },
+    "qwen3tts/ryan/en": {
+        "voice_id": "qwen3tts/ryan/en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "en-US",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ryan (dynamic male)",
+        "engine_options": {
+            "speaker": "ryan",
+            "language": "en-US"
+        }
+    },
+    "qwen3tts/aiden/en": {
+        "voice_id": "qwen3tts/aiden/en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "en-US",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Aiden (sunny American male)",
+        "engine_options": {
+            "speaker": "aiden",
+            "language": "en-US"
+        }
+    },
+    "qwen3tts/ono_anna/ja": {
+        "voice_id": "qwen3tts/ono_anna/ja",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "ja-JP",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ono Anna (playful Japanese female)",
+        "engine_options": {
+            "speaker": "ono_anna",
+            "language": "ja-JP"
+        }
+    },
+    "qwen3tts/sohee/ko": {
+        "voice_id": "qwen3tts/sohee/ko",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "ko-KR",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Sohee (warm Korean female)",
+        "engine_options": {
+            "speaker": "sohee",
+            "language": "ko-KR"
+        }
+    },
+    "qwen3tts/ryan/de": {
+        "voice_id": "qwen3tts/ryan/de",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "de-DE",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ryan (German)",
+        "engine_options": {
+            "speaker": "ryan",
+            "language": "de-DE"
+        }
+    },
+    "qwen3tts/ryan/fr": {
+        "voice_id": "qwen3tts/ryan/fr",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "fr-FR",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ryan (French)",
+        "engine_options": {
+            "speaker": "ryan",
+            "language": "fr-FR"
+        }
+    },
+    "qwen3tts/ryan/ru": {
+        "voice_id": "qwen3tts/ryan/ru",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "ru-RU",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ryan (Russian)",
+        "engine_options": {
+            "speaker": "ryan",
+            "language": "ru-RU"
+        }
+    },
+    "qwen3tts/ryan/pt": {
+        "voice_id": "qwen3tts/ryan/pt",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "pt-BR",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ryan (Portuguese)",
+        "engine_options": {
+            "speaker": "ryan",
+            "language": "pt-BR"
+        }
+    },
+    "qwen3tts/ryan/es": {
+        "voice_id": "qwen3tts/ryan/es",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "es-ES",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ryan (Spanish)",
+        "engine_options": {
+            "speaker": "ryan",
+            "language": "es-ES"
+        }
+    },
+    "qwen3tts/ryan/it": {
+        "voice_id": "qwen3tts/ryan/it",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx",
+        "config_url": null,
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "qwen3tts",
+        "lang": "it-IT",
+        "aux_model_urls": {
+            "text_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/text_embed.onnx",
+            "codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_embed.onnx",
+            "code_predictor_prefill_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_prefill.onnx",
+            "code_predictor_step_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/code_predictor_step.onnx",
+            "sub_codec_embed_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/sub_codec_embed.onnx",
+            "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/codec_decoder.onnx",
+            "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/tokenizer.json"
+        },
+        "display_name": "Qwen3-TTS Ryan (Italian)",
+        "engine_options": {
+            "speaker": "ryan",
+            "language": "it-IT"
+        }
+    }
+}

--- a/scripts/conversion/qwen3tts/README.md
+++ b/scripts/conversion/qwen3tts/README.md
@@ -1,0 +1,21 @@
+# Qwen3-TTS conversion
+
+Two scripts: one exports the graphs, one proves the export matches the source model.
+
+```bash
+pip install qwen-tts torch onnx onnxruntime onnxscript
+python export_qwen3tts_onnx.py --out ./onnx
+python verify_parity.py --onnx ./onnx
+```
+
+`export_qwen3tts_onnx.py` writes the seven graphs phoonnx loads plus `tokenizer.json`.
+It checks three of its own assumptions before it exports anything: that mRoPE reduces to
+plain RoPE at batch 1, that the hand-built causal masks match the stock model, and that
+the hand-built sliding-window mask matches transformers.
+
+`verify_parity.py` runs one greedy synthesis through both the PyTorch model and the
+phoonnx adapter and reports prompt, logit, token and waveform differences. Greedy is the
+only comparable setting: with sampling the two sides draw from different random streams.
+
+Source model: [`Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice), Apache-2.0.
+Mirror: [`OpenVoiceOS/phoonnx-qwen3-tts`](https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts).

--- a/scripts/conversion/qwen3tts/export_qwen3tts_onnx.py
+++ b/scripts/conversion/qwen3tts/export_qwen3tts_onnx.py
@@ -350,6 +350,26 @@ def main():
             hidden_state = hidden_state[..., : -self.right_pad]
         return hidden_state.contiguous()
 
+    def upstream_trim(hidden_state, right_pad):
+        """Upstream indexes with an explicit shape subtraction; ``[..., :-right_pad]``
+        is the dynamo/onnx-export-friendly equivalent used above."""
+        if right_pad > 0:
+            hidden_state = hidden_state[..., : hidden_state.shape[-1] - right_pad]
+        return hidden_state.contiguous()
+
+    class _StubConv:
+        def __init__(self, right_pad):
+            self.right_pad = right_pad
+            self.conv = lambda x: x
+
+    for right_pad, length in ((0, 4), (1, 4), (3, 9), (5, 40), (5, 137)):
+        conv_out = torch.randn(1, 4, length + right_pad)
+        mine = trim_from_the_right(_StubConv(right_pad), conv_out)
+        stock = upstream_trim(conv_out, right_pad)
+        assert torch.equal(mine, stock), \
+            f"transposed-conv trim differs from upstream at right_pad={right_pad}, length={length}"
+    print("transposed-conv trim matches upstream slicing: ok")
+
     TOK.Qwen3TTSTokenizerV2CausalTransConvNet.forward = trim_from_the_right
 
     class CodecDecoder(nn.Module):
@@ -396,8 +416,10 @@ def main():
             stock = decoder(codes).numpy()
             got = session.run(None, {"codes": codes.numpy()})[0]
             assert got.shape == stock.shape, "codec decoder length is not dynamic"
-            print(f"codec decoder T={length}: max abs diff "
-                  f"{np.abs(got - stock).max():.3e}")
+            max_diff = np.abs(got - stock).max()
+            print(f"codec decoder T={length}: max abs diff {max_diff:.3e}")
+            assert max_diff < 1e-5, \
+                f"codec decoder ONNX output diverges from stock at T={length}: {max_diff:.3e}"
 
     # ---- 6. tokenizer ----------------------------------------------------
     wrapper.processor.tokenizer.backend_tokenizer.save(f"{out}/tokenizer.json")

--- a/scripts/conversion/qwen3tts/export_qwen3tts_onnx.py
+++ b/scripts/conversion/qwen3tts/export_qwen3tts_onnx.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Export Qwen3-TTS-12Hz CustomVoice to the seven ONNX graphs phoonnx loads.
+
+Usage::
+
+    pip install qwen-tts torch onnx onnxruntime onnxscript
+    python export_qwen3tts_onnx.py --out ./onnx
+
+Default source model: ``Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`` (Apache-2.0).
+
+Graphs written
+--------------
+
+``talker.onnx``
+    The 28-layer talker. One step per 80 ms audio frame; reads summed text and
+    codec embeddings, writes the logits of code group 0 and the hidden state the
+    code predictor conditions on.
+``text_embed.onnx`` / ``codec_embed.onnx``
+    The two embedding tables the prompt is built from. The text table is the
+    largest single file: 151936 rows of 2048, projected down to 1024.
+``code_predictor_prefill.onnx`` / ``code_predictor_step.onnx``
+    The 5-layer code predictor that writes code groups 1..15 of a frame. Each
+    group has its own embedding table and its own output head, so the step graph
+    takes the group index as an input and gathers both from a stacked weight.
+``sub_codec_embed.onnx``
+    A flat gather over those stacked per-group embedding tables.
+``codec_decoder.onnx``
+    The 12.5 Hz codec decoder: 16 code groups per frame to 24 kHz audio.
+
+Three things in the upstream model do not trace
+-----------------------------------------------
+
+1. **mRoPE.** ``apply_interleaved_rope`` assigns into strided slices, which bakes
+   the traced sequence length into the graph. phoonnx runs batch 1 with no left
+   padding, so the three mRoPE position rows are always equal, and when they are
+   the whole thing reduces to plain RoPE. The script checks that before it swaps
+   the implementation.
+2. **Mask builders.** ``create_causal_mask`` and its sliding-window sibling use
+   ``torch.vmap`` and reshape ``cache_position`` with the traced length baked in.
+   Every mask here is built with plain tensor ops and checked against the
+   transformers one first.
+3. **The codec decoder's transposed convolutions** trim with a computed stop
+   index. Trimming from the right instead keeps the output length dynamic; the
+   decoder is exported with the dynamo exporter, which follows the length.
+"""
+import argparse
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+from transformers.cache_utils import DynamicCache
+
+from qwen_tts import Qwen3TTSModel
+from qwen_tts.core.models import modeling_qwen3_tts as MOD
+from qwen_tts.core.tokenizer_12hz import modeling_qwen3_tts_tokenizer_v2 as TOK
+
+OPSET = 17
+
+
+def past_names(n):
+    return sum(([f"past_key_values.{i}.key", f"past_key_values.{i}.value"]
+                for i in range(n)), [])
+
+
+def present_names(n):
+    return sum(([f"present.{i}.key", f"present.{i}.value"] for i in range(n)), [])
+
+
+def make_cache(flat):
+    cache = DynamicCache(config=None)
+    for i in range(len(flat) // 2):
+        cache.update(flat[2 * i], flat[2 * i + 1], i)
+    return cache
+
+
+def flatten_cache(cache, n):
+    return sum(([cache.layers[i].keys, cache.layers[i].values] for i in range(n)), [])
+
+
+def causal_mask(query_positions, total, dtype):
+    """Additive mask where every query attends to every earlier key."""
+    kv = torch.arange(total).view(1, -1)
+    mask = torch.zeros(1, 1, query_positions.numel(), total, dtype=dtype)
+    return mask.masked_fill(kv > query_positions.view(-1, 1), torch.finfo(dtype).min)
+
+
+def export(module, args, path, input_names, output_names, dynamic_axes):
+    module.eval()
+    with torch.inference_mode():
+        torch.onnx.export(module, args, path, input_names=input_names,
+                          output_names=output_names, dynamic_axes=dynamic_axes,
+                          opset_version=OPSET, do_constant_folding=True, dynamo=False)
+    print(f"wrote {path} {os.path.getsize(path) / 1e6:.1f} MB")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice")
+    ap.add_argument("--out", default="./onnx")
+    ap.add_argument("--threads", type=int, default=os.cpu_count())
+    args = ap.parse_args()
+    torch.set_num_threads(args.threads)
+    out = args.out
+    os.makedirs(out, exist_ok=True)
+
+    wrapper = Qwen3TTSModel.from_pretrained(
+        args.model, dtype=torch.float32, device_map="cpu", attn_implementation="eager")
+    model = wrapper.model
+    talker = model.talker
+    cfg = model.config.talker_config
+    predictor = talker.code_predictor
+    pcfg = cfg.code_predictor_config
+    decoder = model.speech_tokenizer.model.decoder
+
+    n_talker = cfg.num_hidden_layers
+    kv_talker, hd_talker = cfg.num_key_value_heads, cfg.head_dim
+    n_pred = pcfg.num_hidden_layers
+    kv_pred, hd_pred = pcfg.num_key_value_heads, pcfg.head_dim
+    groups = cfg.num_code_groups
+    vocab_pred = pcfg.vocab_size
+
+    assert isinstance(predictor.small_to_mtp_projection, nn.Identity), (
+        "the sub-talker projection is no longer the identity; sub_codec_embed "
+        "would have to apply it")
+
+    # ---- 1. mRoPE reduces to plain RoPE at batch 1 -----------------------
+    original_rope = MOD.apply_multimodal_rotary_pos_emb
+
+    def plain_rope(q, k, cos, sin, mrope_section, mrope_interleaved=False, unsqueeze_dim=1):
+        c, s = cos[0].unsqueeze(unsqueeze_dim), sin[0].unsqueeze(unsqueeze_dim)
+        return ((q * c) + (MOD.rotate_half(q) * s),
+                (k * c) + (MOD.rotate_half(k) * s))
+
+    for length in (1, 7, 33):
+        pos = torch.arange(length).view(1, 1, length).expand(3, 1, length)
+        cos, sin = talker.model.rotary_emb(torch.zeros(1, length, cfg.hidden_size), pos)
+        q = torch.randn(1, cfg.num_attention_heads, length, hd_talker)
+        k = torch.randn(1, kv_talker, length, hd_talker)
+        a = original_rope(q, k, cos, sin, cfg.rope_scaling["mrope_section"], True)
+        b = plain_rope(q, k, cos, sin, cfg.rope_scaling["mrope_section"], True)
+        assert torch.equal(a[0], b[0]) and torch.equal(a[1], b[1]), \
+            f"mRoPE differs from plain RoPE at length {length}"
+    print("mRoPE equals plain RoPE for equal position rows: ok")
+    MOD.apply_multimodal_rotary_pos_emb = plain_rope
+
+    # ---- 2. embeddings ---------------------------------------------------
+    class TextEmbed(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = talker.model.text_embedding
+            self.projection = talker.text_projection
+
+        def forward(self, input_ids):
+            return self.projection(self.embedding(input_ids))
+
+    class CodecEmbed(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = talker.model.codec_embedding
+
+        def forward(self, input_ids):
+            return self.embedding(input_ids)
+
+    export(TextEmbed(), (torch.zeros(1, 5, dtype=torch.long),),
+           f"{out}/text_embed.onnx", ["input_ids"], ["hidden"],
+           {"input_ids": {1: "T"}, "hidden": {1: "T"}})
+    export(CodecEmbed(), (torch.zeros(1, 5, dtype=torch.long),),
+           f"{out}/codec_embed.onnx", ["input_ids"], ["hidden"],
+           {"input_ids": {1: "T"}, "hidden": {1: "T"}})
+
+    class SubCodecEmbed(nn.Module):
+        """Gather over the stacked per-group tables: table i holds code group i+1."""
+
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("weight", torch.stack(
+                [e.weight.detach() for e in predictor.model.codec_embedding]
+            ).reshape(-1, cfg.hidden_size))
+
+        def forward(self, input_ids, tables):
+            return self.weight[tables * vocab_pred + input_ids].unsqueeze(0)
+
+    sub_embed = SubCodecEmbed().eval()
+    with torch.inference_mode():
+        ids = torch.randint(0, vocab_pred, (groups - 1,))
+        ref = torch.cat([predictor.model.codec_embedding[i](ids[i].view(1, 1))
+                         for i in range(groups - 1)], dim=1)
+        assert torch.equal(sub_embed(ids, torch.arange(groups - 1)), ref)
+    export(sub_embed, (ids, torch.arange(groups - 1)), f"{out}/sub_codec_embed.onnx",
+           ["input_ids", "tables"], ["hidden"],
+           {"input_ids": {0: "G"}, "tables": {0: "G"}, "hidden": {1: "G"}})
+
+    # ---- 3. talker -------------------------------------------------------
+    class Talker(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = talker.model
+            self.head = talker.codec_head
+
+        def forward(self, inputs_embeds, position_ids, *past):
+            cache = make_cache(list(past))
+            positions = position_ids[0]
+            total = past[0].shape[2] + inputs_embeds.shape[1]
+            mask = causal_mask(positions, total, inputs_embeds.dtype)
+            hidden = inputs_embeds
+            embeddings = self.model.rotary_emb(
+                hidden, position_ids.unsqueeze(0).expand(3, -1, -1))
+            for layer in self.model.layers:
+                hidden = layer(hidden, attention_mask=mask,
+                               position_ids=positions.view(1, -1), past_key_values=cache,
+                               use_cache=True, cache_position=positions,
+                               position_embeddings=embeddings)[0]
+            hidden = self.model.norm(hidden)
+            return ((self.head(hidden[:, -1:]), hidden[:, -1:])
+                    + tuple(flatten_cache(cache, n_talker)))
+
+    talker_module = Talker().eval()
+    with torch.inference_mode():
+        for width, cached in ((7, 0), (1, 11)):
+            embeds = torch.randn(1, width, cfg.hidden_size)
+            positions = torch.arange(cached, cached + width).unsqueeze(0)
+            zeros = [torch.zeros(1, kv_talker, cached, hd_talker)
+                     for _ in range(2 * n_talker)]
+            mine = talker_module(embeds, positions, *zeros)[1]
+            stock = talker.model(
+                inputs_embeds=embeds,
+                position_ids=positions.unsqueeze(0).expand(3, -1, -1),
+                attention_mask=None, past_key_values=make_cache(zeros),
+                use_cache=True, cache_position=positions[0]
+            ).last_hidden_state[:, -1:]
+            assert torch.equal(mine, stock), "talker mask differs from the stock model"
+    print("talker mask matches the stock model: ok")
+
+    width, cached = 7, 3
+    zeros = [torch.zeros(1, kv_talker, cached, hd_talker) for _ in range(2 * n_talker)]
+    axes = {"inputs_embeds": {1: "S"}, "position_ids": {1: "S"}}
+    axes.update({n: {2: "P"} for n in past_names(n_talker)})
+    axes.update({n: {2: "P_S"} for n in present_names(n_talker)})
+    export(talker_module,
+           (torch.randn(1, width, cfg.hidden_size),
+            torch.arange(cached, cached + width).unsqueeze(0), *zeros),
+           f"{out}/talker.onnx",
+           ["inputs_embeds", "position_ids"] + past_names(n_talker),
+           ["logits", "last_hidden"] + present_names(n_talker), axes)
+
+    # ---- 4. code predictor ----------------------------------------------
+    class PredictorPrefill(nn.Module):
+        """Two input positions, output head 0: gives code group 1."""
+
+        def __init__(self):
+            super().__init__()
+            self.model = predictor.model
+            self.projection = predictor.small_to_mtp_projection
+            self.head = predictor.lm_head[0]
+
+        def forward(self, inputs_embeds):
+            embeds = self.projection(inputs_embeds)
+            cache = DynamicCache(config=None)
+            positions = torch.arange(embeds.shape[1])
+            result = self.model(inputs_embeds=embeds, attention_mask=None,
+                                past_key_values=cache, use_cache=True,
+                                cache_position=positions,
+                                position_ids=positions.unsqueeze(0))
+            logits = self.head(result.last_hidden_state[:, -1:])[:, 0]
+            return (logits,) + tuple(flatten_cache(result.past_key_values, n_pred))
+
+    axes = {n: {2: "P"} for n in present_names(n_pred)}
+    export(PredictorPrefill(), (torch.randn(1, 2, cfg.hidden_size),),
+           f"{out}/code_predictor_prefill.onnx", ["inputs_embeds"],
+           ["logits"] + present_names(n_pred), axes)
+
+    class PredictorStep(nn.Module):
+        """One later group: the group index picks the output head."""
+
+        def __init__(self):
+            super().__init__()
+            self.model = predictor.model
+            self.register_buffer("head", torch.stack(
+                [h.weight.detach() for h in predictor.lm_head]))
+
+        def forward(self, inputs_embeds, step, position_ids, *past):
+            cache = make_cache(list(past))
+            positions = position_ids[0]
+            total = past[0].shape[2] + inputs_embeds.shape[1]
+            mask = causal_mask(positions, total, inputs_embeds.dtype)
+            hidden = inputs_embeds
+            embeddings = self.model.rotary_emb(hidden, position_ids)
+            for layer in self.model.layers:
+                hidden = layer(hidden, attention_mask=mask, position_ids=position_ids,
+                               past_key_values=cache, use_cache=True,
+                               cache_position=positions,
+                               position_embeddings=embeddings)[0]
+            hidden = self.model.norm(hidden)[:, -1:]
+            logits = torch.matmul(hidden, self.head[step].transpose(0, 1))[:, 0]
+            return (logits,) + tuple(flatten_cache(cache, n_pred))
+
+    step_module = PredictorStep().eval()
+    with torch.inference_mode():
+        for cached in (2, 6):
+            embeds = torch.randn(1, 1, pcfg.hidden_size)
+            positions = torch.tensor([[cached]])
+            zeros = [torch.zeros(1, kv_pred, cached, hd_pred) for _ in range(2 * n_pred)]
+            mine = step_module(embeds, torch.tensor(1), positions, *zeros)[0]
+            stock_hidden = predictor.model(
+                inputs_embeds=embeds, attention_mask=None,
+                past_key_values=make_cache(zeros), use_cache=True,
+                cache_position=positions[0], position_ids=positions
+            ).last_hidden_state[:, -1:]
+            stock = torch.matmul(stock_hidden,
+                                 predictor.lm_head[1].weight.transpose(0, 1))[:, 0]
+            assert torch.equal(mine, stock), "code-predictor mask differs from stock"
+    print("code-predictor mask matches the stock model: ok")
+
+    zeros = [torch.zeros(1, kv_pred, 2, hd_pred) for _ in range(2 * n_pred)]
+    axes = {n: {2: "P"} for n in past_names(n_pred)}
+    axes.update({n: {2: "P1"} for n in present_names(n_pred)})
+    export(step_module,
+           (torch.randn(1, 1, pcfg.hidden_size), torch.tensor(1),
+            torch.tensor([[2]]), *zeros),
+           f"{out}/code_predictor_step.onnx",
+           ["inputs_embeds", "step", "position_ids"] + past_names(n_pred),
+           ["logits"] + present_names(n_pred), axes)
+
+    # ---- 5. codec decoder ------------------------------------------------
+    pre = decoder.pre_transformer
+    pre.config._attn_implementation = "eager"
+    window = pre.config.sliding_window
+
+    def sliding_mask(positions, dtype):
+        q, kv = positions.unsqueeze(1), positions.unsqueeze(0)
+        allowed = (kv <= q) & (kv > q - window)
+        return torch.zeros_like(allowed, dtype=dtype).masked_fill(
+            ~allowed, torch.finfo(dtype).min).unsqueeze(0).unsqueeze(0)
+
+    from transformers.masking_utils import create_sliding_window_causal_mask
+    for length in (5, 40, 300):
+        stock = create_sliding_window_causal_mask(
+            config=pre.config, input_embeds=torch.zeros(1, length, pre.config.hidden_size),
+            attention_mask=None, cache_position=torch.arange(length),
+            past_key_values=None, position_ids=torch.arange(length).unsqueeze(0))
+        mine = sliding_mask(torch.arange(length), torch.float32)
+        assert torch.equal(stock == 0, mine == 0), \
+            f"sliding-window mask differs at length {length}"
+    print("sliding-window mask matches transformers: ok")
+
+    def trim_from_the_right(self, hidden_state):
+        hidden_state = self.conv(hidden_state)
+        if self.right_pad > 0:
+            hidden_state = hidden_state[..., : -self.right_pad]
+        return hidden_state.contiguous()
+
+    TOK.Qwen3TTSTokenizerV2CausalTransConvNet.forward = trim_from_the_right
+
+    class CodecDecoder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = decoder
+
+        def forward(self, codes):
+            hidden = self.decoder.quantizer.decode(codes)
+            hidden = self.decoder.pre_conv(hidden).transpose(1, 2)
+            positions = torch.arange(hidden.shape[1], device=hidden.device)
+            mask = sliding_mask(positions, hidden.dtype)
+            hidden = self.decoder.pre_transformer(
+                inputs_embeds=hidden,
+                attention_mask={"sliding_attention": mask, "full_attention": mask},
+                position_ids=positions.unsqueeze(0), cache_position=positions,
+                use_cache=False).last_hidden_state
+            hidden = hidden.permute(0, 2, 1)
+            for blocks in self.decoder.upsample:
+                for block in blocks:
+                    hidden = block(hidden)
+            wav = hidden
+            for block in self.decoder.decoder:
+                wav = block(wav)
+            return wav.clamp(min=-1, max=1)
+
+    frames = torch.export.Dim("T", min=4, max=4096)
+    with torch.inference_mode():
+        program = torch.onnx.export(
+            CodecDecoder().eval(), (torch.randint(0, 2000, (1, groups, 40)),),
+            dynamo=True, opset_version=18, input_names=["codes"], output_names=["wav"],
+            dynamic_shapes={"codes": {2: frames}})
+        program.optimize()
+        program.save(f"{out}/codec_decoder.onnx")
+    print(f"wrote {out}/codec_decoder.onnx "
+          f"{os.path.getsize(f'{out}/codec_decoder.onnx') / 1e6:.1f} MB")
+
+    import onnxruntime as ort
+    session = ort.InferenceSession(f"{out}/codec_decoder.onnx",
+                                   providers=["CPUExecutionProvider"])
+    with torch.inference_mode():
+        for length in (40, 137):
+            codes = torch.randint(0, 2000, (1, groups, length))
+            stock = decoder(codes).numpy()
+            got = session.run(None, {"codes": codes.numpy()})[0]
+            assert got.shape == stock.shape, "codec decoder length is not dynamic"
+            print(f"codec decoder T={length}: max abs diff "
+                  f"{np.abs(got - stock).max():.3e}")
+
+    # ---- 6. tokenizer ----------------------------------------------------
+    wrapper.processor.tokenizer.backend_tokenizer.save(f"{out}/tokenizer.json")
+    print(f"wrote {out}/tokenizer.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/qwen3tts/verify_parity.py
+++ b/scripts/conversion/qwen3tts/verify_parity.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Check the exported Qwen3-TTS graphs against the upstream PyTorch model.
+
+Usage::
+
+    python verify_parity.py --onnx ./onnx
+
+Runs one greedy synthesis both ways on the same prompt and reports:
+
+* the prompt embeddings the talker reads;
+* the talker logits at the prefill step and at every decode step;
+* how many of the 16 code groups per frame agree, token for token;
+* the codec decoder's waveform, decoded from the *same* codes on both sides.
+
+Greedy decoding is the only setting where the two sides are comparable token for
+token: with sampling they draw from different random streams. A quantized export
+that does not reach full greedy agreement here should not ship.
+"""
+import argparse
+import functools
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.qwen3tts import Qwen3TTSAdapter
+from phoonnx.providers import make_session
+from qwen_tts import Qwen3TTSModel
+
+GRAPHS = {
+    "text_embed_path": "text_embed.onnx",
+    "codec_embed_path": "codec_embed.onnx",
+    "code_predictor_prefill_path": "code_predictor_prefill.onnx",
+    "code_predictor_step_path": "code_predictor_step.onnx",
+    "sub_codec_embed_path": "sub_codec_embed.onnx",
+    "codec_decoder_path": "codec_decoder.onnx",
+    "bpe_tokenizer_path": "tokenizer.json",
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice")
+    ap.add_argument("--onnx", default="./onnx")
+    ap.add_argument("--text", default="The quick brown fox jumps over the lazy dog.")
+    ap.add_argument("--speaker", default="Ryan")
+    ap.add_argument("--language", default="English")
+    ap.add_argument("--threads", type=int, default=6)
+    args = ap.parse_args()
+    torch.set_num_threads(args.threads)
+
+    # ---- upstream, greedy ------------------------------------------------
+    wrapper = Qwen3TTSModel.from_pretrained(
+        args.model, dtype=torch.float32, device_map="cpu")
+    model = wrapper.model
+    talker = model.talker
+
+    captured = {"logits": []}
+    original_forward = talker.forward
+
+    @functools.wraps(original_forward)
+    def spy(*a, **kw):
+        out = original_forward(*a, **kw)
+        captured["logits"].append(out.logits[:, -1:].detach().clone())
+        return out
+
+    original_generate = talker.generate
+
+    def spy_generate(*a, **kw):
+        captured["prompt"] = kw["inputs_embeds"].detach().clone()
+        return original_generate(*a, **kw)
+
+    talker.forward = spy
+    talker.generate = spy_generate
+
+    input_ids = wrapper._tokenize_texts([wrapper._build_assistant_text(args.text)])
+    codes_list, _ = model.generate(
+        input_ids=input_ids, instruct_ids=[None], languages=[args.language],
+        speakers=[args.speaker], non_streaming_mode=True, do_sample=False,
+        subtalker_dosample=False,
+        repetition_penalty=model.generate_config["repetition_penalty"])
+    torch_codes = codes_list[0].numpy()
+    torch_wav = model.speech_tokenizer.decode([{"audio_codes": codes_list[0]}])[0][0]
+    torch_logits = torch.cat(captured["logits"], dim=1).numpy()[0]
+    talker.forward, talker.generate = original_forward, original_generate
+
+    # ---- phoonnx adapter, greedy ----------------------------------------
+    engine_params = {k: f"{args.onnx}/{v}" for k, v in GRAPHS.items()}
+    engine_params.update(speaker=args.speaker.lower(), language=args.language)
+    adapter = Qwen3TTSAdapter()
+    adapter.configure(SimpleNamespace(engine_params=engine_params, lang_code=None))
+    session = make_session(f"{args.onnx}/talker.onnx")
+
+    ids = np.asarray(adapter.encode_text(args.text, None, None)[0], np.int64)
+    print("token ids match:", np.array_equal(ids, input_ids[0].numpy().reshape(-1)))
+
+    prompt, _ = adapter.build_prompt(ids[None], args.speaker, args.language)
+    print("prompt embeddings, max abs diff: %.3e"
+          % np.abs(prompt - captured["prompt"].numpy()).max())
+
+    request = AdapterSynthesisRequest(
+        phoneme_ids=ids[None], phoneme_lengths=np.array([ids.size], np.int64),
+        params={"do_sample": False})
+    result = adapter.synthesize(request, session)
+    onnx_codes = adapter.generate_codes(
+        session, prompt, adapter._text_hidden([151671]).astype(np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+
+    frames = min(len(onnx_codes), len(torch_codes))
+    agree = onnx_codes[:frames] == torch_codes[:frames]
+    print("frames: onnx %d, torch %d" % (len(onnx_codes), len(torch_codes)))
+    print("greedy token agreement: %.4f%% (%d/%d)"
+          % (100 * agree.mean(), agree.sum(), agree.size))
+
+    onnx_wav = adapter.decode_codes(torch_codes)
+    k = min(len(onnx_wav), len(torch_wav))
+    print("codec decoder on the same codes, max abs diff: %.3e"
+          % np.abs(onnx_wav[:k] - torch_wav[:k]).max())
+    print("waveform lengths: onnx %d, torch %d" % (len(onnx_wav), len(torch_wav)))
+    print("adapter audio seconds: %.2f" % (len(result.audio) / 24000))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qwen3tts.py
+++ b/tests/test_qwen3tts.py
@@ -1,0 +1,728 @@
+import numpy as np
+import pytest
+
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.qwen3tts import (
+    CODEC_BOS,
+    CODEC_EOS,
+    CODEC_NOTHINK,
+    CODEC_PAD,
+    CODEC_THINK,
+    CODEC_THINK_BOS,
+    CODEC_THINK_EOS,
+    DECODE_CHUNK,
+    DECODE_LEFT_CONTEXT,
+    LANGUAGE_IDS,
+    MIN_NEW_TOKENS,
+    NUM_CODE_GROUPS,
+    PREDICTOR_LAYERS,
+    ROLE_PREFIX_TOKENS,
+    SAMPLE_RATE,
+    SPEAKER_DIALECT,
+    SPEAKER_IDS,
+    SUPPRESS_FROM,
+    TAIL_TOKENS,
+    TALKER_HEAD_DIM,
+    TALKER_KV_HEADS,
+    TALKER_LAYERS,
+    TALKER_VOCAB,
+    UPSAMPLE,
+    Qwen3TTSAdapter,
+    apply_logits_processors,
+    chunk_text,
+    empty_cache,
+    resolve_language_id,
+    resolve_language_name,
+    roll_cache,
+    sample_token,
+)
+
+HIDDEN = 1024
+
+
+# ----------------------------------------------------------------------
+# registration / config
+# ----------------------------------------------------------------------
+
+def test_qwen3tts_registered():
+    from phoonnx.engines import list_engines
+    assert "qwen3tts" in list_engines()
+
+
+def test_qwen3tts_detect():
+    assert Qwen3TTSAdapter.detect({"engine": "qwen3tts"})
+    assert not Qwen3TTSAdapter.detect({"engine": "sparktts"})
+    assert not Qwen3TTSAdapter.detect(None)
+
+
+def test_engine_enum_and_config_alphabet():
+    from phoonnx.config import Alphabet, Engine, VoiceConfig
+    cfg = VoiceConfig.from_dict({"engine": "qwen3tts"}, engine=Engine.QWEN3TTS,
+                                lang_code="en-US")
+    # graphemes routes text->ids through the adapter, never through a phonemizer
+    assert cfg.engine == Engine.QWEN3TTS
+    assert cfg.alphabet == Alphabet.GRAPHEMES
+    assert cfg.sample_rate == SAMPLE_RATE == 24000
+
+
+def test_default_params_match_upstream_generation_config():
+    # Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice generation_config.json
+    assert Qwen3TTSAdapter().default_params() == {
+        "temperature": 0.9, "top_k": 50.0, "top_p": 1.0, "repetition_penalty": 1.05,
+        "subtalker_temperature": 0.9, "subtalker_top_k": 50.0, "subtalker_top_p": 1.0}
+
+
+def test_param_labels_cover_every_default():
+    adapter = Qwen3TTSAdapter()
+    assert set(adapter.param_labels()) == set(adapter.default_params())
+
+
+def test_frame_geometry_matches_the_codec():
+    # 12.5 Hz codec at 24 kHz: one frame is 1920 samples
+    assert UPSAMPLE == SAMPLE_RATE // 12.5 == 1920
+
+
+# ----------------------------------------------------------------------
+# language and speaker resolution
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize("tag,expected", [
+    ("en-US", "english"), ("en", "english"), ("zh-CN", "chinese"),
+    ("pt-BR", "portuguese"), ("ja-JP", "japanese"), ("ko-KR", "korean"),
+    ("de-DE", "german"), ("fr-FR", "french"), ("ru-RU", "russian"),
+    ("es-ES", "spanish"), ("it-IT", "italian"),
+    ("English", "english"), ("auto", "auto"), (None, "auto"), ("", "auto"),
+    ("xx-YY", "auto"),
+])
+def test_resolve_language_name(tag, expected):
+    assert resolve_language_name(tag) == expected
+
+
+def test_every_supported_language_has_a_talker_token():
+    for name in set(resolve_language_name(t) for t in
+                    ("en", "zh", "de", "it", "pt", "es", "ja", "ko", "fr", "ru")):
+        assert name in LANGUAGE_IDS
+
+
+def test_auto_language_drops_the_language_token():
+    assert resolve_language_id("auto", "ryan") is None
+
+
+def test_language_id_for_a_plain_voice():
+    assert resolve_language_id("en-US", "ryan") == LANGUAGE_IDS["english"]
+    assert resolve_language_id("zh-CN", "vivian") == LANGUAGE_IDS["chinese"]
+
+
+@pytest.mark.parametrize("speaker,dialect", sorted(SPEAKER_DIALECT.items()))
+def test_dialect_voice_overrides_chinese_and_auto(speaker, dialect):
+    assert resolve_language_id("zh-CN", speaker) == LANGUAGE_IDS[dialect]
+    assert resolve_language_id("auto", speaker) == LANGUAGE_IDS[dialect]
+
+
+@pytest.mark.parametrize("speaker", sorted(SPEAKER_DIALECT))
+def test_dialect_voice_keeps_a_non_chinese_language(speaker):
+    # upstream only overrides when the language is Chinese or unset
+    assert resolve_language_id("en-US", speaker) == LANGUAGE_IDS["english"]
+
+
+def test_speaker_table_is_the_checkpoint_roster():
+    assert sorted(SPEAKER_IDS) == [
+        "aiden", "dylan", "eric", "ono_anna", "ryan", "serena", "sohee",
+        "uncle_fu", "vivian"]
+    assert all(0 <= i < TALKER_VOCAB for i in SPEAKER_IDS.values())
+    assert len(set(SPEAKER_IDS.values())) == len(SPEAKER_IDS)
+
+
+def test_dialect_speakers_are_real_speakers():
+    assert set(SPEAKER_DIALECT) <= set(SPEAKER_IDS)
+
+
+# ----------------------------------------------------------------------
+# logits processors
+# ----------------------------------------------------------------------
+
+def _logits(value=0.0):
+    return np.full(TALKER_VOCAB, value, np.float64)
+
+
+def test_suppressed_range_is_masked():
+    scores = apply_logits_processors(_logits(1.0), [], 1.0, step=5)
+    assert np.all(np.isneginf(scores[SUPPRESS_FROM:][:CODEC_EOS - SUPPRESS_FROM]))
+    assert np.all(np.isneginf(scores[CODEC_EOS + 1:]))
+    assert np.isfinite(scores[SUPPRESS_FROM - 1])
+
+
+def test_end_of_speech_survives_suppression_after_the_floor():
+    scores = apply_logits_processors(_logits(1.0), [], 1.0, step=MIN_NEW_TOKENS)
+    assert scores[CODEC_EOS] == 1.0
+
+
+def test_end_of_speech_is_blocked_below_the_floor():
+    for step in range(MIN_NEW_TOKENS):
+        scores = apply_logits_processors(_logits(1.0), [], 1.0, step=step)
+        assert np.isneginf(scores[CODEC_EOS])
+
+
+def test_repetition_penalty_divides_positive_scores():
+    logits = _logits(0.0)
+    logits[7] = 2.0
+    scores = apply_logits_processors(logits, [7], 1.05, step=5)
+    assert scores[7] == pytest.approx(2.0 / 1.05)
+
+
+def test_repetition_penalty_multiplies_negative_scores():
+    logits = _logits(0.0)
+    logits[7] = -2.0
+    scores = apply_logits_processors(logits, [7], 1.05, step=5)
+    assert scores[7] == pytest.approx(-2.0 * 1.05)
+
+
+def test_repetition_penalty_applies_once_per_repeated_token():
+    logits = _logits(0.0)
+    logits[7] = 2.0
+    once = apply_logits_processors(logits, [7], 1.05, step=5)
+    twice = apply_logits_processors(logits, [7, 7, 7], 1.05, step=5)
+    assert once[7] == pytest.approx(twice[7])
+
+
+def test_repetition_penalty_leaves_unseen_tokens_alone():
+    logits = _logits(0.0)
+    logits[7] = 2.0
+    scores = apply_logits_processors(logits, [9], 1.05, step=5)
+    assert scores[7] == 2.0
+
+
+def test_suppression_runs_after_the_penalty():
+    # a penalised suppressed token must still be masked, not merely scaled
+    logits = _logits(0.0)
+    logits[SUPPRESS_FROM + 3] = 9.0
+    scores = apply_logits_processors(logits, [SUPPRESS_FROM + 3], 1.05, step=5)
+    assert np.isneginf(scores[SUPPRESS_FROM + 3])
+
+
+def test_processors_do_not_mutate_the_caller_array():
+    logits = _logits(1.0)
+    apply_logits_processors(logits, [7], 1.05, step=5)
+    assert np.all(logits == 1.0)
+
+
+# ----------------------------------------------------------------------
+# sampler
+# ----------------------------------------------------------------------
+
+def test_sample_token_greedy_when_sampling_is_off():
+    assert sample_token(np.array([1.0, 9.0, 2.0]), 0.9, 50, 1.0,
+                        np.random.default_rng(0), do_sample=False) == 1
+
+
+def test_sample_token_greedy_at_zero_temperature():
+    assert sample_token(np.array([1.0, 9.0, 2.0]), 0.0, 50, 1.0,
+                        np.random.default_rng(0)) == 1
+
+
+def test_sample_token_top_k_one_is_argmax():
+    logits = np.array([0.1, 5.0, 0.2, 0.3])
+    for seed in range(5):
+        assert sample_token(logits, 1.0, 1, 1.0, np.random.default_rng(seed)) == 1
+
+
+def test_sample_token_top_p_keeps_only_the_nucleus():
+    logits = np.array([10.0, 0.0, -10.0, -20.0])
+    picks = {sample_token(logits, 1.0, 50, 0.5, np.random.default_rng(s))
+             for s in range(20)}
+    assert picks == {0}
+
+
+def test_sample_token_is_reproducible_for_a_seed():
+    logits = np.random.default_rng(3).normal(size=64)
+    a = [sample_token(logits, 0.9, 50, 1.0, np.random.default_rng(11)) for _ in range(3)]
+    assert len(set(a)) == 1
+
+
+def test_sample_token_never_picks_a_masked_token():
+    logits = np.array([1.0, 2.0, 3.0])
+    logits[2] = -np.inf
+    picks = {sample_token(logits, 0.9, 50, 1.0, np.random.default_rng(s))
+             for s in range(20)}
+    assert 2 not in picks
+
+
+# ----------------------------------------------------------------------
+# text chunking
+# ----------------------------------------------------------------------
+
+def test_chunk_text_keeps_short_text_whole():
+    assert chunk_text("Hello there.") == ["Hello there."]
+
+
+def test_chunk_text_respects_the_character_budget():
+    text = " ".join(["This is a sentence."] * 60)
+    chunks = chunk_text(text, max_len=100)
+    assert len(chunks) > 1
+    assert all(len(c) <= 100 for c in chunks[:-1])
+
+
+def test_chunk_text_splits_paragraphs():
+    assert len(chunk_text("One.\n\nTwo.")) == 2
+
+
+def test_chunk_text_on_empty_input():
+    assert chunk_text("   ") == []
+
+
+# ----------------------------------------------------------------------
+# KV-cache helpers
+# ----------------------------------------------------------------------
+
+def test_empty_cache_shape_and_names():
+    cache = empty_cache(TALKER_LAYERS, TALKER_KV_HEADS, TALKER_HEAD_DIM)
+    assert len(cache) == 2 * TALKER_LAYERS
+    assert cache["past_key_values.0.key"].shape == (1, TALKER_KV_HEADS, 0, TALKER_HEAD_DIM)
+    assert cache["past_key_values.27.value"].dtype == np.float32
+
+
+def test_roll_cache_maps_present_onto_past():
+    outputs = {f"present.{i}.{k}": np.full((1, 2, 3, 4), i, np.float32)
+               for i in range(PREDICTOR_LAYERS) for k in ("key", "value")}
+    rolled = roll_cache(outputs, PREDICTOR_LAYERS)
+    assert set(rolled) == {f"past_key_values.{i}.{k}"
+                           for i in range(PREDICTOR_LAYERS) for k in ("key", "value")}
+    assert rolled["past_key_values.3.key"][0, 0, 0, 0] == 3
+
+
+# ----------------------------------------------------------------------
+# fake sessions: the full two-loop pipeline without any real weights
+# ----------------------------------------------------------------------
+
+class FakeSession:
+    """Records every feed and returns shaped outputs, like a real ORT session."""
+
+    def __init__(self, output_names, handler):
+        self._names = list(output_names)
+        self._handler = handler
+        self.calls = []
+
+    def get_outputs(self):
+        return [type("O", (), {"name": n})() for n in self._names]
+
+    def get_inputs(self):
+        return []
+
+    def run(self, _outputs, feed):
+        self.calls.append({k: (v.copy() if isinstance(v, np.ndarray) else v)
+                           for k, v in feed.items()})
+        return self._handler(feed, len(self.calls) - 1)
+
+
+def _embed_session():
+    """An embedding graph: one row of ones per id, scaled by the id."""
+    def handler(feed, _call):
+        ids = np.asarray(feed["input_ids"]).reshape(1, -1)
+        return [np.ones((1, ids.shape[1], HIDDEN), np.float32) * ids.reshape(1, -1, 1)]
+    return FakeSession(["hidden"], handler)
+
+
+def _sub_embed_session():
+    def handler(feed, _call):
+        ids = np.asarray(feed["input_ids"]).reshape(-1)
+        tables = np.asarray(feed["tables"]).reshape(-1)
+        assert ids.shape == tables.shape, "token and table streams must line up"
+        return [(np.ones((1, ids.size, HIDDEN), np.float32)
+                 * (ids + 1000 * tables).reshape(1, -1, 1))]
+    return FakeSession(["hidden"], handler)
+
+
+def _talker_session(tokens, layers=TALKER_LAYERS, heads=TALKER_KV_HEADS,
+                    head_dim=TALKER_HEAD_DIM):
+    """Emit ``tokens`` in order and grow a KV cache exactly like a real step."""
+    names = ["logits", "last_hidden"] + [f"present.{i}.{k}" for i in range(layers)
+                                         for k in ("key", "value")]
+
+    def handler(feed, call):
+        width = feed["inputs_embeds"].shape[1]
+        past = feed["past_key_values.0.key"].shape[2]
+        logits = np.full((1, 1, TALKER_VOCAB), -5.0, np.float32)
+        logits[0, 0, tokens[min(call, len(tokens) - 1)]] = 50.0
+        present = np.zeros((1, heads, past + width, head_dim), np.float32)
+        return ([logits, np.full((1, 1, HIDDEN), 0.25, np.float32)]
+                + [present.copy() for _ in range(2 * layers)])
+    return FakeSession(names, handler)
+
+
+def _predictor_sessions(group_token=7):
+    prefill_names = ["logits"] + [f"present.{i}.{k}" for i in range(PREDICTOR_LAYERS)
+                                  for k in ("key", "value")]
+    step_names = list(prefill_names)
+
+    def prefill(feed, _call):
+        assert feed["inputs_embeds"].shape[1] == 2, "prefill reads exactly two positions"
+        logits = np.full((1, 2048), -5.0, np.float32)
+        logits[0, group_token] = 9.0
+        present = np.zeros((1, PREDICTOR_KV, 2, PREDICTOR_HD), np.float32)
+        return [logits] + [present.copy() for _ in range(2 * PREDICTOR_LAYERS)]
+
+    def step(feed, _call):
+        past = feed["past_key_values.0.key"].shape[2]
+        logits = np.full((1, 2048), -5.0, np.float32)
+        logits[0, group_token] = 9.0
+        present = np.zeros((1, PREDICTOR_KV, past + 1, PREDICTOR_HD), np.float32)
+        return [logits] + [present.copy() for _ in range(2 * PREDICTOR_LAYERS)]
+
+    return FakeSession(prefill_names, prefill), FakeSession(step_names, step)
+
+
+PREDICTOR_KV, PREDICTOR_HD = 8, 128
+
+
+def _decoder_session():
+    def handler(feed, _call):
+        frames = feed["codes"].shape[-1]
+        return [np.full((1, 1, frames * UPSAMPLE), 0.5, np.float32)]
+    return FakeSession(["wav"], handler)
+
+
+def _adapter(tokens=(11, 12, CODEC_EOS)):
+    adapter = Qwen3TTSAdapter()
+    adapter.text_embed = _embed_session()
+    adapter.codec_embed = _embed_session()
+    adapter.predictor_prefill, adapter.predictor_step = _predictor_sessions()
+    adapter.sub_codec_embed = _sub_embed_session()
+    adapter.decoder = _decoder_session()
+    adapter.speaker = "ryan"
+    adapter.language = "english"
+    return adapter, _talker_session(list(tokens))
+
+
+def _ids(n_text=6):
+    return np.arange(1, ROLE_PREFIX_TOKENS + n_text + TAIL_TOKENS + 1,
+                     dtype=np.int64)[None]
+
+
+# -- prompt ------------------------------------------------------------
+
+def test_prompt_length_follows_the_text():
+    adapter, _ = _adapter()
+    for n_text in (1, 6, 30):
+        prompt, _ = adapter.build_prompt(_ids(n_text), "ryan", "english")
+        # role(3) + think block(4) + speaker + pad + text + eos + codec bos
+        assert prompt.shape == (1, ROLE_PREFIX_TOKENS + 6 + n_text + 1 + 1, HIDDEN)
+
+
+def test_prompt_without_a_language_is_one_position_shorter():
+    adapter, _ = _adapter()
+    tagged, _ = adapter.build_prompt(_ids(), "ryan", "english")
+    auto, _ = adapter.build_prompt(_ids(), "ryan", "auto")
+    assert auto.shape[1] == tagged.shape[1] - 1
+
+
+def test_prompt_carries_the_language_token():
+    adapter, _ = _adapter()
+    adapter.build_prompt(_ids(), "ryan", "german")
+    fed = [c["input_ids"].reshape(-1).tolist() for c in adapter.codec_embed.calls]
+    assert [CODEC_THINK, CODEC_THINK_BOS, LANGUAGE_IDS["german"], CODEC_THINK_EOS] in fed
+
+
+def test_prompt_uses_the_no_language_block_for_auto():
+    adapter, _ = _adapter()
+    adapter.build_prompt(_ids(), "ryan", "auto")
+    fed = [c["input_ids"].reshape(-1).tolist() for c in adapter.codec_embed.calls]
+    assert [CODEC_NOTHINK, CODEC_THINK_BOS, CODEC_THINK_EOS] in fed
+
+
+def test_prompt_carries_the_speaker_token():
+    adapter, _ = _adapter()
+    adapter.build_prompt(_ids(), "vivian", "chinese")
+    fed = [c["input_ids"].reshape(-1).tolist() for c in adapter.codec_embed.calls]
+    assert [SPEAKER_IDS["vivian"]] in fed
+
+
+def test_prompt_pads_the_codec_side_across_the_text():
+    adapter, _ = _adapter()
+    adapter.build_prompt(_ids(n_text=6), "ryan", "english")
+    fed = [c["input_ids"].reshape(-1).tolist() for c in adapter.codec_embed.calls]
+    assert [CODEC_PAD] * 7 in fed          # six text tokens plus the text EOS
+
+
+def test_prompt_ends_on_the_codec_bos():
+    adapter, _ = _adapter()
+    adapter.build_prompt(_ids(), "ryan", "english")
+    assert adapter.codec_embed.calls[-1]["input_ids"].reshape(-1).tolist() == [CODEC_BOS]
+
+
+def test_prompt_rejects_an_unknown_speaker():
+    adapter, _ = _adapter()
+    with pytest.raises(ValueError, match="no speaker"):
+        adapter.build_prompt(_ids(), "nobody", "english")
+
+
+def test_prompt_rejects_text_free_input():
+    adapter, _ = _adapter()
+    short = np.arange(ROLE_PREFIX_TOKENS + TAIL_TOKENS, dtype=np.int64)[None]
+    with pytest.raises(ValueError, match="no text"):
+        adapter.build_prompt(short, "ryan", "english")
+
+
+# -- code predictor ----------------------------------------------------
+
+def test_code_predictor_emits_every_remaining_group():
+    adapter, _ = _adapter()
+    groups = adapter.predict_code_groups(
+        np.zeros((1, 1, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        np.random.default_rng(0), 0.9, 50, 1.0, do_sample=False)
+    assert len(groups) == NUM_CODE_GROUPS - 1 == 15
+
+
+def test_code_predictor_advances_step_and_position_together():
+    adapter, _ = _adapter()
+    adapter.predict_code_groups(
+        np.zeros((1, 1, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        np.random.default_rng(0), 0.9, 50, 1.0, do_sample=False)
+    steps = [int(c["step"]) for c in adapter.predictor_step.calls]
+    positions = [int(c["position_ids"][0, 0]) for c in adapter.predictor_step.calls]
+    assert steps == list(range(1, NUM_CODE_GROUPS - 1))
+    # the prefill wrote positions 0 and 1, so step n sits at n + 1
+    assert positions == [s + 1 for s in steps]
+
+
+def test_code_predictor_cache_grows_one_position_per_step():
+    adapter, _ = _adapter()
+    adapter.predict_code_groups(
+        np.zeros((1, 1, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        np.random.default_rng(0), 0.9, 50, 1.0, do_sample=False)
+    lengths = [c["past_key_values.0.key"].shape[2] for c in adapter.predictor_step.calls]
+    assert lengths == list(range(2, 2 + NUM_CODE_GROUPS - 2))
+
+
+def test_code_predictor_reads_the_previous_group_through_its_own_table():
+    adapter, _ = _adapter()
+    adapter.predict_code_groups(
+        np.zeros((1, 1, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        np.random.default_rng(0), 0.9, 50, 1.0, do_sample=False)
+    tables = [int(c["tables"][0]) for c in adapter.sub_codec_embed.calls
+              if c["tables"].size == 1]
+    assert tables == list(range(NUM_CODE_GROUPS - 2))
+
+
+# -- talker loop -------------------------------------------------------
+
+def test_generate_codes_stops_on_end_of_speech():
+    adapter, talker = _adapter(tokens=(11, 12, 13, CODEC_EOS))
+    codes = adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+    assert codes.shape == (3, NUM_CODE_GROUPS)
+    assert codes[:, 0].tolist() == [11, 12, 13]
+
+
+def test_generate_codes_honours_the_length_cap():
+    adapter, talker = _adapter(tokens=(11,))
+    codes = adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False, "max_new_tokens": 4}, np.random.default_rng(0))
+    assert codes.shape == (4, NUM_CODE_GROUPS)
+
+
+def test_generate_codes_feeds_the_prompt_once_then_single_frames():
+    adapter, talker = _adapter(tokens=(11, 12, CODEC_EOS))
+    adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+    widths = [c["inputs_embeds"].shape[1] for c in talker.calls]
+    assert widths == [9, 1, 1]
+
+
+def test_generate_codes_advances_positions_past_the_prompt():
+    adapter, talker = _adapter(tokens=(11, 12, CODEC_EOS))
+    adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+    positions = [c["position_ids"].reshape(-1).tolist() for c in talker.calls]
+    assert positions[0] == list(range(9))
+    assert positions[1] == [9]
+    assert positions[2] == [10]
+
+
+def test_generate_codes_grows_the_talker_cache_by_the_fed_width():
+    adapter, talker = _adapter(tokens=(11, 12, 13, CODEC_EOS))
+    adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+    lengths = [c["past_key_values.0.key"].shape[2] for c in talker.calls]
+    assert lengths == [0, 9, 10, 11]
+
+
+def test_generate_codes_passes_every_layer_of_cache():
+    adapter, talker = _adapter(tokens=(11, CODEC_EOS))
+    adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+    keys = {k for k in talker.calls[-1] if k.startswith("past_key_values.")}
+    assert len(keys) == 2 * TALKER_LAYERS
+
+
+def test_generate_codes_sums_all_sixteen_groups_into_the_next_step():
+    adapter, talker = _adapter(tokens=(11, CODEC_EOS))
+    adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32),
+        np.full((1, 1, HIDDEN), 3.0, np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+    # group 0 embeds to 11; each of the 15 other groups embeds to token + 1000*table
+    expected = 11 + sum(7 + 1000 * t for t in range(NUM_CODE_GROUPS - 1)) + 3.0
+    assert talker.calls[1]["inputs_embeds"][0, 0, 0] == pytest.approx(expected)
+
+
+def test_generate_codes_cannot_end_before_the_floor():
+    # the fake talker asks to end at every step; the floor holds it off
+    adapter, talker = _adapter(tokens=(CODEC_EOS,))
+    codes = adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False}, np.random.default_rng(0))
+    assert codes.shape == (MIN_NEW_TOKENS, NUM_CODE_GROUPS)
+
+
+def test_generate_codes_returns_an_empty_matrix_when_the_cap_is_zero():
+    adapter, talker = _adapter(tokens=(11,))
+    codes = adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False, "max_new_tokens": 0}, np.random.default_rng(0))
+    assert codes.shape == (0, NUM_CODE_GROUPS)
+
+
+def test_generate_codes_never_emits_a_suppressed_token():
+    # the fake talker points every step at a suppressed control token
+    adapter, talker = _adapter(tokens=(SUPPRESS_FROM + 4,))
+    codes = adapter.generate_codes(
+        talker, np.zeros((1, 9, HIDDEN), np.float32), np.zeros((1, 1, HIDDEN), np.float32),
+        {"do_sample": False, "max_new_tokens": 3}, np.random.default_rng(0))
+    assert np.all(codes[:, 0] < SUPPRESS_FROM)
+
+
+# -- codec decoder -----------------------------------------------------
+
+def test_decode_codes_transposes_to_the_graph_layout():
+    adapter, _ = _adapter()
+    adapter.decode_codes(np.zeros((7, NUM_CODE_GROUPS), np.int64))
+    assert adapter.decoder.calls[0]["codes"].shape == (1, NUM_CODE_GROUPS, 7)
+
+
+def test_decode_codes_length_matches_the_frame_count():
+    adapter, _ = _adapter()
+    wav = adapter.decode_codes(np.zeros((7, NUM_CODE_GROUPS), np.int64))
+    assert wav.shape == (7 * UPSAMPLE,)
+    assert wav.dtype == np.float32
+
+
+def test_decode_codes_chunks_long_input_with_left_context():
+    adapter, _ = _adapter()
+    frames = DECODE_CHUNK + 40
+    wav = adapter.decode_codes(np.zeros((frames, NUM_CODE_GROUPS), np.int64))
+    widths = [c["codes"].shape[-1] for c in adapter.decoder.calls]
+    assert widths == [DECODE_CHUNK, 40 + DECODE_LEFT_CONTEXT]
+    # the left context is decoded again and then dropped, so length is unchanged
+    assert wav.shape == (frames * UPSAMPLE,)
+
+
+def test_decode_codes_first_chunk_has_no_left_context():
+    adapter, _ = _adapter()
+    adapter.decode_codes(np.zeros((10, NUM_CODE_GROUPS), np.int64))
+    assert adapter.decoder.calls[0]["codes"].shape[-1] == 10
+
+
+# -- synthesize --------------------------------------------------------
+
+def _request(**params):
+    return AdapterSynthesisRequest(
+        phoneme_ids=_ids(), phoneme_lengths=np.array([_ids().size], np.int64),
+        params=params)
+
+
+def test_synthesize_returns_audio_and_extras():
+    adapter, talker = _adapter(tokens=(11, 12, CODEC_EOS))
+    result = adapter.synthesize(_request(do_sample=False), talker)
+    assert result.audio.shape == (2 * UPSAMPLE,)
+    assert result.extras["frame_count"] == 2
+    assert result.extras["speaker"] == "ryan"
+    assert result.extras["language"] == "english"
+
+
+def test_synthesize_takes_the_speaker_from_the_request():
+    adapter, talker = _adapter(tokens=(11, CODEC_EOS))
+    result = adapter.synthesize(_request(do_sample=False, speaker="vivian"), talker)
+    assert result.extras["speaker"] == "vivian"
+    fed = [c["input_ids"].reshape(-1).tolist() for c in adapter.codec_embed.calls]
+    assert [SPEAKER_IDS["vivian"]] in fed
+
+
+def test_synthesize_returns_silence_when_no_frame_is_produced():
+    adapter, talker = _adapter(tokens=(11,))
+    result = adapter.synthesize(_request(do_sample=False, max_new_tokens=0), talker)
+    assert result.audio.shape == (0,)
+
+
+def test_synthesize_is_reproducible_for_a_seed():
+    outputs = []
+    for _ in range(2):
+        adapter, talker = _adapter(tokens=(11, 12, CODEC_EOS))
+        outputs.append(adapter.synthesize(_request(seed=7), talker).audio)
+    assert np.array_equal(outputs[0], outputs[1])
+
+
+@pytest.mark.parametrize("missing,key", [
+    ("text_embed", "text_embed_path"),
+    ("codec_embed", "codec_embed_path"),
+    ("predictor_prefill", "code_predictor_prefill_path"),
+    ("predictor_step", "code_predictor_step_path"),
+    ("sub_codec_embed", "sub_codec_embed_path"),
+    ("decoder", "codec_decoder_path"),
+])
+def test_synthesize_names_the_missing_graph(missing, key):
+    adapter, talker = _adapter()
+    setattr(adapter, missing, None)
+    with pytest.raises(RuntimeError, match=key):
+        adapter.synthesize(_request(), talker)
+
+
+def test_feed_dict_path_is_refused():
+    adapter, talker = _adapter()
+    with pytest.raises(NotImplementedError):
+        adapter.build_feed_dict(_request(), talker)
+    with pytest.raises(NotImplementedError):
+        adapter.parse_outputs([], _request())
+
+
+# -- configure ---------------------------------------------------------
+
+class _Config:
+    def __init__(self, engine_params, lang_code=None):
+        self.engine_params = engine_params
+        self.lang_code = lang_code
+
+
+def test_configure_rejects_an_unknown_speaker():
+    with pytest.raises(ValueError, match="no speaker"):
+        Qwen3TTSAdapter().configure(_Config({"speaker": "nobody"}))
+
+
+def test_configure_takes_the_language_from_the_voice():
+    adapter = Qwen3TTSAdapter()
+    adapter.configure(_Config({"speaker": "vivian"}, lang_code="zh-CN"))
+    assert adapter.language == "chinese"
+    assert adapter.speaker == "vivian"
+
+
+def test_configure_prefers_an_explicit_language():
+    adapter = Qwen3TTSAdapter()
+    adapter.configure(_Config({"speaker": "ryan", "language": "English"},
+                              lang_code="zh-CN"))
+    assert adapter.language == "english"
+
+
+def test_configure_without_a_language_falls_back_to_auto():
+    adapter = Qwen3TTSAdapter()
+    adapter.configure(_Config({"speaker": "ryan"}))
+    assert adapter.language == "auto"
+
+
+def test_encode_text_needs_a_tokenizer():
+    with pytest.raises(RuntimeError, match="bpe_tokenizer_path"):
+        Qwen3TTSAdapter().encode_text("hello", None, None)


### PR DESCRIPTION
Add the Qwen3-TTS engine: a two-stage codec LM that speaks ten languages with nine
fixed timbres, at 24 kHz.

Source model: [`Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice)
(Alibaba Qwen, Apache-2.0). No community ONNX export of the 0.6B checkpoint existed, so
this PR exports it. The IO contracts follow the checkpoint's own `config.json` and the
`qwen-tts` reference package, not a third-party export.

## Architecture

Qwen3-TTS predicts the tokens of a 12.5 Hz neural codec. It has two stacked
autoregressive models:

* the **talker** — 28 decoder layers, one step per 80 ms frame, emitting code group 0
  and the hidden state that conditions the second model;
* the **code predictor** — 5 decoder layers that write the other 15 code groups of the
  *same* frame, one group per step, each group with its own embedding table and its own
  output head.

One frame costs one talker step plus 15 code-predictor steps. The 16 groups are summed
into one embedding and fed back to the talker with the next slice of the text.

The talker reads embeddings, never token ids: at each prompt position a text hidden state
and a codec hidden state are added. `build_prompt` reproduces the layout upstream builds
for non-streaming input — role tokens, a language "think" block, the speaker, the whole
text against codec padding, then the codec BOS.

A voice is a name, not a reference clip: the CustomVoice checkpoint has nine trained
timbres and no speaker encoder, so this engine does not do cloning. Two of the timbres
are Chinese dialect voices, and the language tag is overridden for them exactly as
upstream does.

## IO contracts

| Graph | Inputs | Outputs |
| --- | --- | --- |
| `talker.onnx` | `inputs_embeds (1,S,1024)`, `position_ids (1,S)`, 28x2 past KV `(1,8,P,128)` | `logits (1,1,3072)`, `last_hidden (1,1,1024)`, 28x2 present KV |
| `text_embed.onnx` | `input_ids (1,T)` | `hidden (1,T,1024)` |
| `codec_embed.onnx` | `input_ids (1,T)` | `hidden (1,T,1024)` |
| `code_predictor_prefill.onnx` | `inputs_embeds (1,2,1024)` | `logits (1,2048)`, 5x2 present KV `(1,8,2,128)` |
| `code_predictor_step.onnx` | `inputs_embeds (1,1,1024)`, `step ()`, `position_ids (1,1)`, 5x2 past KV | `logits (1,2048)`, 5x2 present KV |
| `sub_codec_embed.onnx` | `input_ids (G)`, `tables (G)` | `hidden (1,G,1024)` |
| `codec_decoder.onnx` | `codes (1,16,T)` int64 | `wav (1,1,T*1920)` |

Three upstream constructs do not trace, and the export script checks its replacement for
each before it exports anything:

1. **mRoPE.** `apply_interleaved_rope` assigns into strided slices, baking the traced
   length in. At batch 1 with no left padding the three position rows are always equal,
   and then mRoPE is exactly plain RoPE — verified bit-exact at three lengths.
2. **Mask builders.** `create_causal_mask` and `create_sliding_window_causal_mask` use
   `torch.vmap` and reshape `cache_position` with the traced length baked in. Both masks
   are rebuilt with plain tensor ops and checked against the stock model / transformers.
3. **Transposed-convolution trimming** in the codec decoder used a computed stop index.
   Trimming from the right plus the dynamo exporter keeps the output length dynamic;
   asserted equal to upstream's slicing on synthetic tensors across five
   (right_pad, length) combinations, then the exported ONNX decoder is asserted
   within 1e-5 max abs diff of the stock decoder at two frame counts.

## Parity vs upstream torch (CPU, fp32, greedy)

Fixed prompt: "The quick brown fox jumps over the lazy dog.", speaker Ryan, English.

| Measurement | Result |
| --- | --- |
| Tokenizer ids | identical |
| Prompt embeddings, max abs diff | 2.384e-07 |
| Talker prefill logits, max abs diff | 2.265e-05 |
| Talker decode logits, steps 1..52, max abs diff | 4.959e-05 |
| Greedy token agreement, 52 frames x 16 groups | **100.0000 % (832/832)** |
| Codec decoder on the same codes, max abs diff | 9.853e-07 |
| End-to-end waveform vs torch, max abs diff | 9.853e-07 |

No quantized variant is shipped: only the fp32 export reaches full greedy agreement, and
per the Spark-TTS precedent only what matches is shipped. Quantization is a follow-up.

## Sampler semantics

Verified against the stack upstream actually uses (HuggingFace `generate`, not
llama.cpp). Instrumenting `_get_logits_processor` on both models gives:

* talker: `RepetitionPenalty` -> `MinLength` -> `MinNewTokensLength` -> `SuppressTokens`
  -> `Temperature` -> `TopK` (TopP is dropped because `top_p == 1.0`);
* code predictor: `Temperature` -> `TopK`, no processors at all.

`apply_logits_processors` runs the processors in that order and `sample_token` runs the
warpers in that order. Suppression is last, so a penalised control token stays masked;
the end-of-speech token is the one id inside the suppressed range that survives, and only
after the minimum-new-tokens floor.

## ASR gate

Synthesized with the shipped defaults (sampling, seed 1), one sentence per supported
language, default voice. Transcribed on CPU with onnx-asr: `nemo-parakeet-tdt-0.6b-v3`
for the European languages, `whisper-base` for zh/ja/ko. CER for zh/ja/ko, WER elsewhere.

| Language | Voice | ASR model | Metric | Score | Transcript |
| --- | --- | --- | --- | --- | --- |
| en | ryan | parakeet-tdt-0.6b-v3 | WER | **0.0 %** | The quick brown fox jumps over the lazy dog. |
| zh | vivian | whisper-base | CER | **18.8 %** | 今天天氣很好,我們一起去公園散步吧。 |
| ja | ono_anna | whisper-base | CER | **4.3 %** | 今日はとてもよい天気ですね 公園を散歩しましょう |
| ko | sohee | whisper-base | CER | **0.0 %** | 오늘 날씨가 정말 좋네요. 같이 공원에 산책하러 가요. |
| de | ryan | parakeet-tdt-0.6b-v3 | WER | **0.0 %** | Der schnelle braune Fuchs springt über den faulen Hund. |
| fr | ryan | parakeet-tdt-0.6b-v3 | WER | **0.0 %** | Le vif renard brun saute par-dessus le chien paresseux. |
| ru | ryan | parakeet-tdt-0.6b-v3 | WER | **0.0 %** | Быстрая коричневая лиса прыгает через ленивую собаку. |
| pt | ryan | parakeet-tdt-0.6b-v3 | WER | **0.0 %** | A rápida raposa castanha salta sobre o cão preguiçoso. |
| es | ryan | parakeet-tdt-0.6b-v3 | WER | **0.0 %** | El veloz zorro marrón salta sobre el perro perezoso. |
| it | ryan | parakeet-tdt-0.6b-v3 | WER | **0.0 %** | La rapida volpe marrone salta sopra il cane pigro! |

Worst score 18.8 %, well inside the 30 % gate. The Chinese number is a transcriber
artifact, not a synthesis error: `whisper-base` writes the sentence in traditional
characters (天氣 for 天气, 我們 for 我们), and every differing character is one of those.
Nine of the ten languages are at or below 4.3 %.

## RTF

Measured with the shipped defaults on the workstation (6 physical cores, no GPU,
onnxruntime CPU provider, fp32). Wall time covers both autoregressive loops plus the
codec decoder.

| Language | Voice | Frames | Audio (s) | Wall (s) | RTF |
| --- | --- | --- | --- | --- | --- |
| en | ryan | 44 | 3.52 | 21.8 | 6.19 |
| zh | vivian | 53 | 4.24 | 57.87 | 13.65 |
| ja | ono_anna | 64 | 5.12 | 38.44 | 7.51 |
| ko | sohee | 80 | 6.40 | 54.36 | 8.49 |
| de | ryan | 48 | 3.84 | 41.86 | 10.90 |
| fr | ryan | 64 | 5.12 | 43.71 | 8.54 |
| ru | ryan | 84 | 6.72 | 33.10 | 4.93 |
| pt | ryan | 58 | 4.64 | 23.61 | 5.09 |
| es | ryan | 69 | 5.52 | 30.33 | 5.49 |
| it | ryan | 67 | 5.36 | 32.44 | 6.05 |

This is a slow engine, and the PR does not claim otherwise: 16 forward passes per 80 ms
frame is 16 times the work of a single-codebook codec LM. The upstream PyTorch model on
the same box is far slower still — RTF 29.7 on the English sentence, against 6.2 here.

Thread count matters more than usual because the code predictor issues many tiny runs:
on this 6-core / 12-thread box the same synthesis takes 12.8 s at 6 intra-op threads and
23.2 s at 12. `make_session` cannot set that today (follow-up 3 below).

## Mirror

* [`OpenVoiceOS/phoonnx-qwen3-tts`](https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts)
  — seven graphs plus `tokenizer.json`, about 4.4 GB fp32.
* Added to the
  [phoonnx community mirror collection](https://huggingface.co/collections/OpenVoiceOS/phoonnx-community-mirror-6a2204d302e0e7497870cd68).
* The voice index points only at the mirror.

Verified end to end through the manager, downloading from the published mirror:

```
voice: qwen3tts/ryan/en | Qwen3-TTS Ryan (dynamic male) | en-US
model_url: https://huggingface.co/OpenVoiceOS/phoonnx-qwen3-tts/resolve/main/talker.onnx
download + session load: 626.2s
sample rate 24000, audio 4.00s, wall 34.5s, RTF 8.64
```

`TTSModelManager` resolved the index entry, fetched all eight files, built the seven
sessions and synthesized. The 626 s is the one-time 4.4 GB download.

## Licence

Apache-2.0, the licence of the upstream model, matching phoonnx. The card carries the
Qwen attribution and the technical-report citation. The weights, the architecture and the
nine timbres are the work of the Alibaba Qwen team.

## Shared-code follow-ups (not in this PR)

The diff is purely additive: one engine file, one voice index, one engine page, the
conversion scripts, a test file, and the minimal enum/registration entries. Three things
belong in shared code but would have touched other engines, so they are noted rather than
done:

1. **KV-cache plumbing.** `empty_cache` and `roll_cache` are the fourth copy of the same
   present-to-past mapping (Chatterbox, NeuTTS, Spark-TTS, Qwen3-TTS). A shared helper on
   `BaseOnnxAdapter` would remove all four.
2. **`chunk_text`.** Byte-identical to the Spark-TTS one apart from the default budget.
3. **Session thread control.** `make_session` takes no thread count. On this 6-core /
   12-thread box the sub-talker's many tiny runs are twice as fast at 6 intra-op threads
   as at the onnxruntime default, and there is no way to set that from a voice config.

## Authorship

Written by Claude Opus under Fable orchestration. Model export, parity, ASR gate and RTF
measurements ran on the workstation at 192.168.1.200 (6 cores, no GPU).


## Samples

Per-language WAVs, the greedy parity audio and the upstream reference clips are on the
homelab share at `tts_samples/qwen3tts/`, with `bench.json` and `bench_wer.json`
alongside them.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Qwen3-TTS support for multilingual speech synthesis.
  - Added 15 voices across Chinese, English, Japanese, Korean, German, French, Spanish, Italian, Portuguese, and Russian.
  - Added support for 24 kHz audio output, configurable languages and speakers, and voice loading.
  - Expanded the supported voice catalog to 2,422 voices.

- **Documentation**
  - Added setup, configuration, engine usage, voice management, conversion, and performance guidance for Qwen3-TTS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->