### PR TITLE
feat: ArkTTS engine (Zortzi Basque + Audio8 multilingual)

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -1,7 +1,7 @@
 ## Supported Voices
 
-**Total Voices:** 2445
-**Total Languages:** 1242
+**Total Voices:** 2469
+**Total Languages:** 1243
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
 
@@ -414,6 +414,8 @@
 | `supertonic/M3/de` | `de` | `supertonic` | `unicode` |
 | `supertonic/M4/de` | `de` | `supertonic` | `unicode` |
 | `supertonic/M5/de` | `de` | `supertonic` | `unicode` |
+| `arktts/audio8-antton/de` | `de-DE` | `arktts` | `unicode` |
+| `arktts/audio8-maider/de` | `de-DE` | `arktts` | `unicode` |
 | `chatterbox/multilingual/de` | `de-DE` | `chatterbox` | `unicode` |
 | `larynx/de-de-eva_k-glow_tts` | `de-DE` | `glowtts` | `gruut` |
 | `larynx/de-de-hokuspokus-glow_tts` | `de-DE` | `glowtts` | `gruut` |
@@ -570,6 +572,8 @@
 | `piper_community/nardocolin/en-GB_Colin` | `en-GB` | `piper` | `espeak` |
 | `piper_neurlang/en-GB_jane-eyre-english-british` | `en-GB` | `piper` | `goruut` |
 | `piper_community/agentvibe/en-IE_jenny` | `en-IE` | `piper` | `espeak` |
+| `arktts/audio8-antton/en` | `en-US` | `arktts` | `unicode` |
+| `arktts/audio8-maider/en` | `en-US` | `arktts` | `unicode` |
 | `chatterbox/base/en` | `en-US` | `chatterbox` | `unicode` |
 | `chatterbox/multilingual/en` | `en-US` | `chatterbox` | `unicode` |
 | `chatterbox/turbo/en` | `en-US` | `chatterbox` | `unicode` |
@@ -791,6 +795,8 @@
 | `piper_community/larcanio/es-AR_daniela` | `es-AR` | `piper` | `espeak` |
 | `hf_community/ylacombe/mms-spa-finetuned-chilean-monospeaker` | `es-CL` | `transformers` | `graphemes` |
 | `hf_community/ylacombe/mms-spa-finetuned-colombian-monospeaker` | `es-CO` | `transformers` | `graphemes` |
+| `arktts/audio8-antton/es` | `es-ES` | `arktts` | `unicode` |
+| `arktts/audio8-maider/es` | `es-ES` | `arktts` | `unicode` |
 | `chatterbox/multilingual/es` | `es-ES` | `chatterbox` | `unicode` |
 | `hitz/es_alejandro-vits` | `es-ES` | `coqui` | `ahotts` |
 | `hitz/es_laura-vits` | `es-ES` | `coqui` | `ahotts` |
@@ -827,6 +833,8 @@
 | `facebook/mms-tts-eus-Basque` | `eu` | `transformers` | `graphemes` |
 | `piper_community/itzune/eu-antton-medium` | `eu` | `piper` | `espeak` |
 | `piper_community/itzune/eu-maider-medium` | `eu` | `piper` | `espeak` |
+| `arktts/zortzi-antton/eu` | `eu-ES` | `arktts` | `unicode` |
+| `arktts/zortzi-maider/eu` | `eu-ES` | `arktts` | `unicode` |
 | `hitz/eu-antton` | `eu-ES` | `styletts2` | `ahotts` |
 | `hitz/eu-antton-happy` | `eu-ES` | `styletts2` | `ahotts` |
 | `hitz/eu-antton-neutral` | `eu-ES` | `styletts2` | `ahotts` |
@@ -928,6 +936,8 @@
 | `supertonic/M3/fr` | `fr` | `supertonic` | `unicode` |
 | `supertonic/M4/fr` | `fr` | `supertonic` | `unicode` |
 | `supertonic/M5/fr` | `fr` | `supertonic` | `unicode` |
+| `arktts/audio8-antton/fr` | `fr-FR` | `arktts` | `unicode` |
+| `arktts/audio8-maider/fr` | `fr-FR` | `arktts` | `unicode` |
 | `chatterbox/multilingual/fr` | `fr-FR` | `chatterbox` | `unicode` |
 | `larynx/fr-fr-gilles_le_blanc-glow_tts` | `fr-FR` | `glowtts` | `gruut` |
 | `larynx/fr-fr-siwis-glow_tts` | `fr-FR` | `glowtts` | `gruut` |
@@ -1191,6 +1201,8 @@
 | `supertonic/M3/it` | `it` | `supertonic` | `unicode` |
 | `supertonic/M4/it` | `it` | `supertonic` | `unicode` |
 | `supertonic/M5/it` | `it` | `supertonic` | `unicode` |
+| `arktts/audio8-antton/it` | `it-IT` | `arktts` | `unicode` |
+| `arktts/audio8-maider/it` | `it-IT` | `arktts` | `unicode` |
 | `chatterbox/multilingual/it` | `it-IT` | `chatterbox` | `unicode` |
 | `hf_community/kirys79/piper_italiano/it_IT-aurora-medium` | `it-IT` | `piper` | `espeak` |
 | `hf_community/paolapersico1/Piper-TTS-Italian` | `it-IT` | `piper` | `espeak` |
@@ -1226,6 +1238,8 @@
 | `supertonic/M3/ja` | `ja` | `supertonic` | `unicode` |
 | `supertonic/M4/ja` | `ja` | `supertonic` | `unicode` |
 | `supertonic/M5/ja` | `ja` | `supertonic` | `unicode` |
+| `arktts/audio8-antton/ja` | `ja-JP` | `arktts` | `unicode` |
+| `arktts/audio8-maider/ja` | `ja-JP` | `arktts` | `unicode` |
 | `chatterbox/multilingual/ja` | `ja-JP` | `chatterbox` | `unicode` |
 | `kokoro/jf_alpha` | `ja-JP` | `styletts2` | `misaki_ja` |
 | `kokoro/jf_gongitsune` | `ja-JP` | `styletts2` | `misaki_ja` |
@@ -1329,6 +1343,8 @@
 | `supertonic/M5/ko` | `ko` | `supertonic` | `unicode` |
 | `mimic3/ko_KO/kss_low` | `ko-KO` | `mimic3` | `espeak` |
 | `piper_neurlang/ko-KO_kss-korean` | `ko-KO` | `piper` | `goruut` |
+| `arktts/audio8-antton/ko` | `ko-KR` | `arktts` | `unicode` |
+| `arktts/audio8-maider/ko` | `ko-KR` | `arktts` | `unicode` |
 | `chatterbox/multilingual/ko` | `ko-KR` | `chatterbox` | `unicode` |
 | `facebook/mms-tts-kor-Korean` | `ko-KR` | `transformers` | `graphemes` |
 | `outetts/0.6B/ko` | `ko-KR` | `outetts` | `unicode` |
@@ -1657,6 +1673,8 @@
 | `piper/nl_BE-nathalie-x_low` | `nl-BE` | `piper` | `espeak` |
 | `piper/nl_BE-rdh-medium` | `nl-BE` | `piper` | `espeak` |
 | `piper/nl_BE-rdh-x_low` | `nl-BE` | `piper` | `espeak` |
+| `arktts/audio8-antton/nl` | `nl-NL` | `arktts` | `unicode` |
+| `arktts/audio8-maider/nl` | `nl-NL` | `arktts` | `unicode` |
 | `chatterbox/multilingual/nl` | `nl-NL` | `chatterbox` | `unicode` |
 | `OpenVoiceOS/pipertts_nl-NL_dii` | `nl-NL` | `piper` | `espeak` |
 | `OpenVoiceOS/pipertts_nl-NL_miro` | `nl-NL` | `piper` | `espeak` |
@@ -1744,6 +1762,8 @@
 | `supertonic/M3/pl` | `pl` | `supertonic` | `unicode` |
 | `supertonic/M4/pl` | `pl` | `supertonic` | `unicode` |
 | `supertonic/M5/pl` | `pl` | `supertonic` | `unicode` |
+| `arktts/audio8-antton/pl` | `pl-PL` | `arktts` | `unicode` |
+| `arktts/audio8-maider/pl` | `pl-PL` | `arktts` | `unicode` |
 | `chatterbox/multilingual/pl` | `pl-PL` | `chatterbox` | `unicode` |
 | `coqui/pl-mai_female-vits` | `pl-PL` | `coqui` | `graphemes` |
 | `facebook/mms-tts-pol-Polish` | `pl-PL` | `transformers` | `graphemes` |
@@ -2296,6 +2316,8 @@
 | `mimic3/yo/openbible_low` | `yo` | `mimic3` | `epitran` |
 | `facebook/mms-tts-yre-Yaouré` | `yre` | `transformers` | `graphemes` |
 | `facebook/mms-tts-yua-Maya, Yucatec` | `yua` | `transformers` | `graphemes` |
+| `arktts/audio8-antton/yue` | `yue-HK` | `arktts` | `unicode` |
+| `arktts/audio8-maider/yue` | `yue-HK` | `arktts` | `unicode` |
 | `facebook/mms-tts-yuz-Yuracare` | `yuz` | `transformers` | `graphemes` |
 | `facebook/mms-tts-yva-Yawa` | `yva` | `transformers` | `graphemes` |
 | `facebook/mms-tts-zaa-Zapotec, Sierra de Juárez` | `zaa` | `transformers` | `graphemes` |
@@ -2421,6 +2443,8 @@
 | `kokoro/zm_yunxi` | `zh` | `styletts2` | `misaki_zh` |
 | `kokoro/zm_yunxia` | `zh` | `styletts2` | `misaki_zh` |
 | `kokoro/zm_yunyang` | `zh` | `styletts2` | `misaki_zh` |
+| `arktts/audio8-antton/zh` | `zh-CN` | `arktts` | `unicode` |
+| `arktts/audio8-maider/zh` | `zh-CN` | `arktts` | `unicode` |
 | `chatterbox/multilingual/zh` | `zh-CN` | `chatterbox` | `unicode` |
 | `hf_community/BricksDisplay/vits-cmn` | `zh-CN` | `transformers` | `graphemes` |
 | `outetts/0.6B/zh` | `zh-CN` | `outetts` | `unicode` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ how to obtain or train it, and a synthesis example:
 [Chatterbox](training/engines/chatterbox.md) ·
 [Spark-TTS](training/engines/sparktts.md) ·
 [Qwen3-TTS](training/engines/qwen3tts.md) ·
+[ArkTTS](training/engines/arktts.md) ·
 [F5-TTS](training/engines/f5tts.md) ·
 [Shami](training/engines/shami.md) ·
 [Pocket TTS](pockettts.md) ·

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,6 +175,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `sparktts` | Autoregressive codec-LM (Qwen2 + BiCodec), en/zh | [Spark-TTS](training/engines/sparktts.md) |
 | `qwen3tts` | Two-stage codec LM (talker + code predictor), 10 languages | [Qwen3-TTS](training/engines/qwen3tts.md) |
 | `outetts` | Autoregressive codec-LM (Qwen3 or Llama-3.2 + DAC.speech), raw-text, 23 languages | [OuteTTS](training/engines/outetts.md) |
+| `arktts` | Two-stage codec LM (slow AR + fast AR), Basque or 11 languages, 44.1 kHz | [ArkTTS](training/engines/arktts.md) |
 
 ## Execution Providers
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -94,6 +94,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | [Spark-TTS](training/engines/sparktts.md) | `phoonnx/engines/sparktts.py` | `engine == "sparktts"` — autoregressive codec-LM (Qwen2 + BiCodec), raw-text, en/zh; preset 32-token speakers or zero-shot [cloning](cloning.md) |
 | [Qwen3-TTS](training/engines/qwen3tts.md) | `phoonnx/engines/qwen3tts.py` | `engine == "qwen3tts"` — two autoregressive stages (28-layer talker + 5-layer code predictor) writing 16 code groups per 12.5 Hz frame, raw-text, 10 languages, nine fixed timbres, 24 kHz |
 | [OuteTTS](training/engines/outetts.md) | `phoonnx/engines/outetts.py` | `engine == "outetts"` — autoregressive two-codebook codec-LM (Qwen3 backbone + DAC.speech decoder), raw text in 23 languages, in-context [cloning](cloning.md) from pre-encoded speaker profiles, 24 kHz |
+| [ArkTTS (Zortzi + Audio8)](training/engines/arktts.md) | `phoonnx/engines/arktts.py` | `engine == "arktts"` — two autoregressive stages (24-layer slow AR + 4-layer fast AR) writing 10 codebooks per 21.5 Hz frame, raw-text, Basque or 11 languages, reference-clip voices, 44.1 kHz |
 
 ---
 

--- a/docs/training/engines/arktts.md
+++ b/docs/training/engines/arktts.md
@@ -1,0 +1,132 @@
+# ArkTTS Engine (Zortzi + Audio8)
+
+This page is for integrators who want ArkTTS voices in phoonnx. After reading it you can
+pick a checkpoint and a voice, you know what each of the three ONNX graphs does, and you
+know what one second of audio costs.
+
+> Related: [adapter architecture](../../engines.md) ·
+> [configuration](../../configuration.md) ·
+> [Qwen3-TTS — the sibling two-stage codec-LM engine](qwen3tts.md)
+
+## What it is
+
+**ArkTTS** predicts the tokens of a 21.5 Hz neural codec and turns them into a waveform at
+44.1 kHz — the highest sample rate of any engine in phoonnx. Like Qwen3-TTS it has two
+stacked autoregressive models, not one:
+
+* the **slow AR** — 24 decoder layers that emit one token per audio frame. That token is
+  codebook 0, and the slow AR's hidden state conditions the second model;
+* the **fast AR** — 4 decoder layers that read the slow hidden state and write codebooks
+  1 to 9 of the *same* frame, one codebook per step.
+
+One 46 ms frame therefore costs one slow step and nine fast steps. The ten codebooks of a
+frame are summed into a single embedding and fed back to the slow AR at the next position.
+
+The prompt is a `[1, 11, T]` matrix, not a flat token sequence. Row 0 carries the token
+stream — a system block, then the reference clip's codes shifted into the model's semantic
+range, then the text. Rows 1 to 10 carry the reference clip's ten codebooks, aligned under
+those semantic positions and zero everywhere else.
+
+Two checkpoints share this architecture, and phoonnx drives both through one adapter
+because they ship byte-identical model code, tokenizer and codec weights:
+
+| Checkpoint | Mirror | Languages |
+| --- | --- | --- |
+| [`Audio8/Audio8-TTS-Preview-0.6b`](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.6b) | `OpenVoiceOS/phoonnx-audio8-tts` | Cantonese, Chinese, Dutch, English, French, German, Italian, Japanese, Korean, Polish, Spanish |
+| [`itzune/zortzi-tts`](https://huggingface.co/itzune/zortzi-tts) | `OpenVoiceOS/phoonnx-zortzi-tts` | Basque |
+
+Both are Apache-2.0. Zortzi is a Basque fine-tune of Audio8 and speaks only Basque.
+
+## When to pick it
+
+Pick ArkTTS when you want **Basque**, where it is currently the only codec-LM voice
+phoonnx offers, or when you want 44.1 kHz output and can afford the cost.
+
+Do not pick it when you need real-time synthesis. Two autoregressive stages at ten steps
+per frame are expensive: measured on twelve cores, one second of audio takes about eight
+seconds of CPU time. Both upstream model cards say the same thing and point at a GPU for
+real-time use. For a cheaper multilingual voice use [Qwen3-TTS](qwen3tts.md); for cloning
+on CPU use [Spark-TTS](sparktts.md).
+
+## Voices
+
+A voice here is **not** a speaker id. ArkTTS has no speaker table and always emits the
+`<|speaker:0|>` token; the speaker is carried by the codec codes of a short reference clip,
+which the prompt embeds directly. The mirrors therefore ship the codes rather than the
+audio, in one small JSON per voice that also holds the clip's transcription.
+
+| Voice | Timbre | Reference clip |
+| --- | --- | --- |
+| `maider` | female | HiTZ-Aholab Basque TTS, 2.2 s |
+| `antton` | male | HiTZ-Aholab Basque TTS, 3.3 s |
+
+Audio8 bundles no reference voices of its own — upstream ships it as a cloning-only model —
+so its mirror carries the same two clips. They condition timbre, not language: both voices
+are listed for every language Audio8 was trained on.
+
+Voice ids follow `arktts/<checkpoint>-<voice>/<language>`, for example
+`arktts/zortzi-maider/eu` or `arktts/audio8-antton/ja`.
+
+To add a voice, encode a clip offline with `scripts/conversion/arktts/mint_voice.py`. Keep
+it short and prosodically flat: upstream selected its own references by pitch-range ratio
+because an expressive reference bleeds its intonation into every later sentence.
+
+## Sampling
+
+**ArkTTS must sample.** Both model cards state that greedy decoding runs into repetition
+loops that never reach the end-of-speech token, so this engine does not offer a greedy
+mode. The defaults are the ones both cards pin: temperature `0.8`, top-p `0.95`, top-k `50`.
+
+The sampler reproduces upstream's own order, which is not the HuggingFace one: the semantic
+mask runs first, then top-k and top-p together against the softmax of the **unscaled**
+logits, and temperature divides last. Applying temperature first, as HuggingFace does,
+changes which tokens survive the nucleus cut.
+
+On top of that sits repetition-aware sampling. If a draw lands on a semantic token that is
+already among the last ten emitted, it is discarded and redrawn under tighter settings
+(top-p `0.9` at temperature `1.0`). That fallback is what stops the model looping, and it
+is why greedy decoding cannot terminate — with sampling off, both draws are the same argmax.
+
+Pass a `seed` in `engine_params` to make a call reproducible.
+
+## Graphs
+
+| File | Role |
+| --- | --- |
+| `slow_ar_fp16.onnx` | 24-layer backbone, KV-cached; this is the voice's `model_url` |
+| `fast_ar_fp16.onnx` | 4-layer depth transformer over the ten codebooks |
+| `codec_decoder_fp16.onnx` | `(1, 10, T)` codes to a 44.1 kHz waveform |
+| `tokenizer.json` | the model's own Qwen2 subword BPE |
+| `voices/<name>.json` | one voice's reference codes and transcription |
+
+The KV cache is a fixed 2048-position window rather than a growing tensor: each graph writes
+its new keys and values at `input_pos` and attends over the whole window. The slow AR's
+logits are sliced to 4097 entries — the 4096 semantic logits followed by end-of-speech — so
+an index below 4096 is already codebook 0's value.
+
+Only half precision is published. The `int4` graphs upstream also publishes fail numeric
+parity against the PyTorch checkpoint and are deliberately not mirrored.
+
+Text longer than about 200 characters is split on sentence boundaries and synthesized one
+chunk per autoregressive pass, because the model's own frame budget runs out before a long
+chunk does.
+
+## Limitations
+
+These are upstream's, and they are not worked around in phoonnx:
+
+* **Numbers are not spoken correctly.** Both cards report that digits come out in a mix of
+  languages even when expanded to words. Spell numbers out in the text.
+* **No text normalization.** Text is tokenized verbatim, so expand acronyms yourself —
+  upstream's own example is "TTS" written as "te te ese".
+* **Zortzi speaks only Basque**, with these two voices and no others.
+* **Cloning is offline.** phoonnx ships the codec decoder but not the encoder, so a new
+  reference clip becomes a voice through `mint_voice.py` rather than at synthesis time.
+
+## Licence and attribution
+
+Both checkpoints are Apache-2.0. The reference clips that carry the voices come from the
+[HiTZ-Aholab Basque TTS dataset](https://doi.org/10.5281/zenodo.17952596), which is
+CC BY 4.0, so redistributing the voices or audio generated from them carries that
+attribution. The mirrors state it, and it is repeated here because it travels with the
+audio, not only with the files.

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -12,7 +12,7 @@ The catalog is not fetched from a handful of live endpoints. `merge_default_voic
 `transformers_community`, `piper_community`, `optispeech`, `glowtts`, `mixertts`,
 `fastpitch`, `coqui_community`, `vits2`, `styletts2`, `f5tts`, `coqui_vits`, `BSC`,
 `shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`, `qwen3tts`,
-`outetts`.
+`outetts`, `arktts`.
 
 Each JSON entry becomes a `TTSModelInfo`. Model/config/vocoder files are only fetched from their URLs when a voice is actually downloaded or loaded.
 

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -38,6 +38,7 @@ class Engine(str, Enum):
     SPARKTTS = "sparktts"  # Spark-TTS: Qwen2 codec-LM + BiCodec, preset or zero-shot speakers
     QWEN3TTS = "qwen3tts"  # Qwen3-TTS: talker + code predictor, 16 code groups, 12.5 Hz codec
     OUTETTS = "outetts"  # OuteTTS 1.0: Llama/Qwen codec-LM + DAC.speech decoder, 23 languages
+    ARKTTS = "arktts"  # ArkTTS (Audio8 / Zortzi): DualAR codec-LM, 10 codebooks, 44.1 kHz codec
 
 
 # Alphabet and PhonemeType are wire-format enums shared with scriptconv;
@@ -385,6 +386,26 @@ class VoiceConfig:
             phoneme_type = phoneme_type or PhonemeType.UNICODE
             alphabet = alphabet or Alphabet.GRAPHEMES
             config.setdefault("audio", {}).setdefault("sample_rate", 16000)
+            tokenizer = TTSTokenizer(
+                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
+                add_blank_char=False,
+                add_blank_word=False,
+                use_eos_bos=False,
+                blank_at_end=False,
+                blank_at_start=False,
+            )
+
+        elif (engine == Engine.ARKTTS or
+                (isinstance(engine, str) and engine == "arktts") or
+                config.get("engine") == "arktts"):
+            # ArkTTS consumes raw text: the adapter owns text -> id conversion with the
+            # model's own subword BPE (loaded from engine_params, like Qwen3-TTS), so no
+            # phonemizer vocabulary is needed here. Alphabet.GRAPHEMES routes
+            # TTSVoice.synthesize() through adapter.encode_text().
+            engine = Engine.ARKTTS
+            phoneme_type = phoneme_type or PhonemeType.UNICODE
+            alphabet = alphabet or Alphabet.GRAPHEMES
+            config.setdefault("audio", {}).setdefault("sample_rate", 44100)
             tokenizer = TTSTokenizer(
                 Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
                 add_blank_char=False,

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -145,6 +145,7 @@ def _register_builtins() -> None:
     from phoonnx.engines.sparktts import SparkTTSAdapter
     from phoonnx.engines.qwen3tts import Qwen3TTSAdapter
     from phoonnx.engines.outetts import OuteTTSAdapter
+    from phoonnx.engines.arktts import ArkTTSAdapter
 
     # OptiSpeech shares VITS-like x/x_lengths/scales inputs with Matcha, but has
     # a distinctive metadata + wav/durations output signature — check it first.
@@ -170,6 +171,7 @@ def _register_builtins() -> None:
     register_engine("sparktts", SparkTTSAdapter, detect_priority=25)
     register_engine("qwen3tts", Qwen3TTSAdapter, detect_priority=24)
     register_engine("outetts", OuteTTSAdapter, detect_priority=23)
+    register_engine("arktts", ArkTTSAdapter, detect_priority=22)
 
 
 _register_builtins()

--- a/phoonnx/engines/arktts.py
+++ b/phoonnx/engines/arktts.py
@@ -1,0 +1,493 @@
+"""ArkTTS inference adapter — DualAR codec LM with a 10-codebook 44.1 kHz codec.
+
+ArkTTS is the architecture behind ``Audio8/Audio8-TTS-Preview-0.6b`` (Apache-2.0,
+11 languages, zero-shot cloning) and its Basque fine-tune ``itzune/zortzi-tts``
+(Apache-2.0, two voices). The two checkpoints ship byte-identical model code, tokenizer
+and codec weights, so one adapter drives both and the differences live in the voice index.
+
+Like Qwen3-TTS it has two stacked autoregressive models, not one:
+
+* the **slow AR** — 24 decoder layers that emit one token per audio frame. That token is
+  codebook 0, and its hidden state conditions the second model;
+* the **fast AR** — 4 decoder layers that read the slow hidden state and write codebooks
+  1..9 of the *same* frame, one codebook per step.
+
+One 46 ms frame therefore costs one slow step plus nine fast steps. The ten codebooks are
+fed back to the slow AR as a single summed embedding on the next position. This engine
+drives the overridable ``BaseOnnxAdapter.synthesize`` rather than the single-graph
+``build_feed_dict`` path, like its siblings :mod:`phoonnx.engines.qwen3tts` and
+:mod:`phoonnx.engines.sparktts`.
+
+Three ONNX graphs (HF: ``OpenVoiceOS/phoonnx-zortzi-tts``, ``OpenVoiceOS/phoonnx-audio8-tts``)::
+
+    slow_ar.onnx        24-layer KV-cached backbone step (= the voice's ``session``)
+    fast_ar.onnx        4-layer depth transformer over the ten codebooks
+    codec_decoder.onnx  (1, 10, T) codes -> waveform @ 44.1 kHz
+
+plus ``tokenizer.json`` (the model's own Qwen2 subword BPE) and one small JSON per voice
+holding that voice's pre-encoded reference codes and the transcription of the clip they
+came from.
+
+**The voice is a reference clip, not a speaker id.** ArkTTS has no speaker table; the
+speaker token is always ``<|speaker:0|>``. A voice is carried by the codec codes of a
+short clip, which the prompt embeds directly, so the mirrors ship those codes rather than
+the audio — the adapter never needs the codec *encoder*, only the decoder.
+
+Two details of the ONNX contract are load-bearing:
+
+* **The KV cache is a fixed 2048-wide window**, not a growing tensor. Each graph writes
+  its new keys and values at ``input_pos`` and attends over the whole window, masking by
+  ``key <= input_pos[query]``. The graph returns only the delta, so this module keeps the
+  window and scatters into it. Writing a delta at the wrong offset gives wrong attention
+  and no error.
+* **The slow logits are sliced to 4097**, not the full 155776-entry vocabulary: the 4096
+  semantic logits followed by the EOS logit. Upstream masks everything else away before it
+  samples, so the export drops it. An index below 4096 is therefore already codebook 0's
+  value, with no offset to subtract.
+
+The sampler reproduces upstream's ``ArkttsModel._sample_semantic`` rather than the
+HuggingFace ``generate`` stack, and the order is *not* the usual one: the semantic mask
+runs first, then top-k and top-p together against the softmax of the **unscaled** logits,
+and temperature divides last. Upstream calls this the "legacy" order; applying temperature
+first, as HuggingFace does, changes which tokens survive the nucleus cut. On top of that
+sits repetition-aware sampling — see :func:`sample_semantic`.
+
+Greedy decoding is not offered. Both model cards state it runs into repetition loops that
+never reach EOS, so ``do_sample`` defaults to true and the parity harness in
+``scripts/conversion/arktts/`` is the only place greedy is used.
+"""
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import onnxruntime
+from quebra_frases import sentence_tokenize
+
+from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
+from phoonnx.tokenizer import BPETokenizer
+from phoonnx.util import LOG
+
+SAMPLE_RATE = 44100
+"""The codec decoder writes 44.1 kHz audio."""
+
+FRAME_SIZE = 2048
+"""Waveform samples per code frame — about 21.5 frames per second."""
+
+NUM_CODEBOOKS = 10
+"""Codebooks per frame: codebook 0 from the slow AR, 1..9 from the fast AR."""
+
+CODEBOOK_SIZE = 4096
+"""Entries per codebook, and the width of the slow AR's semantic logit block."""
+
+EOS_INDEX = CODEBOOK_SIZE
+"""Where EOS sits in the sliced slow logits, right after the 4096 semantic entries."""
+
+SLOW_LAYERS, SLOW_KV_HEADS, SLOW_HEAD_DIM = 24, 2, 64
+FAST_LAYERS, FAST_KV_HEADS, FAST_HEAD_DIM = 4, 2, 64
+
+MAX_SEQ_LEN = 2048
+"""The model's hard ceiling and the width of the slow cache."""
+
+MAX_NEW_TOKENS = 512
+"""Upstream's generation budget — about 24 seconds of audio at 21.5 frames per second."""
+
+RAS_WINDOW_SIZE = 10
+RAS_TOP_P = 0.9
+RAS_TEMPERATURE = 1.0
+"""Repetition-aware sampling: window length and the settings of the fallback draw."""
+
+SEMANTIC_BEGIN_ID = 151678
+"""First semantic token in the text vocabulary; sliced index ``i`` is this plus ``i``."""
+
+MAX_CHUNK_CHARS = 200
+"""Longest text handed to one autoregressive pass; longer input is split on sentences."""
+
+SYSTEM_PROMPT = "convert the provided text to speech reference to the following:\n\nText:\n"
+"""Opens the reference block. Upstream ``ArkttsProcessor._prompt_segments`` builds this."""
+
+
+def chunk_text(text: str, max_len: int = MAX_CHUNK_CHARS) -> List[str]:
+    """Pack whole sentences into chunks of at most ``max_len`` characters.
+
+    One chunk is one autoregressive pass. The budget is smaller than Qwen3-TTS's because
+    ArkTTS emits 21.5 frames per second against a 512-frame default, so a long chunk runs
+    out of frames before it runs out of text.
+    """
+    chunks: List[str] = []
+    for paragraph in (p.strip() for p in re.split(r"\n\s*\n+", text.strip())):
+        if not paragraph:
+            continue
+        current = ""
+        for sentence in sentence_tokenize(paragraph):
+            if len(current) + len(sentence) + 1 <= max_len:
+                current += (" " if current else "") + sentence
+            else:
+                if current:
+                    chunks.append(current.strip())
+                current = sentence
+        if current:
+            chunks.append(current.strip())
+    return chunks or ([text.strip()] if text.strip() else [])
+
+
+def filter_top_k_top_p(logits: np.ndarray, top_k: int, top_p: float) -> np.ndarray:
+    """Upstream's ``ArkttsLegacyTopKTopPLogitsProcessor``, kept in its own order.
+
+    Two things differ from the usual HuggingFace warpers and both change the result:
+
+    * the nucleus is measured on ``softmax(logits)`` *before* temperature is applied, so
+      temperature cannot widen or narrow it;
+    * the token that crosses the ``top_p`` threshold is removed rather than kept, because
+      the test is ``cumulative > top_p`` on the inclusive cumulative sum.
+
+    The top-ranked token always survives, which is what keeps the distribution non-empty
+    when one token already carries more than ``top_p`` of the mass.
+    """
+    scores = np.asarray(logits, np.float64).reshape(-1)
+    order = np.argsort(-scores, kind="stable")
+    ordered = scores[order]
+    shifted = np.exp(ordered - ordered.max())
+    cumulative = np.cumsum(shifted / shifted.sum())
+    remove = (cumulative > top_p) | (np.arange(ordered.size) >= top_k)
+    remove[0] = False
+    out = scores.copy()
+    out[order[remove]] = -np.inf
+    return out
+
+
+def draw(scores: np.ndarray, rng: np.random.Generator, do_sample: bool) -> int:
+    """Draw one index from already-filtered, already-tempered scores."""
+    scores = np.asarray(scores, np.float64).reshape(-1)
+    if not do_sample:
+        return int(np.argmax(scores))
+    finite = np.isfinite(scores)
+    shifted = np.where(finite, scores - scores[finite].max(), -np.inf)
+    probabilities = np.exp(shifted)
+    probabilities /= probabilities.sum()
+    return int(rng.choice(probabilities.size, p=probabilities))
+
+
+def sample_semantic(logits: np.ndarray, window: List[int], rng: np.random.Generator,
+                    temperature: float, top_k: int, top_p: float, do_sample: bool) -> int:
+    """Draw codebook 0 for one frame, with upstream's repetition-aware fallback.
+
+    The regular draw uses the caller's settings. If it lands on a semantic token that is
+    already in the last :data:`RAS_WINDOW_SIZE` tokens, upstream discards it and takes a
+    second draw made under tighter settings (``top_p`` 0.9 at temperature 1.0) instead.
+    That is what stops the model looping on one frame, and it is why the model cards say
+    greedy decoding never terminates: with ``do_sample`` off both draws are the same
+    argmax, so the fallback cannot break the loop.
+
+    ``window`` holds *text-vocabulary* ids, not sliced indices. That is not cosmetic —
+    upstream seeds the window with zeros, and zero is not a semantic token in the text
+    vocabulary but *is* a valid sliced index, so a window kept in sliced space would treat
+    an unfilled slot as a repeat of codebook value 0.
+    """
+    normal = draw(filter_top_k_top_p(logits, top_k, top_p) / max(temperature, 1e-5),
+                  rng, do_sample)
+    if not do_sample or normal == EOS_INDEX:
+        return normal
+    if SEMANTIC_BEGIN_ID + normal not in window:
+        return normal
+    return draw(filter_top_k_top_p(logits, top_k, RAS_TOP_P) / max(RAS_TEMPERATURE, 1e-5),
+                rng, do_sample)
+
+
+class ArkTTSAdapter(BaseOnnxAdapter):
+    """Adapter for ArkTTS (slow AR + fast AR + 44.1 kHz codec decoder)."""
+
+    def __init__(self):
+        self.fast_ar: Optional[onnxruntime.InferenceSession] = None
+        self.decoder: Optional[onnxruntime.InferenceSession] = None
+        self.tokenizer: Optional[BPETokenizer] = None
+        self.reference_codes: Optional[np.ndarray] = None
+        self.reference_text: str = ""
+        self._params: Dict[str, Any] = {}
+        self._prefix_ids: List[int] = []
+
+    def default_params(self) -> Dict[str, float]:
+        # Both model cards pin these and warn against greedy decoding; the checkpoints'
+        # generation_config.json is looser (0.7 / 0.9) and the cards override it.
+        return {"temperature": 0.8, "top_k": 50.0, "top_p": 0.95,
+                "max_new_tokens": float(MAX_NEW_TOKENS)}
+
+    def param_labels(self) -> Dict[str, str]:
+        return {"temperature": "Sampling temperature", "top_k": "Top-k",
+                "top_p": "Nucleus (top-p)", "max_new_tokens": "Frame budget per chunk"}
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def configure(self, voice_config: Any) -> None:
+        """Open the two side graphs, the model's subword BPE, and the voice's codes."""
+        ep = getattr(voice_config, "engine_params", None) or {}
+        self._params = dict(ep)
+        providers = ep.get("providers")
+
+        for attribute, key in (("fast_ar", "fast_ar_path"), ("decoder", "codec_decoder_path")):
+            if getattr(self, attribute) is None and ep.get(key):
+                setattr(self, attribute, make_session(ep[key], providers=providers))
+
+        if self.tokenizer is None and ep.get("bpe_tokenizer_path"):
+            self.tokenizer = BPETokenizer(ep["bpe_tokenizer_path"])
+
+        if self.reference_codes is None and ep.get("voice_codes_path"):
+            self.load_voice(ep["voice_codes_path"])
+
+    def load_voice(self, path: str) -> None:
+        """Read a voice asset: the reference clip's codes and its transcription.
+
+        The transcription is not decoration. It goes into the system prompt next to the
+        codes, so the model sees what the reference clip says; a wrong transcription
+        degrades the voice rather than raising anything.
+        """
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        codes = np.asarray(data["codes"], np.int64)
+        if codes.ndim != 2 or codes.shape[0] != NUM_CODEBOOKS or codes.shape[1] == 0:
+            raise ValueError(f"ArkTTS voice codes must have shape [{NUM_CODEBOOKS}, T>0], "
+                             f"got {codes.shape} from '{path}'")
+        if codes.min() < 0 or codes.max() >= CODEBOOK_SIZE:
+            raise ValueError(f"ArkTTS voice codes must be in [0, {CODEBOOK_SIZE - 1}]")
+        reference_text = str(data.get("reference_text") or "").strip()
+        if not reference_text:
+            raise ValueError(f"ArkTTS voice '{path}' has no reference_text")
+        self.reference_codes = codes
+        self.reference_text = reference_text
+        self._prefix_ids = []
+
+    # ------------------------------------------------------------------
+    # Text
+    # ------------------------------------------------------------------
+
+    def prefix_ids(self) -> List[int]:
+        """The system block that opens the reference, tokenized once per voice.
+
+        Upstream builds it by encoding each literal separately rather than encoding the
+        joined string, and the two are not the same under BPE — a merge across a boundary
+        would produce different ids. This reproduces the split.
+        """
+        if not self._prefix_ids:
+            speaker = self.reference_text
+            if not re.search(r"<\|speaker:\d+\|>", speaker):
+                speaker = f"<|speaker:0|>{speaker}"
+            self._prefix_ids = [
+                token
+                for part in ("<|im_start|>system\n", SYSTEM_PROMPT, speaker, "\n\nSpeech:\n")
+                for token in self.tokenizer.tokenize(part)
+            ]
+        return self._prefix_ids
+
+    def encode_text(self, text: str, voice: Any, syn_config: Any) -> List[List[int]]:
+        """Turn text into one *suffix* id list per autoregressive pass.
+
+        Only the suffix is returned. The prefix and the reference codes have to sit between
+        the two halves of the prompt, so :meth:`build_prompt` reassembles them; the prefix
+        depends on the voice alone and is cached by :meth:`prefix_ids`.
+        """
+        if self.tokenizer is None:
+            raise RuntimeError("ArkTTS voice missing bpe_tokenizer_path in engine_params")
+        return [
+            [token
+             for part in ("<|im_end|>\n", "<|im_start|>user\n", " ".join(chunk.split()),
+                          "<|im_end|>\n", "<|im_start|>assistant\n<|voice|>")
+             for token in self.tokenizer.tokenize(part)]
+            for chunk in chunk_text(text) if chunk.strip()
+        ]
+
+    # ------------------------------------------------------------------
+    # Prompt
+    # ------------------------------------------------------------------
+
+    def build_prompt(self, suffix_ids: np.ndarray) -> np.ndarray:
+        """Assemble the ``[1, 11, T]`` prompt the slow AR was trained on.
+
+        Row 0 is the token stream: the system prefix, then the reference clip's codebook-0
+        codes shifted into the semantic range, then the user text. Rows 1..10 hold the
+        reference clip's ten codebooks, aligned under those semantic tokens and zero
+        everywhere else — the model reads them only where row 0 names a semantic token.
+        """
+        if self.reference_codes is None:
+            raise RuntimeError("ArkTTS voice missing voice_codes_path in engine_params")
+        prefix = np.asarray(self.prefix_ids(), np.int64)
+        suffix = np.asarray(suffix_ids, np.int64).reshape(-1)
+        codes = self.reference_codes
+        frames = codes.shape[1]
+
+        row0 = np.concatenate([prefix, codes[0] + SEMANTIC_BEGIN_ID, suffix])
+        prompt = np.zeros((1, NUM_CODEBOOKS + 1, row0.size), np.int64)
+        prompt[0, 0] = row0
+        prompt[0, 1:, prefix.size:prefix.size + frames] = codes
+        if prompt.shape[2] >= MAX_SEQ_LEN:
+            raise ValueError(f"ArkTTS prompt is {prompt.shape[2]} tokens; the model holds "
+                             f"fewer than {MAX_SEQ_LEN}")
+        return prompt
+
+    # ------------------------------------------------------------------
+    # Cache plumbing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def cache_dtype(session: onnxruntime.InferenceSession) -> np.dtype:
+        """Half or single precision, whichever this graph was exported in."""
+        types = {i.name: i.type for i in session.get_inputs()}
+        return np.float16 if types.get("cache_key_0") == "tensor(float16)" else np.float32
+
+    def empty_cache(self, session, layers: int, width: int, heads: int,
+                    head_dim: int) -> Dict[str, np.ndarray]:
+        """The fixed-width window a fresh pass starts from.
+
+        Slots are zero and stay unread until the loop writes them: the graph masks by
+        ``key <= input_pos[query]``, so an unwritten slot can never enter a softmax.
+        """
+        dtype = self.cache_dtype(session)
+        return {f"cache_{kind}_{i}": np.zeros((1, heads, width, head_dim), dtype)
+                for i in range(layers) for kind in ("key", "value")}
+
+    @staticmethod
+    def scatter_cache(cache: Dict[str, np.ndarray], outputs: Dict[str, np.ndarray],
+                      layers: int, input_pos: np.ndarray) -> None:
+        """Write this step's deltas into the window at the positions they belong to."""
+        for index in range(layers):
+            for kind in ("key", "value"):
+                cache[f"cache_{kind}_{index}"][:, :, input_pos] = outputs[f"{kind}_delta_{index}"]
+
+    # ------------------------------------------------------------------
+    # Fast AR
+    # ------------------------------------------------------------------
+
+    def generate_codebooks(self, slow_hidden: np.ndarray, first: int, rng, temperature: float,
+                           top_k: int, top_p: float, do_sample: bool) -> List[int]:
+        """Run the fast AR over codebooks 1..9 of one frame.
+
+        Codebook 0 is the slow AR's own token and is passed in, not predicted here.
+        Position 0 of the fast AR reads the slow hidden state and its logits are thrown
+        away — it exists to seed the depth cache, which is what upstream's
+        ``_generate_codebooks`` does before its loop starts.
+        """
+        names = [o.name for o in self.fast_ar.get_outputs()]
+        dtype = np.float16 if self.fast_ar.get_inputs()[0].type == "tensor(float16)" else np.float32
+        cache = self.empty_cache(self.fast_ar, FAST_LAYERS, NUM_CODEBOOKS,
+                                 FAST_KV_HEADS, FAST_HEAD_DIM)
+
+        def step(position: int, hidden: np.ndarray, token: int, use_hidden: bool):
+            input_pos = np.asarray([position], np.int64)
+            outputs = dict(zip(names, self.fast_ar.run(None, {
+                "slow_hidden": hidden.astype(dtype),
+                "token_id": np.asarray([[token]], np.int64),
+                "use_slow_hidden": np.asarray([use_hidden], bool),
+                "input_pos": input_pos, **cache})))
+            self.scatter_cache(cache, outputs, FAST_LAYERS, input_pos)
+            return outputs["logits"]
+
+        zeros = np.zeros((1, 1, slow_hidden.shape[-1]), dtype)
+        step(0, slow_hidden, 0, True)
+        codebooks = [first]
+        for position in range(1, NUM_CODEBOOKS):
+            logits = step(position, zeros, codebooks[-1], False)
+            scores = filter_top_k_top_p(logits[0, -1], top_k, top_p) / max(temperature, 1e-5)
+            codebooks.append(draw(scores, rng, do_sample))
+        return codebooks
+
+    # ------------------------------------------------------------------
+    # Slow AR
+    # ------------------------------------------------------------------
+
+    def generate_codes(self, session: onnxruntime.InferenceSession, prompt: np.ndarray,
+                       params: Dict[str, Any], rng: np.random.Generator) -> np.ndarray:
+        """Run both autoregressive loops and return the ``(10, frames)`` code matrix."""
+        do_sample = bool(params.get("do_sample", True))
+        temperature = float(params.get("temperature", 0.8))
+        top_k = int(params.get("top_k", 50))
+        top_p = float(params.get("top_p", 0.95))
+        width = prompt.shape[2]
+        budget = min(int(params.get("max_new_tokens", MAX_NEW_TOKENS)), MAX_SEQ_LEN - width)
+
+        names = [o.name for o in session.get_outputs()]
+        cache = self.empty_cache(session, SLOW_LAYERS, MAX_SEQ_LEN, SLOW_KV_HEADS, SLOW_HEAD_DIM)
+        input_pos = np.arange(width, dtype=np.int64)
+        step_codes = prompt
+        window: List[int] = []
+        frames: List[List[int]] = []
+
+        for _ in range(budget):
+            outputs = dict(zip(names, session.run(
+                None, {"codes": step_codes, "input_pos": input_pos, **cache})))
+            self.scatter_cache(cache, outputs, SLOW_LAYERS, input_pos)
+
+            semantic = sample_semantic(outputs["logits"][0, -1], window, rng,
+                                       temperature, top_k, top_p, do_sample)
+            if semantic == EOS_INDEX:
+                break
+            codebooks = self.generate_codebooks(
+                outputs["slow_hidden"][:, -1:], semantic, rng, temperature, top_k, top_p, do_sample)
+            frames.append(codebooks)
+
+            # Upstream fills the window only from the *second* frame on: it creates the
+            # buffer after the first draw and writes into it from the next one. Reproduced
+            # here, so the first frame is never treated as a repeat of itself.
+            if window:
+                window.append(SEMANTIC_BEGIN_ID + semantic)
+                del window[:-RAS_WINDOW_SIZE]
+            else:
+                window = [0] * RAS_WINDOW_SIZE
+
+            input_pos = np.asarray([input_pos[-1] + 1], np.int64)
+            step_codes = np.asarray(codebooks, np.int64).reshape(1, NUM_CODEBOOKS, 1)
+            step_codes = np.concatenate(
+                [np.full((1, 1, 1), SEMANTIC_BEGIN_ID + semantic, np.int64), step_codes], axis=1)
+
+        if not frames:
+            return np.zeros((NUM_CODEBOOKS, 0), np.int64)
+        return np.asarray(frames, np.int64).T
+
+    # ------------------------------------------------------------------
+    # Codec decoder
+    # ------------------------------------------------------------------
+
+    def decode_codes(self, codes: np.ndarray) -> np.ndarray:
+        """Turn a ``(10, frames)`` code matrix into a waveform at 44.1 kHz."""
+        feed = np.asarray(codes, np.int64).reshape(1, NUM_CODEBOOKS, -1)
+        audio = self.decoder.run(None, {"codes": feed})[0]
+        return np.asarray(audio, np.float32).reshape(-1)
+
+    # ------------------------------------------------------------------
+    # Synthesis
+    # ------------------------------------------------------------------
+
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        for attribute, key in (("fast_ar", "fast_ar_path"), ("decoder", "codec_decoder_path")):
+            if getattr(self, attribute) is None:
+                raise RuntimeError(f"ArkTTS voice missing {key} in engine_params")
+
+        params = request.params
+        prompt = self.build_prompt(request.phoneme_ids)
+        rng = np.random.default_rng(params.get("seed"))
+        codes = self.generate_codes(session, prompt, params, rng)
+        if codes.shape[1] == 0:
+            LOG.warning("ArkTTS produced no code frames for this chunk")
+            return AdapterSynthesisResult(audio=np.zeros(0, np.float32))
+
+        audio = self.decode_codes(codes)
+        return AdapterSynthesisResult(
+            audio=audio, extras={"frame_count": int(codes.shape[1]),
+                                 "reference_text": self.reference_text})
+
+    # build_feed_dict / parse_outputs are required by the ABC but unused — synthesize()
+    # drives the two autoregressive loops directly.
+    def build_feed_dict(self, request: AdapterSynthesisRequest,
+                        session: onnxruntime.InferenceSession) -> Dict[str, np.ndarray]:
+        raise NotImplementedError("ArkTTS is autoregressive — use synthesize()")
+
+    def parse_outputs(self, outputs: List[np.ndarray], request: AdapterSynthesisRequest,
+                      output_names: Optional[List[str]] = None) -> AdapterSynthesisResult:
+        raise NotImplementedError("ArkTTS is autoregressive — use synthesize()")
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        return bool(config and config.get("engine") == "arktts")

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -658,7 +658,7 @@ class TTSModelManager:
         "coqui_vits.json", "BSC.json", "shami.json", "chatterbox.json",
         "supertonic.json", "neutts.json", "pockettts.json", "sparktts.json",
         "qwen3tts.json",
-        "outetts.json",
+        "outetts.json", "arktts.json",
     )
 
     @classmethod

--- a/phoonnx/voice_index/arktts.json
+++ b/phoonnx/voice_index/arktts.json
@@ -2,7 +2,7 @@
  "arktts/zortzi-maider/eu": {
   "voice_id": "arktts/zortzi-maider/eu",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -25,7 +25,7 @@
  "arktts/zortzi-antton/eu": {
   "voice_id": "arktts/zortzi-antton/eu",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -48,7 +48,7 @@
  "arktts/audio8-maider/yue": {
   "voice_id": "arktts/audio8-maider/yue",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -71,7 +71,7 @@
  "arktts/audio8-maider/zh": {
   "voice_id": "arktts/audio8-maider/zh",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -94,7 +94,7 @@
  "arktts/audio8-maider/nl": {
   "voice_id": "arktts/audio8-maider/nl",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -117,7 +117,7 @@
  "arktts/audio8-maider/en": {
   "voice_id": "arktts/audio8-maider/en",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -140,7 +140,7 @@
  "arktts/audio8-maider/fr": {
   "voice_id": "arktts/audio8-maider/fr",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -163,7 +163,7 @@
  "arktts/audio8-maider/de": {
   "voice_id": "arktts/audio8-maider/de",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -186,7 +186,7 @@
  "arktts/audio8-maider/it": {
   "voice_id": "arktts/audio8-maider/it",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -209,7 +209,7 @@
  "arktts/audio8-maider/ja": {
   "voice_id": "arktts/audio8-maider/ja",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -232,7 +232,7 @@
  "arktts/audio8-maider/ko": {
   "voice_id": "arktts/audio8-maider/ko",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -255,7 +255,7 @@
  "arktts/audio8-maider/pl": {
   "voice_id": "arktts/audio8-maider/pl",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -278,7 +278,7 @@
  "arktts/audio8-maider/es": {
   "voice_id": "arktts/audio8-maider/es",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -301,7 +301,7 @@
  "arktts/audio8-antton/yue": {
   "voice_id": "arktts/audio8-antton/yue",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -324,7 +324,7 @@
  "arktts/audio8-antton/zh": {
   "voice_id": "arktts/audio8-antton/zh",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -347,7 +347,7 @@
  "arktts/audio8-antton/nl": {
   "voice_id": "arktts/audio8-antton/nl",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -370,7 +370,7 @@
  "arktts/audio8-antton/en": {
   "voice_id": "arktts/audio8-antton/en",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -393,7 +393,7 @@
  "arktts/audio8-antton/fr": {
   "voice_id": "arktts/audio8-antton/fr",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -416,7 +416,7 @@
  "arktts/audio8-antton/de": {
   "voice_id": "arktts/audio8-antton/de",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -439,7 +439,7 @@
  "arktts/audio8-antton/it": {
   "voice_id": "arktts/audio8-antton/it",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -462,7 +462,7 @@
  "arktts/audio8-antton/ja": {
   "voice_id": "arktts/audio8-antton/ja",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -485,7 +485,7 @@
  "arktts/audio8-antton/ko": {
   "voice_id": "arktts/audio8-antton/ko",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -508,7 +508,7 @@
  "arktts/audio8-antton/pl": {
   "voice_id": "arktts/audio8-antton/pl",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,
@@ -531,7 +531,7 @@
  "arktts/audio8-antton/es": {
   "voice_id": "arktts/audio8-antton/es",
   "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
-  "config_url": null,
+  "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/config.json",
   "vocab_url": null,
   "tokens_url": null,
   "tokenizer_config_url": null,

--- a/phoonnx/voice_index/arktts.json
+++ b/phoonnx/voice_index/arktts.json
@@ -1,0 +1,554 @@
+{
+ "arktts/zortzi-maider/eu": {
+  "voice_id": "arktts/zortzi-maider/eu",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "eu-ES",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Zortzi-TTS Maider (female, Basque)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/zortzi-antton/eu": {
+  "voice_id": "arktts/zortzi-antton/eu",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "eu-ES",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Zortzi-TTS Antton (male, Basque)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-maider/yue": {
+  "voice_id": "arktts/audio8-maider/yue",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "yue-HK",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Cantonese)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/zh": {
+  "voice_id": "arktts/audio8-maider/zh",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "zh-CN",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Chinese)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/nl": {
+  "voice_id": "arktts/audio8-maider/nl",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "nl-NL",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Dutch)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/en": {
+  "voice_id": "arktts/audio8-maider/en",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "en-US",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, English)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/fr": {
+  "voice_id": "arktts/audio8-maider/fr",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "fr-FR",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, French)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/de": {
+  "voice_id": "arktts/audio8-maider/de",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "de-DE",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, German)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/it": {
+  "voice_id": "arktts/audio8-maider/it",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "it-IT",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Italian)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/ja": {
+  "voice_id": "arktts/audio8-maider/ja",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "ja-JP",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Japanese)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/ko": {
+  "voice_id": "arktts/audio8-maider/ko",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "ko-KR",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Korean)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/pl": {
+  "voice_id": "arktts/audio8-maider/pl",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "pl-PL",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Polish)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-maider/es": {
+  "voice_id": "arktts/audio8-maider/es",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "es-ES",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/maider.json"
+  },
+  "display_name": "Audio8-TTS Maider (female, Spanish)",
+  "engine_options": {
+   "voice": "maider"
+  }
+ },
+ "arktts/audio8-antton/yue": {
+  "voice_id": "arktts/audio8-antton/yue",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "yue-HK",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Cantonese)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/zh": {
+  "voice_id": "arktts/audio8-antton/zh",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "zh-CN",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Chinese)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/nl": {
+  "voice_id": "arktts/audio8-antton/nl",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "nl-NL",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Dutch)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/en": {
+  "voice_id": "arktts/audio8-antton/en",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "en-US",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, English)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/fr": {
+  "voice_id": "arktts/audio8-antton/fr",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "fr-FR",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, French)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/de": {
+  "voice_id": "arktts/audio8-antton/de",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "de-DE",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, German)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/it": {
+  "voice_id": "arktts/audio8-antton/it",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "it-IT",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Italian)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/ja": {
+  "voice_id": "arktts/audio8-antton/ja",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "ja-JP",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Japanese)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/ko": {
+  "voice_id": "arktts/audio8-antton/ko",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "ko-KR",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Korean)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/pl": {
+  "voice_id": "arktts/audio8-antton/pl",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "pl-PL",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Polish)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ },
+ "arktts/audio8-antton/es": {
+  "voice_id": "arktts/audio8-antton/es",
+  "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/slow_ar_fp16.onnx",
+  "config_url": null,
+  "vocab_url": null,
+  "tokens_url": null,
+  "tokenizer_config_url": null,
+  "phoneme_map_url": null,
+  "phoneme_type": "unicode",
+  "alphabet": "graphemes",
+  "engine": "arktts",
+  "lang": "es-ES",
+  "aux_model_urls": {
+   "fast_ar_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/fast_ar_fp16.onnx",
+   "codec_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/codec_decoder_fp16.onnx",
+   "bpe_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/tokenizer.json",
+   "voice_codes_path": "https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts/resolve/main/voices/antton.json"
+  },
+  "display_name": "Audio8-TTS Antton (male, Spanish)",
+  "engine_options": {
+   "voice": "antton"
+  }
+ }
+}

--- a/scripts/conversion/arktts/README.md
+++ b/scripts/conversion/arktts/README.md
@@ -1,0 +1,146 @@
+# ArkTTS conversion toolchain
+
+ArkTTS is the DualAR text-to-speech architecture behind two Apache-2.0 checkpoints:
+
+| Checkpoint | Languages | Voices |
+|---|---|---|
+| [`Audio8/Audio8-TTS-Preview-0.6b`](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.6b) | yue, zh, nl, en, fr, de, it, ja, ko, pl, es | none bundled — zero-shot cloning |
+| [`itzune/zortzi-tts`](https://huggingface.co/itzune/zortzi-tts) | eu (Basque) | Maider, Antton |
+
+The second is a fine-tune of the first, and the two ship **byte-identical**
+`modeling_arktts.py`, `modeling_arktts_codec.py`, `processing_arktts.py`, `tokenizer.json`
+and `codec.pth`. One ONNX contract therefore covers both, one engine
+(`phoonnx/engines/arktts.py`) drives both, and the codec decoder graph is interchangeable
+between them.
+
+## The contract
+
+Three graphs, named exactly as the official export at
+[`itzune/zortzi-tts-onnx`](https://huggingface.co/itzune/zortzi-tts-onnx) names them, so
+graphs from either source are drop-in replacements for each other.
+
+```
+slow_ar_<precision>.onnx     24-layer backbone; one step over T positions
+  in   codes[1, 11, T] int64, input_pos[T] int64,
+       cache_key_{0..23} / cache_value_{0..23}  [1, 2, 2048, 64]
+  out  logits[1, T, 4097], slow_hidden[1, T, 896],
+       key_delta_{i} / value_delta_{i}          [1, 2, T, 64]
+
+fast_ar_<precision>.onnx     4-layer depth transformer over the ten codebooks
+  in   slow_hidden[1, 1, 896], token_id[1, 1] int64, use_slow_hidden[1] bool,
+       input_pos[1] int64, cache_key_{0..3} / cache_value_{0..3}  [1, 2, 10, 64]
+  out  logits[1, 1, 4096], key_delta_{i} / value_delta_{i}        [1, 2, 1, 64]
+
+codec_decoder_fp16.onnx      codes[1, 10, T] int64 -> audio[1, 1, samples] @ 44.1 kHz
+```
+
+Two properties are load-bearing:
+
+* **The KV cache is a fixed 2048-wide window.** A graph writes its new keys and values at
+  `input_pos` and attends over the whole window, masking by `key <= input_pos[query]`.
+  Slots the loop never wrote hold zeros and stay out of the softmax. The graph returns only
+  the delta, so the caller keeps the window. Scattering a delta to the wrong offset gives
+  wrong attention and no error.
+* **The slow logits are sliced to 4097** — the 4096 semantic logits followed by the EOS
+  logit. Upstream masks everything else before sampling, so the full 155776-entry vocabulary
+  is never read. An index below 4096 is already codebook 0's value.
+
+## Scripts
+
+### `export_arktts_onnx.py`
+
+```bash
+python export_arktts_onnx.py --repo Audio8/Audio8-TTS-Preview-0.6b \
+    --out-dir ./onnx --fp16 --drop-fp32
+```
+
+Nothing is vendored: the checkpoint's own modeling code loads through `transformers`, and
+`arktts_wrappers.py` only re-plumbs the KV cache, which upstream hides in `nn.Module`
+buffers the exporter cannot carry.
+
+Four upstream constructs need handling before the tracer accepts the model, and each is a
+named function with the reasoning in its docstring:
+
+| Construct | Why it blocks | What the script does |
+|---|---|---|
+| `mask &= ...` in the codec's window transformer | `aten::__iand_` has no opset-17 lowering | registers a symbolic mapping it to `And` |
+| `torch.polar` in the codec's rotary table | opset 17 has no complex tensors | rebuilds the table from `cos`/`sin` |
+| `_extra_padding`'s `math.ceil` over a traced shape | lowers to an unsupported op | drops it, after asserting every causal convolution *on the decode path* is stride 1, where the padding is provably zero |
+| `x.float()` / `.to(x.dtype)` in the RMS norms and rotary application | become `Cast` nodes with hard-coded types that the fp16 converter cannot reconcile | removes them; they are no-ops in a float32 export |
+
+**Use `transformers==4.57.x`.** On transformers 5.x the checkpoint's non-persistent RoPE
+buffer is never initialised, and the reference model silently produces `NaN` logits rather
+than failing — every parity number would come out as `NaN`.
+
+**The codec decoder is written in single precision only.** Its window transformer builds a
+rotary table inside the graph, and the half-precision converter leaves that `Einsum` with
+one single- and one half-precision operand, which ONNX Runtime rejects. Since both
+checkpoints carry the same `codec.pth`, the fp16 codec decoder published at
+`itzune/zortzi-tts-onnx` decodes either model's codes; `verify_parity.py` confirms it
+against whichever checkpoint you point it at.
+
+### `verify_parity.py`
+
+```bash
+python verify_parity.py --repo itzune/zortzi-tts --onnx-dir ./onnx --precision fp16 \
+    --voice-codes voices/maider.json --text "Kaixo mundua." --steps 24
+```
+
+Compares four things against the PyTorch checkpoint, and all four must hold before a mirror
+is published:
+
+1. the `[1, 11, T]` prompt the engine builds against the one upstream's own processor and
+   `_prepare_prompt` build — exact equality, no tolerance;
+2. slow-AR logits and hidden states at prefill and at every decode step;
+3. fast-AR logits for all nine predicted codebooks of every frame;
+4. the codec decoder's waveform for a fixed code matrix.
+
+Both stacks are driven in lockstep by greedy decoding so they follow the same path. Greedy
+is used *only here* — both model cards state it loops forever in real synthesis.
+
+The gate is greedy agreement, not the raw difference. For each disagreement the script also
+reports the reference's own top-1 minus top-2 margin: a miss whose margin is smaller than
+the logit difference is the two stacks splitting a tie that precision decided, while a miss
+with a wide margin is a defect.
+
+### `mint_voice.py`
+
+An ArkTTS voice is not a speaker id — the model has no speaker table and always emits
+`<|speaker:0|>`. A voice is the codec codes of a short clip plus that clip's transcription,
+and the prompt embeds both.
+
+```bash
+python mint_voice.py --repo Audio8/Audio8-TTS-Preview-0.6b \
+    --audio antton.wav --text "Inguru hura gerrillarien esku izan da denbora luzean." \
+    --name antton --out voices/antton.json
+```
+
+The codec *encoder* runs here and never ships: phoonnx only needs the decoder at synthesis
+time, because voices arrive pre-encoded. Minting is an offline step.
+
+Keep the clip short and prosodically flat — upstream selected its own references by
+pitch-range ratio precisely because an expressive reference bleeds its intonation into
+every sentence the voice later speaks.
+
+### `synthesize_samples.py` and `wer_gate.py`
+
+Drive the adapter over a sentence list, write WAVs and per-voice CPU RTF, then transcribe
+the result with a CPU `onnx-asr` model and score it. Sentences may carry a `lang|` prefix so
+one run can cover several languages; `zh`, `yue` and `ja` are scored by character.
+
+The WER gate is an intelligibility check, not an ASR benchmark. It catches what logit parity
+cannot see: a wrong prompt layout, a mis-scattered cache, or a sampler drifting into a
+repetition loop.
+
+## Known limitations
+
+* **INT4 is not shipped.** The official `*_int4.onnx` graphs fail parity badly — see the
+  table in the pull request. They are left out rather than published.
+* **No codec encoder graph.** Zero-shot cloning from a user's own clip therefore needs
+  `mint_voice.py` offline. The encoder's strided causal convolutions do need the dynamic
+  right-padding this script removes for the decode path, so exporting it is real work rather
+  than a flag.
+* **The slow AR carries the tied embedding twice**, about 270 MB of half-precision weights,
+  because the tracer materialises the output projection separately from the embedding table.
+  `deduplicate_initializers` collapses byte-identical initializers and does not catch this
+  one.

--- a/scripts/conversion/arktts/arktts_wrappers.py
+++ b/scripts/conversion/arktts/arktts_wrappers.py
@@ -1,0 +1,267 @@
+"""Export wrappers that put the ArkTTS DualAR model into the phoonnx ONNX contract.
+
+ArkTTS (``itzune/zortzi-tts``, ``Audio8/Audio8-TTS-Preview-0.6b``) ships its model code
+on the Hub, so nothing is vendored here: ``AutoModel(trust_remote_code=True)`` builds the
+graph and these wrappers only re-plumb the KV cache, which the upstream code hides inside
+``nn.Module`` buffers that ``torch.onnx.export`` cannot carry.
+
+Three graphs come out, and they match the contract of the official export at
+``itzune/zortzi-tts-onnx`` name for name, so either set of weights drives the same runtime:
+
+``slow_ar``
+    ``codes[1, 11, T] int64``, ``input_pos[T] int64``, ``cache_key_{0..23}`` and
+    ``cache_value_{0..23}``, each ``[1, 2, 2048, 64]``
+    -> ``logits[1, T, 4097]``, ``slow_hidden[1, T, 896]``,
+    ``key_delta_{i}`` / ``value_delta_{i}`` ``[1, 2, T, 64]``
+
+``fast_ar``
+    ``slow_hidden[1, 1, 896]``, ``token_id[1, 1] int64``, ``use_slow_hidden[1] bool``,
+    ``input_pos[1] int64``, ``cache_key_{0..3}`` / ``cache_value_{0..3}`` ``[1, 2, 10, 64]``
+    -> ``logits[1, 1, 4096]``, ``key_delta_{i}`` / ``value_delta_{i}`` ``[1, 2, 1, 64]``
+
+``codec_decoder``
+    ``codes[1, 10, T] int64`` -> ``audio[1, 1, samples]`` at 44.1 kHz
+
+Two decisions in the contract are worth spelling out, because getting either wrong gives
+audio that sounds plausible and is wrong:
+
+* **The cache is a fixed 2048-wide window, not a growing tensor.** The graph writes the
+  new keys and values into a copy of the cache at ``input_pos``, then attends over the
+  whole window. Positions that were never written are masked out by the causal rule
+  ``key <= input_pos[query]`` — this is the ``"valid_prefix"`` layout the official
+  ``runtime_manifest.json`` declares. The caller still gets the deltas back so it can
+  keep its own copy of the cache in sync.
+* **The slow logits are sliced, not full.** Upstream masks every token outside the
+  semantic range and the EOS token before it samples, so a full ``[1, T, 155776]`` output
+  would be ~600 MB of prefill that sampling never reads. The graph emits the 4096 semantic
+  logits followed by the EOS logit at index 4096 — the ``"semantic_then_eos"`` layout.
+
+The wrappers hold no state: every cache tensor is an input and every update is an output,
+which is what lets one graph serve both prefill and decode.
+"""
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+SLOW_CACHE_WIDTH = 2048
+"""Positions the slow cache holds — ``config.max_seq_len``, the model's hard ceiling."""
+
+EOS_LOGIT_INDEX = 4096
+"""Where the EOS logit sits in the sliced slow output, right after the 4096 semantic ones."""
+
+
+def precompute_rope(length: int, head_dim: int, base: float) -> Tensor:
+    """The rotary table upstream builds, in float32 instead of bfloat16.
+
+    Upstream casts the table to bfloat16 in ``_precompute_rope``. Keeping float32 here
+    costs nothing at export time and removes a quantisation step that would otherwise be
+    baked into the graph as a constant, so the exported model is never *worse* than the
+    checkpoint it came from.
+    """
+    frequencies = 1.0 / (base ** (torch.arange(0, head_dim, 2).float()[: head_dim // 2] / head_dim))
+    phases = torch.outer(torch.arange(length).float(), frequencies)
+    return torch.stack((torch.cos(phases), torch.sin(phases)), dim=-1)
+
+
+def apply_rope(x: Tensor, rope: Tensor) -> Tensor:
+    """Rotate ``[B, T, H, D]`` by the ``[T, D/2, 2]`` table, as upstream's ``_apply_rope``.
+
+    Upstream brackets this in ``x.float()`` / ``.to(x.dtype)`` to protect a bfloat16
+    checkpoint. Export runs in float32, where both are no-ops, and they are left out on
+    purpose: they survive tracing as ``Cast`` nodes with hard-coded target types, and those
+    are what make the half-precision converter produce a graph ONNX Runtime will not load.
+    """
+    shaped = x.reshape(*x.shape[:-1], -1, 2)
+    rope = rope[None, :, None]
+    rotated = torch.stack(
+        (
+            shaped[..., 0] * rope[..., 0] - shaped[..., 1] * rope[..., 1],
+            shaped[..., 1] * rope[..., 0] + shaped[..., 0] * rope[..., 1],
+        ),
+        dim=-1,
+    )
+    return rotated.flatten(3)
+
+
+def attention_with_cache(
+    module: nn.Module,
+    x: Tensor,
+    rope: Tensor,
+    input_pos: Tensor,
+    cache_key: Tensor,
+    cache_value: Tensor,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """One attention block against an explicit fixed-width cache.
+
+    Returns the block output plus the new keys and values, so the caller can emit them as
+    graph outputs. ``module`` is an upstream ``ArkttsAttention``; only its weights are used.
+
+    The mask is ``key <= input_pos[query]`` over the whole cache window. Slots the loop has
+    not written yet hold zeros, and this rule is what keeps them out of the softmax — there
+    is no separate validity mask, which is why a caller that writes the deltas back to the
+    wrong offset gets silently wrong attention rather than an error.
+    """
+    batch, length, _ = x.shape
+    query_size = module.n_head * module.head_dim
+    kv_size = module.n_local_heads * module.head_dim
+    query, key, value = module.wqkv(x).split((query_size, kv_size, kv_size), dim=-1)
+    query = query.view(batch, length, module.n_head, module.head_dim)
+    key = key.view(batch, length, module.n_local_heads, module.head_dim)
+    value = value.view(batch, length, module.n_local_heads, module.head_dim)
+    if module.qk_norm:
+        query = module.q_norm(query)
+        key = module.k_norm(key)
+    query = apply_rope(query, rope).transpose(1, 2)
+    key = apply_rope(key, rope).transpose(1, 2)
+    value = value.transpose(1, 2)
+
+    full_key = cache_key.index_copy(2, input_pos, key)
+    full_value = cache_value.index_copy(2, input_pos, value)
+
+    repeats = module.n_head // module.n_local_heads
+    attend_key = full_key.repeat_interleave(repeats, dim=1)
+    attend_value = full_value.repeat_interleave(repeats, dim=1)
+
+    key_positions = torch.arange(full_key.shape[2], device=x.device)
+    mask = (key_positions[None, :] <= input_pos[:, None])[None, None]
+    scores = query @ attend_key.transpose(-2, -1) / math.sqrt(module.head_dim)
+    scores = scores.masked_fill(~mask, torch.finfo(scores.dtype).min)
+    output = torch.softmax(scores, dim=-1) @ attend_value
+    output = output.transpose(1, 2).contiguous().view(batch, length, query_size)
+    return module.wo(output), key, value
+
+
+def block_with_cache(block: nn.Module, x, rope, input_pos, cache_key, cache_value):
+    """An upstream ``ArkttsTransformerBlock`` driven through :func:`attention_with_cache`."""
+    attended, key, value = attention_with_cache(
+        block.attention, block.attention_norm(x), rope, input_pos, cache_key, cache_value
+    )
+    hidden = x + attended
+    return hidden + block.feed_forward(block.ffn_norm(hidden)), key, value
+
+
+class SlowARWrapper(nn.Module):
+    """The 24-layer backbone: one step over ``T`` positions, cache in and cache out.
+
+    ``T`` is the whole prompt on the first call and 1 on every call after it. The same
+    graph serves both, so the runtime never loads a second copy of 600 M parameters just
+    to prefill.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+        config = model.config
+        self.num_codebooks = int(config.num_codebooks)
+        self.codebook_size = int(config.codebook_size)
+        self.semantic_begin_id = int(config.semantic_begin_id)
+        self.semantic_end_id = int(config.semantic_end_id)
+        self.eos_token_id = int(config.eos_token_id)
+        self.norm_fastlayer_input = bool(config.norm_fastlayer_input)
+        self.register_buffer(
+            "rope_table",
+            precompute_rope(SLOW_CACHE_WIDTH, config.head_dim, config.rope_base),
+            persistent=False,
+        )
+
+    def embed(self, codes: Tensor) -> Tensor:
+        """Row 0 is the semantic token; rows 1..10 are the codebooks of the *same* frame.
+
+        The codebook rows only contribute when row 0 names a semantic token. On the text
+        part of the prompt they are zero-filled padding, and adding their embeddings there
+        would corrupt the text conditioning — hence the ``torch.where``, which upstream
+        also applies in ``ArkttsModel._embed``.
+        """
+        model = self.model
+        codebook_embeds = [
+            model.codebook_embeddings(codes[:, index + 1] + index * self.codebook_size)
+            for index in range(self.num_codebooks)
+        ]
+        codebook_sum = torch.stack(codebook_embeds, dim=1).sum(dim=1)
+        semantic = (codes[:, 0] >= self.semantic_begin_id) & (codes[:, 0] <= self.semantic_end_id)
+        codebook_sum = torch.where(semantic.unsqueeze(-1), codebook_sum, torch.zeros_like(codebook_sum))
+        return model.embeddings(codes[:, 0]) + codebook_sum
+
+    def forward(self, codes: Tensor, input_pos: Tensor, *cache: Tensor) -> Tuple[Tensor, ...]:
+        model = self.model
+        hidden = self.embed(codes)
+        rope = self.rope_table[input_pos]
+        deltas: List[Tensor] = []
+        for index, layer in enumerate(model.layers):
+            hidden, key, value = block_with_cache(
+                layer, hidden, rope, input_pos, cache[2 * index], cache[2 * index + 1]
+            )
+            deltas.extend((key, value))
+        normalized = model.norm(hidden)
+        full_logits = F.linear(normalized, model.embeddings.weight)
+        logits = torch.cat(
+            (
+                full_logits[..., self.semantic_begin_id : self.semantic_end_id + 1],
+                full_logits[..., self.eos_token_id : self.eos_token_id + 1],
+            ),
+            dim=-1,
+        )
+        slow_hidden = normalized if self.norm_fastlayer_input else hidden
+        return (logits, slow_hidden, *deltas)
+
+
+class FastARWrapper(nn.Module):
+    """The 4-layer depth transformer that writes codebooks 1..9 of one frame.
+
+    Position 0 reads the backbone's hidden state and exists only to seed the cache — its
+    logits are discarded, exactly as upstream's ``_generate_codebooks`` discards them.
+    Positions 1..9 read the previous codebook's token. ``use_slow_hidden`` selects between
+    the two, so one graph covers all ten positions.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+        config = model.config
+        self.register_buffer(
+            "rope_table",
+            precompute_rope(config.num_codebooks, config.fast_head_dim, config.rope_base),
+            persistent=False,
+        )
+
+    def forward(
+        self,
+        slow_hidden: Tensor,
+        token_id: Tensor,
+        use_slow_hidden: Tensor,
+        input_pos: Tensor,
+        *cache: Tensor,
+    ) -> Tuple[Tensor, ...]:
+        model = self.model
+        projected = model.fast_project_in(slow_hidden)
+        embedded = model.fast_embeddings(token_id)
+        hidden = torch.where(use_slow_hidden.reshape(-1, 1, 1), projected, embedded)
+        rope = self.rope_table[input_pos]
+        deltas: List[Tensor] = []
+        for index, layer in enumerate(model.fast_layers):
+            hidden, key, value = block_with_cache(
+                layer, hidden, rope, input_pos, cache[2 * index], cache[2 * index + 1]
+            )
+            deltas.extend((key, value))
+        logits = model.fast_output(model.fast_norm(hidden))
+        return (logits, *deltas)
+
+
+class CodecDecoderWrapper(nn.Module):
+    """``[1, 10, T]`` residual-VQ codes -> ``[1, 1, samples]`` waveform at 44.1 kHz.
+
+    Both checkpoints carry a byte-identical ``codec.pth``, so this graph is interchangeable
+    between them; it is exported per mirror anyway so each mirror stands alone.
+    """
+
+    def __init__(self, codec: nn.Module):
+        super().__init__()
+        self.codec = codec
+
+    def forward(self, codes: Tensor) -> Tensor:
+        return self.codec.decode(codes)

--- a/scripts/conversion/arktts/export_arktts_onnx.py
+++ b/scripts/conversion/arktts/export_arktts_onnx.py
@@ -1,0 +1,409 @@
+"""Export an ArkTTS checkpoint to the three phoonnx ONNX graphs.
+
+    python export_arktts_onnx.py --repo Audio8/Audio8-TTS-Preview-0.6b --out-dir ./onnx
+    python export_arktts_onnx.py --repo itzune/zortzi-tts --out-dir ./onnx --fp16
+
+The output layout and every tensor name match the official export at
+``itzune/zortzi-tts-onnx``, so a mirror built from this script and the official one are
+drop-in replacements for each other. See ``arktts_wrappers.py`` for the contract and why
+the cache is a fixed window.
+
+``--fp16`` writes a second copy of the two autoregressive graphs in half precision. The
+codec decoder is written in single precision only. Its window transformer builds a rotary
+table inside the graph, and the half-precision converter leaves that ``Einsum`` with one
+single-precision and one half-precision operand, which ONNX Runtime rejects. This is not
+worth solving here: both published ArkTTS checkpoints carry a byte-identical ``codec.pth``,
+so the fp16 codec decoder published at ``itzune/zortzi-tts-onnx`` decodes either model's
+codes, and ``verify_parity.py`` confirms it against whichever checkpoint you point it at.
+
+Verify what comes out with ``verify_parity.py`` before mirroring it. Half precision is
+cheap to produce and easy to get wrong; nothing here proves the result is usable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from transformers import AutoModel
+
+from arktts_wrappers import SLOW_CACHE_WIDTH, CodecDecoderWrapper, FastARWrapper, SlowARWrapper
+
+OPSET = 17
+"""Matches the official export; every operator used here is core opset 17."""
+
+
+def cache_names(layers: int) -> tuple[list[str], list[str]]:
+    """Input and output names for one model's cache, in the order the wrappers expect."""
+    inputs = [f"cache_{kind}_{i}" for i in range(layers) for kind in ("key", "value")]
+    outputs = [f"{kind}_delta_{i}" for i in range(layers) for kind in ("key", "value")]
+    return inputs, outputs
+
+
+def drop_norm_casts(model) -> None:
+    """Remove the RMS norms' explicit float32 round-trip before tracing.
+
+    ``ArkttsRMSNorm.forward`` writes ``x.float() * rsqrt(...)`` then ``.to(x.dtype)``. That
+    protects bfloat16 checkpoints from accumulating the sum of squares in low precision.
+    Here the module is already float32, so both casts are no-ops and the traced graph is
+    numerically unchanged — but they survive as ``Cast`` nodes with hard-coded target
+    types, and those are what make the half-precision converter emit a graph whose operands
+    disagree and which ONNX Runtime then refuses to load.
+
+    The consequence is real and worth stating: in the fp16 graph the norm accumulates in
+    half precision rather than single. ``verify_parity.py`` measures exactly that.
+    """
+    import torch as torch_module
+
+    def forward(self, x):
+        return x * torch_module.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps) * self.weight
+
+    type(model.norm).forward = forward
+
+
+def export_slow_ar(model, path: Path) -> None:
+    drop_norm_casts(model)
+    wrapper = SlowARWrapper(model).eval()
+    config = model.config
+    layers = int(config.n_layer)
+    cache_in, cache_out = cache_names(layers)
+    width = 5
+    codes = torch.zeros((1, config.num_codebooks + 1, width), dtype=torch.long)
+    codes[0, 0] = torch.arange(width) + config.semantic_begin_id
+    input_pos = torch.arange(width, dtype=torch.long)
+    cache = [
+        torch.zeros((1, config.n_local_heads, SLOW_CACHE_WIDTH, config.head_dim))
+        for _ in range(2 * layers)
+    ]
+    torch.onnx.export(
+        wrapper,
+        (codes, input_pos, *cache),
+        str(path),
+        input_names=["codes", "input_pos", *cache_in],
+        output_names=["logits", "slow_hidden", *cache_out],
+        dynamic_axes={
+            "codes": {2: "T"}, "input_pos": {0: "T"},
+            "logits": {1: "T"}, "slow_hidden": {1: "T"},
+            **{name: {2: "T"} for name in cache_out},
+        },
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+
+def export_fast_ar(model, path: Path) -> None:
+    drop_norm_casts(model)
+    wrapper = FastARWrapper(model).eval()
+    config = model.config
+    layers = int(config.n_fast_layer)
+    cache_in, cache_out = cache_names(layers)
+    cache = [
+        torch.zeros((1, config.fast_n_local_heads, config.num_codebooks, config.fast_head_dim))
+        for _ in range(2 * layers)
+    ]
+    torch.onnx.export(
+        wrapper,
+        (
+            torch.zeros((1, 1, config.dim)),
+            torch.zeros((1, 1), dtype=torch.long),
+            torch.ones(1, dtype=torch.bool),
+            torch.zeros(1, dtype=torch.long),
+            *cache,
+        ),
+        str(path),
+        input_names=["slow_hidden", "token_id", "use_slow_hidden", "input_pos", *cache_in],
+        output_names=["logits", *cache_out],
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+
+def simplify_causal_padding(codec) -> int:
+    """Drop the codec's dynamic right-padding, which the ONNX tracer cannot lower.
+
+    ``ArkttsCausalConv1d.forward`` calls ``_extra_padding``, whose ``math.ceil`` over a
+    traced shape lowers to ``aten::__iand_`` and has no opset-17 equivalent. The helper
+    is dead weight in this graph: with ``stride == 1`` it reduces to
+
+        frames = (L - k + (k - 1)) / 1 + 1 = L,  ideal = (L - 1) + k - (k - 1) = L
+
+    so the extra padding is exactly zero for every input length.
+
+    The check is scoped to what ``ArkttsCodec.decode`` actually runs — the quantizer's
+    codebook lookups, the post module, the upsampler and the decoder stack. The analysis
+    encoder does contain strided causal convolutions, and it is not exported here: this
+    engine never needs it, because voices ship as pre-encoded codes rather than as audio.
+    A strided convolution *on the decode path* would make the simplification wrong rather
+    than merely untraceable, so this raises instead of writing a subtly different model.
+    """
+    import torch.nn.functional as functional
+
+    module = type(codec).__mro__[0].__module__
+    causal = __import__(module, fromlist=["ArkttsCausalConv1d"]).ArkttsCausalConv1d
+    on_decode_path = [
+        (name, child)
+        for root in (codec.decoder, codec.quantizer.post_module, codec.quantizer.upsample)
+        for name, child in root.named_modules()
+        if isinstance(child, causal)
+    ]
+    strided = [name for name, child in on_decode_path if child.stride != 1]
+    if strided:
+        raise RuntimeError(f"strided causal convolutions on the decode path: {strided}; "
+                           "the zero-extra-padding simplification does not hold")
+
+    def forward(self, x):
+        return self.conv(functional.pad(x, (self.padding, 0))).contiguous()
+
+    causal.forward = forward
+    return len(on_decode_path)
+
+
+def register_inplace_and() -> None:
+    """Teach the tracer the in-place boolean ``and`` the codec's window mask uses.
+
+    ``ArkttsCodecWindowTransformer.forward`` narrows its causal mask with ``mask &= ...``.
+    The tracer records that as ``aten::__iand_``, for which opset 17 has no built-in
+    lowering, so the export stops. Boolean ``And`` is the same operation — the only thing
+    the in-place form adds is reusing the buffer, which has no meaning in a graph.
+    """
+    from torch.onnx import register_custom_op_symbolic
+
+    register_custom_op_symbolic(
+        "aten::__iand_", lambda g, self, other: g.op("And", self, other), OPSET)
+
+
+def replace_complex_rope(codec) -> None:
+    """Rebuild the codec's rotary table without complex numbers.
+
+    ``_rope`` builds it with ``torch.polar``, which opset 17 cannot express because it has
+    no complex tensors at all. ``polar(1, phase)`` is ``cos(phase) + i·sin(phase)``, and
+    the function immediately splits the result back into its real and imaginary parts, so
+    building those two directly is the identical computation with the complex step removed.
+
+    The rotary table is left in float32 rather than the checkpoint's bfloat16. Casting a
+    table of sines to bfloat16 only loses precision, and it would force a bfloat16 tensor
+    into a graph that has none anywhere else.
+
+    The codec's own norms and rotary application are rebuilt at the same time, for the
+    reason :func:`drop_norm_casts` explains: their explicit float32 round-trips are no-ops
+    in a float32 export and become ``Cast`` nodes that break the half-precision converter.
+    """
+    import torch as torch_module
+
+    module = __import__(type(codec).__mro__[0].__module__,
+                        fromlist=["_rope", "ArkttsCodecRMSNorm"])
+
+    def rope(length: int, head_dim: int, base: float, device=None):
+        frequencies = 1.0 / (
+            base ** (torch_module.arange(0, head_dim, 2, device=device).float() / head_dim))
+        phases = torch_module.outer(
+            torch_module.arange(length, device=device).float(), frequencies)
+        return torch_module.stack(
+            (torch_module.cos(phases), torch_module.sin(phases)), dim=-1)
+
+    def apply_rope(x, values):
+        shaped = x.reshape(*x.shape[:-1], -1, 2)
+        values = values.view(1, shaped.shape[1], 1, shaped.shape[3], 2)
+        return torch_module.stack(
+            (
+                shaped[..., 0] * values[..., 0] - shaped[..., 1] * values[..., 1],
+                shaped[..., 1] * values[..., 0] + shaped[..., 0] * values[..., 1],
+            ),
+            dim=-1,
+        ).flatten(3)
+
+    def norm_forward(self, x):
+        return x * torch_module.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps) * self.weight
+
+    module._rope = rope
+    module._apply_rope = apply_rope
+    module.ArkttsCodecRMSNorm.forward = norm_forward
+
+
+def export_codec_decoder(model, path: Path) -> None:
+    register_inplace_and()
+    codec = model.load_codec(device="cpu")
+    replace_complex_rope(codec)
+    patched = simplify_causal_padding(codec)
+    print(f"  simplified right-padding on {patched} causal convolutions")
+    wrapper = CodecDecoderWrapper(codec).eval()
+    codes = torch.zeros((1, model.config.num_codebooks, 16), dtype=torch.long)
+    torch.onnx.export(
+        wrapper,
+        (codes,),
+        str(path),
+        input_names=["codes"],
+        output_names=["audio"],
+        dynamic_axes={"codes": {2: "T"}, "audio": {2: "samples"}},
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+
+def consolidate(path: Path) -> None:
+    """Rewrite a graph so its weights live in one sidecar file next to it.
+
+    Past 2 GB ``torch.onnx.export`` spills every initializer into its own file named after
+    the parameter, which turns one graph into hundreds of loose files that no mirror can
+    sanely carry. This reloads the model and writes a single ``<name>.data`` beside it,
+    the layout the official export uses.
+    """
+    import onnx
+
+    model = onnx.load(str(path))
+    deduplicate_initializers(model)
+    for stale in path.parent.iterdir():
+        if stale.is_file() and stale.suffix not in (".onnx", ".json", ".data"):
+            stale.unlink()
+    onnx.save(model, str(path), save_as_external_data=True, all_tensors_to_one_file=True,
+              location=path.name + ".data", size_threshold=1024)
+
+
+def deduplicate_initializers(model) -> int:
+    """Collapse initializers that hold identical bytes onto one copy.
+
+    These checkpoints tie the output projection to the input embedding table, so the
+    155776 x 896 matrix is reachable twice — once as the embedding and once as the
+    projection's operand — and the tracer materialises it twice. On Audio8 that is an extra
+    558 MB of single-precision weights for a tensor the graph already has. Merging them is
+    safe because ONNX initializers are immutable.
+    """
+    seen: dict[tuple, str] = {}
+    rename: dict[str, str] = {}
+    keep = []
+    for initializer in model.graph.initializer:
+        key = (initializer.data_type, tuple(initializer.dims), initializer.raw_data)
+        if key in seen:
+            rename[initializer.name] = seen[key]
+            continue
+        seen[key] = initializer.name
+        keep.append(initializer)
+    if not rename:
+        return 0
+    del model.graph.initializer[:]
+    model.graph.initializer.extend(keep)
+    for node in model.graph.node:
+        for index, name in enumerate(node.input):
+            if name in rename:
+                node.input[index] = rename[name]
+    return len(rename)
+
+
+def to_fp16(source: Path, target: Path) -> None:
+    """Cast a graph's initializers to half precision.
+
+    ONNX Runtime upcasts fp16 back to fp32 for CPU compute, so this buys disk and memory,
+    not speed. It is still worth doing: the AR graphs are read once per token.
+    """
+    import onnx
+    from onnxconverter_common import float16
+
+    # The converter needs to know every intermediate's type so it can insert the casts that
+    # keep an op's operands in one precision; without them the slow AR ends up with a
+    # float32 tensor feeding a float16 Add and will not load. Its own shape inference
+    # round-trips the model through a single protobuf, which the slow AR's weights alone
+    # exceed, so inference runs file-to-file first and the converter is handed the result.
+    inferred = target.with_suffix(".inferred.onnx")
+    onnx.shape_inference.infer_shapes_path(str(source), str(inferred))
+    model = onnx.load(str(inferred))
+    converted = float16.convert_float_to_float16(model, keep_io_types=False,
+                                                 disable_shape_infer=True)
+    # The inferred types describe the *single-precision* graph. Leaving them in place makes
+    # ONNX Runtime reject nodes whose real output is now half precision, so they are dropped
+    # and the runtime re-infers them at load.
+    del converted.graph.value_info[:]
+    onnx.save(
+        converted,
+        str(target),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=target.name + ".data",
+    )
+    inferred.unlink(missing_ok=True)
+
+
+def write_manifest(model, out_dir: Path, precisions: list[str]) -> None:
+    """The runtime manifest, in the shape the official ONNX export publishes."""
+    config = model.config
+    manifest = {
+        "model_family": "audio8_tts",
+        "activation_dtype": "float32",
+        "slow_logits_layout": "semantic_then_eos",
+        "slow_logits_size": int(config.codebook_size) + 1,
+        "kv_attention_layout": "valid_prefix",
+        "max_seq_len": int(config.max_seq_len),
+        "num_layers": int(config.n_layer),
+        "num_fast_layers": int(config.n_fast_layer),
+        "num_codebooks": int(config.num_codebooks),
+        "n_local_heads": int(config.n_local_heads),
+        "fast_n_local_heads": int(config.fast_n_local_heads),
+        "head_dim": int(config.head_dim),
+        "fast_head_dim": int(config.fast_head_dim),
+        "fast_dim": int(config.fast_dim),
+        "vocab_size": int(config.vocab_size),
+        "codebook_size": int(config.codebook_size),
+        "semantic_begin_id": int(config.semantic_begin_id),
+        "semantic_end_id": int(config.semantic_end_id),
+        "eos_token_id": int(config.eos_token_id),
+        "pad_token_id": int(config.pad_token_id),
+        "sample_rate": int(config.codec_sample_rate),
+        "codec_sample_rate": int(config.codec_sample_rate),
+        "codec_frame_size": int(config.codec_frame_size),
+        "codec_hop_length": int(config.codec_frame_size),
+        "ras_window_size": int(config.ras_window_size),
+        "ras_top_p": float(config.ras_top_p),
+        "ras_temperature": float(config.ras_temperature),
+        "default_precision": precisions[0],
+        "available_precisions": precisions,
+        "slow_models": {p: f"slow_ar_{p}.onnx" for p in precisions},
+        "fast_models": {p: f"fast_ar_{p}.onnx" for p in precisions},
+        "default_codec_precision": "fp32",
+        "available_codec_precisions": ["fp32"],
+        "codec_models": {"fp32": "codec_decoder_fp32.onnx"},
+    }
+    (out_dir / "runtime_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="Hub id or local directory of the checkpoint")
+    parser.add_argument("--out-dir", required=True, type=Path)
+    parser.add_argument("--fp16", action="store_true", help="also write half-precision AR graphs")
+    parser.add_argument("--drop-fp32", action="store_true",
+                        help="delete the single-precision graphs once the fp16 ones exist")
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    model = AutoModel.from_pretrained(args.repo, dtype=torch.float32, trust_remote_code=True).eval()
+
+    print("exporting slow_ar_fp32.onnx")
+    export_slow_ar(model, args.out_dir / "slow_ar_fp32.onnx")
+    consolidate(args.out_dir / "slow_ar_fp32.onnx")
+    print("exporting fast_ar_fp32.onnx")
+    export_fast_ar(model, args.out_dir / "fast_ar_fp32.onnx")
+    print("exporting codec_decoder_fp32.onnx")
+    export_codec_decoder(model, args.out_dir / "codec_decoder_fp32.onnx")
+
+    precisions = ["fp32"]
+    if args.fp16:
+        precisions.append("fp16")
+        for name in ("slow_ar", "fast_ar"):
+            print(f"casting {name} to fp16")
+            to_fp16(args.out_dir / f"{name}_fp32.onnx", args.out_dir / f"{name}_fp16.onnx")
+
+    if args.drop_fp32 and args.fp16:
+        precisions.remove("fp32")
+        for name in ("slow_ar", "fast_ar"):
+            for stale in args.out_dir.glob(f"{name}_fp32.onnx*"):
+                stale.unlink()
+
+    write_manifest(model, args.out_dir, precisions)
+    print("wrote", args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/arktts/export_arktts_onnx.py
+++ b/scripts/conversion/arktts/export_arktts_onnx.py
@@ -316,14 +316,24 @@ def to_fp16(source: Path, target: Path) -> None:
     # ONNX Runtime reject nodes whose real output is now half precision, so they are dropped
     # and the runtime re-infers them at load.
     del converted.graph.value_info[:]
-    onnx.save(
-        converted,
-        str(target),
-        save_as_external_data=True,
-        all_tensors_to_one_file=True,
-        location=target.name + ".data",
-    )
+    # A sidecar weights file is only carried along by whoever knows to look for it, and the
+    # phoonnx voice downloader fetches the URLs an index entry lists and nothing else. Half
+    # precision usually brings these graphs back under the 2 GB protobuf ceiling, so they
+    # are written as one self-contained file — the layout the official export uses — and
+    # fall back to a sidecar only when they genuinely do not fit.
+    try:
+        onnx.save(converted, str(target))
+    except (ValueError, google_protobuf_error()):
+        onnx.save(converted, str(target), save_as_external_data=True,
+                  all_tensors_to_one_file=True, location=target.name + ".data")
     inferred.unlink(missing_ok=True)
+
+
+def google_protobuf_error():
+    """The error protobuf raises when a message crosses its 2 GB serialisation limit."""
+    from google.protobuf.message import EncodeError
+
+    return EncodeError
 
 
 def write_manifest(model, out_dir: Path, precisions: list[str]) -> None:

--- a/scripts/conversion/arktts/mint_voice.py
+++ b/scripts/conversion/arktts/mint_voice.py
@@ -1,0 +1,101 @@
+"""Turn a reference clip into an ArkTTS voice asset.
+
+    python mint_voice.py --repo Audio8/Audio8-TTS-Preview-0.6b \
+        --audio antton.wav --text "Inguru hura gerrillarien esku izan da denbora luzean." \
+        --name antton --out voices/antton.json
+
+    python mint_voice.py --from-npy codes.npy --text "..." --name maider \
+        --out voices/maider.json
+
+An ArkTTS voice is not a speaker id — the model has no speaker table and always emits
+``<|speaker:0|>``. A voice is the codec codes of a short clip plus the transcription of
+that clip, and the prompt embeds both. This script produces the small JSON the engine
+reads, either by encoding a clip with the checkpoint's codec encoder or by repackaging
+codes that upstream already published.
+
+The encoder runs here and never ships: ``phoonnx`` only needs the codec *decoder* at
+synthesis time, because voices arrive pre-encoded. Minting a new voice is therefore an
+offline step, not something the runtime does.
+
+Keep the clip short and prosodically flat. Upstream selected its own references by
+pitch-range ratio precisely because an expressive reference bleeds its intonation into
+every sentence the voice later speaks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+NUM_CODEBOOKS = 10
+CODEBOOK_SIZE = 4096
+
+
+def encode_clip(repo: str, audio_path: Path) -> np.ndarray:
+    """Run the checkpoint's codec encoder over one clip and return ``[10, frames]``."""
+    import soundfile
+    import torch
+    from transformers import AutoModel
+
+    model = AutoModel.from_pretrained(repo, dtype=torch.float32, trust_remote_code=True).eval()
+    samples, rate = soundfile.read(str(audio_path), dtype="float32", always_2d=True)
+    mono = samples.mean(axis=1)
+    target = int(model.config.codec_sample_rate)
+    if rate != target:
+        # scipy rather than torchaudio: the codec is the only thing that needs torch here,
+        # and torchaudio pins its own build against a matching torch, which is a heavy
+        # constraint to inherit for one polyphase resample.
+        from math import gcd
+
+        from scipy.signal import resample_poly
+
+        divisor = gcd(int(rate), target)
+        mono = resample_poly(mono, target // divisor, int(rate) // divisor).astype("float32")
+    audio = torch.from_numpy(mono)
+    with torch.inference_mode():
+        codes, lengths = model.encode_audio(
+            audio.reshape(1, 1, -1), torch.tensor([audio.numel()]))
+    return codes[0, :, : int(lengths[0])].cpu().numpy().astype(np.int64)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="checkpoint whose codec encodes the clip")
+    parser.add_argument("--audio", type=Path)
+    parser.add_argument("--from-npy", type=Path, help="repackage published codes instead")
+    parser.add_argument("--text", required=True, help="what the reference clip says")
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--display-name", default=None)
+    parser.add_argument("--provenance", default="", help="where the clip came from and its licence")
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+
+    if args.from_npy:
+        codes = np.load(args.from_npy).astype(np.int64)
+    elif args.repo and args.audio:
+        codes = encode_clip(args.repo, args.audio)
+    else:
+        raise SystemExit("give either --from-npy or both --repo and --audio")
+
+    if codes.ndim != 2 or codes.shape[0] != NUM_CODEBOOKS or codes.shape[1] == 0:
+        raise SystemExit(f"codes must have shape [{NUM_CODEBOOKS}, T>0], got {codes.shape}")
+    if codes.min() < 0 or codes.max() >= CODEBOOK_SIZE:
+        raise SystemExit(f"codes must be in [0, {CODEBOOK_SIZE - 1}]")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps({
+        "name": args.name,
+        "display_name": args.display_name or args.name.title(),
+        "reference_text": " ".join(args.text.split()),
+        "frames": int(codes.shape[1]),
+        "provenance": args.provenance,
+        "codes": codes.tolist(),
+    }, ensure_ascii=False, indent=1) + "\n", encoding="utf-8")
+    print(f"wrote {args.out} — {codes.shape[1]} frames "
+          f"({codes.shape[1] * 2048 / 44100:.2f} s of reference)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/arktts/sentences_eu.txt
+++ b/scripts/conversion/arktts/sentences_eu.txt
@@ -1,0 +1,6 @@
+# Basque test sentences for the Zortzi-TTS WER gate.
+Kaixo mundua, gaur eguraldi ona dago Bilbon.
+Bihar goizean mendira joango gara lagunekin.
+Liburu hori oso interesgarria iruditu zait.
+Eskerrik asko zure laguntzagatik, benetan.
+Non dago hurbilen dagoen tren geltokia?

--- a/scripts/conversion/arktts/sentences_multi.txt
+++ b/scripts/conversion/arktts/sentences_multi.txt
@@ -1,0 +1,8 @@
+# Audio8 multilingual test sentences, tagged with the language the WER gate should score.
+en|The quick brown fox jumps over the lazy dog.
+fr|Le soleil brille sur la vieille ville ce matin.
+de|Der Zug nach Berlin fährt in zehn Minuten ab.
+es|La biblioteca abre todos los días por la mañana.
+it|Domani andremo al mercato a comprare del pane.
+nl|De trein naar Amsterdam vertrekt over tien minuten.
+pl|Pociąg do Warszawy odjeżdża za dziesięć minut.

--- a/scripts/conversion/arktts/synthesize_samples.py
+++ b/scripts/conversion/arktts/synthesize_samples.py
@@ -1,0 +1,112 @@
+"""Synthesize a sentence list through the ArkTTS adapter and report per-voice CPU RTF.
+
+    python synthesize_samples.py --onnx-dir ~/zortzi-tts-onnx --precision fp16 \
+        --tokenizer ~/zortzi-tts-onnx/tokenizer/tokenizer.json \
+        --voice maider=voices/maider.json --voice antton=voices/antton.json \
+        --sentences eu.txt --out-dir ./samples --report rtf.json
+
+This drives :class:`phoonnx.engines.arktts.ArkTTSAdapter` exactly as the voice layer does,
+so what it measures is what a phoonnx user gets: one slow-AR step and nine fast-AR steps
+per 46 ms frame, on CPU, single stream.
+
+Every call is seeded, so a rerun reproduces the same audio. That matters because ArkTTS
+*must* sample — greedy decoding never terminates — and an unseeded benchmark would compare
+different utterances between runs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import onnxruntime
+import soundfile
+
+from phoonnx.engines.arktts import SAMPLE_RATE, ArkTTSAdapter
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.tokenizer import BPETokenizer
+
+
+def build_adapter(onnx_dir: Path, precision: str, tokenizer: Path, codec: Path):
+    """Open the three graphs and return the adapter plus the slow-AR session."""
+    def session(path: Path):
+        return onnxruntime.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+
+    adapter = ArkTTSAdapter()
+    adapter.fast_ar = session(onnx_dir / f"fast_ar_{precision}.onnx")
+    adapter.decoder = session(codec)
+    adapter.tokenizer = BPETokenizer(str(tokenizer))
+    return adapter, session(onnx_dir / f"slow_ar_{precision}.onnx")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--onnx-dir", required=True, type=Path)
+    parser.add_argument("--precision", default="fp16")
+    parser.add_argument("--tokenizer", required=True, type=Path)
+    parser.add_argument("--codec", type=Path, default=None,
+                        help="codec decoder graph (defaults to codec_decoder_fp16.onnx)")
+    parser.add_argument("--voice", action="append", required=True, metavar="NAME=PATH")
+    parser.add_argument("--sentences", required=True, type=Path,
+                        help="one sentence per line, optionally prefixed 'lang|'; "
+                             "blank lines and '#' comments ignored")
+    parser.add_argument("--out-dir", required=True, type=Path)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--report", type=Path, default=None)
+    args = parser.parse_args()
+
+    codec = args.codec or args.onnx_dir / "codec_decoder_fp16.onnx"
+    adapter, slow = build_adapter(args.onnx_dir, args.precision, args.tokenizer, codec)
+    # A line may carry its own language tag as "en|The quick brown fox ...". The tag is not
+    # used for synthesis — ArkTTS infers the language from the text itself and has no
+    # language token — it travels to the report so the WER gate knows how to score the clip.
+    sentences = []
+    for line in args.sentences.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        language, separator, text = line.partition("|")
+        sentences.append((language if separator else "", text if separator else line))
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for spec in args.voice:
+        name, _, path = spec.partition("=")
+        adapter.load_voice(path)
+        audio_total = wall_total = 0.0
+        for index, (language, sentence) in enumerate(sentences):
+            ids = adapter.encode_text(sentence, None, None)[0]
+            request = AdapterSynthesisRequest(
+                phoneme_ids=np.asarray(ids, np.int64).reshape(1, -1),
+                phoneme_lengths=np.asarray([len(ids)], np.int64),
+                params={"seed": args.seed + index})
+            started = time.perf_counter()
+            result = adapter.synthesize(request, slow)
+            elapsed = time.perf_counter() - started
+            duration = result.audio.size / SAMPLE_RATE
+            audio_total += duration
+            wall_total += elapsed
+            out = args.out_dir / f"{name}_{index:02d}.wav"
+            soundfile.write(str(out), result.audio, SAMPLE_RATE)
+            rows.append({"voice": name, "index": index, "text": sentence,
+                         "language": language,
+                         "wav": out.name, "frames": result.extras["frame_count"],
+                         "audio_seconds": round(duration, 3),
+                         "wall_seconds": round(elapsed, 3),
+                         "rtf": round(elapsed / max(duration, 1e-9), 3)})
+            print(f"  {out.name}  {duration:5.2f}s audio  {elapsed:6.1f}s wall  "
+                  f"RTF {elapsed / max(duration, 1e-9):5.2f}")
+        print(f"{name}: aggregate RTF {wall_total / max(audio_total, 1e-9):.2f} "
+              f"over {audio_total:.1f}s of audio")
+        rows.append({"voice": name, "aggregate_rtf": round(wall_total / max(audio_total, 1e-9), 3),
+                     "audio_seconds": round(audio_total, 2)})
+
+    if args.report:
+        args.report.write_text(json.dumps(rows, ensure_ascii=False, indent=2) + "\n")
+        print("wrote", args.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/arktts/verify_parity.py
+++ b/scripts/conversion/arktts/verify_parity.py
@@ -1,0 +1,253 @@
+"""Check an ArkTTS ONNX export against the PyTorch checkpoint it came from.
+
+    python verify_parity.py --repo itzune/zortzi-tts \
+        --onnx-dir ~/zortzi-tts-onnx --precision fp16 \
+        --voice-codes ~/zortzi-tts-onnx/voices/maider/codes.npy \
+        --reference-text "Aurrelaria prest dago jokatzeko." \
+        --text "Kaixo mundua, gaur eguraldi ona dago." --steps 24
+
+Four things are compared, and all four have to hold before a mirror is published:
+
+1. **Prompt** — the ``[1, 11, T]`` matrix this repo's adapter builds against the one
+   upstream's own processor and ``_prepare_prompt`` build. Exact equality, no tolerance.
+   Everything downstream is meaningless if the prompts differ.
+2. **Slow AR** — logits and hidden states, at prefill and at every decode step, driven in
+   lockstep by greedy decoding so both sides see the same history.
+3. **Fast AR** — logits for all nine predicted codebooks of every frame, again in lockstep.
+4. **Codec decoder** — the waveform for a fixed code matrix.
+
+Greedy decoding is used *only here*. Both model cards say greedy loops forever in real
+synthesis; that does not matter for a fixed step budget, and it is the only way to make
+the two stacks follow the same path. Agreement rate is the gate that matters — a logit
+difference that never changes an argmax is a rounding artefact, and one that does is a
+defect no matter how small it looks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import onnxruntime
+import torch
+from transformers import AutoModel, AutoProcessor
+
+from phoonnx.engines.arktts import (
+    FAST_HEAD_DIM, FAST_KV_HEADS, FAST_LAYERS, MAX_SEQ_LEN, NUM_CODEBOOKS,
+    SEMANTIC_BEGIN_ID, SLOW_HEAD_DIM, SLOW_KV_HEADS, SLOW_LAYERS, ArkTTSAdapter,
+)
+
+
+def summarize(name: str, diffs: list[float], agree: list[bool],
+              gaps: list[float] | None = None) -> dict:
+    """Report the differences, the greedy agreement, and how close the misses were.
+
+    ``gaps`` holds, for each disagreement, the reference's own top-1 minus top-2 margin.
+    A miss whose margin is under the logit difference is the two stacks splitting a tie
+    that precision alone decided; a miss with a wide margin is a real defect. The
+    distinction is the whole point of the gate, so it is reported rather than averaged
+    away.
+    """
+    row = {
+        "tensor": name,
+        "max_abs_diff": float(max(diffs)) if diffs else 0.0,
+        "mean_abs_diff": float(np.mean(diffs)) if diffs else 0.0,
+        "greedy_agreement": f"{sum(agree)}/{len(agree)}" if agree else "n/a",
+    }
+    tail = ""
+    if gaps:
+        row["miss_margins"] = [round(float(g), 5) for g in sorted(gaps)]
+        row["max_miss_margin"] = float(max(gaps))
+        tail = f"  worst miss margin {max(gaps):.4g}"
+    print(f"  {row['tensor']:<24} max {row['max_abs_diff']:.4g}  "
+          f"mean {row['mean_abs_diff']:.4g}  greedy {row['greedy_agreement']}{tail}")
+    return row
+
+
+def margin(logits: np.ndarray) -> float:
+    """The reference's top-1 minus top-2 logit — how decided this argmax was."""
+    top = np.partition(logits, -2)[-2:]
+    return float(abs(top[1] - top[0]))
+
+
+def build_reference_prompt(model, processor, text: str, codes: np.ndarray,
+                           reference_text: str) -> torch.Tensor:
+    """The prompt upstream builds, through its own processor and packer."""
+    batch = processor(text=text, reference_text=reference_text,
+                      reference_codes=torch.as_tensor(codes, dtype=torch.long))
+    prompt, _ = model._prepare_prompt(**batch)
+    return prompt
+
+
+@torch.inference_mode()
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--onnx-dir", required=True, type=Path)
+    parser.add_argument("--precision", default="fp16")
+    parser.add_argument("--voice-codes", required=True, type=Path, help=".npy or voice JSON")
+    parser.add_argument("--reference-text", default="")
+    parser.add_argument("--text", required=True)
+    parser.add_argument("--steps", type=int, default=24)
+    parser.add_argument("--tokenizer", type=Path, default=None,
+                        help="tokenizer.json for the adapter's prompt builder")
+    parser.add_argument("--report", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.voice_codes.suffix == ".npy":
+        codes = np.load(args.voice_codes).astype(np.int64)
+        reference_text = args.reference_text
+    else:
+        data = json.loads(args.voice_codes.read_text())
+        codes = np.asarray(data["codes"], np.int64)
+        reference_text = args.reference_text or data["reference_text"]
+    if not reference_text:
+        raise SystemExit("--reference-text is required with a .npy voice")
+
+    print(f"torch reference: {args.repo}")
+    model = AutoModel.from_pretrained(args.repo, dtype=torch.float32, trust_remote_code=True).eval()
+    processor = AutoProcessor.from_pretrained(args.repo, trust_remote_code=True)
+
+    # --- 1. prompt -------------------------------------------------------------
+    reference_prompt = build_reference_prompt(model, processor, args.text, codes, reference_text)
+    adapter = ArkTTSAdapter()
+    adapter.tokenizer = __import__("phoonnx.tokenizer", fromlist=["BPETokenizer"]).BPETokenizer(
+        str(args.tokenizer or Path(args.onnx_dir) / "tokenizer" / "tokenizer.json"))
+    adapter.reference_codes = codes
+    adapter.reference_text = reference_text
+    suffix = adapter.encode_text(args.text, None, None)[0]
+    prompt = adapter.build_prompt(np.asarray(suffix, np.int64))
+    prompt_ok = bool(np.array_equal(prompt, reference_prompt.cpu().numpy()))
+    print(f"prompt: adapter {prompt.shape} vs upstream {tuple(reference_prompt.shape)} -> "
+          f"{'MATCH' if prompt_ok else 'MISMATCH'}")
+    if not prompt_ok:
+        raise SystemExit("prompt mismatch — nothing below this line is meaningful")
+
+    # --- sessions --------------------------------------------------------------
+    slow = onnxruntime.InferenceSession(
+        str(args.onnx_dir / f"slow_ar_{args.precision}.onnx"), providers=["CPUExecutionProvider"])
+    fast = onnxruntime.InferenceSession(
+        str(args.onnx_dir / f"fast_ar_{args.precision}.onnx"), providers=["CPUExecutionProvider"])
+    adapter.fast_ar = fast
+
+    slow_names = [o.name for o in slow.get_outputs()]
+    fast_names = [o.name for o in fast.get_outputs()]
+    cache = adapter.empty_cache(slow, SLOW_LAYERS, MAX_SEQ_LEN, SLOW_KV_HEADS, SLOW_HEAD_DIM)
+
+    model._setup_generation_caches(1, MAX_SEQ_LEN, torch.float32)
+    width = prompt.shape[2]
+    torch_mask = torch.ones((1, width), dtype=torch.long)
+    torch_pos = torch_mask.cumsum(-1).sub(1).clamp_min(0)
+    torch_logits, torch_hidden = model._slow_step(
+        reference_prompt, torch.arange(width), torch_pos, torch_mask)
+
+    input_pos = np.arange(width, dtype=np.int64)
+    outputs = dict(zip(slow_names, slow.run(None, {"codes": prompt, "input_pos": input_pos, **cache})))
+    adapter.scatter_cache(cache, outputs, SLOW_LAYERS, input_pos)
+
+    def slice_torch(logits: torch.Tensor) -> np.ndarray:
+        semantic = logits[..., SEMANTIC_BEGIN_ID:model.config.semantic_end_id + 1]
+        eos = logits[..., model.config.eos_token_id:model.config.eos_token_id + 1]
+        return torch.cat((semantic, eos), dim=-1).float().numpy().reshape(-1)
+
+    slow_diffs, slow_agree, hidden_diffs, slow_gaps = [], [], [], []
+    fast_diffs, fast_agree, fast_gaps = [], [], []
+    rows = []
+
+    print(f"\nlockstep greedy decode, {args.steps} steps")
+    for step in range(args.steps):
+        reference_logits = slice_torch(torch_logits)
+        onnx_logits = np.asarray(outputs["logits"][0, -1], np.float32)
+        slow_diffs.append(float(np.abs(reference_logits - onnx_logits).max()))
+        slow_agree.append(int(reference_logits.argmax()) == int(onnx_logits.argmax()))
+        if not slow_agree[-1]:
+            slow_gaps.append(margin(reference_logits))
+        hidden_diffs.append(float(np.abs(
+            torch_hidden[:, -1:].float().numpy()
+            - np.asarray(outputs["slow_hidden"][:, -1:], np.float32)).max()))
+
+        semantic = int(reference_logits.argmax())
+        if semantic == model.config.codebook_size:
+            print(f"  EOS at step {step}")
+            break
+
+        # fast AR, both stacks driven by the same codebook history
+        torch_fast_hidden = model.fast_project_in(torch_hidden[:, -1:])
+        model._fast_step(torch_fast_hidden, 0)
+        current = torch.tensor([semantic], dtype=torch.long)
+        codebooks = [semantic]
+
+        fast_cache = adapter.empty_cache(fast, FAST_LAYERS, NUM_CODEBOOKS,
+                                         FAST_KV_HEADS, FAST_HEAD_DIM)
+        fast_dtype = (np.float16 if fast.get_inputs()[0].type == "tensor(float16)"
+                      else np.float32)
+        onnx_out = dict(zip(fast_names, fast.run(None, {
+            "slow_hidden": np.asarray(outputs["slow_hidden"][:, -1:], fast_dtype),
+            "token_id": np.zeros((1, 1), np.int64),
+            "use_slow_hidden": np.asarray([True]),
+            "input_pos": np.asarray([0], np.int64), **fast_cache})))
+        adapter.scatter_cache(fast_cache, onnx_out, FAST_LAYERS, np.asarray([0], np.int64))
+
+        for position in range(1, NUM_CODEBOOKS):
+            torch_fast_logits = model._fast_step(
+                model.fast_embeddings(current)[:, None], position)
+            onnx_out = dict(zip(fast_names, fast.run(None, {
+                "slow_hidden": np.zeros((1, 1, model.config.dim), fast_dtype),
+                "token_id": np.asarray([[codebooks[-1]]], np.int64),
+                "use_slow_hidden": np.asarray([False]),
+                "input_pos": np.asarray([position], np.int64), **fast_cache})))
+            adapter.scatter_cache(fast_cache, onnx_out, FAST_LAYERS,
+                                  np.asarray([position], np.int64))
+            reference = torch_fast_logits.float().numpy().reshape(-1)
+            produced = np.asarray(onnx_out["logits"][0, -1], np.float32)
+            fast_diffs.append(float(np.abs(reference - produced).max()))
+            fast_agree.append(int(reference.argmax()) == int(produced.argmax()))
+            if not fast_agree[-1]:
+                fast_gaps.append(margin(reference))
+            current = torch.tensor([int(reference.argmax())], dtype=torch.long)
+            codebooks.append(int(reference.argmax()))
+
+        # advance both stacks with the same frame
+        column = torch.tensor([[SEMANTIC_BEGIN_ID + semantic] + codebooks],
+                              dtype=torch.long).T[None]
+        torch_mask = torch.cat((torch_mask, torch.ones((1, 1), dtype=torch.long)), dim=1)
+        torch_logits, torch_hidden = model._slow_step(
+            column, torch.tensor([width + step]), torch.tensor([[width + step]]), torch_mask)
+        input_pos = np.asarray([width + step], np.int64)
+        outputs = dict(zip(slow_names, slow.run(
+            None, {"codes": column.numpy(), "input_pos": input_pos, **cache})))
+        adapter.scatter_cache(cache, outputs, SLOW_LAYERS, input_pos)
+
+    print("\nresults")
+    rows.append(summarize("slow_ar logits", slow_diffs, slow_agree, slow_gaps))
+    rows.append(summarize("slow_ar hidden", hidden_diffs, []))
+    rows.append(summarize("fast_ar logits", fast_diffs, fast_agree, fast_gaps))
+
+    # --- 4. codec decoder ------------------------------------------------------
+    decoder_path = args.onnx_dir / "codec_decoder_fp16.onnx"
+    if decoder_path.is_file():
+        decoder = onnxruntime.InferenceSession(str(decoder_path),
+                                               providers=["CPUExecutionProvider"])
+        feed = codes.reshape(1, NUM_CODEBOOKS, -1)
+        produced = np.asarray(decoder.run(None, {"codes": feed})[0], np.float32).reshape(-1)
+        reference = model.decode_audio(
+            torch.as_tensor(feed, dtype=torch.long))[0][0].float().numpy()
+        length = min(produced.size, reference.size)
+        diff = float(np.abs(produced[:length] - reference[:length]).max())
+        correlation = float(np.corrcoef(produced[:length], reference[:length])[0, 1])
+        print(f"  {'codec decoder':<24} max {diff:.4g}  corr {correlation:.6f}  "
+              f"samples onnx {produced.size} torch {reference.size}")
+        rows.append({"tensor": "codec_decoder", "max_abs_diff": diff,
+                     "correlation": correlation})
+
+    if args.report:
+        args.report.write_text(json.dumps(
+            {"repo": args.repo, "onnx_dir": str(args.onnx_dir),
+             "precision": args.precision, "prompt_match": prompt_ok, "rows": rows},
+            indent=2) + "\n")
+        print("wrote", args.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/arktts/wer_gate.py
+++ b/scripts/conversion/arktts/wer_gate.py
@@ -1,0 +1,121 @@
+"""Transcribe synthesized samples with a CPU ASR model and score them against the prompts.
+
+    python wer_gate.py --samples ./samples --report rtf.json --language eu \
+        --asr onnx-community/whisper-large-v3-turbo --out wer.json
+
+This is an intelligibility check, not an ASR benchmark. The question it answers is whether
+the words the engine was asked to say come back out, which catches the failure modes a
+logit-parity check cannot see: a wrong prompt layout, a mis-scattered KV cache, or a
+sampler that drifts into a repetition loop.
+
+**ASR coverage for Basque.** ``nemo-canary-1b-v2`` covers the 25 official EU languages;
+Basque is not one of them, and no other model ``onnx-asr`` ships recognises ``eu`` either.
+There is no capable Basque CPU model available here, so Basque is scored with
+``whisper-large-v3-turbo`` as an explicit best-effort: Whisper lists ``eu`` among its
+languages, but it is a low-resource one for the model and its own error rate is high. A
+Basque number here therefore bounds the engine's intelligibility from below and must not
+be read as a measurement of the voice's quality.
+
+For Chinese, Cantonese and Japanese the same run reports CER rather than WER, since
+whitespace does not delimit words in those scripts.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import unicodedata
+from pathlib import Path
+
+CHARACTER_SCORED = {"zh", "yue", "ja"}
+"""Languages scored by character: their orthography has no whitespace word boundaries."""
+
+
+def normalize(text: str) -> str:
+    """Casefold, strip punctuation and collapse whitespace — the usual WER preprocessing."""
+    text = unicodedata.normalize("NFKC", text).casefold()
+    text = "".join(" " if unicodedata.category(ch).startswith("P") else ch for ch in text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def edit_distance(reference: list[str], hypothesis: list[str]) -> int:
+    """Levenshtein distance over tokens, the numerator of both WER and CER."""
+    previous = list(range(len(hypothesis) + 1))
+    for i, want in enumerate(reference, start=1):
+        current = [i]
+        for j, got in enumerate(hypothesis, start=1):
+            current.append(min(previous[j] + 1, current[j - 1] + 1,
+                               previous[j - 1] + (want != got)))
+        previous = current
+    return previous[-1]
+
+
+def tokenize(text: str, language: str) -> list[str]:
+    return list(text.replace(" ", "")) if language in CHARACTER_SCORED else text.split()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path,
+                        help="the JSON synthesize_samples.py wrote, for wav -> text")
+    parser.add_argument("--language", required=True,
+                        help="fallback for clips whose report row carries no language tag")
+    parser.add_argument("--asr", default="onnx-community/whisper-large-v3-turbo")
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    import onnx_asr
+    import soundfile
+
+    rows = [row for row in json.loads(args.report.read_text()) if "wav" in row]
+    model = onnx_asr.load_model(args.asr, providers=["CPUExecutionProvider"])
+
+    scored: list[dict] = []
+    tally: dict[str, list[int]] = {}
+    for row in rows:
+        path = args.samples / row["wav"]
+        if not path.is_file():
+            continue
+        waveform, rate = soundfile.read(str(path), dtype="float32", always_2d=True)
+        mono = waveform.mean(axis=1)
+        if rate != 16000:
+            from math import gcd
+
+            from scipy.signal import resample_poly
+
+            divisor = gcd(rate, 16000)
+            mono = resample_poly(mono, 16000 // divisor, rate // divisor).astype("float32")
+        language = row.get("language") or args.language
+        hypothesis = model.recognize(mono, sample_rate=16000, language=language)
+        want = tokenize(normalize(row["text"]), language)
+        got = tokenize(normalize(str(hypothesis)), language)
+        distance = edit_distance(want, got)
+        counts = tally.setdefault(language, [0, 0, 0])
+        counts[0] += distance
+        counts[1] += len(want)
+        counts[2] += 1
+        scored.append({"wav": row["wav"], "voice": row["voice"], "language": language,
+                       "reference": row["text"], "hypothesis": str(hypothesis),
+                       "rate": round(distance / max(len(want), 1), 4)})
+        print(f"  {row['wav']}  [{language}]  {distance}/{len(want)}  {hypothesis!r}")
+
+    summary = {}
+    print()
+    for language, (errors, total, clips) in sorted(tally.items()):
+        metric = "CER" if language in CHARACTER_SCORED else "WER"
+        rate = errors / max(total, 1)
+        summary[language] = {"metric": metric, "aggregate": round(rate, 4),
+                             "errors": errors, "tokens": total, "clips": clips}
+        print(f"{language}: {metric} {rate:.3f} ({errors}/{total}) over {clips} clips")
+    print(f"ASR {args.asr}")
+
+    if args.out:
+        args.out.write_text(json.dumps(
+            {"asr": args.asr, "by_language": summary, "clips": scored},
+            ensure_ascii=False, indent=2) + "\n")
+        print("wrote", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_arktts.py
+++ b/tests/test_arktts.py
@@ -1,0 +1,804 @@
+"""Tests for the ArkTTS engine (Zortzi Basque + Audio8 multilingual).
+
+The two checkpoints share their model code, tokenizer and codec byte for byte, so one
+adapter drives both and these tests exercise both configurations through it. Nothing here
+downloads weights: the autoregressive loops run against fake sessions that reproduce the
+ONNX contract — a fixed-width KV cache, sliced slow logits, and a fast AR that reads either
+the slow hidden state or the previous codebook's token.
+"""
+import json
+
+import numpy as np
+import pytest
+
+from phoonnx.engines.arktts import (
+    CODEBOOK_SIZE,
+    EOS_INDEX,
+    FAST_HEAD_DIM,
+    FAST_KV_HEADS,
+    FAST_LAYERS,
+    FRAME_SIZE,
+    MAX_NEW_TOKENS,
+    MAX_SEQ_LEN,
+    NUM_CODEBOOKS,
+    RAS_TOP_P,
+    RAS_WINDOW_SIZE,
+    SAMPLE_RATE,
+    SEMANTIC_BEGIN_ID,
+    SLOW_HEAD_DIM,
+    SLOW_KV_HEADS,
+    SLOW_LAYERS,
+    ArkTTSAdapter,
+    chunk_text,
+    draw,
+    filter_top_k_top_p,
+    sample_semantic,
+)
+from phoonnx.engines.base import AdapterSynthesisRequest
+
+HIDDEN = 896
+
+
+# ----------------------------------------------------------------------
+# registration / config
+# ----------------------------------------------------------------------
+
+def test_arktts_registered():
+    from phoonnx.engines import list_engines
+    assert "arktts" in list_engines()
+
+
+def test_arktts_detect():
+    assert ArkTTSAdapter.detect({"engine": "arktts"})
+    assert not ArkTTSAdapter.detect({"engine": "qwen3tts"})
+    assert not ArkTTSAdapter.detect(None)
+
+
+def test_engine_enum_and_config_alphabet():
+    from phoonnx.config import Alphabet, Engine, VoiceConfig
+    config = VoiceConfig.from_dict({"engine": "arktts"}, engine=Engine.ARKTTS,
+                                   phoneme_type=None, alphabet=None)
+    assert config.engine == Engine.ARKTTS
+    # Graphemes routes synthesis through the adapter's own tokenizer instead of a phonemizer.
+    assert config.alphabet == Alphabet.GRAPHEMES
+    assert config.sample_rate == SAMPLE_RATE
+
+
+def test_config_detects_arktts_from_the_engine_string_alone():
+    from phoonnx.config import Engine, VoiceConfig
+    config = VoiceConfig.from_dict({"engine": "arktts"})
+    assert config.engine == Engine.ARKTTS
+
+
+def test_default_params_follow_the_model_cards():
+    # Both cards pin 0.8 / 0.95 and warn that greedy decoding never terminates.
+    defaults = ArkTTSAdapter().default_params()
+    assert defaults["temperature"] == pytest.approx(0.8)
+    assert defaults["top_p"] == pytest.approx(0.95)
+    assert defaults["max_new_tokens"] == MAX_NEW_TOKENS
+
+
+def test_param_labels_cover_every_default():
+    adapter = ArkTTSAdapter()
+    assert set(adapter.param_labels()) == set(adapter.default_params())
+
+
+def test_frame_geometry_matches_the_codec():
+    # 44.1 kHz at 2048 samples per frame is the ~21.5 Hz the model cards quote.
+    assert SAMPLE_RATE / FRAME_SIZE == pytest.approx(21.53, abs=0.01)
+    assert EOS_INDEX == CODEBOOK_SIZE
+
+
+# ----------------------------------------------------------------------
+# sampler — upstream's order, not HuggingFace's
+# ----------------------------------------------------------------------
+
+def test_top_k_keeps_only_the_k_best():
+    logits = np.array([5.0, 4.0, 3.0, 2.0], np.float64)
+    filtered = filter_top_k_top_p(logits, top_k=2, top_p=1.0)
+    assert np.isfinite(filtered[:2]).all()
+    assert np.isneginf(filtered[2:]).all()
+
+
+def test_top_p_drops_the_token_that_crosses_the_threshold():
+    # Upstream tests `cumulative > top_p` on the inclusive sum, so the crossing token goes.
+    # HuggingFace keeps it; the difference is visible whenever the nucleus lands mid-token.
+    logits = np.log(np.array([0.6, 0.3, 0.1]))
+    filtered = filter_top_k_top_p(logits, top_k=100, top_p=0.6)
+    assert np.isfinite(filtered[0])
+    assert np.isneginf(filtered[1:]).all()
+
+
+def test_top_ranked_token_always_survives():
+    logits = np.log(np.array([0.99, 0.005, 0.005]))
+    filtered = filter_top_k_top_p(logits, top_k=100, top_p=0.1)
+    assert np.isfinite(filtered[0])
+
+
+def test_nucleus_is_measured_before_temperature():
+    """Temperature must not widen or narrow the nucleus.
+
+    Upstream filters first and divides afterwards. If the order were reversed a high
+    temperature would flatten the distribution and let more tokens through, which is what
+    the HuggingFace stack does and what this engine must not do.
+    """
+    logits = np.log(np.array([0.7, 0.2, 0.1]))
+    cold = filter_top_k_top_p(logits, top_k=100, top_p=0.9) / 0.1
+    hot = filter_top_k_top_p(logits, top_k=100, top_p=0.9) / 10.0
+    assert np.isneginf(cold).tolist() == np.isneginf(hot).tolist()
+
+
+def test_filter_does_not_mutate_the_caller_array():
+    logits = np.array([3.0, 2.0, 1.0])
+    original = logits.copy()
+    filter_top_k_top_p(logits, top_k=1, top_p=1.0)
+    assert np.array_equal(logits, original)
+
+
+def test_draw_is_argmax_without_sampling():
+    assert draw(np.array([1.0, 9.0, 3.0]), np.random.default_rng(0), do_sample=False) == 1
+
+
+def test_draw_never_returns_a_filtered_token():
+    scores = np.array([1.0, -np.inf, -np.inf, 2.0])
+    rng = np.random.default_rng(7)
+    assert {draw(scores, rng, True) for _ in range(50)} <= {0, 3}
+
+
+def test_draw_is_reproducible_for_a_seed():
+    scores = np.log(np.array([0.4, 0.35, 0.25]))
+    first = [draw(scores, np.random.default_rng(3), True) for _ in range(5)]
+    second = [draw(scores, np.random.default_rng(3), True) for _ in range(5)]
+    assert first == second
+
+
+# ----------------------------------------------------------------------
+# repetition-aware sampling
+# ----------------------------------------------------------------------
+
+def _peaked(index: int, size: int = CODEBOOK_SIZE + 1) -> np.ndarray:
+    logits = np.full(size, -20.0, np.float64)
+    logits[index] = 20.0
+    return logits
+
+
+def test_ras_returns_the_regular_draw_when_the_window_is_clean():
+    assert sample_semantic(_peaked(5), [], np.random.default_rng(0),
+                           0.8, 50, 0.95, do_sample=True) == 5
+
+
+def test_ras_falls_back_when_the_token_is_already_in_the_window():
+    """A repeat must be redrawn under the tighter settings, not returned again.
+
+    The fallback is the whole anti-looping mechanism. With one dominant token both draws
+    land on it anyway, so this checks the *path* rather than the outcome: a window holding
+    the token must make the function reach for the fallback distribution.
+    """
+    logits = np.full(CODEBOOK_SIZE + 1, -20.0, np.float64)
+    logits[5], logits[6] = 1.0, 0.999
+    seen = {sample_semantic(logits, [SEMANTIC_BEGIN_ID + 5], np.random.default_rng(seed),
+                            0.8, 50, 0.95, do_sample=True) for seed in range(40)}
+    assert seen <= {5, 6}
+
+
+def test_ras_window_holds_text_vocabulary_ids_not_sliced_indices():
+    """Sliced index 0 must not collide with upstream's zero-filled window.
+
+    Upstream seeds its window with zeros. Zero is not a semantic token in the text
+    vocabulary, but it *is* a valid sliced index, so a window kept in sliced space would
+    read an unfilled slot as a repeat of codebook value 0 and redraw for no reason.
+    """
+    window = [0] * RAS_WINDOW_SIZE
+    assert sample_semantic(_peaked(0), window, np.random.default_rng(0),
+                           0.8, 50, 0.95, do_sample=True) == 0
+
+
+def test_ras_leaves_end_of_speech_alone():
+    window = [SEMANTIC_BEGIN_ID + EOS_INDEX]
+    assert sample_semantic(_peaked(EOS_INDEX), window, np.random.default_rng(0),
+                           0.8, 50, 0.95, do_sample=True) == EOS_INDEX
+
+
+def test_ras_is_inert_without_sampling():
+    assert sample_semantic(_peaked(5), [SEMANTIC_BEGIN_ID + 5], np.random.default_rng(0),
+                           0.8, 50, 0.95, do_sample=False) == 5
+
+
+def test_ras_settings_are_the_checkpoint_values():
+    assert (RAS_TOP_P, RAS_WINDOW_SIZE) == (0.9, 10)
+
+
+# ----------------------------------------------------------------------
+# text chunking
+# ----------------------------------------------------------------------
+
+def test_chunk_text_keeps_short_text_whole():
+    assert chunk_text("Kaixo mundua.") == ["Kaixo mundua."]
+
+
+def test_chunk_text_respects_the_character_budget():
+    sentence = "Hau esaldi luze bat da eta askotan errepikatzen da. "
+    chunks = chunk_text(sentence * 12, max_len=100)
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 100 for chunk in chunks)
+
+
+def test_chunk_text_splits_paragraphs():
+    assert len(chunk_text("Lehen zatia.\n\nBigarren zatia.")) == 2
+
+
+def test_chunk_text_on_empty_input():
+    assert chunk_text("   ") == []
+
+
+# ----------------------------------------------------------------------
+# voice assets
+# ----------------------------------------------------------------------
+
+def _voice_file(tmp_path, codes=None, text="Aurrelaria prest dago jokatzeko."):
+    codes = np.arange(NUM_CODEBOOKS * 4).reshape(NUM_CODEBOOKS, 4) if codes is None else codes
+    path = tmp_path / "voice.json"
+    path.write_text(json.dumps({"name": "maider", "reference_text": text,
+                                "codes": np.asarray(codes).tolist()}))
+    return str(path)
+
+
+def test_load_voice_reads_codes_and_text(tmp_path):
+    adapter = ArkTTSAdapter()
+    adapter.load_voice(_voice_file(tmp_path))
+    assert adapter.reference_codes.shape == (NUM_CODEBOOKS, 4)
+    assert adapter.reference_text == "Aurrelaria prest dago jokatzeko."
+
+
+def test_load_voice_rejects_the_wrong_codebook_count(tmp_path):
+    with pytest.raises(ValueError, match="shape"):
+        ArkTTSAdapter().load_voice(_voice_file(tmp_path, codes=np.zeros((3, 4), int)))
+
+
+def test_load_voice_rejects_out_of_range_codes(tmp_path):
+    codes = np.zeros((NUM_CODEBOOKS, 4), int)
+    codes[0, 0] = CODEBOOK_SIZE
+    with pytest.raises(ValueError, match=r"\[0, 4095\]"):
+        ArkTTSAdapter().load_voice(_voice_file(tmp_path, codes=codes))
+
+
+def test_load_voice_requires_a_reference_text(tmp_path):
+    with pytest.raises(ValueError, match="reference_text"):
+        ArkTTSAdapter().load_voice(_voice_file(tmp_path, text="   "))
+
+
+def test_load_voice_resets_the_cached_prefix(tmp_path):
+    adapter = ArkTTSAdapter()
+    adapter.tokenizer = _FakeTokenizer()
+    adapter.load_voice(_voice_file(tmp_path, text="First reference."))
+    first = list(adapter.prefix_ids())
+    adapter.load_voice(_voice_file(tmp_path, text="A completely different reference."))
+    assert adapter.prefix_ids() != first
+
+
+# ----------------------------------------------------------------------
+# prompt
+# ----------------------------------------------------------------------
+
+class _FakeTokenizer:
+    """Deterministic ids from a string, so prompt layout can be asserted exactly."""
+
+    def tokenize(self, text):
+        return [(sum(text.encode()) + index) % 1000 for index in range(max(1, len(text) // 4))]
+
+
+def _adapter_with_voice(codes=None, text="Reference clip text."):
+    adapter = ArkTTSAdapter()
+    adapter.tokenizer = _FakeTokenizer()
+    adapter.reference_codes = (np.arange(NUM_CODEBOOKS * 5).reshape(NUM_CODEBOOKS, 5) % CODEBOOK_SIZE
+                               if codes is None else np.asarray(codes))
+    adapter.reference_text = text
+    return adapter
+
+
+def test_prompt_has_eleven_rows():
+    adapter = _adapter_with_voice()
+    prompt = adapter.build_prompt(np.arange(7, dtype=np.int64))
+    assert prompt.shape[:2] == (1, NUM_CODEBOOKS + 1)
+    assert prompt.dtype == np.int64
+
+
+def test_prompt_length_is_prefix_plus_reference_plus_suffix():
+    adapter = _adapter_with_voice()
+    prefix = len(adapter.prefix_ids())
+    prompt = adapter.build_prompt(np.arange(7, dtype=np.int64))
+    assert prompt.shape[2] == prefix + adapter.reference_codes.shape[1] + 7
+
+
+def test_prompt_shifts_the_reference_into_the_semantic_range():
+    adapter = _adapter_with_voice()
+    prefix = len(adapter.prefix_ids())
+    prompt = adapter.build_prompt(np.arange(3, dtype=np.int64))
+    frames = adapter.reference_codes.shape[1]
+    assert np.array_equal(prompt[0, 0, prefix:prefix + frames],
+                          adapter.reference_codes[0] + SEMANTIC_BEGIN_ID)
+
+
+def test_prompt_aligns_the_codebooks_under_the_reference_only():
+    """Codebook rows must be zero everywhere row 0 is not a semantic token.
+
+    The model sums the codebook embeddings only at semantic positions. Codes leaking into
+    the text region would silently corrupt the conditioning rather than raise.
+    """
+    adapter = _adapter_with_voice()
+    prefix = len(adapter.prefix_ids())
+    prompt = adapter.build_prompt(np.arange(4, dtype=np.int64))
+    frames = adapter.reference_codes.shape[1]
+    assert np.array_equal(prompt[0, 1:, prefix:prefix + frames], adapter.reference_codes)
+    assert not prompt[0, 1:, :prefix].any()
+    assert not prompt[0, 1:, prefix + frames:].any()
+
+
+def test_prompt_without_a_voice_is_refused():
+    adapter = ArkTTSAdapter()
+    adapter.tokenizer = _FakeTokenizer()
+    with pytest.raises(RuntimeError, match="voice_codes_path"):
+        adapter.build_prompt(np.arange(3, dtype=np.int64))
+
+
+def test_prompt_longer_than_the_model_is_refused():
+    adapter = _adapter_with_voice()
+    with pytest.raises(ValueError, match="fewer than"):
+        adapter.build_prompt(np.arange(MAX_SEQ_LEN, dtype=np.int64))
+
+
+def test_prefix_is_tokenized_piece_by_piece():
+    """Upstream encodes each literal separately; joining them first changes the ids.
+
+    A BPE merge that spans two literals would produce a different token stream, and the
+    prompt would no longer be the one the model was trained on.
+    """
+    adapter = _adapter_with_voice(text="Hello there.")
+    expected = [token
+                for part in ("<|im_start|>system\n",
+                             "convert the provided text to speech reference to the "
+                             "following:\n\nText:\n",
+                             "<|speaker:0|>Hello there.",
+                             "\n\nSpeech:\n")
+                for token in adapter.tokenizer.tokenize(part)]
+    assert adapter.prefix_ids() == expected
+
+
+def test_prefix_keeps_an_explicit_speaker_tag():
+    adapter = _adapter_with_voice(text="<|speaker:3|>Already tagged.")
+    joined = adapter.tokenizer.tokenize("<|speaker:3|>Already tagged.")
+    assert all(token in adapter.prefix_ids() for token in joined)
+
+
+def test_encode_text_returns_one_suffix_per_chunk():
+    adapter = _adapter_with_voice()
+    chunks = adapter.encode_text("Lehen esaldia.\n\nBigarren esaldia.", None, None)
+    assert len(chunks) == 2
+    assert all(isinstance(ids, list) and ids for ids in chunks)
+
+
+def test_encode_text_without_a_tokenizer_is_refused():
+    with pytest.raises(RuntimeError, match="bpe_tokenizer_path"):
+        ArkTTSAdapter().encode_text("hi", None, None)
+
+
+# ----------------------------------------------------------------------
+# fake sessions: the two loops with no real weights
+# ----------------------------------------------------------------------
+
+class FakeSession:
+    """Records every feed and returns shaped outputs, like a real ORT session."""
+
+    def __init__(self, output_names, handler, input_names=("cache_key_0",), half=False):
+        self._names = list(output_names)
+        self._handler = handler
+        self._inputs = list(input_names)
+        self._half = half
+        self.calls = []
+
+    def get_outputs(self):
+        return [type("O", (), {"name": name})() for name in self._names]
+
+    def get_inputs(self):
+        kind = "tensor(float16)" if self._half else "tensor(float)"
+        return [type("I", (), {"name": name, "type": kind})() for name in self._inputs]
+
+    # Only the tensors the tests read are recorded. The slow AR's cache is 48 arrays of
+    # 1 MB each, and copying all of them on every step turns a long decode into gigabytes
+    # of pointless allocation.
+    RECORDED = ("codes", "input_pos", "token_id", "use_slow_hidden", "slow_hidden",
+                "cache_key_0")
+
+    def run(self, _outputs, feed):
+        self.calls.append({key: (value.copy() if isinstance(value, np.ndarray) else value)
+                           for key, value in feed.items() if key in self.RECORDED})
+        return self._handler(feed, len(self.calls) - 1)
+
+
+def _slow_session(tokens, half=False):
+    """Emit ``tokens`` in order and return deltas shaped like the real graph."""
+    names = (["logits", "slow_hidden"]
+             + [f"{kind}_delta_{i}" for i in range(SLOW_LAYERS) for kind in ("key", "value")])
+    dtype = np.float16 if half else np.float32
+
+    def handler(feed, call):
+        width = feed["codes"].shape[2]
+        logits = np.full((1, width, CODEBOOK_SIZE + 1), -20.0, dtype)
+        logits[0, -1, tokens[min(call, len(tokens) - 1)]] = 20.0
+        delta = np.full((1, SLOW_KV_HEADS, width, SLOW_HEAD_DIM), call + 1, dtype)
+        return ([logits, np.full((1, width, HIDDEN), 0.25, dtype)]
+                + [delta.copy() for _ in range(2 * SLOW_LAYERS)])
+
+    return FakeSession(names, handler, ["codes", "input_pos", "cache_key_0"], half)
+
+
+def _fast_session(token=7, half=False):
+    names = (["logits"]
+             + [f"{kind}_delta_{i}" for i in range(FAST_LAYERS) for kind in ("key", "value")])
+    dtype = np.float16 if half else np.float32
+
+    def handler(feed, _call):
+        logits = np.full((1, 1, CODEBOOK_SIZE), -20.0, dtype)
+        logits[0, 0, token] = 20.0
+        delta = np.zeros((1, FAST_KV_HEADS, 1, FAST_HEAD_DIM), dtype)
+        return [logits] + [delta.copy() for _ in range(2 * FAST_LAYERS)]
+
+    return FakeSession(names, handler, ["slow_hidden", "cache_key_0"], half)
+
+
+def _decoder_session():
+    def handler(feed, _call):
+        frames = feed["codes"].shape[-1]
+        return [np.full((1, 1, frames * FRAME_SIZE), 0.5, np.float32)]
+    return FakeSession(["audio"], handler, ["codes"])
+
+
+def _ready_adapter(fast_token=7, half=False):
+    adapter = _adapter_with_voice()
+    adapter.fast_ar = _fast_session(fast_token, half)
+    adapter.decoder = _decoder_session()
+    return adapter
+
+
+# ----------------------------------------------------------------------
+# fast AR loop
+# ----------------------------------------------------------------------
+
+def test_fast_ar_returns_ten_codebooks():
+    adapter = _ready_adapter()
+    codebooks = adapter.generate_codebooks(np.zeros((1, 1, HIDDEN), np.float32), 3,
+                                           np.random.default_rng(0), 0.8, 50, 0.95, False)
+    assert len(codebooks) == NUM_CODEBOOKS
+    assert codebooks[0] == 3
+
+
+def test_fast_ar_first_position_reads_the_slow_hidden_state():
+    adapter = _ready_adapter()
+    adapter.generate_codebooks(np.zeros((1, 1, HIDDEN), np.float32), 3,
+                               np.random.default_rng(0), 0.8, 50, 0.95, False)
+    first = adapter.fast_ar.calls[0]
+    assert bool(first["use_slow_hidden"][0]) is True
+    assert int(first["input_pos"][0]) == 0
+
+
+def test_fast_ar_later_positions_read_the_previous_codebook():
+    adapter = _ready_adapter(fast_token=11)
+    adapter.generate_codebooks(np.zeros((1, 1, HIDDEN), np.float32), 3,
+                               np.random.default_rng(0), 0.8, 50, 0.95, False)
+    second = adapter.fast_ar.calls[1]
+    assert bool(second["use_slow_hidden"][0]) is False
+    assert int(second["token_id"][0, 0]) == 3          # codebook 0, passed in
+    assert int(adapter.fast_ar.calls[2]["token_id"][0, 0]) == 11   # then the fast AR's own
+
+
+def test_fast_ar_walks_positions_zero_to_nine():
+    adapter = _ready_adapter()
+    adapter.generate_codebooks(np.zeros((1, 1, HIDDEN), np.float32), 0,
+                               np.random.default_rng(0), 0.8, 50, 0.95, False)
+    assert [int(call["input_pos"][0]) for call in adapter.fast_ar.calls] == list(
+        range(NUM_CODEBOOKS))
+
+
+def test_fast_ar_cache_is_the_codebook_width():
+    adapter = _ready_adapter()
+    adapter.generate_codebooks(np.zeros((1, 1, HIDDEN), np.float32), 0,
+                               np.random.default_rng(0), 0.8, 50, 0.95, False)
+    assert adapter.fast_ar.calls[0]["cache_key_0"].shape == (
+        1, FAST_KV_HEADS, NUM_CODEBOOKS, FAST_HEAD_DIM)
+
+
+def test_fast_ar_cache_grows_one_position_per_step():
+    """Each step must see exactly its predecessors written, and nothing beyond.
+
+    The graph masks by ``key <= input_pos``, so a delta written at the wrong offset is
+    invisible to the mask and produces wrong attention with no error anywhere.
+    """
+    adapter = _ready_adapter()
+    adapter.fast_ar = _fast_session()
+
+    def handler(feed, call):
+        written = np.abs(feed["cache_key_0"]).sum(axis=(0, 1, 3)) > 0
+        assert int(written.sum()) == call, f"step {call} saw {int(written.sum())} written slots"
+        logits = np.full((1, 1, CODEBOOK_SIZE), -20.0, np.float32)
+        logits[0, 0, 7] = 20.0
+        delta = np.ones((1, FAST_KV_HEADS, 1, FAST_HEAD_DIM), np.float32)
+        return [logits] + [delta.copy() for _ in range(2 * FAST_LAYERS)]
+
+    adapter.fast_ar._handler = handler
+    adapter.generate_codebooks(np.zeros((1, 1, HIDDEN), np.float32), 0,
+                               np.random.default_rng(0), 0.8, 50, 0.95, False)
+
+
+def test_fast_ar_feeds_half_precision_when_the_graph_is_half():
+    adapter = _ready_adapter(half=True)
+    adapter.generate_codebooks(np.zeros((1, 1, HIDDEN), np.float32), 0,
+                               np.random.default_rng(0), 0.8, 50, 0.95, False)
+    assert adapter.fast_ar.calls[0]["slow_hidden"].dtype == np.float16
+
+
+# ----------------------------------------------------------------------
+# slow AR loop
+# ----------------------------------------------------------------------
+
+def test_slow_ar_stops_at_end_of_speech():
+    adapter = _ready_adapter()
+    session = _slow_session([3, 4, EOS_INDEX])
+    codes = adapter.generate_codes(session, adapter.build_prompt(np.arange(4, dtype=np.int64)),
+                                   {"do_sample": False}, np.random.default_rng(0))
+    assert codes.shape == (NUM_CODEBOOKS, 2)
+
+
+def test_end_of_speech_frame_is_not_emitted():
+    adapter = _ready_adapter()
+    session = _slow_session([EOS_INDEX])
+    codes = adapter.generate_codes(session, adapter.build_prompt(np.arange(4, dtype=np.int64)),
+                                   {"do_sample": False}, np.random.default_rng(0))
+    assert codes.shape[1] == 0
+
+
+def test_slow_ar_honours_the_frame_budget():
+    adapter = _ready_adapter()
+    session = _slow_session([3])            # never emits EOS
+    codes = adapter.generate_codes(session, adapter.build_prompt(np.arange(4, dtype=np.int64)),
+                                   {"do_sample": False, "max_new_tokens": 5},
+                                   np.random.default_rng(0))
+    assert codes.shape[1] == 5
+
+
+def test_frame_budget_is_capped_by_the_sequence_limit():
+    """The budget can never push the sequence past the cache width.
+
+    The prompt here nearly fills the 2048-position window, so an unbounded
+    ``max_new_tokens`` has to shrink to the handful of positions that are left rather than
+    overrun the cache. A prompt this long is also what makes the assertion cheap to run.
+    """
+    adapter = _ready_adapter()
+    adapter.reference_codes = np.zeros((NUM_CODEBOOKS, 8), np.int64)
+    prefix = len(adapter.prefix_ids())
+    room = MAX_SEQ_LEN - prefix - 8 - 6
+    prompt = adapter.build_prompt(np.arange(room, dtype=np.int64))
+    session = _slow_session([3])            # never emits EOS
+    codes = adapter.generate_codes(session, prompt,
+                                   {"do_sample": False, "max_new_tokens": MAX_SEQ_LEN * 2},
+                                   np.random.default_rng(0))
+    assert codes.shape[1] == MAX_SEQ_LEN - prompt.shape[2] == 6
+
+
+def test_prefill_reads_the_whole_prompt_then_one_position_per_step():
+    adapter = _ready_adapter()
+    prompt = adapter.build_prompt(np.arange(4, dtype=np.int64))
+    session = _slow_session([3, 4, EOS_INDEX])
+    adapter.generate_codes(session, prompt, {"do_sample": False}, np.random.default_rng(0))
+    widths = [call["codes"].shape[2] for call in session.calls]
+    assert widths[0] == prompt.shape[2]
+    assert widths[1:] == [1] * (len(widths) - 1)
+
+
+def test_positions_continue_from_the_prompt():
+    adapter = _ready_adapter()
+    prompt = adapter.build_prompt(np.arange(4, dtype=np.int64))
+    session = _slow_session([3, 4, 5, EOS_INDEX])
+    adapter.generate_codes(session, prompt, {"do_sample": False}, np.random.default_rng(0))
+    width = prompt.shape[2]
+    assert list(session.calls[0]["input_pos"]) == list(range(width))
+    assert [int(call["input_pos"][0]) for call in session.calls[1:]] == [
+        width, width + 1, width + 2]
+
+
+def test_slow_cache_is_the_full_window_from_the_first_call():
+    adapter = _ready_adapter()
+    session = _slow_session([EOS_INDEX])
+    adapter.generate_codes(session, adapter.build_prompt(np.arange(4, dtype=np.int64)),
+                           {"do_sample": False}, np.random.default_rng(0))
+    assert session.calls[0]["cache_key_0"].shape == (
+        1, SLOW_KV_HEADS, MAX_SEQ_LEN, SLOW_HEAD_DIM)
+
+
+def test_slow_cache_starts_empty_and_fills_the_prompt_prefix():
+    adapter = _ready_adapter()
+    prompt = adapter.build_prompt(np.arange(4, dtype=np.int64))
+    session = _slow_session([3, EOS_INDEX])
+    adapter.generate_codes(session, prompt, {"do_sample": False}, np.random.default_rng(0))
+    assert not session.calls[0]["cache_key_0"].any()
+    written = np.abs(session.calls[1]["cache_key_0"]).sum(axis=(0, 1, 3)) > 0
+    assert int(written.sum()) == prompt.shape[2]
+    assert written[:prompt.shape[2]].all()
+
+
+def test_slow_cache_grows_one_slot_per_decode_step():
+    adapter = _ready_adapter()
+    prompt = adapter.build_prompt(np.arange(4, dtype=np.int64))
+    session = _slow_session([3, 4, 5, EOS_INDEX])
+    adapter.generate_codes(session, prompt, {"do_sample": False}, np.random.default_rng(0))
+    counts = [int((np.abs(call["cache_key_0"]).sum(axis=(0, 1, 3)) > 0).sum())
+              for call in session.calls]
+    assert counts == [0, prompt.shape[2], prompt.shape[2] + 1, prompt.shape[2] + 2]
+
+
+def test_next_step_feeds_the_frame_it_just_produced():
+    """Row 0 carries the semantic token in text-vocabulary space, rows 1..10 the codebooks."""
+    adapter = _ready_adapter(fast_token=11)
+    session = _slow_session([3, EOS_INDEX])
+    adapter.generate_codes(session, adapter.build_prompt(np.arange(4, dtype=np.int64)),
+                           {"do_sample": False}, np.random.default_rng(0))
+    column = session.calls[1]["codes"]
+    assert column.shape == (1, NUM_CODEBOOKS + 1, 1)
+    assert int(column[0, 0, 0]) == SEMANTIC_BEGIN_ID + 3
+    assert int(column[0, 1, 0]) == 3
+    assert list(column[0, 2:, 0]) == [11] * (NUM_CODEBOOKS - 1)
+
+
+def test_slow_ar_feeds_half_precision_when_the_graph_is_half():
+    adapter = _ready_adapter(half=True)
+    session = _slow_session([EOS_INDEX], half=True)
+    adapter.generate_codes(session, adapter.build_prompt(np.arange(4, dtype=np.int64)),
+                           {"do_sample": False}, np.random.default_rng(0))
+    assert session.calls[0]["cache_key_0"].dtype == np.float16
+
+
+# ----------------------------------------------------------------------
+# synthesis
+# ----------------------------------------------------------------------
+
+def _request(ids=None, **params):
+    ids = np.arange(6, dtype=np.int64) if ids is None else ids
+    return AdapterSynthesisRequest(phoneme_ids=ids.reshape(1, -1),
+                                   phoneme_lengths=np.asarray([ids.size], np.int64),
+                                   params=params)
+
+
+def test_synthesize_returns_audio_and_frame_count():
+    adapter = _ready_adapter()
+    session = _slow_session([3, 4, EOS_INDEX])
+    result = adapter.synthesize(_request(do_sample=False), session)
+    assert result.extras["frame_count"] == 2
+    assert result.audio.shape == (2 * FRAME_SIZE,)
+    assert result.audio.dtype == np.float32
+
+
+def test_synthesize_carries_the_reference_text():
+    adapter = _ready_adapter()
+    result = adapter.synthesize(_request(do_sample=False), _slow_session([3, EOS_INDEX]))
+    assert result.extras["reference_text"] == adapter.reference_text
+
+
+def test_synthesize_returns_empty_audio_when_nothing_is_emitted():
+    adapter = _ready_adapter()
+    result = adapter.synthesize(_request(do_sample=False), _slow_session([EOS_INDEX]))
+    assert result.audio.size == 0
+
+
+def test_synthesize_is_reproducible_for_a_seed():
+    logits_tokens = [3, 4, 5, EOS_INDEX]
+    first = _ready_adapter().synthesize(_request(seed=99), _slow_session(logits_tokens))
+    second = _ready_adapter().synthesize(_request(seed=99), _slow_session(logits_tokens))
+    assert np.array_equal(first.audio, second.audio)
+
+
+def test_synthesize_without_the_fast_graph_is_refused():
+    adapter = _adapter_with_voice()
+    adapter.decoder = _decoder_session()
+    with pytest.raises(RuntimeError, match="fast_ar_path"):
+        adapter.synthesize(_request(), _slow_session([EOS_INDEX]))
+
+
+def test_synthesize_without_the_decoder_is_refused():
+    adapter = _adapter_with_voice()
+    adapter.fast_ar = _fast_session()
+    with pytest.raises(RuntimeError, match="codec_decoder_path"):
+        adapter.synthesize(_request(), _slow_session([EOS_INDEX]))
+
+
+def test_decode_codes_feeds_the_decoder_one_batch_of_ten_rows():
+    adapter = _ready_adapter()
+    adapter.decode_codes(np.zeros((NUM_CODEBOOKS, 9), np.int64))
+    assert adapter.decoder.calls[0]["codes"].shape == (1, NUM_CODEBOOKS, 9)
+
+
+def test_single_graph_path_is_not_offered():
+    adapter = ArkTTSAdapter()
+    with pytest.raises(NotImplementedError):
+        adapter.build_feed_dict(_request(), None)
+    with pytest.raises(NotImplementedError):
+        adapter.parse_outputs([], _request())
+
+
+# ----------------------------------------------------------------------
+# configure() — both checkpoints go through the same code path
+# ----------------------------------------------------------------------
+
+class _VoiceConfig:
+    def __init__(self, **engine_params):
+        self.engine_params = engine_params
+        self.lang_code = engine_params.pop("lang_code", None)
+
+
+def test_configure_loads_the_voice_asset(tmp_path, monkeypatch):
+    monkeypatch.setattr("phoonnx.engines.arktts.make_session", lambda path, providers=None: path)
+    monkeypatch.setattr("phoonnx.engines.arktts.BPETokenizer", lambda path: path)
+    adapter = ArkTTSAdapter()
+    adapter.configure(_VoiceConfig(fast_ar_path="fast", codec_decoder_path="codec",
+                                   bpe_tokenizer_path="tok",
+                                   voice_codes_path=_voice_file(tmp_path)))
+    assert adapter.fast_ar == "fast"
+    assert adapter.decoder == "codec"
+    assert adapter.reference_codes.shape == (NUM_CODEBOOKS, 4)
+
+
+@pytest.mark.parametrize("lang_code", ["eu-ES", "en-US", "ja-JP"])
+def test_configure_is_language_agnostic(tmp_path, monkeypatch, lang_code):
+    """Zortzi (Basque) and Audio8 (11 languages) take the identical path.
+
+    ArkTTS has no language token — the language comes from the text and the reference
+    clip — so nothing in the adapter may branch on the voice's language.
+    """
+    monkeypatch.setattr("phoonnx.engines.arktts.make_session", lambda path, providers=None: path)
+    monkeypatch.setattr("phoonnx.engines.arktts.BPETokenizer", lambda path: path)
+    adapter = ArkTTSAdapter()
+    adapter.configure(_VoiceConfig(fast_ar_path="fast", codec_decoder_path="codec",
+                                   bpe_tokenizer_path="tok", lang_code=lang_code,
+                                   voice_codes_path=_voice_file(tmp_path)))
+    assert adapter.reference_text == "Aurrelaria prest dago jokatzeko."
+
+
+def test_configure_tolerates_a_voice_without_aux_paths():
+    adapter = ArkTTSAdapter()
+    adapter.configure(_VoiceConfig())
+    assert adapter.fast_ar is None and adapter.reference_codes is None
+
+
+# ----------------------------------------------------------------------
+# voice index
+# ----------------------------------------------------------------------
+
+def _index():
+    from phoonnx.model_manager import TTSModelManager
+    path = TTSModelManager.voice_index_path() / "arktts.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_voice_index_is_bundled():
+    from phoonnx.model_manager import TTSModelManager
+    assert any(path.name == "arktts.json" for path in TTSModelManager.voice_index_files())
+
+
+def test_voice_index_entries_are_complete():
+    for voice_id, entry in _index().items():
+        assert entry["engine"] == "arktts", voice_id
+        assert entry["voice_id"] == voice_id
+        aux = entry["aux_model_urls"]
+        for key in ("fast_ar_path", "codec_decoder_path", "bpe_tokenizer_path",
+                    "voice_codes_path"):
+            assert key in aux, f"{voice_id} is missing {key}"
+        assert entry["model_url"].endswith(".onnx")
+
+
+def test_voice_index_covers_both_checkpoints():
+    mirrors = {entry["model_url"].split("/resolve/")[0] for entry in _index().values()}
+    assert any("zortzi" in mirror for mirror in mirrors)
+    assert any("audio8" in mirror for mirror in mirrors)
+
+
+def test_voice_index_languages_are_tagged():
+    for voice_id, entry in _index().items():
+        assert entry["lang"], voice_id


### PR DESCRIPTION
## What this adds

The `arktts` engine, driving **two** Apache-2.0 checkpoints that share one architecture:

| Checkpoint | Mirror | Languages | Voices |
|---|---|---|---|
| [`itzune/zortzi-tts`](https://huggingface.co/itzune/zortzi-tts) | [`OpenVoiceOS/phoonnx-zortzi-tts`](https://huggingface.co/OpenVoiceOS/phoonnx-zortzi-tts) | Basque | Maider, Antton |
| [`Audio8/Audio8-TTS-Preview-0.6b`](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.6b) | [`OpenVoiceOS/phoonnx-audio8-tts`](https://huggingface.co/OpenVoiceOS/phoonnx-audio8-tts) | yue, zh, nl, en, fr, de, it, ja, ko, pl, es | Maider, Antton |

Zortzi is a Basque fine-tune of Audio8. The two ship **byte-identical**
`modeling_arktts.py`, `modeling_arktts_codec.py`, `processing_arktts.py`, `tokenizer.json`
and `codec.pth`, so one adapter drives both and the differences live entirely in the voice
index. 24 new voice ids; Basque gains its first codec-LM voice in phoonnx.

Both mirrors are in the
[community mirror collection](https://huggingface.co/collections/OpenVoiceOS/phoonnx-community-mirror-6a2204d302e0e7497870cd68).

Semantically additive: `detect_priority=22`, below every existing engine, so it never steals
detection from anything already registered. The branch is now rebased onto `dev` after
`outetts` (#342) landed there — `Engine.OUTETTS` and `Engine.ARKTTS` coexist, `outetts`
keeps `detect_priority=23` and `arktts` keeps 22, and both engines' voice-index entries,
docs rows and `VOICES.md` lines are merged rather than overwritten.

## Architecture

ArkTTS is DualAR — two stacked autoregressive models, like Qwen3-TTS:

* **slow AR** — 24 decoder layers emitting one token per 46 ms frame. That token *is*
  codebook 0, and its hidden state conditions the second model;
* **fast AR** — 4 decoder layers that read the slow hidden state and write codebooks 1..9
  of the *same* frame, one codebook per step.

One frame therefore costs one slow step plus nine fast steps, and the ten codebooks are fed
back to the slow AR as a summed embedding at the next position. Output is **44.1 kHz**, the
highest of any phoonnx engine.

The prompt is a `[1, 11, T]` matrix, not a flat token sequence. Row 0 is the token stream —
a system block, the reference clip's codes shifted into the semantic range, then the text.
Rows 1..10 hold the reference clip's ten codebooks, aligned under those semantic positions
and zero elsewhere, because the model sums codebook embeddings only where row 0 names a
semantic token.

**A voice is a reference clip, not a speaker id.** ArkTTS has no speaker table and always
emits `<|speaker:0|>`; the speaker is carried by the codec codes of a short clip. The
mirrors ship those codes plus the clip's transcription in one small JSON per voice, so the
runtime needs the codec *decoder* only.

## IO contracts

```
slow_ar_fp16.onnx
  in   codes[1, 11, T] int64, input_pos[T] int64,
       cache_key_{0..23} / cache_value_{0..23}  [1, 2, 2048, 64]
  out  logits[1, T, 4097], slow_hidden[1, T, 896],
       key_delta_{i} / value_delta_{i}          [1, 2, T, 64]

fast_ar_fp16.onnx
  in   slow_hidden[1, 1, 896], token_id[1, 1] int64, use_slow_hidden[1] bool,
       input_pos[1] int64, cache_key_{0..3} / cache_value_{0..3}  [1, 2, 10, 64]
  out  logits[1, 1, 4096], key_delta_{i} / value_delta_{i}        [1, 2, 1, 64]

codec_decoder_fp16.onnx
  in   codes[1, 10, T] int64        out  audio[1, 1, samples] @ 44.1 kHz
```

Two properties are load-bearing and are what the tests guard:

* **The KV cache is a fixed 2048-wide window**, not a growing tensor. Each graph writes its
  new keys and values at `input_pos` and attends over the whole window, masking by
  `key <= input_pos[query]`; unwritten slots hold zeros and can never enter a softmax. The
  graph returns only the delta, so the engine keeps the window and scatters into it. A delta
  written at the wrong offset gives wrong attention and **no error**.
* **The slow logits are sliced to 4097** — 4096 semantic entries then EOS. Upstream masks
  everything else before sampling, so an index below 4096 is already codebook 0's value with
  no offset to subtract.

## Sampler semantics

Verified against `ArkttsModel._sample_semantic` and `ArkttsLegacyTopKTopPLogitsProcessor`,
not the HuggingFace stack. Two differences change which tokens survive:

1. **The nucleus is measured before temperature.** Upstream filters top-k/top-p against the
   softmax of the *unscaled* logits, then divides by temperature. HuggingFace does the
   reverse, which lets temperature widen or narrow the nucleus.
2. **The token that crosses the top-p threshold is dropped**, not kept — the test is
   `cumulative > top_p` on the inclusive sum.

On top sits repetition-aware sampling: a draw landing on a semantic token already among the
last ten is discarded and redrawn at top-p 0.9 / temperature 1.0. That is the anti-looping
mechanism, and it is why both model cards say greedy decoding never reaches EOS — with
sampling off both draws are the same argmax. **The engine therefore offers no greedy mode**;
defaults are the cards' 0.8 / 0.95.

One subtlety is pinned by a test: the repetition window holds *text-vocabulary* ids, not
sliced indices. Upstream seeds the window with zeros, and zero is not a semantic token in
the text vocabulary but *is* a valid sliced index — a window kept in sliced space would read
an unfilled slot as a repeat of codebook value 0.

## Numeric parity

`scripts/conversion/arktts/verify_parity.py`, against the PyTorch checkpoints in float32,
24 lockstep greedy decode steps. Greedy is used only here.

The prompt is checked first, with **no tolerance**: the `[1, 11, T]` matrix the engine builds
is byte-identical to the one upstream's own processor and `_prepare_prompt` produce, for both
checkpoints. Nothing below would mean anything otherwise.

**Zortzi — official fp16 graphs from `itzune/zortzi-tts-onnx` (shipped):**

| Tensor | max abs diff | mean | greedy agreement | worst miss margin |
|---|---|---|---|---|
| slow AR logits | 0.041 | 0.023 | **24/24** | — |
| slow AR hidden | 0.017 | 0.011 | — | — |
| fast AR logits | 0.088 | 0.046 | 211/216 | 0.022 |
| codec decoder | 5.6e-4 | — | corr 0.999999 | — |

**Audio8 — my own export (shipped):**

| Tensor | max abs diff | mean | greedy agreement | worst miss margin |
|---|---|---|---|---|
| slow AR logits | 0.118 | 0.061 | **24/24** | — |
| slow AR hidden | 0.039 | 0.026 | — | — |
| fast AR logits | 1.36 | 0.457 | 208/216 | 0.225 |
| codec decoder | 6.3e-4 | — | corr 0.999999 | — |

Every fast-AR disagreement is a tie the reference itself barely decided — the worst margin
is well below the logit difference in both tables. Audio8's fast AR is noisier because the
fp16 graph accumulates its RMS norms in half precision: upstream's explicit float32
round-trip cannot survive the fp16 converter, and the trade is documented in the exporter.

**INT4 is rejected**, following the Spark-TTS precedent. Upstream publishes it and defaults
to it; it is not mirrored:

| Tensor | max abs diff | greedy agreement |
|---|---|---|
| slow AR logits | 4.13 | 17/24 |
| fast AR logits | 7.38 | **55/216** |

The fast AR disagrees on three quarters of its codebook predictions and the misses are not
ties. Upstream's card calls this "flatter prosody and less reliable question intonation";
that is what it looks like measured.

## ASR / WER gate

`scripts/conversion/arktts/wer_gate.py`, `onnx-asr` on CPU.

**Basque — coverage is a real gap, stated plainly.** `nemo-canary-1b-v2` covers the 25
official EU languages and Basque is not one; no other model `onnx-asr` ships recognises
`eu`. Whisper lists `eu`, so `onnx-community/whisper-large-v3-turbo` is used as an explicit
best-effort, with Basque a low-resource language for it.

| Model | Language | Metric | Clips |
|---|---|---|---|
| Zortzi (Maider + Antton) | eu | **WER 0.300** (18/60) | 10 |

Read that as a lower bound on intelligibility, not as voice quality — 3 of 10 clips are
perfect and most errors are the recogniser mis-splitting words it heard correctly
("Nondago urbile endagoen" for "Non dago hurbilen dagoen").

**Audio8**, one sentence per language per voice (unchanged from the first pass):

| Language | WER | Note |
|---|---|---|
| en | **0.000** | |
| de | **0.000** | |
| es | **0.000** | |
| it | **0.000** | |
| nl | 0.125 | one recogniser slip in one clip |
| pl | 0.143 | recogniser wrote "10" for "dziesięć" |

**French, redone at n=12** (the original n=2 number above, WER 0.333, is superseded).
Twelve distinct sentences, Audio8 Maider, scored against two independent CPU ASR models —
`nemo-canary-1b-v2` (the same model the rest of this gate uses) and `OpenVoiceOS/qwen3-asr-0.6b-onnx`
(TigreGotico `onnx-asr` fork, `speech-llm` type) — so no single recogniser's quirks decide the
number:

| Model | WER | Errors/tokens |
|---|---|---|
| nemo-canary-1b-v2 | 0.1275 | 13/102 |
| qwen3-asr-0.6b | 0.0882 | 9/102 |
| **mean** | **0.108** | — |

Both models independently mis-hear the same 2 of 12 clips as plural — "Le train part…" heard
as "Les trains partent…", "Le marché…" as "Les marchés…" — and agree on 10 of 12 clips
exactly. Two unrelated recognisers converging on the same two "singular read as plural"
misses, rather than scattering errors across different clips, is what you'd expect if the
TTS itself is under-articulating the `le`/`les` distinction on those two sentences (a
liaison/vowel-length cue that carries less signal at synthesis time than in read speech),
not recogniser noise. It is not a phonemization bug — Audio8 has no phonemizer, it is raw
text in — and it is not a text-normalization bug, since both references are already the
literal singular sentence. Read the 10.8% as intelligibility on real, varied French
sentences, well inside normal TTS territory and not the outlier the n=2 number suggested.

**CJK**, 5 sentences per language, Audio8 Maider:

| Language | Model | Metric | Result | Errors/tokens |
|---|---|---|---|---|
| zh | qwen3-asr-0.6b | CER | **0.000** | 0/47 |
| zh | omnilingual-asr-ctc-1b (TigreGotico fork) | CER | 0.064 | 3/47 |
| ja | whisper-large-v3-turbo | CER | **0.000** | 0/68 |
| ja | qwen3-asr-0.6b | CER | **0.000** | 0/68 |
| ko | whisper-large-v3-turbo | CER | **0.000** | 0/60 |
| ko | qwen3-asr-0.6b | CER | 0.017 | 1/60 |

zh and ja come back perfect on at least one model each, and the qwen3-asr/whisper pair
agrees on ko; the 3 omnilingual-ctc zh errors don't reproduce on qwen3-asr, which puts them
on the recogniser, not the voice.

**yue stays exempt, and that was rechecked rather than assumed.** `omnilingual-asr-ctc-1b`
claims 1600+ languages, so it was tried first: on the same 5 Cantonese sentences it returned
simplified-Mandarin-flavoured fragments and outright Latin-alphabet noise, CER 1.31 (63/48) —
worse than no signal, since a CER over 1 means the hypothesis is longer garbage than the
reference is text. `whisper-large-v3-turbo` with `language="yue"` does no better, CER 1.10
(53/48), mixing romanization and wrong-script guesses. Neither model gives a usable Cantonese
signal on this hardware, so yue is still scored by ear only, and the follow-up below is
updated to name what was actually tried rather than leaving it open-ended.

## CPU RTF and samples

Twelve cores, single stream, seeded, `synthesize_samples.py`:

| Model | Voice | Aggregate RTF | Audio |
|---|---|---|---|
| Zortzi | Maider | **8.0x** | 15.2 s |
| Zortzi | Antton | **8.6x** | 14.4 s |
| Audio8 | Maider | 13.1x | 20.0 s |
| Audio8 | Antton | 14.3x | 20.7 s |

Zortzi's 8x matches the 7.7x upstream reports for fp16 on eight cores, which corroborates
that this runtime reproduces upstream's work per frame. Audio8 is slower because that export
carries the tied embedding twice and is not otherwise optimised. **Neither is real-time on
CPU**, and both model cards say the same.

Sample WAVs are on the homelab share.

## End-to-end through the published mirrors

`TTSModelManager` → index → download → `TTSVoice` → audio, from the live mirrors:

```
arktts/zortzi-maider/eu  -> phoonnx-zortzi-tts/slow_ar_fp16.onnx
  adapter: ArkTTSAdapter | engine: Engine.ARKTTS
  2.04s @ 44100 Hz
arktts/audio8-antton/en  -> phoonnx-audio8-tts/slow_ar_fp16.onnx
  adapter: ArkTTSAdapter | engine: Engine.ARKTTS
  2.60s @ 44100 Hz
```

This is what caught the last bug in the branch: with no config in the mirror the voice layer
had nothing to detect on, fell back to the VITS adapter, dropped every character as
out-of-vocabulary and returned no audio. Each mirror now ships a `config.json` naming the
engine.

## Tests

`tests/test_arktts.py`, **75 tests, 1.3 s, no weights downloaded** — the loops run against
fake sessions reproducing the ONNX contract.

The KV coverage is the point of the file, for both AR models: cache width, present→past
hand-off, exactly one written slot per step, positions continuing from the prompt, the frame
being fed back at the right offset, EOS not being emitted as a frame, and the length cap
shrinking to what the 2048-position window leaves. A mis-scattered delta is invisible to the
graph's mask, so these assertions are the only thing standing between a wrong offset and
plausible-sounding wrong audio.

Sampler tests pin both upstream/HuggingFace divergences and the text-vocabulary window.
`configure()` is exercised for both checkpoints and parametrised over language tags, since
nothing in the adapter may branch on language.

## Conversion toolchain

`scripts/conversion/arktts/` — exporter, parity harness, voice minting, sample/RTF runner,
WER gate, and a README documenting the contract. Nothing is vendored; the checkpoints ship
their model code on the Hub and the wrappers only re-plumb the KV cache.

Four upstream constructs block the tracer, each handled in a named function with its
reasoning attached: an in-place boolean `&=` in the codec's window mask, `torch.polar` in its
rotary table, a `math.ceil` over a traced shape in the causal padding, and the explicit
float32 round-trips in the RMS norms. The padding simplification **asserts** every causal
convolution on the decode path is stride 1 before applying itself, so a future checkpoint
gets an error rather than a subtly different model.

One environment note worth carrying: **use `transformers==4.57.x`**. On 5.x the checkpoint's
non-persistent RoPE buffer is never initialised and the reference model silently returns
`NaN` logits instead of failing — every parity number comes out as `NaN`. That cost a
debugging cycle here.

## Licence and provenance

Both checkpoints are Apache-2.0. Upstream work is by **itzune** and **Audio8**; the mirrors
repackage it with attribution.

The voices are anchored to the **HiTZ-Aholab Basque TTS dataset** (CC BY 4.0,
[10.5281/zenodo.17952596](https://doi.org/10.5281/zenodo.17952596)) — the Zortzi card
confirms this, and the reference clips are `NEU_05850.wav` (Maider) and `NEU_11782.wav`
(Antton). That licence conditions the voices themselves, so redistributing the files *or
audio generated with them* carries the attribution, which both mirror cards and the engine
doc reproduce along with the ILENIA / IKER-GAITU funding acknowledgement.

Audio8 bundles no reference voices, so its mirror carries the same two clips. Re-encoding
them with Audio8's own codec reproduces upstream's published Zortzi codes — codebook 0
exactly, all ten codebooks on 99.2–99.6 % of frames — which is what confirms the shared
`codec.pth` and makes the published codes the reproducible artifact to ship.

## Follow-ups (not in this PR)

* **Codec encoder export**, which would make zero-shot cloning work at synthesis time
  instead of offline through `mint_voice.py`. The encoder's strided causal convolutions
  genuinely need the dynamic right-padding this export drops for the decode path.
* **`slow_ar_fp16.onnx` is ~270 MB larger than needed** — the tracer materialises the tied
  output projection separately from the embedding table, and the byte-identical initializer
  dedup does not catch it.
* **Shared code, deliberately untouched here.** `chunk_text`, `roll`/`empty` cache helpers
  and the top-k/top-p sampler now exist in near-identical form in `qwen3tts.py`,
  `sparktts.py`, `neutts.py` and `arktts.py`. Factoring them into a shared module is the
  right move but it edits four live engines, so it wants its own PR rather than riding along
  with a new one. Note that the samplers are *not* actually interchangeable — ArkTTS's order
  differs from Qwen3-TTS's — so any such refactor has to keep the ordering explicit per
  engine.
* **yue intelligibility scoring** — both CPU ASR models tried (`omnilingual-asr-ctc-1b`,
  `whisper-large-v3-turbo`) return CER above 1.0 on Cantonese; nothing on this hardware gives
  a trustworthy number yet, so the voice is still shipped unevaluated by ASR (ear-check only).
* Sibling codec-LM mirrors (`phoonnx-qwen3-tts`, `phoonnx-spark-tts`) also ship no
  `config.json`; if they rely on the caller naming the engine they have the same latent
  fallback-to-VITS trap this PR fixed for ArkTTS.
* **Residual risk, stated plainly: the vocab-offset claim is single-sourced.** The "slow
  logits sliced to 4097, index below 4096 is already codebook 0's value with no offset to
  subtract" claim in the IO-contracts section is verified by one script
  (`verify_parity.py`) against one PyTorch reference per checkpoint, not cross-checked
  against a second independent implementation. The 24/24 greedy agreement on slow-AR logits
  for both checkpoints is strong evidence for it, but "strong evidence from one source" is
  not the same as "confirmed by two". Anyone extending this adapter to a third ArkTTS-family
  checkpoint should re-verify the slicing rather than assume it as a fixed constant of the
  architecture.

## Authorship

Implemented by Claude Opus under Fable orchestration. Parity, WER, RTF and the end-to-end
run were executed on a separate workstation; all figures above are measured, none estimated.
The French and CJK re-scoring above was likewise synthesized and scored on a separate
workstation, against the rebased branch, after the adversarial review that flagged the
original n=2 French number and the missing CJK numbers.

Do not merge — draft pending review.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArkTTS text-to-speech support with 44.1 kHz audio output.
  * Added voices across 12 language and locale groups, including Basque and Chinese variants.
  * Increased the available voice catalog to 2,469 voices across 1,243 languages.
  * Added support for custom voice creation from audio or reference data.

* **Documentation**
  * Added comprehensive ArkTTS setup, configuration, usage, and voice-management guides.
  * Added conversion, synthesis, and quality-validation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->