### PR TITLE
docs: retroactive Habibi voice quality audit (WER/CER/RTF)

### DIFF
--- a/docs/training/engines/f5tts.md
+++ b/docs/training/engines/f5tts.md
@@ -283,7 +283,7 @@ of scope for this pass.
 
 - **ASR**: [`OpenVoiceOS/nemotron-3.5-asr-arabic-dialectal-v2-onnx`](https://huggingface.co/OpenVoiceOS/nemotron-3.5-asr-arabic-dialectal-v2-onnx)
   (int8, NeMo FastConformer-RNNT, dialectal-Arabic-tuned prompt), loaded through
-  `onnx-asr`'s `nemo-conformer-rnnt` model type on the `feat/nemotron` branch
+  `onnx-asr`'s `nemo-conformer-rnnt` model type on the [`TigreGotico/onnx-asr` fork's `feat/nemotron` branch](https://github.com/TigreGotico/onnx-asr/tree/feat/nemotron) (not yet upstreamed)
   (adds the raw-log-mel preprocessor this checkpoint needs). This is **not**
   Whisper — the OpenVoiceOS org also publishes `whisper-*-arabic-dialectal-v2-onnx`
   exports, but those were deliberately skipped in favor of the non-Whisper

--- a/docs/training/engines/f5tts.md
+++ b/docs/training/engines/f5tts.md
@@ -265,3 +265,159 @@ is supported by this adapter.
 | Paper | [arXiv:2410.06885](https://arxiv.org/abs/2410.06885) |
 | ONNX export | <https://github.com/DakeQQ/F5-TTS-ONNX> |
 | Ready-made ONNX voices | [`OpenVoiceOS/phoonnx-f5tts`](https://huggingface.co/OpenVoiceOS/phoonnx-f5tts) |
+
+## Habibi quality audit (retroactive, 2026-08)
+
+The 8 Habibi voices (`habibi/ar-unified` + 7 specialized dialects) shipped
+before the WER-gate standard existed for phoonnx voice releases. This is a
+retroactive quality pass to backfill that gate, run against the published
+[`OpenVoiceOS/phoonnx-f5tts`](https://huggingface.co/OpenVoiceOS/phoonnx-f5tts)
+mirror through the real `F5TTSAdapter` synthesis path (not a mock).
+
+Note: the catalog has **8 Habibi voices, not 9** — 1 Unified + 7 specialized
+dialects (ALG, EGY, IRQ, MAR, MSA, SAU, UAE). `namaa/ar-sa-v2` is a separate,
+non-Habibi checkpoint (a NAMAA-Space fine-tune of Habibi-Unified) and is out
+of scope for this pass.
+
+### Method
+
+- **ASR**: [`OpenVoiceOS/nemotron-3.5-asr-arabic-dialectal-v2-onnx`](https://huggingface.co/OpenVoiceOS/nemotron-3.5-asr-arabic-dialectal-v2-onnx)
+  (int8, NeMo FastConformer-RNNT, dialectal-Arabic-tuned prompt), loaded through
+  `onnx-asr`'s `nemo-conformer-rnnt` model type on the `feat/nemotron` branch
+  (adds the raw-log-mel preprocessor this checkpoint needs). This is **not**
+  Whisper — the OpenVoiceOS org also publishes `whisper-*-arabic-dialectal-v2-onnx`
+  exports, but those were deliberately skipped in favor of the non-Whisper
+  dialectal model, per the "never Whisper unless nothing else exists" rule.
+- **Sentences**: 5 per voice — 4 shared Modern Standard Arabic sentences plus
+  1 dialect-flavoured sentence per voice (sourced from the phrasing already
+  used in the mirror's `samples/README.md`, e.g. Egyptian "النهاردة الجو جميل
+  جداً...", Gulf/Najdi "اليوم الجو حلو مرة..."). **Only the 5th sentence per
+  voice is genuinely dialectal text** — the first 4 are identical MSA prompts
+  across all 8 voices, run so every voice has a apples-to-apples MSA baseline.
+  This means the WER numbers below are dominated by MSA-on-MSA performance,
+  not true dialectal ASR difficulty; only `idx=4` rows probe dialect-appropriate
+  text through (in most cases) a dialectal ASR path.
+- **Reference clip (in-context conditioning)**: F5-TTS/Habibi is in-context
+  cloning — every synthesis call needs a reference clip **and its
+  transcription**. No verified human reference-clip+transcript pair for any
+  Habibi dialect was available locally. A single ~8s Arabic clip was pulled
+  from the locally-cached `ArabicSpeech/ADI20` dataset (dialect-labeled
+  Tunisian) and **self-transcribed with the same nemotron ASR model** to get
+  its reference text, then reused as the one speaker reference for all 8
+  voices — mirroring the original mirror's methodology of using a single
+  Arabic reference clip (SILMA `ar.ref.24k.wav`) across voices, but with a
+  self-transcribed (not verified/human-checked) transcript.
+  **This is a real methodology weakness**: the ADI20 clip's content
+  ("...باش نظر") visibly bleeds into a large fraction of the synthesized
+  outputs as a spurious leading phrase (visible in the ASR hypotheses below,
+  e.g. "باش نظر مرحبا بكم..."). This in-context leakage — a known F5TTS
+  failure mode when the reference transcript is imperfect — inflates WER
+  across the board and should be re-run with a clean, verified reference
+  clip+transcript pair before these numbers are treated as final quality
+  gates.
+- **RTF**: wall-clock synth time / output audio duration, CPU inference
+  (ser9, `onnxruntime`, shared box with other production TTS/STT/translate
+  services running concurrently — these numbers are an upper bound, not a
+  clean benchmark).
+- **Human floor**: **not available**. No per-dialect Habibi reference dataset
+  with verified transcripts was found locally or on the Habibi/NAMAA/SILMA
+  HF pages (the upstream training datasets — SADA, Mixat, MGB-3/5, FLEURS,
+  various `oddadmix`/dialect collections — are not bundled with matching
+  transcripts in a form usable here). Dialectal Arabic ASR itself is hard and
+  imperfect even on human speech, so **absolute WER/CER numbers below should
+  not be read as voice-quality scores** — they should be read relative to
+  each other and re-checked once a verified reference pair and/or a real
+  per-dialect floor becomes available.
+
+### Results — per-voice averages (5 sentences each)
+
+| voice | avg WER | avg CER | avg duration (s) | avg RTF (CPU, shared box) |
+|---|---|---|---|---|
+| `habibi/ar-unified` | 0.33 | 0.18 | 7.1 | 11.2 |
+| `habibi/ar-msa` | 0.33 | 0.21 | 6.4 | 11.4 |
+| `habibi/ar-egy` | 0.34 | 0.18 | 6.6 | 12.6 |
+| `habibi/ar-sau` | 0.25 | 0.11 | 6.6 | 13.1 |
+| `habibi/ar-uae` | 0.38 | 0.27 | 6.4 | 12.6 |
+| `habibi/ar-alg` | 0.34 | 0.16 | 6.7 | 16.6 |
+| `habibi/ar-irq` | 0.35 | 0.21 | 6.6 | 12.8 |
+| `habibi/ar-mar` | 0.41 | 0.22 | 6.6 | 13.3 |
+
+No dialect stands out as catastrophically broken relative to the others —
+`ar-sau` scores best (lowest WER/CER), `ar-mar` and `ar-uae` score worst, but
+all 8 sit within roughly the same band once the reference-leakage artifact
+above is taken into account. RTF is CPU-only and NFE=32 (F5-TTS default);
+all voices are firmly non-real-time on CPU (RTF > 8), consistent with
+flow-matching TTS in general — GPU or lower NFE would be needed for
+interactive use.
+
+### Results — per-sentence detail
+
+`dialectal?` = `yes` only for `idx=4`, the one genuinely dialect-flavoured
+sentence per voice; `idx=0..3` are the shared MSA prompts.
+
+| voice | idx | dialectal? | text | ASR hypothesis | WER | CER | dur (s) | RTF |
+|---|---|---|---|---|---|---|---|---|
+| ar-unified | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | التكنولوجيا حديثة غيرت غيرت طريقة تواصل الناس حول العالم. | 0.25 | 0.13 | 7.2 | 8.1 |
+| ar-unified | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | مرحبا بكم في نظام الصوت المفتوح يسعدنا انضمامكم إلينا | 0.11 | 0.02 | 7.3 | 9.4 |
+| ar-unified | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | ضرد التعليم هو أساس أساس التقدم في أي مجتمع يسعى نحو المستقبل. | 0.20 | 0.17 | 7.0 | 11.4 |
+| ar-unified | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | ضرد الماء هو سر الحياة على كو كوكب الأرض منذ آلاف سنين | 0.30 | 0.18 | 6.7 | 12.9 |
+| ar-unified | 4 | yes | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | ضر مرحبا بيكم في النظام الصوت المفتوح يسعدنا وسعنا يسعدنا انضمامكم إلينا ال | 0.78 | 0.41 | 7.3 | 14.1 |
+| ar-msa | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | بعشر نظرة التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | 0.25 | 0.19 | 6.8 | 8.7 |
+| ar-msa | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | باش باش نظم حبا بكم في في نظام الصوت المفتوح يسعدنا انضمامكم إلينا. | 0.67 | 0.28 | 6.8 | 10.5 |
+| ar-msa | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | ظر التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل | 0.10 | 0.06 | 6.7 | 11.9 |
+| ar-msa | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | سنين باش نظر الماء هو سر الحياة على كوكب الأرض منذ آلاف سنين. | 0.40 | 0.31 | 6.3 | 12.4 |
+| ar-msa | 4 | yes | الطقس اليوم مشمس وجميل في معظم مناطق البلاد. | باش نظرا الطقس اليوم مشمس وجميل في معظم مناطق البلاد. | 0.25 | 0.21 | 5.5 | 13.4 |
+| ar-egy | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | ظلون الوجه الحديثة غير الطريقة تواصل الناس حول العالم. | 0.50 | 0.19 | 6.8 | 9.4 |
+| ar-egy | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | باش نظرة مرحبا بكم في نظام الصوت المفتوح يسعدنا انضمامكم إلينا | 0.33 | 0.19 | 6.9 | 13.2 |
+| ar-egy | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | باش نظرها التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقب | 0.30 | 0.21 | 6.7 | 13.2 |
+| ar-egy | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | زر الماء سر الحياة على كوكب الأرض منذ آلاف سنين. | 0.30 | 0.16 | 6.3 | 13.4 |
+| ar-egy | 4 | yes | النهاردة الجو جميل جداً في القاهرة والناس مبسوطة. | باش نظر النهاردة الجو جميل جدا في القاهرة والناس مبسوطة. | 0.25 | 0.17 | 6.1 | 13.5 |
+| ar-sau | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | ضرار التكنولوجيا الحديثة غير الطريقة تواصل الناس حول العالم. | 0.38 | 0.15 | 6.8 | 11.0 |
+| ar-sau | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | ظر مرحبا بابكم في نظام الصوت المفتوح يسعدنا انضمامكم إلنا | 0.44 | 0.13 | 6.9 | 14.0 |
+| ar-sau | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل | 0.00 | 0.00 | 6.7 | 13.3 |
+| ar-sau | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | هو سر الحياة على كوكب الأرض منذ آف سنين. | 0.30 | 0.20 | 6.3 | 13.7 |
+| ar-sau | 4 | yes | اليوم الجو حلو مرة في الرياض والناس طالعين يتمشون. | ضرا اليوم الجو حلو مرة في الرياض والناس طالعين يتمشون. | 0.11 | 0.08 | 6.3 | 13.7 |
+| ar-uae | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | نظرك الحديثة غيرت هي الطريقة طريقة تواصل الناس حول العالم. | 0.38 | 0.40 | 6.8 | 9.6 |
+| ar-uae | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | باش نظر رحبان بكم في نظام الصوت المفتوح يسعدنا انضمامكم إلينا. | 0.44 | 0.19 | 6.9 | 12.1 |
+| ar-uae | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | باش نش نظر التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل المستقبل | 0.40 | 0.38 | 6.7 | 12.9 |
+| ar-uae | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | الماء هو سر سر الحياة على كوكب الأرض منذ آلاف السنين. | 0.10 | 0.06 | 6.3 | 13.3 |
+| ar-uae | 4 | yes | اليوم الجو وايد حلو في دبي والناس كلهم برع. | باش نظرة اليوم الجوايد حلو في في دبي والناس كلهم برع | 0.56 | 0.33 | 5.4 | 15.0 |
+| ar-alg | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | ضرار شكل التكنولوجيا الحديثة غير الطريقة تواصل الناس حول العالم. | 0.50 | 0.23 | 6.8 | 11.4 |
+| ar-alg | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | باش نظر مرحبا بيكم في نظام الصوت المفتوح يسعدنا انضمامكم إلينا | 0.44 | 0.19 | 6.9 | 14.9 |
+| ar-alg | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | ظر التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقب | 0.20 | 0.08 | 6.7 | 14.8 |
+| ar-alg | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | الماء هو سر الحياة على على كوكب الأرض منذ آلاف السنين. | 0.10 | 0.08 | 6.3 | 20.2 |
+| ar-alg | 4 | yes | اليوم الجو شباب بزاف في الجزائر والناس خارجين يتساراو. | باش نظر اليوم الجو شباب زاف في الجزائر والناس خارجين يتساروا | 0.44 | 0.21 | 6.8 | 21.8 |
+| ar-irq | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | نظرة تكليفة غير ت غير طريقة تواصل الناس حول العالم. | 0.62 | 0.36 | 6.8 | 11.3 |
+| ar-irq | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | باش نظر مرة حبان بكم في نظام الصوت المفتوح يسعدنا انضمامكم إلينا | 0.56 | 0.22 | 6.9 | 13.0 |
+| ar-irq | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | نظرة التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل | 0.10 | 0.10 | 6.7 | 13.1 |
+| ar-irq | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | نظر الماء هو سر الحياة الحياة على كوكب الأرض منذ آلاف السنين. | 0.20 | 0.22 | 6.3 | 13.4 |
+| ar-irq | 4 | yes | اليوم الجو حلو هواية ببغداد والناس طالعين يتمشون. | باش نظر اليوم الجو حلو هواية ببغداد والناس طالعين يتمشون | 0.25 | 0.17 | 6.1 | 13.4 |
+| ar-mar | 0 | no (MSA) | التكنولوجيا الحديثة غيرت طريقة تواصل الناس حول العالم. | ضرار التكنولوجيا الحديثة غير طريقة تواصل الناس حول العالم. | 0.25 | 0.11 | 6.8 | 11.1 |
+| ar-mar | 1 | no (MSA) | مرحباً بكم في نظام الصوت المفتوح، يسعدنا انضمامكم إلينا. | باش نظر مرحبا بيكم في نظام الصوت المفتوح يساعدنا انضمامكم إلينا | 0.56 | 0.20 | 6.9 | 13.3 |
+| ar-mar | 2 | no (MSA) | التعليم هو أساس التقدم في أي مجتمع يسعى نحو المستقبل. | ضر التعليم هو أساس التقدم في في أي مجتمع يسعى نحو المستقب | 0.30 | 0.13 | 6.7 | 13.7 |
+| ar-mar | 3 | no (MSA) | الماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | درال ماء باش النظرالماء هو سر الحياة على كوكب الأرض منذ آلاف السنين. | 0.40 | 0.37 | 6.3 | 14.6 |
+| ar-mar | 4 | yes | اليوم الجو زوين بزاف في الرباط والناس خارجين يتسارا. | باش ضرا اليوم الجوين زوين بزاف الرباط والناس خارجين يتصارى. | 0.56 | 0.29 | 6.5 | 13.7 |
+
+### Interpretation
+
+- **No gate failure identified.** All 8 voices land in a broadly similar
+  WER/CER band (0.25-0.41 avg WER, 0.11-0.27 avg CER); none is a dramatic
+  outlier suggesting a broken checkpoint or export. This is consistent with
+  (not proof of) acceptable quality, given the reference-leakage caveat above.
+- **The dominant error source in this pass is methodology, not the voices**:
+  the self-transcribed, non-verified reference clip visibly leaks into a
+  majority of outputs as a spurious leading phrase. A follow-up pass with a
+  clean, hand-verified reference clip (ideally one per dialect, spoken by a
+  native speaker) would very likely lower WER/CER across the board and is
+  the highest-value next step before treating any of these numbers as a
+  hard release gate.
+- **No trustworthy per-dialect human floor exists yet** for any of the 8
+  Habibi dialects in this environment — this pass can only compare voices to
+  each other, not to a ceiling. Building one (e.g. sampling a handful of
+  verified-transcript clips per dialect from SADA/Mixat/MGB-3/MGB-5/FLEURS)
+  is tracked as follow-up work, not done here.
+- Dialectal Arabic ASR is inherently harder than MSA ASR (dialect/orthography
+  mismatch, code-switching, ASR training-data scarcity per dialect), so even
+  a "clean" re-run should expect WER/CER to run higher on `idx=4` dialectal
+  rows than on the shared MSA rows — that gap is expected, not necessarily a
+  TTS quality problem.


### PR DESCRIPTION
## Summary
- Backfills the WER-gate standard for the 8 Habibi Arabic voices (unified + 7 specialized dialects), which shipped before that standard existed.
- 5 sentences per voice (4 shared MSA + 1 dialect-flavoured) synthesized through the real `F5TTSAdapter` path against the published `OpenVoiceOS/phoonnx-f5tts` mirror, scored with the non-Whisper `OpenVoiceOS/nemotron-3.5-asr-arabic-dialectal-v2-onnx` (dialectal-Arabic-tuned FastConformer-RNNT).
- Includes per-voice and per-sentence WER/CER/RTF tables, and an explicit methodology-limitations section (no verified human reference clip/transcript was available locally; no per-dialect human WER floor exists yet).
- Flags a real finding: a reference-clip content leak into a majority of synthesized outputs, likely inflating WER — attributed to the self-transcribed (non-verified) reference clip used for in-context conditioning, not to the voices themselves.

## Test plan
- [x] Ran all 8 Habibi voices × 5 sentences through the real phoonnx `F5TTSAdapter` + ASR pipeline on ser9 (not mocked)
- [x] Verified `habibi/ar-*` catalog entries in `phoonnx/voice_index/f5tts.json` (8 voices, not 9 — corrected in the doc)
- [x] Docs-only change, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a quality audit for eight published Habibi text-to-speech voices.
  * Documented evaluation methods covering transcription accuracy, sentence quality, reference clips, and CPU performance.
  * Included per-voice and per-sentence results for error rates, duration, and real-time performance.
  * Recorded limitations and recommendations for verified reference data and human-quality benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->