### PR TITLE
feat: Indic-Parler-TTS engine

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -1,6 +1,6 @@
 ## Supported Voices
 
-**Total Voices:** 3166
+**Total Voices:** 3190
 **Total Languages:** 1812
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
@@ -783,6 +783,30 @@
 | `hf_community/russdill/kronk` | `en-US` | `piper` | `espeak` |
 | `hf_community/samarthshrivas/piper-finetune-Andrew-Huberman` | `en-US` | `piper` | `espeak` |
 | `hf_community/swqg-messiah/kusaal_chitti_piper` | `en-US` | `piper` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-2-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-2-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-3-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-3-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-4-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-4-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-5-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/mini-0.1-expr-voice-5-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-2-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-2-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-3-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-3-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-4-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-4-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-5-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.1-expr-voice-5-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-2-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-2-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-3-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-3-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-4-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-4-m` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-5-f` | `en-US` | `styletts2` | `espeak` |
+| `kittentts/nano-0.2-expr-voice-5-m` | `en-US` | `styletts2` | `espeak` |
 | `kokoro-v019/af` | `en-US` | `styletts2` | `misaki_en` |
 | `kokoro-v019/af_bella` | `en-US` | `styletts2` | `misaki_en` |
 | `kokoro-v019/af_nicole` | `en-US` | `styletts2` | `misaki_en` |

--- a/VOICES.md
+++ b/VOICES.md
@@ -1,7 +1,7 @@
 ## Supported Voices
 
-**Total Voices:** 3158
-**Total Languages:** 1810
+**Total Voices:** 3166
+**Total Languages:** 1812
 
 > ⚠️ some languages are duplicated, either using a different script or less specific language code (eg. Kurdish is available in latin, cyrillic and arabic scripts)
 
@@ -145,6 +145,8 @@
 | `omnivoice/ars` | `ars` | `omnivoice` | `unicode` |
 | `omnivoice/ary` | `ary` | `omnivoice` | `unicode` |
 | `omnivoice/arz` | `arz` | `omnivoice` | `unicode` |
+| `indic_parler/amit/as` | `as` | `indic_parler` | `unicode` |
+| `indic_parler/sita/as` | `as` | `indic_parler` | `unicode` |
 | `omnivoice/as` | `as` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-asm-Assamese` | `as-IN` | `transformers` | `graphemes` |
 | `facebook/mms-tts-asa-Asu` | `asa` | `transformers` | `graphemes` |
@@ -281,6 +283,8 @@
 | `facebook/mms-tts-bmv-Bum` | `bmv` | `transformers` | `graphemes` |
 | `coqui/bn-custom-vits-male` | `bn` | `coqui` | `graphemes` |
 | `facebook/mms-tts-ben-Bengali` | `bn` | `transformers` | `graphemes` |
+| `indic_parler/aditi/bn` | `bn` | `indic_parler` | `unicode` |
+| `indic_parler/arjun/bn` | `bn` | `indic_parler` | `unicode` |
 | `mimic3/bn/multi_low` | `bn` | `mimic3` | `espeak` |
 | `omnivoice/bn` | `bn` | `omnivoice` | `unicode` |
 | `outetts/1B/bn` | `bn-BD` | `outetts` | `unicode` |
@@ -311,6 +315,8 @@
 | `omnivoice/brh` | `brh` | `omnivoice` | `unicode` |
 | `omnivoice/bri` | `bri` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-bru-Bru, Eastern` | `bru` | `transformers` | `graphemes` |
+| `indic_parler/bikram/brx` | `brx` | `indic_parler` | `unicode` |
+| `indic_parler/maya/brx` | `brx` | `indic_parler` | `unicode` |
 | `omnivoice/brx` | `brx` | `omnivoice` | `unicode` |
 | `omnivoice/bs` | `bs` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-bsc-Oniyan` | `bsc` | `transformers` | `graphemes` |
@@ -625,6 +631,7 @@
 | `facebook/mms-tts-dnj-dialect_gweetaawueast-Dan` | `dnj-x-gweetaaw-ueast` | `transformers` | `graphemes` |
 | `facebook/mms-tts-dnt-Dani, Mid Grand Valley` | `dnt` | `transformers` | `graphemes` |
 | `facebook/mms-tts-dnw-Dani, Western` | `dnw` | `transformers` | `graphemes` |
+| `indic_parler/karan/doi` | `doi` | `indic_parler` | `unicode` |
 | `facebook/mms-tts-dop-Lukpa` | `dop` | `transformers` | `graphemes` |
 | `facebook/mms-tts-dos-Dogosé` | `dos` | `transformers` | `graphemes` |
 | `omnivoice/dru` | `dru` | `omnivoice` | `unicode` |
@@ -683,6 +690,8 @@
 | `hf_community/nardocolin/nardocolin-pipertts` | `en` | `piper` | `espeak` |
 | `hf_community/wasmdashai/vits-en-v1` | `en` | `transformers` | `graphemes` |
 | `hf_community/wasmdashai/vits-eng-us-ljs` | `en` | `transformers` | `graphemes` |
+| `indic_parler/mary/en` | `en` | `indic_parler` | `unicode` |
+| `indic_parler/thoma/en` | `en` | `indic_parler` | `unicode` |
 | `nipponjo/mixer-tts-ljspeech-128` | `en` | `mixertts` | `espeak` |
 | `nipponjo/mixer-tts-ljspeech-384` | `en` | `mixertts` | `espeak` |
 | `nipponjo/mixer-tts-ljspeech-80` | `en` | `mixertts` | `espeak` |
@@ -774,30 +783,6 @@
 | `hf_community/russdill/kronk` | `en-US` | `piper` | `espeak` |
 | `hf_community/samarthshrivas/piper-finetune-Andrew-Huberman` | `en-US` | `piper` | `espeak` |
 | `hf_community/swqg-messiah/kusaal_chitti_piper` | `en-US` | `piper` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-2-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-2-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-3-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-3-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-4-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-4-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-5-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/mini-0.1-expr-voice-5-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-2-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-2-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-3-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-3-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-4-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-4-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-5-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.1-expr-voice-5-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-2-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-2-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-3-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-3-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-4-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-4-m` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-5-f` | `en-US` | `styletts2` | `espeak` |
-| `kittentts/nano-0.2-expr-voice-5-m` | `en-US` | `styletts2` | `espeak` |
 | `kokoro-v019/af` | `en-US` | `styletts2` | `misaki_en` |
 | `kokoro-v019/af_bella` | `en-US` | `styletts2` | `misaki_en` |
 | `kokoro-v019/af_nicole` | `en-US` | `styletts2` | `misaki_en` |
@@ -1268,6 +1253,8 @@
 | `facebook/mms-tts-grt-Garo` | `grt` | `transformers` | `graphemes` |
 | `omnivoice/gsl` | `gsl` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-gso-Gbaya, Southwest` | `gso` | `transformers` | `graphemes` |
+| `indic_parler/neha/gu` | `gu` | `indic_parler` | `unicode` |
+| `indic_parler/yash/gu` | `gu` | `indic_parler` | `unicode` |
 | `omnivoice/gu` | `gu` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-guj-Gujarati` | `gu-IN` | `transformers` | `graphemes` |
 | `hf_community/ylacombe/mms-guj-finetuned-monospeaker` | `gu-IN` | `transformers` | `graphemes` |
@@ -1321,6 +1308,8 @@
 | `facebook/mms-tts-hin-Hindi` | `hi` | `transformers` | `graphemes` |
 | `hf_community/PravalX/piper-voices/hi_IN-pratham-medium` | `hi` | `piper` | `espeak` |
 | `hf_community/PravalX/piper-voices/hi_IN-priyamvada-medium` | `hi` | `piper` | `espeak` |
+| `indic_parler/divya/hi` | `hi` | `indic_parler` | `unicode` |
+| `indic_parler/rohit/hi` | `hi` | `indic_parler` | `unicode` |
 | `kokoro/hf_alpha` | `hi` | `styletts2` | `espeak` |
 | `kokoro/hf_beta` | `hi` | `styletts2` | `espeak` |
 | `kokoro/hm_omega` | `hi` | `styletts2` | `espeak` |
@@ -1351,6 +1340,8 @@
 | `facebook/mms-tts-hlb-Halbi` | `hlb` | `transformers` | `graphemes` |
 | `facebook/mms-tts-hlt-Chin, Matu` | `hlt` | `transformers` | `graphemes` |
 | `facebook/mms-tts-hne-Chhattisgarhi` | `hne` | `transformers` | `graphemes` |
+| `indic_parler/bhanu/hne` | `hne` | `indic_parler` | `unicode` |
+| `indic_parler/champa/hne` | `hne` | `indic_parler` | `unicode` |
 | `facebook/mms-tts-hnn-Hanunoo` | `hnn` | `transformers` | `graphemes` |
 | `omnivoice/hno` | `hno` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-hns-Hindustani, Sarnami` | `hns` | `transformers` | `graphemes` |
@@ -1670,6 +1661,8 @@
 | `facebook/mms-tts-kmr-script_latin-Kurdish, Northern` | `kmr-Latn` | `transformers` | `graphemes` |
 | `facebook/mms-tts-kmu-Kanite` | `kmu` | `transformers` | `graphemes` |
 | `omnivoice/kmy` | `kmy` | `omnivoice` | `unicode` |
+| `indic_parler/anu/kn` | `kn` | `indic_parler` | `unicode` |
+| `indic_parler/suresh/kn` | `kn` | `indic_parler` | `unicode` |
 | `omnivoice/kn` | `kn` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-kan-Kannada` | `kn-IN` | `transformers` | `graphemes` |
 | `omnivoice/kna` | `kna` | `omnivoice` | `unicode` |
@@ -1964,6 +1957,8 @@
 | `omnivoice/mki` | `mki` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-mkl-Mokole` | `mkl` | `transformers` | `graphemes` |
 | `facebook/mms-tts-mkn-Malay, Kupang` | `mkn` | `transformers` | `graphemes` |
+| `indic_parler/anjali/ml` | `ml` | `indic_parler` | `unicode` |
+| `indic_parler/harish/ml` | `ml` | `indic_parler` | `unicode` |
 | `omnivoice/ml` | `ml` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-mal-Malayalam` | `ml-IN` | `transformers` | `graphemes` |
 | `piper/ml_IN-arjun-medium` | `ml-IN` | `piper` | `espeak` |
@@ -1975,6 +1970,8 @@
 | `facebook/mms-tts-mnb-Muna` | `mnb` | `transformers` | `graphemes` |
 | `omnivoice/mne` | `mne` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-mnf-Mundani` | `mnf` | `transformers` | `graphemes` |
+| `indic_parler/laishram/mni` | `mni` | `indic_parler` | `unicode` |
+| `indic_parler/ranjit/mni` | `mni` | `indic_parler` | `unicode` |
 | `omnivoice/mni` | `mni` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-mnk-Mandinka` | `mnk` | `transformers` | `graphemes` |
 | `facebook/mms-tts-mnw-Mon` | `mnw` | `transformers` | `graphemes` |
@@ -1995,6 +1992,8 @@
 | `facebook/mms-tts-mqj-Mamasa` | `mqj` | `transformers` | `graphemes` |
 | `facebook/mms-tts-mqn-Moronene` | `mqn` | `transformers` | `graphemes` |
 | `omnivoice/mqy` | `mqy` | `omnivoice` | `unicode` |
+| `indic_parler/sanjay/mr` | `mr` | `indic_parler` | `unicode` |
+| `indic_parler/sunita/mr` | `mr` | `indic_parler` | `unicode` |
 | `omnivoice/mr` | `mr` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-mar-Marathi` | `mr-IN` | `transformers` | `graphemes` |
 | `hf_community/ylacombe/mms-mar-finetuned-monospeaker` | `mr-IN` | `transformers` | `graphemes` |
@@ -2078,6 +2077,7 @@
 | `facebook/mms-tts-ndy-Lutos` | `ndy` | `transformers` | `graphemes` |
 | `facebook/mms-tts-ndz-Ndogo` | `ndz` | `transformers` | `graphemes` |
 | `hf_community/Wiseyak/piper_tts` | `ne` | `piper` | `espeak` |
+| `indic_parler/amrita/ne` | `ne` | `indic_parler` | `unicode` |
 | `mimic3/ne_NP/ne-google_low` | `ne-NP` | `mimic3` | `espeak` |
 | `piper/ne_NP-chitwan-medium` | `ne-NP` | `piper` | `espeak` |
 | `piper/ne_NP-google-medium` | `ne-NP` | `piper` | `espeak` |
@@ -2206,6 +2206,8 @@
 | `facebook/mms-tts-omw-Tairora, South` | `omw` | `transformers` | `graphemes` |
 | `facebook/mms-tts-onb-Lingao` | `onb` | `transformers` | `graphemes` |
 | `facebook/mms-tts-ood-Tohono O’odham` | `ood` | `transformers` | `graphemes` |
+| `indic_parler/debjani/or` | `or` | `indic_parler` | `unicode` |
+| `indic_parler/manas/or` | `or` | `indic_parler` | `unicode` |
 | `omnivoice/orc` | `orc` | `omnivoice` | `unicode` |
 | `omnivoice/oru` | `oru` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-ory-Odia` | `ory` | `transformers` | `graphemes` |
@@ -2216,6 +2218,8 @@
 | `facebook/mms-tts-otq-Otomi, Querétaro` | `otq` | `transformers` | `graphemes` |
 | `facebook/mms-tts-ozm-Koonzime` | `ozm` | `transformers` | `graphemes` |
 | `facebook/mms-tts-pan-Punjabi, Eastern` | `pa` | `transformers` | `graphemes` |
+| `indic_parler/divjot/pa` | `pa` | `indic_parler` | `unicode` |
+| `indic_parler/gurpreet/pa` | `pa` | `indic_parler` | `unicode` |
 | `omnivoice/pa` | `pa` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-pab-Parecís` | `pab` | `transformers` | `graphemes` |
 | `facebook/mms-tts-pad-Paumarí` | `pad` | `transformers` | `graphemes` |
@@ -2496,6 +2500,7 @@
 | `omnivoice/rup` | `rup` | `omnivoice` | `unicode` |
 | `omnivoice/rw` | `rw` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-kin-Kinyarwanda` | `rw-RW` | `transformers` | `graphemes` |
+| `indic_parler/aryan/sa` | `sa` | `indic_parler` | `unicode` |
 | `omnivoice/sa` | `sa` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-sab-Buglere` | `sab` | `transformers` | `graphemes` |
 | `facebook/mms-tts-sah-Yakut` | `sah` | `transformers` | `graphemes` |
@@ -2652,6 +2657,7 @@
 | `omnivoice/szy` | `szy` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-tam-Tamil` | `ta` | `transformers` | `graphemes` |
 | `hf_community/ylacombe/mms-tam-finetuned-monospeaker` | `ta` | `transformers` | `graphemes` |
+| `indic_parler/jaya/ta` | `ta` | `indic_parler` | `unicode` |
 | `omnivoice/ta` | `ta` | `omnivoice` | `unicode` |
 | `chatterbox/multilingual/ta` | `ta-IN` | `chatterbox` | `unicode` |
 | `outetts/1B/ta` | `ta-IN` | `outetts` | `unicode` |
@@ -2681,6 +2687,8 @@
 | `omnivoice/tdn` | `tdn` | `omnivoice` | `unicode` |
 | `piper_community/raphaelmerx/tdt-TL_joao` | `tdt-TL` | `piper` | `espeak` |
 | `omnivoice/tdx` | `tdx` | `omnivoice` | `unicode` |
+| `indic_parler/lalitha/te` | `te` | `indic_parler` | `unicode` |
+| `indic_parler/prakash/te` | `te` | `indic_parler` | `unicode` |
 | `omnivoice/te` | `te` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-tel-Telugu` | `te-IN` | `transformers` | `graphemes` |
 | `mimic3/te_IN/cmu-indic_low` | `te-IN` | `mimic3` | `epitran` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,7 @@ to a dedicated adapter. The adapter registry itself is described in [Engines](en
 | `outetts` | Autoregressive codec-LM (Qwen3 or Llama-3.2 + DAC.speech), raw-text, 23 languages | [OuteTTS](training/engines/outetts.md) |
 | `arktts` | Two-stage codec LM (slow AR + fast AR), Basque or 11 languages, 44.1 kHz | [ArkTTS](training/engines/arktts.md) |
 | `omnivoice` | Masked-diffusion codec LM (Qwen3 + Higgs Audio V2), raw-text, 600+ languages, 24 kHz | [OmniVoice](training/engines/omnivoice.md) |
+| `indic_parler` | Encoder-decoder codec LM (Flan-T5 + AR DAC decoder), description-controlled voices, 20 Indic languages + English, 44.1 kHz | [Indic Parler-TTS](training/engines/indic_parler.md) |
 
 ## Execution Providers
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -96,6 +96,7 @@ Lower `detect_priority` values are probed first during auto-detection.
 | [OuteTTS](training/engines/outetts.md) | `phoonnx/engines/outetts.py` | `engine == "outetts"` — autoregressive two-codebook codec-LM (Qwen3 backbone + DAC.speech decoder), raw text in 23 languages, in-context [cloning](cloning.md) from pre-encoded speaker profiles, 24 kHz |
 | [ArkTTS (Zortzi + Audio8)](training/engines/arktts.md) | `phoonnx/engines/arktts.py` | `engine == "arktts"` — two autoregressive stages (24-layer slow AR + 4-layer fast AR) writing 10 codebooks per 21.5 Hz frame, raw-text, Basque or 11 languages, reference-clip voices, 44.1 kHz |
 | [OmniVoice](training/engines/omnivoice.md) | `phoonnx/engines/omnivoice.py` | `engine == "omnivoice"` — first **masked-diffusion** engine: a Qwen3 backbone unmasks 8 Higgs-codec streams over 32 bidirectional full-sequence steps, raw-text, 600+ languages, in-context [cloning](cloning.md), 24 kHz |
+| [Indic Parler-TTS](training/engines/indic_parler.md) | `phoonnx/engines/indic_parler.py` | `engine == "indic_parler"` — first **encoder-decoder** engine: a frozen Flan-T5 encoder turns a natural-language voice description into cross-attention states for a 24-layer AR decoder over 9 delayed DAC codebooks, raw-text, 20 Indic languages + English, 44.1 kHz |
 
 ---
 

--- a/docs/training/engines/indic_parler.md
+++ b/docs/training/engines/indic_parler.md
@@ -1,7 +1,8 @@
 # Indic Parler-TTS
 
 [Indic Parler-TTS](https://huggingface.co/ai4bharat/indic-parler-tts) (AI4Bharat) speaks
-20 Indic languages and English. Set `engine: indic_parler`.
+21 Indic languages and English — 22 languages total (`AVAILABLE_LANGS` in
+`phoonnx/engines/indic_parler.py`). Set `engine: indic_parler`.
 
 It is the Indic fine-tune of [Parler-TTS](https://github.com/huggingface/parler-tts)
 (Yoach Lacombe, Vaibhav Srivastav, Sanchit Gandhi). You do not pick a voice with a
@@ -95,12 +96,61 @@ for chunk in voice.synthesize("नमस्ते, आप कैसे हैं
 Any of the 69 speakers upstream lists can be reached by passing a `description` at call
 time; the index covers the recommended subset.
 
+## Intelligibility
+
+Reference sentences and reference audio come from **FLEURS** (test split, 3 sentences per
+language). ASR is the **OpenVoiceOS org's own IndicConformer ONNX** family (AI4Bharat's
+own ASR models), via `onnx-asr`; English uses `nvidia-parakeet-tdt_ctc-110m-onnx`. The
+**human floor** column is the same ASR run on the natural FLEURS recording of the same
+sentence, so the two columns are directly comparable. CER is the headline metric for
+Malayalam, Tamil, Telugu, Kannada and Odia, where whitespace does not delimit words the
+way WER assumes; both numbers are reported for every language regardless.
+
+| Language | Voice | TTS WER | TTS CER | Human floor WER | Human floor CER | Headline | RTF |
+|---|---|---|---|---|---|---|---|
+| Hindi (`hi`) | `rohit` | 0.160 | 0.039 | 0.040 | 0.019 | WER | 4.14 |
+| English (`en`) | `mary` | 0.291 | 0.155 | 0.255 | 0.108 | WER | 4.42 |
+| Bengali (`bn`) | `arjun` | 0.333 | 0.056 | 0.104 | 0.025 | WER | 4.26 |
+| Gujarati (`gu`) | `yash` | 0.250 | 0.123 | 0.225 | 0.090 | WER | 4.67 |
+| Kannada (`kn`) | `suresh` | 0.212 | 0.141 | 0.061 | 0.053 | CER | 4.55 |
+| Malayalam (`ml`) | `anjali` | 0.520 | 0.100 | 0.440 | 0.185 | CER | 4.48 |
+| Marathi (`mr`) | `sanjay` | 0.209 | 0.102 | 0.302 | 0.056 | WER | 4.60 |
+| Nepali (`ne`) | `amrita` | 0.235 | 0.069 | 0.265 | 0.051 | WER | 4.58 |
+| Odia (`or`) | `manas` | 0.174 | 0.032 | 0.109 | 0.025 | CER | 4.56 |
+| Punjabi (`pa`) | `divjot` | 0.176 | 0.044 | 0.176 | 0.040 | WER | 4.74 |
+| Tamil (`ta`) | `jaya` | 0.176 | 0.067 | 0.088 | 0.018 | CER | 4.67 |
+| Telugu (`te`) | `prakash` | 0.100 | 0.045 | 0.033 | 0.004 | CER | 4.48 |
+
+Every language above is intelligible. Marathi and Nepali beat the natural FLEURS
+recording on WER; Malayalam beats it on CER. English is the weakest column, and the
+human floor (0.255 WER) says that is the 110M parakeet ASR, not the voice.
+
+**Measured vs. unmeasured — explicit.** 12 of the 18 indexed languages (22 of the 32
+voices) are measured above. Six ship unmeasured:
+
+| Language | Voices | Why |
+|---|---|---|
+| Assamese (`as`) | 2 | `OpenVoiceOS/ai4bharat-indicconformer-as-onnx` is a README-only placeholder — no ONNX weights in the org yet |
+| Bodo (`brx`) | 2 | not in FLEURS |
+| Chhattisgarhi (`hne`) | 2 | not in FLEURS |
+| Dogri (`doi`) | 1 | not in FLEURS |
+| Manipuri (`mni`) | 2 | not in FLEURS |
+| Sanskrit (`sa`) | 1 | not in FLEURS |
+
+Parity vs. torch holds for all six by construction — it is the same four graphs the
+measured languages use — but there is no intelligibility number for them yet. Assamese
+becomes measurable as soon as the `as` IndicConformer export lands in the org.
+
+Urdu (`ur`), Sindhi (`sd`), Maithili (`mai`), Konkani (`kok`) and Santali (`sat`) are
+supported by the checkpoint but have no recommended speaker in AI4Bharat's table, so they
+are not indexed as voices; they are reachable by passing a custom `description`.
+
 ## Cost
 
 The checkpoint is ~880M parameters and the decoder runs one step per 22 ms of audio, so
-this is the slowest engine phoonnx ships. Measured on a 24-core CPU across 12 languages,
-real-time factor is **4.1 to 4.7** (mean 4.5). Use it where quality matters more than
-latency.
+this is the slowest engine phoonnx ships. Measured on a 24-core CPU across the 12 measured
+languages, real-time factor is **4.1 to 4.7** (mean 4.5). Use it where quality matters
+more than latency.
 
 Per-language samples and the intelligibility report live in the mirror under
 [`samples/`](https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/tree/main/samples).

--- a/docs/training/engines/indic_parler.md
+++ b/docs/training/engines/indic_parler.md
@@ -96,5 +96,9 @@ time; the index covers the recommended subset.
 ## Cost
 
 The checkpoint is ~880M parameters and the decoder runs one step per 22 ms of audio, so
-this is the slowest engine phoonnx ships. Measured on a 24-core CPU (ser9), real-time
-factor is around 3.5–4.0. Use it where quality matters more than latency.
+this is the slowest engine phoonnx ships. Measured on a 24-core CPU across 12 languages,
+real-time factor is **4.1 to 4.7** (mean 4.5). Use it where quality matters more than
+latency.
+
+Per-language samples and the intelligibility report live in the mirror under
+[`samples/`](https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/tree/main/samples).

--- a/docs/training/engines/indic_parler.md
+++ b/docs/training/engines/indic_parler.md
@@ -1,0 +1,100 @@
+# Indic Parler-TTS
+
+[Indic Parler-TTS](https://huggingface.co/ai4bharat/indic-parler-tts) (AI4Bharat) speaks
+20 Indic languages and English. Set `engine: indic_parler`.
+
+It is the Indic fine-tune of [Parler-TTS](https://github.com/huggingface/parler-tts)
+(Yoach Lacombe, Vaibhav Srivastav, Sanchit Gandhi). You do not pick a voice with a
+speaker id or a reference clip. You **describe** it:
+
+> *"Rohit's voice is clear and expressive, with a moderate speed and pitch, recorded in a
+> very close-sounding environment with no background noise."*
+
+## Why this engine is different
+
+Every other autoregressive engine in phoonnx — Chatterbox, NeuTTS, Spark-TTS, OuteTTS,
+ArkTTS, Qwen3-TTS — is **decoder-only**: one token stream, one KV cache. Indic Parler is
+phoonnx's first **encoder-decoder** engine, and the conditioning arrives on two different
+paths:
+
+1. The **description** goes through a frozen Flan-T5 encoder. All 24 decoder layers
+   **cross-attend** to the result. Those cross-attention keys and values never change
+   while decoding, so the prefill graph computes them once and the decode graph reads
+   them back unchanged, step after step.
+2. The **text to speak** is embedded by `embed_prompts` and **prepended to the decoder's
+   input embeddings**. It is part of the self-attention stream, not the cross-attention
+   stream. Upstream calls this `prompt_cross_attention: false`.
+
+Two tokenizers follow from that split, and they are **different vocabularies**: the
+checkpoint's own tokenizer for the prompt, the Flan-T5 tokenizer for the description.
+Mixing them up produces speech, just not the speech you asked for.
+
+## Graphs
+
+Published at
+[`OpenVoiceOS/phoonnx-indic-parler`](https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler).
+
+| `engine_params` key | Graph | Contract |
+|---|---|---|
+| *(the voice's own model)* | `decoder_prefill.onnx` | codec ids + prompt ids + encoder states → `logits[9,1088]`, self-KV (24×2), cross-KV (24×2) |
+| `decoder_decode_path` | `decoder_decode.onnx` | one codec frame + both caches → `logits[9,1088]`, self-KV (24×2) |
+| `text_encoder_path` | `text_encoder.onnx` | description ids + mask → encoder states `[1,S,1024]` |
+| `dac_decoder_path` | `dac_decoder.onnx` | 9 codebooks → waveform @ 44.1 kHz |
+| `prompt_tokenizer_path` | `tokenizer.json` | the checkpoint's prompt vocabulary |
+| `description_tokenizer_path` | `description_tokenizer.json` | the Flan-T5 vocabulary |
+
+## The delay pattern
+
+The decoder writes 9 DAC codebooks at once, but staggered: codebook *k* starts *k* steps
+late. A frame is only complete 9 steps after it begins, and the first and last 8 steps of
+a generation are partly filler.
+
+Two rules keep that staircase well-formed, both ported from upstream:
+
+* forced cells — the lower triangle is BOS, the upper triangle is PAD, and only the `-1`
+  cells are ever predicted (`build_delay_pattern_mask` / `apply_delay_pattern_mask`);
+* end-of-speech walks one codebook at a time, in order. Codebook *k+1* may not stop before
+  codebook *k* has. This is `ParlerTTSLogitsProcessor` upstream and
+  `_eos_delay_constraint` here.
+
+So a generation does not end the moment the model wants to stop: it takes 8 more steps to
+unwind the staircase.
+
+## Sampling
+
+Upstream defaults to `do_sample: true`, and so does this adapter. Greedy decoding is
+available (`do_sample: 0`) and is what the parity tests use, but it tends to run past the
+end of the sentence rather than emitting end-of-speech.
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `temperature` | `1.0` | sampling temperature |
+| `top_k` | `0` | top-k cutoff, `0` disables |
+| `do_sample` | `1` | `0` selects greedy |
+| `max_new_tokens` | `1500` | frame ceiling; upstream's hard limit is 2610 |
+| `seed` | *(none)* | fixes the sampler for reproducible output |
+| `description` | *(from the voice)* | overrides the indexed description for one call |
+
+## Voices
+
+The bundled index carries **32 voices**: every speaker AI4Bharat lists as *recommended*
+for its language, across 18 languages. The description of each voice is the wording from
+AI4Bharat's own model card, so a voice id resolves to exactly the sentence the model was
+trained to answer to.
+
+```python
+from phoonnx.model_manager import TTSModelManager
+
+manager = TTSModelManager()
+voice = manager.load_voice_by_id("indic_parler/rohit/hi")
+audio = voice.synthesize("नमस्ते, आप कैसे हैं?")
+```
+
+Any of the 69 speakers upstream lists can be reached by passing a `description` at call
+time; the index covers the recommended subset.
+
+## Cost
+
+The checkpoint is ~880M parameters and the decoder runs one step per 22 ms of audio, so
+this is the slowest engine phoonnx ships. Measured on a 24-core CPU (ser9), real-time
+factor is around 3.5–4.0. Use it where quality matters more than latency.

--- a/docs/training/engines/indic_parler.md
+++ b/docs/training/engines/indic_parler.md
@@ -86,8 +86,10 @@ trained to answer to.
 from phoonnx.model_manager import TTSModelManager
 
 manager = TTSModelManager()
-voice = manager.load_voice_by_id("indic_parler/rohit/hi")
-audio = voice.synthesize("नमस्ते, आप कैसे हैं?")
+manager.merge_default_voices()
+voice = manager.voices["indic_parler/rohit/hi"].load()
+for chunk in voice.synthesize("नमस्ते, आप कैसे हैं?"):
+    audio = chunk.audio_float_array          # float32 @ 44.1 kHz
 ```
 
 Any of the 69 speakers upstream lists can be reached by passing a `description` at call

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -12,7 +12,7 @@ The catalog is not fetched from a handful of live endpoints. `merge_default_voic
 `transformers_community`, `piper_community`, `optispeech`, `glowtts`, `mixertts`,
 `fastpitch`, `coqui_community`, `vits2`, `styletts2`, `f5tts`, `coqui_vits`, `BSC`,
 `shami`, `chatterbox`, `supertonic`, `neutts`, `pockettts`, `sparktts`, `qwen3tts`,
-`outetts`, `arktts`, `omnivoice`.
+`outetts`, `arktts`, `omnivoice`, `indic_parler`.
 
 Each JSON entry becomes a `TTSModelInfo`. Model/config/vocoder files are only fetched from their URLs when a voice is actually downloaded or loaded.
 
@@ -166,7 +166,7 @@ relevant to specific engine families (see [engines.md](engines.md), [cloning.md]
 | `vocoder_type` | `str` \| `None` | Vocoder implementation (`vocos`, `wavenext`, `hifigan`, `melgan`, `raw`, `griffinlim`) |
 | `style_url` | `str` \| `None` | Per-voice StyleTTS2/Kokoro style embedding |
 | `speaker_encoder_url` / `speaker_encoder_type` | `str` \| `None` | Cloning speaker-encoder ONNX (reference audio → d-vector) |
-| `aux_model_urls` | `dict` \| `None` | Extra ONNX graphs/files for multi-graph engines (F5-TTS; SuperTonic's `duration_predictor`/`text_encoder`/`vocoder` graphs plus its `tts.json` config, `unicode_indexer.json` and per-speaker `style.json`; NeuTTS's NeuCodec decoder graph plus its `tokenizer.json` and `voices.json`), keyed by engine-param name |
+| `aux_model_urls` | `dict` \| `None` | Extra ONNX graphs/files for multi-graph engines (F5-TTS; SuperTonic's `duration_predictor`/`text_encoder`/`vocoder` graphs plus its `tts.json` config, `unicode_indexer.json` and per-speaker `style.json`; NeuTTS's NeuCodec decoder graph plus its `tokenizer.json` and `voices.json`; Indic Parler's `text_encoder`/`decoder_decode`/`dac_decoder` graphs plus its two tokenizers), keyed by engine-param name |
 | `engine_options` | `dict` \| `None` | Plain per-voice engine settings that are not downloadable files, merged into `engine_params` as-is (e.g. NeuTTS's `voice` preset name) |
 | `display_name` | `str` \| `None` | Friendly name for UIs/CLIs; may contain `{engine}`/`{phoneme_type}` placeholders |
 | `vocab_override` | `dict` \| `None` | Custom token-to-ID mapping |

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -40,6 +40,7 @@ class Engine(str, Enum):
     OUTETTS = "outetts"  # OuteTTS 1.0: Llama/Qwen codec-LM + DAC.speech decoder, 23 languages
     ARKTTS = "arktts"  # ArkTTS (Audio8 / Zortzi): DualAR codec-LM, 10 codebooks, 44.1 kHz codec
     OMNIVOICE = "omnivoice"  # OmniVoice (k2-fsa): masked-diffusion codec LM, 600+ languages
+    INDIC_PARLER = "indic_parler"  # AI4Bharat Indic Parler-TTS: T5 encoder + AR DAC codec LM
 
 
 # Alphabet and PhonemeType are wire-format enums shared with scriptconv;
@@ -387,6 +388,28 @@ class VoiceConfig:
             phoneme_type = phoneme_type or PhonemeType.UNICODE
             alphabet = alphabet or Alphabet.GRAPHEMES
             config.setdefault("audio", {}).setdefault("sample_rate", 16000)
+            tokenizer = TTSTokenizer(
+                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
+                add_blank_char=False,
+                add_blank_word=False,
+                use_eos_bos=False,
+                blank_at_end=False,
+                blank_at_start=False,
+            )
+
+        elif (engine == Engine.INDIC_PARLER or
+                (isinstance(engine, str) and engine == "indic_parler") or
+                config.get("engine") == "indic_parler"):
+            # Indic Parler-TTS consumes raw text and a natural-language voice description.
+            # The adapter owns both: the prompt tokenizer (the checkpoint's own vocabulary)
+            # and the description tokenizer (the Flan-T5 one) are two *different*
+            # vocabularies loaded from engine_params, so no phonemizer vocabulary is built
+            # here. Alphabet.GRAPHEMES routes TTSVoice.synthesize() through
+            # adapter.encode_text(). DAC runs at 44.1 kHz.
+            engine = Engine.INDIC_PARLER
+            phoneme_type = phoneme_type or PhonemeType.UNICODE
+            alphabet = alphabet or Alphabet.GRAPHEMES
+            config.setdefault("audio", {}).setdefault("sample_rate", 44100)
             tokenizer = TTSTokenizer(
                 Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
                 add_blank_char=False,

--- a/phoonnx/engines/__init__.py
+++ b/phoonnx/engines/__init__.py
@@ -147,6 +147,7 @@ def _register_builtins() -> None:
     from phoonnx.engines.outetts import OuteTTSAdapter
     from phoonnx.engines.arktts import ArkTTSAdapter
     from phoonnx.engines.omnivoice import OmniVoiceAdapter
+    from phoonnx.engines.indic_parler import IndicParlerAdapter
 
     # OptiSpeech shares VITS-like x/x_lengths/scales inputs with Matcha, but has
     # a distinctive metadata + wav/durations output signature — check it first.
@@ -167,6 +168,10 @@ def _register_builtins() -> None:
     register_engine("f5tts", F5TTSAdapter, detect_priority=30)
     register_engine("chatterbox", ChatterboxAdapter, detect_priority=29)
     register_engine("supertonic", SuperTonicAdapter, detect_priority=28)
+    # Indic Parler is the only encoder-decoder engine: its prefill graph is the
+    # only one that takes codec_input_ids + prompt_input_ids + encoder_hidden_states
+    # together, so it is probed early and can never steal another engine's model.
+    register_engine("indic_parler", IndicParlerAdapter, detect_priority=18)
     register_engine("neutts", NeuTTSAdapter, detect_priority=27)
     register_engine("pockettts", PocketTTSAdapter, detect_priority=26)
     register_engine("sparktts", SparkTTSAdapter, detect_priority=25)

--- a/phoonnx/engines/indic_parler.py
+++ b/phoonnx/engines/indic_parler.py
@@ -1,0 +1,361 @@
+"""Indic Parler-TTS inference adapter — AI4Bharat's description-controlled codec LM.
+
+Indic Parler-TTS (``ai4bharat/indic-parler-tts``) is the Indic fine-tune of Parler-TTS
+(Lacombe, Srivastav, Gandhi). It speaks 20 Indic languages plus English, and the voice is
+chosen by a **natural-language description** ("Rohit's voice is clear and expressive...")
+rather than by a speaker id or a reference clip.
+
+This is phoonnx's first **encoder-decoder** engine. Every other autoregressive engine
+here (Chatterbox, NeuTTS, Spark-TTS, OuteTTS, ArkTTS, Qwen3-TTS) is decoder-only: one
+KV cache, one token stream. Parler splits the conditioning in two:
+
+* a frozen Flan-T5 encoder turns the *description* into encoder states that every decoder
+  layer **cross-attends** to. Those cross-attention keys/values do not change during
+  generation, so they are computed once in the prefill graph and then held constant --
+  the decode graph consumes them but never re-emits them;
+* the *text to speak* is embedded by ``embed_prompts`` and **prepended to the decoder's
+  input embeddings** (``prompt_cross_attention=False`` upstream). It is part of the
+  self-attention stream, not of the cross-attention stream.
+
+Four ONNX graphs (mirror: ``OpenVoiceOS/phoonnx-indic-parler``)::
+
+    text_encoder     : input_ids, attention_mask -> encoder_hidden_states
+    decoder_prefill  : codec_input_ids, prompt_input_ids, encoder_hidden_states,
+                       encoder_attention_mask
+                       -> logits, self-KV (24x2), cross-KV (24x2)      (= ``session``)
+    decoder_decode   : codec_input_ids, encoder_attention_mask, self-KV, cross-KV
+                       -> logits, self-KV (24x2)
+    dac_decoder      : audio_codes (9 codebooks) -> waveform @ 44.1 kHz
+
+The decoder writes 9 DAC codebooks under a **delay pattern**: codebook *k* is offset by
+*k* steps, so a frame is only complete 9 steps after it starts. ``build_delay_pattern_mask``
+and ``apply_delay_pattern_mask`` below are numpy ports of the upstream helpers, and
+``_eos_delay_constraint`` ports ``ParlerTTSLogitsProcessor``: end-of-speech may only move
+one codebook at a time, in order, so the tail of the delay pattern stays well-formed.
+
+Upstream defaults to sampling (``do_sample=True``); greedy decoding tends to ramble past
+the end of the sentence. Sampling is therefore the default here too, with ``temperature``
+and ``top_k`` exposed as engine parameters. Set ``do_sample`` to 0 for the deterministic
+path used by the parity tests.
+"""
+import json
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import onnxruntime
+from quebra_frases import sentence_tokenize
+
+from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
+
+NUM_CODEBOOKS = 9
+BOS_TOKEN_ID = 1025
+EOS_TOKEN_ID = 1024
+PAD_TOKEN_ID = 1024
+AUDIO_VOCAB_SIZE = 1088
+SAMPLE_RATE = 44100
+
+# Languages AI4Bharat lists as officially supported (ISO 639 codes).
+AVAILABLE_LANGS = ["as", "bn", "brx", "doi", "en", "gu", "hi", "kn", "kok", "mai",
+                    "ml", "mni", "mr", "ne", "or", "pa", "sa", "sat", "sd", "ta",
+                    "te", "ur"]
+
+
+def build_delay_pattern_mask(start_len: int, max_length: int,
+                             num_codebooks: int = NUM_CODEBOOKS,
+                             bos_token_id: int = BOS_TOKEN_ID,
+                             pad_token_id: int = PAD_TOKEN_ID):
+    """Numpy port of ``parler_tts.build_delay_pattern_mask`` for a bare BOS start.
+
+    Returns ``(start_ids, pattern)``. ``pattern`` is ``(num_codebooks, max_length)``:
+    ``-1`` marks a position the model must predict, anything else is a forced token
+    (BOS in the lower triangle, PAD in the upper one). ``start_ids`` is the prefix that
+    is already determined before the first prediction.
+    """
+    ids = np.full((1, num_codebooks, start_len), bos_token_id, dtype=np.int64)
+    if max_length < 2 * num_codebooks - 1:
+        # Too short for the staircase to close: upstream returns the ids untouched and a
+        # mask of all -1 ("predict everything"). Matters at the tail, where a sequence
+        # that stopped early is stripped against its own (short) length.
+        return (ids.reshape(num_codebooks, -1),
+                np.full((num_codebooks, max_length), -1, dtype=np.int64))
+    shifted = np.full((1, num_codebooks, max_length), -1, dtype=np.int64)
+    for codebook in range(num_codebooks):
+        shifted[:, codebook, codebook:start_len + codebook] = ids[:, codebook]
+    eos_delay = np.triu(np.ones((num_codebooks, max_length), bool),
+                        k=max_length - num_codebooks + 1)
+    bos_delay = np.tril(np.ones((num_codebooks, max_length), bool))
+    keep = ~(bos_delay | eos_delay)
+    pattern = keep * shifted + bos_delay * bos_token_id + eos_delay * pad_token_id
+    pattern = pattern.reshape(num_codebooks, -1)
+    predict_at = np.nonzero(pattern[0] == -1)[0]
+    first = int(predict_at.min()) if len(predict_at) else start_len
+    return pattern[:, :first].copy(), pattern
+
+
+def apply_delay_pattern_mask(ids: np.ndarray, pattern: np.ndarray) -> np.ndarray:
+    """Keep predictions only where the pattern says ``-1``; force the rest."""
+    p = pattern[..., : ids.shape[-1]]
+    return np.where(p == -1, ids, p)
+
+
+def strip_delay_pattern(raw_ids: np.ndarray, pattern: np.ndarray,
+                        num_codebooks: int = NUM_CODEBOOKS) -> np.ndarray:
+    """Undo the delay: drop the forced BOS/PAD cells and re-square the codebooks."""
+    masked = apply_delay_pattern_mask(raw_ids, pattern)
+    _, full = build_delay_pattern_mask(1, masked.shape[-1], num_codebooks)
+    keep = (full != BOS_TOKEN_ID) & (full != PAD_TOKEN_ID)
+    return masked[keep].reshape(num_codebooks, -1)
+
+
+def sample_logits(logits: np.ndarray, temperature: float, top_k: int, rng) -> np.ndarray:
+    """Temperature + top-k sampling, one draw per codebook row."""
+    x = logits.astype(np.float64) / max(temperature, 1e-5)
+    if top_k and top_k < x.shape[-1]:
+        kth = np.partition(x, -top_k, axis=-1)[:, -top_k][:, None]
+        x = np.where(x < kth, -np.inf, x)
+    x = x - x.max(axis=-1, keepdims=True)
+    probs = np.exp(x)
+    probs /= probs.sum(axis=-1, keepdims=True)
+    return np.array([rng.choice(probs.shape[-1], p=probs[i]) for i in range(probs.shape[0])],
+                    dtype=np.int64)
+
+
+class IndicParlerAdapter(BaseOnnxAdapter):
+    """Adapter for Indic Parler-TTS (T5 encoder -> AR decoder over DAC codes -> DAC decoder)."""
+
+    #: hard ceiling from the upstream generation config (2610 total positions)
+    MAX_LENGTH = 2610
+
+    def __init__(self, temperature: float = 1.0, top_k: int = 0,
+                 do_sample: bool = True, max_new_tokens: int = 1500):
+        self.text_encoder: Optional[onnxruntime.InferenceSession] = None
+        self.decode_session: Optional[onnxruntime.InferenceSession] = None
+        self.dac_decoder: Optional[onnxruntime.InferenceSession] = None
+        self.prompt_tokenizer = None
+        self.description_tokenizer = None
+        self.description: str = ""
+        self.temperature = float(temperature)
+        self.top_k = int(top_k)
+        self.do_sample = bool(do_sample)
+        self.max_new_tokens = int(max_new_tokens)
+        self.seed: Optional[int] = None
+        self.sample_rate = SAMPLE_RATE
+        self._decode_inputs: set = set()
+        self._prefill_outputs: List[str] = []
+        self._decode_outputs: List[str] = []
+
+    # ------------------------------------------------------------------
+    # setup
+    # ------------------------------------------------------------------
+
+    def default_params(self) -> Dict[str, float]:
+        return {"temperature": self.temperature, "top_k": float(self.top_k),
+                "do_sample": float(self.do_sample), "max_new_tokens": float(self.max_new_tokens)}
+
+    def param_labels(self) -> Dict[str, str]:
+        return {"temperature": "Sampling temperature", "top_k": "Top-k cutoff (0 = off)",
+                "do_sample": "Sample (1) or greedy (0)", "max_new_tokens": "Max codec frames"}
+
+    def configure(self, voice_config: Any) -> None:
+        """Load the three auxiliary graphs, both tokenizers and the voice description.
+
+        The description is the *voice*: it is a plain string in ``engine_options`` of the
+        index entry, taken verbatim from AI4Bharat's own recommended-speaker list, so a
+        voice id resolves to exactly the wording the model was trained to answer to.
+        """
+        ep = getattr(voice_config, "engine_params", None) or {}
+        providers = ep.get("providers")
+        if self.text_encoder is None and ep.get("text_encoder_path"):
+            self.text_encoder = make_session(ep["text_encoder_path"], providers=providers)
+        if self.decode_session is None and ep.get("decoder_decode_path"):
+            self.decode_session = make_session(ep["decoder_decode_path"], providers=providers)
+            self._decode_inputs = {i.name for i in self.decode_session.get_inputs()}
+            self._decode_outputs = [o.name for o in self.decode_session.get_outputs()]
+        if self.dac_decoder is None and ep.get("dac_decoder_path"):
+            self.dac_decoder = make_session(ep["dac_decoder_path"], providers=providers)
+        if self.prompt_tokenizer is None and ep.get("prompt_tokenizer_path"):
+            from tokenizers import Tokenizer
+            self.prompt_tokenizer = Tokenizer.from_file(str(ep["prompt_tokenizer_path"]))
+        if self.description_tokenizer is None and ep.get("description_tokenizer_path"):
+            from tokenizers import Tokenizer
+            self.description_tokenizer = Tokenizer.from_file(str(ep["description_tokenizer_path"]))
+        if ep.get("description"):
+            self.description = str(ep["description"])
+        for key, cast in (("temperature", float), ("top_k", int), ("max_new_tokens", int)):
+            if key in ep:
+                setattr(self, key, cast(ep[key]))
+        if "do_sample" in ep:
+            self.do_sample = bool(int(ep["do_sample"]))
+        if "seed" in ep and ep["seed"] is not None:
+            self.seed = int(ep["seed"])
+        if ep.get("model_config_path"):
+            with open(ep["model_config_path"], "r", encoding="utf-8") as f:
+                meta = json.load(f)
+            self.sample_rate = int(meta.get("sample_rate", self.sample_rate))
+
+    # ------------------------------------------------------------------
+    # text
+    # ------------------------------------------------------------------
+
+    def encode_text(self, text: str, voice: Any, syn_config: Any) -> List[List[int]]:
+        """Tokenize raw text with the checkpoint's own prompt tokenizer, one call per
+        sentence. Parler has no phoneme front end: the prompt tokenizer owns
+        normalization, and the description tokenizer (a *different* vocabulary, the
+        Flan-T5 one) is used only for the voice description."""
+        if self.prompt_tokenizer is None:
+            raise RuntimeError("Indic Parler voice missing prompt_tokenizer_path in engine_params")
+        sentences = [s.strip() for s in sentence_tokenize(text) if s.strip()] or [text.strip()]
+        return [list(self.prompt_tokenizer.encode(s).ids) for s in sentences if s]
+
+    # ------------------------------------------------------------------
+    # inference
+    # ------------------------------------------------------------------
+
+    def encode_description(self, description: str):
+        """Run the Flan-T5 encoder over the voice description.
+
+        Returns ``(encoder_hidden_states, encoder_attention_mask)``. The mask is applied
+        to the hidden states inside the exported graph, exactly as upstream does before
+        handing them to the decoder.
+        """
+        if self.text_encoder is None or self.description_tokenizer is None:
+            raise RuntimeError("Indic Parler voice missing text_encoder_path / "
+                               "description_tokenizer_path in engine_params")
+        enc = self.description_tokenizer.encode(description)
+        input_ids = np.asarray([enc.ids], np.int64)
+        attention_mask = np.ones_like(input_ids, np.int64)
+        hidden = self.text_encoder.run(None, {"input_ids": input_ids,
+                                              "attention_mask": attention_mask})[0]
+        return np.asarray(hidden, np.float32), attention_mask
+
+    @staticmethod
+    def _eos_delay_constraint(logits: np.ndarray, raw_ids: np.ndarray,
+                              first_unfinished: int) -> int:
+        """Port of ``ParlerTTSLogitsProcessor``.
+
+        Only one codebook at a time may emit end-of-speech, in codebook order. Every
+        codebook above the lowest unfinished one has its EOS logit driven to ``-inf``,
+        which is what keeps the delay pattern's tail consistent.
+        """
+        seen_eos = (raw_ids == EOS_TOKEN_ID).sum(axis=1)
+        if seen_eos[first_unfinished] > 0 and first_unfinished < NUM_CODEBOOKS - 1:
+            first_unfinished += 1
+        logits[np.arange(NUM_CODEBOOKS) > first_unfinished, EOS_TOKEN_ID] = -np.inf
+        return first_unfinished
+
+    def generate_codes(self, prompt_ids: np.ndarray, encoder_hidden_states: np.ndarray,
+                       encoder_attention_mask: np.ndarray,
+                       session: onnxruntime.InferenceSession,
+                       max_new_tokens: int, do_sample: bool, temperature: float,
+                       top_k: int, rng) -> np.ndarray:
+        """Autoregressive loop: prefill once, then step the decode graph with the cache.
+
+        The cross-attention KV produced by the prefill graph is kept in the cache dict
+        and fed back unchanged on every step; only the self-attention KV is refreshed
+        from the decode graph's outputs.
+        """
+        if self.decode_session is None:
+            raise RuntimeError("Indic Parler voice missing decoder_decode_path in engine_params")
+
+        max_length = min(max_new_tokens + 1, self.MAX_LENGTH)
+        start_ids, pattern = build_delay_pattern_mask(1, max_length)
+        raw = apply_delay_pattern_mask(start_ids, pattern)
+
+        outputs = session.run(None, {
+            "codec_input_ids": raw[None, ...].astype(np.int64),
+            "prompt_input_ids": prompt_ids.astype(np.int64),
+            "encoder_hidden_states": encoder_hidden_states,
+            "encoder_attention_mask": encoder_attention_mask.astype(np.int64),
+        })
+        if not self._prefill_outputs:
+            self._prefill_outputs = [o.name for o in session.get_outputs()]
+        named = dict(zip(self._prefill_outputs, outputs))
+        logits = named["logits"]
+        cache = {k.replace("present.", "past_key_values."): v
+                 for k, v in named.items() if k.startswith("present.")}
+
+        first_unfinished = 0
+        unfinished = np.ones(NUM_CODEBOOKS, bool)
+        for _ in range(max_new_tokens):
+            step_logits = np.asarray(logits, np.float32).reshape(NUM_CODEBOOKS, -1).copy()
+            first_unfinished = self._eos_delay_constraint(step_logits, raw, first_unfinished)
+            if do_sample:
+                nxt = sample_logits(step_logits, temperature, top_k, rng)
+            else:
+                nxt = step_logits.argmax(axis=-1).astype(np.int64)
+            nxt = np.where(unfinished, nxt, PAD_TOKEN_ID)
+            raw = np.concatenate([raw, nxt[:, None]], axis=-1)
+            unfinished &= nxt != EOS_TOKEN_ID
+            if not unfinished.any() or raw.shape[-1] >= max_length:
+                break
+
+            model_ids = apply_delay_pattern_mask(raw, pattern)
+            feed = {"codec_input_ids": model_ids[None, :, -1:].astype(np.int64),
+                    "encoder_attention_mask": encoder_attention_mask.astype(np.int64)}
+            feed = {k: v for k, v in feed.items() if k in self._decode_inputs}
+            for k, v in cache.items():
+                if k in self._decode_inputs:
+                    feed[k] = v
+            step_out = dict(zip(self._decode_outputs, self.decode_session.run(None, feed)))
+            logits = step_out["logits"]
+            for k, v in step_out.items():
+                if k.startswith("present."):
+                    cache[k.replace("present.", "past_key_values.")] = v
+
+        return strip_delay_pattern(raw, pattern)
+
+    def decode_audio(self, codes: np.ndarray) -> np.ndarray:
+        """Run the DAC decoder over ``(9, frames)`` codes and return mono float32."""
+        if self.dac_decoder is None:
+            raise RuntimeError("Indic Parler voice missing dac_decoder_path in engine_params")
+        if codes.shape[-1] == 0:
+            return np.zeros(0, np.float32)
+        wav = self.dac_decoder.run(None, {"audio_codes": codes[None, ...].astype(np.int64)})[0]
+        return np.asarray(wav, np.float32).reshape(-1)
+
+    def synthesize(self, request: AdapterSynthesisRequest,
+                   session: onnxruntime.InferenceSession) -> AdapterSynthesisResult:
+        p = request.params
+        description = str(p.get("description") or self.description)
+        if not description:
+            raise RuntimeError("Indic Parler voices need a speaker description "
+                               "(engine_options['description'])")
+        do_sample = bool(int(p.get("do_sample", self.do_sample)))
+        temperature = float(p.get("temperature", self.temperature))
+        top_k = int(p.get("top_k", self.top_k))
+        max_new_tokens = int(p.get("max_new_tokens", self.max_new_tokens))
+        seed = p.get("seed", self.seed)
+        rng = np.random.default_rng(None if seed is None else int(seed))
+
+        enc_hidden, enc_mask = self.encode_description(description)
+        prompt_ids = np.asarray(request.phoneme_ids, np.int64).reshape(1, -1)
+        codes = self.generate_codes(prompt_ids, enc_hidden, enc_mask, session,
+                                    max_new_tokens, do_sample, temperature, top_k, rng)
+        audio = self.decode_audio(codes)
+        return AdapterSynthesisResult(audio=audio,
+                                      extras={"codes": codes, "description": description,
+                                              "sample_rate": self.sample_rate})
+
+    # build_feed_dict / parse_outputs are required by the ABC but unused —
+    # synthesize() drives the four-graph pipeline directly.
+    def build_feed_dict(self, request: AdapterSynthesisRequest,
+                        session: onnxruntime.InferenceSession) -> Dict[str, np.ndarray]:
+        raise NotImplementedError("Indic Parler is multi-graph — use synthesize()")
+
+    def parse_outputs(self, outputs: List[np.ndarray], request: AdapterSynthesisRequest,
+                      output_names: Optional[List[str]] = None) -> AdapterSynthesisResult:
+        raise NotImplementedError("Indic Parler is multi-graph — use synthesize()")
+
+    @staticmethod
+    def detect(config: Optional[Dict[str, Any]] = None,
+               session: Optional[onnxruntime.InferenceSession] = None) -> bool:
+        if config and config.get("engine") == "indic_parler":
+            return True
+        if session is not None:
+            names = {i.name for i in session.get_inputs()}
+            # the prefill graph's signature: a codec stream plus a *separate* prompt
+            # stream plus cross-attention states — no other phoonnx engine has all three
+            if {"codec_input_ids", "prompt_input_ids", "encoder_hidden_states"} <= names:
+                return True
+        return False

--- a/phoonnx/engines/indic_parler.py
+++ b/phoonnx/engines/indic_parler.py
@@ -53,6 +53,7 @@ BOS_TOKEN_ID = 1025
 EOS_TOKEN_ID = 1024
 PAD_TOKEN_ID = 1024
 AUDIO_VOCAB_SIZE = 1088
+DAC_CODEBOOK_SIZE = 1024   # valid DAC codes are 0..1023; 1024/1025 are PAD/BOS
 SAMPLE_RATE = 44100
 
 # Languages AI4Bharat lists as officially supported (ISO 639 codes).
@@ -105,7 +106,18 @@ def strip_delay_pattern(raw_ids: np.ndarray, pattern: np.ndarray,
     masked = apply_delay_pattern_mask(raw_ids, pattern)
     _, full = build_delay_pattern_mask(1, masked.shape[-1], num_codebooks)
     keep = (full != BOS_TOKEN_ID) & (full != PAD_TOKEN_ID)
-    return masked[keep].reshape(num_codebooks, -1)
+    codes = masked[keep].reshape(num_codebooks, -1)
+    # When the model stops on its own, each codebook's end-of-speech token sits one
+    # column *before* the pattern's PAD staircase, so the staircase does not mask it and
+    # a 1024 survives into the codes. DAC only accepts 0..1023. Cutting at the first
+    # column that carries an out-of-range value drops exactly that frame and reproduces
+    # upstream's own output byte-for-byte (verified against torch: 9x215 with a trailing
+    # 1024 becomes the same 9x214 torch feeds to its DAC). Generations that hit the frame
+    # ceiling instead of stopping have no such column and are left untouched.
+    out_of_range = np.nonzero((codes >= DAC_CODEBOOK_SIZE).any(axis=0))[0]
+    if len(out_of_range):
+        codes = codes[:, : int(out_of_range.min())]
+    return codes
 
 
 def sample_logits(logits: np.ndarray, temperature: float, top_k: int, rng) -> np.ndarray:

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -658,6 +658,8 @@ class TTSModelManager:
         "coqui_vits.json", "BSC.json", "shami.json", "chatterbox.json",
         "supertonic.json", "neutts.json", "pockettts.json", "sparktts.json",
         "qwen3tts.json",
+        # neutts..omnivoice: catch-up entries for engines merged since this list was
+        # last touched; only indic_parler.json is new to this change.
         "outetts.json", "arktts.json", "omnivoice.json", "indic_parler.json",
     )
 

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -658,7 +658,7 @@ class TTSModelManager:
         "coqui_vits.json", "BSC.json", "shami.json", "chatterbox.json",
         "supertonic.json", "neutts.json", "pockettts.json", "sparktts.json",
         "qwen3tts.json",
-        "outetts.json", "arktts.json",
+        "outetts.json", "arktts.json", "omnivoice.json", "indic_parler.json",
     )
 
     @classmethod

--- a/phoonnx/voice_index/indic_parler.json
+++ b/phoonnx/voice_index/indic_parler.json
@@ -1,0 +1,834 @@
+{
+    "indic_parler/amit/as": {
+        "voice_id": "indic_parler/amit/as",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "as",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Amit's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Amit"
+        },
+        "display_name": "Indic Parler Amit (Assamese)"
+    },
+    "indic_parler/sita/as": {
+        "voice_id": "indic_parler/sita/as",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "as",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Sita speaks at a fast pace with a slightly low-pitched voice, captured clearly in a close-sounding environment with excellent recording quality.",
+            "speaker": "Sita"
+        },
+        "display_name": "Indic Parler Sita (Assamese)"
+    },
+    "indic_parler/arjun/bn": {
+        "voice_id": "indic_parler/arjun/bn",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "bn",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Arjun's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Arjun"
+        },
+        "display_name": "Indic Parler Arjun (Bengali)"
+    },
+    "indic_parler/aditi/bn": {
+        "voice_id": "indic_parler/aditi/bn",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "bn",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Aditi speaks with a slightly higher pitch in a close-sounding environment. Her voice is clear, with subtle emotional depth and a normal pace, all captured in high-quality recording.",
+            "speaker": "Aditi"
+        },
+        "display_name": "Indic Parler Aditi (Bengali)"
+    },
+    "indic_parler/bikram/brx": {
+        "voice_id": "indic_parler/bikram/brx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "brx",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Bikram speaks with a higher pitch and fast pace, conveying urgency. The recording is clear and intimate, with great emotional depth.",
+            "speaker": "Bikram"
+        },
+        "display_name": "Indic Parler Bikram (Bodo)"
+    },
+    "indic_parler/maya/brx": {
+        "voice_id": "indic_parler/maya/brx",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "brx",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Maya's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Maya"
+        },
+        "display_name": "Indic Parler Maya (Bodo)"
+    },
+    "indic_parler/bhanu/hne": {
+        "voice_id": "indic_parler/bhanu/hne",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "hne",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Bhanu's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Bhanu"
+        },
+        "display_name": "Indic Parler Bhanu (Chhattisgarhi)"
+    },
+    "indic_parler/champa/hne": {
+        "voice_id": "indic_parler/champa/hne",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "hne",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Champa's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Champa"
+        },
+        "display_name": "Indic Parler Champa (Chhattisgarhi)"
+    },
+    "indic_parler/karan/doi": {
+        "voice_id": "indic_parler/karan/doi",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "doi",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Karan’s high-pitched, engaging voice is captured in a clear, close-sounding recording. His slightly slower delivery conveys a positive tone.",
+            "speaker": "Karan"
+        },
+        "display_name": "Indic Parler Karan (Dogri)"
+    },
+    "indic_parler/thoma/en": {
+        "voice_id": "indic_parler/thoma/en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "en",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Thoma's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Thoma"
+        },
+        "display_name": "Indic Parler Thoma (English)"
+    },
+    "indic_parler/mary/en": {
+        "voice_id": "indic_parler/mary/en",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "en",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Mary's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Mary"
+        },
+        "display_name": "Indic Parler Mary (English)"
+    },
+    "indic_parler/yash/gu": {
+        "voice_id": "indic_parler/yash/gu",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "gu",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Yash's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Yash"
+        },
+        "display_name": "Indic Parler Yash (Gujarati)"
+    },
+    "indic_parler/neha/gu": {
+        "voice_id": "indic_parler/neha/gu",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "gu",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Neha's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Neha"
+        },
+        "display_name": "Indic Parler Neha (Gujarati)"
+    },
+    "indic_parler/rohit/hi": {
+        "voice_id": "indic_parler/rohit/hi",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "hi",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Rohit's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Rohit"
+        },
+        "display_name": "Indic Parler Rohit (Hindi)"
+    },
+    "indic_parler/divya/hi": {
+        "voice_id": "indic_parler/divya/hi",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "hi",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Divya's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Divya"
+        },
+        "display_name": "Indic Parler Divya (Hindi)"
+    },
+    "indic_parler/suresh/kn": {
+        "voice_id": "indic_parler/suresh/kn",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "kn",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Suresh's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Suresh"
+        },
+        "display_name": "Indic Parler Suresh (Kannada)"
+    },
+    "indic_parler/anu/kn": {
+        "voice_id": "indic_parler/anu/kn",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "kn",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Anu's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Anu"
+        },
+        "display_name": "Indic Parler Anu (Kannada)"
+    },
+    "indic_parler/anjali/ml": {
+        "voice_id": "indic_parler/anjali/ml",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "ml",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Anjali speaks with a high pitch at a normal pace in a clear, close-sounding environment. Her neutral tone is captured with excellent audio quality.",
+            "speaker": "Anjali"
+        },
+        "display_name": "Indic Parler Anjali (Malayalam)"
+    },
+    "indic_parler/harish/ml": {
+        "voice_id": "indic_parler/harish/ml",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "ml",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Harish's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Harish"
+        },
+        "display_name": "Indic Parler Harish (Malayalam)"
+    },
+    "indic_parler/laishram/mni": {
+        "voice_id": "indic_parler/laishram/mni",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "mni",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Laishram's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Laishram"
+        },
+        "display_name": "Indic Parler Laishram (Manipuri)"
+    },
+    "indic_parler/ranjit/mni": {
+        "voice_id": "indic_parler/ranjit/mni",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "mni",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Ranjit's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Ranjit"
+        },
+        "display_name": "Indic Parler Ranjit (Manipuri)"
+    },
+    "indic_parler/sanjay/mr": {
+        "voice_id": "indic_parler/sanjay/mr",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "mr",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Sanjay's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Sanjay"
+        },
+        "display_name": "Indic Parler Sanjay (Marathi)"
+    },
+    "indic_parler/sunita/mr": {
+        "voice_id": "indic_parler/sunita/mr",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "mr",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Sunita speaks with a high pitch in a close environment. Her voice is clear, with slight dynamic changes, and the recording is of excellent quality.",
+            "speaker": "Sunita"
+        },
+        "display_name": "Indic Parler Sunita (Marathi)"
+    },
+    "indic_parler/amrita/ne": {
+        "voice_id": "indic_parler/amrita/ne",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "ne",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Amrita speaks with a high pitch at a slow pace. Her voice is clear, with excellent recording quality and only moderate background noise.",
+            "speaker": "Amrita"
+        },
+        "display_name": "Indic Parler Amrita (Nepali)"
+    },
+    "indic_parler/manas/or": {
+        "voice_id": "indic_parler/manas/or",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "or",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Manas's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Manas"
+        },
+        "display_name": "Indic Parler Manas (Odia)"
+    },
+    "indic_parler/debjani/or": {
+        "voice_id": "indic_parler/debjani/or",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "or",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Debjani's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Debjani"
+        },
+        "display_name": "Indic Parler Debjani (Odia)"
+    },
+    "indic_parler/divjot/pa": {
+        "voice_id": "indic_parler/divjot/pa",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "pa",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Divjot's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Divjot"
+        },
+        "display_name": "Indic Parler Divjot (Punjabi)"
+    },
+    "indic_parler/gurpreet/pa": {
+        "voice_id": "indic_parler/gurpreet/pa",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "pa",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Gurpreet's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Gurpreet"
+        },
+        "display_name": "Indic Parler Gurpreet (Punjabi)"
+    },
+    "indic_parler/aryan/sa": {
+        "voice_id": "indic_parler/aryan/sa",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "sa",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Aryan's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Aryan"
+        },
+        "display_name": "Indic Parler Aryan (Sanskrit)"
+    },
+    "indic_parler/jaya/ta": {
+        "voice_id": "indic_parler/jaya/ta",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "ta",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Jaya's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Jaya"
+        },
+        "display_name": "Indic Parler Jaya (Tamil)"
+    },
+    "indic_parler/prakash/te": {
+        "voice_id": "indic_parler/prakash/te",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "te",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Prakash's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Prakash"
+        },
+        "display_name": "Indic Parler Prakash (Telugu)"
+    },
+    "indic_parler/lalitha/te": {
+        "voice_id": "indic_parler/lalitha/te",
+        "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_prefill.onnx",
+        "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json",
+        "vocab_url": null,
+        "tokens_url": null,
+        "tokenizer_config_url": null,
+        "phoneme_map_url": null,
+        "phoneme_type": "unicode",
+        "alphabet": "graphemes",
+        "engine": "indic_parler",
+        "lang": "te",
+        "aux_model_urls": {
+            "text_encoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/text_encoder.onnx",
+            "decoder_decode_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/decoder_decode.onnx",
+            "dac_decoder_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/dac_decoder.onnx",
+            "prompt_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/tokenizer.json",
+            "description_tokenizer_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/description_tokenizer.json",
+            "model_config_path": "https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/resolve/main/config.json"
+        },
+        "engine_options": {
+            "description": "Lalitha's voice is monotone yet slightly fast in delivery, with a very close recording that almost has no background noise.",
+            "speaker": "Lalitha"
+        },
+        "display_name": "Indic Parler Lalitha (Telugu)"
+    }
+}

--- a/scripts/conversion/indicparler/compare_with_community_export.py
+++ b/scripts/conversion/indicparler/compare_with_community_export.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Check ``naklitechie/indic-parler-tts-ONNX`` against upstream PyTorch, step by step.
+
+Usage::
+
+    python compare_with_community_export.py
+
+Requires network access (downloads the community ``decoder_with_past_model.onnx`` plus
+``ai4bharat/indic-parler-tts`` in float32 torch) and the ``parler_tts`` package.
+
+Why this script exists
+-----------------------
+``naklitechie/indic-parler-tts-ONNX`` is the only community export of Indic Parler-TTS
+on the Hub. Its text encoder and its prefill (``decoder_model.onnx``) graph are correct.
+Its decode-with-cache graph (``decoder_with_past_model.onnx``) is not: upstream gates
+cross-attention on ``encoder_hidden_states is not None``
+
+    https://github.com/huggingface/parler-tts/blob/main/parler_tts/modeling_parler_tts.py
+
+and exporting the decode step *without* passing that argument makes the traced graph
+silently drop cross-attention in all 24 layers. It still produces audio -- just audio
+that ignores the voice description. This script reproduces the numbers cited in
+phoonnx PR #363: step-1 logits differ from torch by ~32.6 (mean ~15.9 over 40 steps),
+greedy argmax agreement 0/40. It is the methodology check, not a one-off narrative claim.
+
+For contrast, run the same forced-decode loop against phoonnx's own
+``decoder_decode.onnx`` (see ``export_onnx.py`` in this directory) with ``--onnx`` to
+confirm it does *not* reproduce this divergence.
+"""
+import argparse
+
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+
+NUM_LAYERS = 24
+NUM_CODEBOOKS = 9
+
+
+def _forced_prompt(model, tokenizer, desc_tokenizer, text, description):
+    prompt = tokenizer(text, return_tensors="pt")
+    desc = desc_tokenizer(description, return_tensors="pt")
+    return prompt, desc
+
+
+def run_torch_reference(model, prompt, desc, n_steps):
+    """Greedy-forced decode: at every step, feed the model's *own* previous choice back
+    in (true greedy), and capture the logits before sampling. Returns (logits, codes)
+    with logits shape (n_steps, NUM_CODEBOOKS, vocab)."""
+    with torch.no_grad():
+        enc_out = model.text_encoder(input_ids=desc.input_ids, attention_mask=desc.attention_mask)
+        enc_hidden = enc_out.last_hidden_state * desc.attention_mask[..., None].to(enc_out.last_hidden_state.dtype)
+        prompt_hidden = model.embed_prompts(prompt.input_ids)
+
+        bos = model.generation_config.decoder_start_token_id
+        codec_ids = torch.full((1, NUM_CODEBOOKS, 1), bos, dtype=torch.long)
+        past = None
+        all_logits = []
+        codes = []
+        for step in range(n_steps):
+            out = model.decoder(
+                input_ids=codec_ids.reshape(-1, codec_ids.shape[-1]) if step == 0 else codec_ids[:, :, -1:].reshape(-1, 1),
+                encoder_hidden_states=enc_hidden,
+                encoder_attention_mask=desc.attention_mask,
+                prompt_hidden_states=prompt_hidden if step == 0 else None,
+                past_key_values=past,
+                use_cache=True,
+                return_dict=True,
+            )
+            logits = out.logits[:, -1].reshape(NUM_CODEBOOKS, -1)
+            all_logits.append(logits.numpy())
+            next_tok = logits.argmax(-1)
+            codes.append(next_tok.numpy())
+            codec_ids = torch.cat([codec_ids, next_tok.reshape(1, NUM_CODEBOOKS, 1)], dim=-1)
+            past = out.past_key_values
+        return np.stack(all_logits), np.stack(codes), enc_hidden.numpy(), desc.attention_mask.numpy()
+
+
+def run_community_onnx(onnx_path, torch_codes, enc_hidden, enc_mask, n_steps):
+    """Feed the *same* torch-chosen codes back into the community decode-with-past graph
+    (so a mismatch is attributable to the graph, not to divergent sampling) and record
+    its logits at each step."""
+    import onnxruntime
+
+    sess = onnxruntime.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    input_names = {i.name for i in sess.get_inputs()}
+    print("community decoder_with_past inputs:", sorted(input_names))
+    has_cross_input = "encoder_hidden_states" in input_names
+    print("has encoder_hidden_states input:", has_cross_input)
+
+    past = {n: np.zeros(_zero_shape_for(n), np.float32) for n in input_names
+            if n.startswith(("past_key_values", "past."))}
+    logits_out = []
+    codec_ids = np.full((1, NUM_CODEBOOKS, 1), 1025, np.int64)
+    for step in range(n_steps):
+        feed = {"input_ids" if "input_ids" in input_names else "codec_input_ids":
+                codec_ids[:, :, -1:].reshape(1, NUM_CODEBOOKS, 1)}
+        if has_cross_input:
+            feed["encoder_hidden_states"] = enc_hidden
+        if "encoder_attention_mask" in input_names:
+            feed["encoder_attention_mask"] = enc_mask
+        feed.update({k: v for k, v in past.items() if k in input_names})
+        outs = sess.run(None, feed)
+        out_names = [o.name for o in sess.get_outputs()]
+        result = dict(zip(out_names, outs))
+        logits = result["logits"].reshape(NUM_CODEBOOKS, -1)
+        logits_out.append(logits)
+        next_tok = torch_codes[step].reshape(1, NUM_CODEBOOKS, 1)
+        codec_ids = np.concatenate([codec_ids, next_tok], axis=-1)
+        for name in list(past):
+            present_name = name.replace("past_key_values", "present").replace("past.", "present.")
+            if present_name in result:
+                past[name] = result[present_name]
+    return np.stack(logits_out)
+
+
+def _zero_shape_for(name):
+    # cross-attention caches carry the source length; self-attention caches start empty.
+    return (1, 16, 0, 64)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="ai4bharat/indic-parler-tts")
+    ap.add_argument("--community-repo", default="naklitechie/indic-parler-tts-ONNX")
+    ap.add_argument("--community-file", default="decoder_with_past_model.onnx")
+    ap.add_argument("--text", default="Hello world, this is a test of Indic Parler.")
+    ap.add_argument("--description",
+                    default="Rohit's voice is clear and expressive, recorded in a "
+                             "very close-sounding environment with no background noise.")
+    ap.add_argument("--steps", type=int, default=40)
+    ap.add_argument("--threads", type=int, default=6)
+    args = ap.parse_args()
+    torch.set_num_threads(args.threads)
+
+    from parler_tts import ParlerTTSForConditionalGeneration
+    from transformers import AutoTokenizer
+
+    print("loading torch reference model ...", flush=True)
+    model = ParlerTTSForConditionalGeneration.from_pretrained(
+        args.model, attn_implementation="eager", torch_dtype=torch.float32).eval()
+    for cfg in (model.config, model.config.decoder, model.config.text_encoder, model.config.audio_encoder):
+        cfg._attn_implementation = "eager"
+    prompt_tok = AutoTokenizer.from_pretrained(args.model)
+    desc_tok = AutoTokenizer.from_pretrained(model.config.text_encoder._name_or_path)
+
+    prompt, desc = _forced_prompt(model, prompt_tok, desc_tok, args.text, args.description)
+
+    print("running torch greedy decode, %d steps ..." % args.steps, flush=True)
+    torch_logits, torch_codes, enc_hidden, enc_mask = run_torch_reference(model, prompt, desc, args.steps)
+
+    print("downloading community decode-with-past graph ...", flush=True)
+    onnx_path = hf_hub_download(args.community_repo, args.community_file)
+    hf_hub_download(args.community_repo, args.community_file + ".data")
+
+    print("running community decoder_with_past_model.onnx on the same forced codes ...", flush=True)
+    community_logits = run_community_onnx(onnx_path, torch_codes, enc_hidden, enc_mask, args.steps)
+
+    diff = np.abs(community_logits - torch_logits)
+    step1_diff = diff[0].max()
+    mean_diff = diff.max(axis=(1, 2)).mean()
+    agree = (community_logits.argmax(-1) == torch_logits.argmax(-1))
+    print()
+    print("step-1 logits max abs diff: %.3f" % step1_diff)
+    print("mean per-step max abs diff over %d steps: %.3f" % (args.steps, mean_diff))
+    print("greedy argmax agreement: %d / %d" % (int(agree.sum()), agree.size))
+    print()
+    print("Compare against phoonnx's own decoder_decode.onnx with the same forced-code")
+    print("loop (swap run_community_onnx's feed-building for phoonnx's engine adapter,")
+    print("see scripts/conversion/qwen3tts/verify_parity.py for the pattern) to confirm")
+    print("the OpenVoiceOS export does not reproduce this divergence.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/indicparler/export_onnx.py
+++ b/scripts/conversion/indicparler/export_onnx.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Export ai4bharat/indic-parler-tts to ONNX for phoonnx.
+
+Parler-TTS is an encoder-decoder codec LM:
+
+    Flan-T5 encoder (description)  ->  encoder_hidden_states
+    embed_prompts(prompt_input_ids) ->  prompt_hidden_states  (prepended to the
+                                        decoder input embeddings, NOT cross-attended,
+                                        because `prompt_cross_attention=False`)
+    24-layer AR decoder over 9 delayed DAC codebooks, cross-attending to the encoder
+    DAC decoder (44.1 kHz) turns the 9 codebooks back into a waveform
+
+Four graphs are written:
+
+    text_encoder.onnx     input_ids, attention_mask -> encoder_hidden_states
+    decoder_prefill.onnx  codec_input_ids, prompt_input_ids, encoder_hidden_states,
+                          encoder_attention_mask
+                          -> logits, present self-KV (24x2), present cross-KV (24x2)
+    decoder_decode.onnx   codec_input_ids, encoder_attention_mask,
+                          past self-KV (24x2), cross-KV (24x2)
+                          -> logits, present self-KV (24x2)
+    dac_decoder.onnx      audio_codes -> audio_values
+
+The cross-attention KV is computed once in the prefill graph and then held constant:
+the decode graph consumes it but does not re-emit it. This is the first
+encoder-decoder engine in phoonnx -- every previous AR engine is decoder-only, so
+there is no cross-KV to carry.
+"""
+import argparse
+import json
+import os
+
+import torch
+from torch import nn
+
+NUM_CODEBOOKS = 9
+
+
+class TextEncoderWrapper(nn.Module):
+    """Flan-T5 encoder + the mask-zeroing that ParlerTTS applies to its output."""
+
+    def __init__(self, text_encoder):
+        super().__init__()
+        self.text_encoder = text_encoder
+
+    def forward(self, input_ids, attention_mask):
+        hidden = self.text_encoder(input_ids=input_ids, attention_mask=attention_mask).last_hidden_state
+        return hidden * attention_mask[..., None].to(hidden.dtype)
+
+
+class PrefillWrapper(nn.Module):
+    """First AR step: embed the prompt, prepend it, run the full decoder, keep the cache."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.embed_prompts = model.embed_prompts
+        self.decoder = model.decoder
+
+    def forward(self, codec_input_ids, prompt_input_ids, encoder_hidden_states, encoder_attention_mask):
+        prompt_hidden_states = self.embed_prompts(prompt_input_ids)
+        out = self.decoder(
+            input_ids=codec_input_ids.reshape(-1, codec_input_ids.shape[-1]),
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            prompt_hidden_states=prompt_hidden_states,
+            use_cache=True,
+            return_dict=True,
+        )
+        past = out.past_key_values
+        if hasattr(past, "to_legacy_cache"):
+            past = past.to_legacy_cache()
+        flat = []
+        for layer in past:
+            flat.extend(layer[:4])
+        return (out.logits[:, -1],) + tuple(flat)
+
+
+class DecodeWrapper(nn.Module):
+    """Subsequent AR steps: one codec frame in, cache in, cache out."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.decoder = model.decoder
+        self.num_layers = len(model.decoder.model.decoder.layers)
+
+    def forward(self, codec_input_ids, encoder_hidden_states, encoder_attention_mask, *past):
+        legacy = tuple(tuple(past[4 * i: 4 * i + 4]) for i in range(self.num_layers))
+        out = self.decoder(
+            input_ids=codec_input_ids.reshape(-1, codec_input_ids.shape[-1]),
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            past_key_values=legacy,
+            use_cache=True,
+            return_dict=True,
+        )
+        new = out.past_key_values
+        if hasattr(new, "to_legacy_cache"):
+            new = new.to_legacy_cache()
+        flat = []
+        for layer in new:
+            flat.extend(layer[:2])          # self-attention KV only; cross-KV is invariant
+        return (out.logits[:, -1],) + tuple(flat)
+
+
+class DacDecoderWrapper(nn.Module):
+    def __init__(self, audio_encoder):
+        super().__init__()
+        self.audio_encoder = audio_encoder
+
+    def forward(self, audio_codes):
+        quantized = self.audio_encoder.quantizer.from_codes(audio_codes)[0]
+        return self.audio_encoder.decoder(quantized)
+
+
+def _kv_names(num_layers, prefix, cross=True):
+    names = []
+    for i in range(num_layers):
+        names += [f"{prefix}.{i}.decoder.key", f"{prefix}.{i}.decoder.value"]
+        if cross:
+            names += [f"{prefix}.{i}.encoder.key", f"{prefix}.{i}.encoder.value"]
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="ai4bharat/indic-parler-tts")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--opset", type=int, default=17)
+    ap.add_argument("--only", default=None,
+                    help="comma-separated subset: text_encoder,decoder_prefill,decoder_decode,dac_decoder")
+    args = ap.parse_args()
+
+    from parler_tts import ParlerTTSForConditionalGeneration
+    from transformers import AutoTokenizer
+
+    os.makedirs(args.out, exist_ok=True)
+    model = ParlerTTSForConditionalGeneration.from_pretrained(
+        args.model, attn_implementation="eager", torch_dtype=torch.float32
+    ).eval()
+    for cfg in (model.config, model.config.decoder, model.config.text_encoder, model.config.audio_encoder):
+        cfg._attn_implementation = "eager"
+
+    num_layers = len(model.decoder.model.decoder.layers)
+    d_model = model.decoder.config.hidden_size
+
+    desc_tok = AutoTokenizer.from_pretrained(model.config.text_encoder._name_or_path)
+    prompt_tok = AutoTokenizer.from_pretrained(args.model)
+    want = set(args.only.split(",")) if args.only else None
+    def _do(name):
+        return want is None or name in want
+
+    desc = desc_tok("A clear voice, very close recording, no background noise.", return_tensors="pt")
+    prompt = prompt_tok("Hello world, this is a test.", return_tensors="pt")
+
+    # ---------------- text encoder ----------------
+    if _do("text_encoder"):
+     print("exporting text_encoder ...", flush=True)
+     torch.onnx.export(
+         TextEncoderWrapper(model.text_encoder).eval(),
+         (desc.input_ids, desc.attention_mask),
+         os.path.join(args.out, "text_encoder.onnx"),
+         input_names=["input_ids", "attention_mask"],
+         output_names=["encoder_hidden_states"],
+         dynamic_axes={"input_ids": {0: "batch", 1: "seq"},
+                       "attention_mask": {0: "batch", 1: "seq"},
+                       "encoder_hidden_states": {0: "batch", 1: "seq"}},
+         opset_version=args.opset,
+     )
+
+    with torch.no_grad():
+        enc_hidden = TextEncoderWrapper(model.text_encoder).eval()(desc.input_ids, desc.attention_mask)
+
+    # ---------------- decoder prefill ----------------
+    print("exporting decoder_prefill ...", flush=True)
+    codec = torch.full((1, NUM_CODEBOOKS, 1), model.generation_config.decoder_start_token_id, dtype=torch.long)
+    prefill = PrefillWrapper(model).eval()
+    out_names = ["logits"] + _kv_names(num_layers, "present", cross=True)
+    dyn = {"codec_input_ids": {0: "batch", 2: "tgt"},
+           "prompt_input_ids": {0: "batch", 1: "prompt"},
+           "encoder_hidden_states": {0: "batch", 1: "src"},
+           "encoder_attention_mask": {0: "batch", 1: "src"},
+           "logits": {0: "batch_codebooks"}}
+    for n in out_names[1:]:
+        dyn[n] = {0: "batch", 2: "src" if n.endswith((".encoder.key", ".encoder.value")) else "past"}
+    torch.onnx.export(
+        prefill,
+        (codec, prompt.input_ids, enc_hidden, desc.attention_mask),
+        os.path.join(args.out, "decoder_prefill.onnx"),
+        input_names=["codec_input_ids", "prompt_input_ids", "encoder_hidden_states", "encoder_attention_mask"],
+        output_names=out_names,
+        dynamic_axes=dyn,
+        opset_version=args.opset,
+    )
+
+    with torch.no_grad():
+        pre_out = prefill(codec, prompt.input_ids, enc_hidden, desc.attention_mask)
+    past = list(pre_out[1:])
+
+    # ---------------- decoder decode ----------------
+    print("exporting decoder_decode ...", flush=True)
+    decode = DecodeWrapper(model).eval()
+    in_names = ["codec_input_ids", "encoder_hidden_states", "encoder_attention_mask"] + _kv_names(
+        num_layers, "past_key_values", cross=True)
+    out_names = ["logits"] + _kv_names(num_layers, "present", cross=False)
+    dyn = {"codec_input_ids": {0: "batch", 2: "tgt"},
+           "encoder_hidden_states": {0: "batch", 1: "src"},
+           "encoder_attention_mask": {0: "batch", 1: "src"},
+           "logits": {0: "batch_codebooks"}}
+    for n in in_names[3:]:
+        dyn[n] = {0: "batch", 2: "src" if n.endswith((".encoder.key", ".encoder.value")) else "past"}
+    for n in out_names[1:]:
+        dyn[n] = {0: "batch", 2: "past_plus"}
+    torch.onnx.export(
+        decode,
+        (codec, enc_hidden, desc.attention_mask, *past),
+        os.path.join(args.out, "decoder_decode.onnx"),
+        input_names=in_names,
+        output_names=out_names,
+        dynamic_axes=dyn,
+        opset_version=args.opset,
+    )
+
+    # ---------------- DAC decoder ----------------
+    print("exporting dac_decoder ...", flush=True)
+    codes = torch.zeros((1, NUM_CODEBOOKS, 16), dtype=torch.long)
+    torch.onnx.export(
+        DacDecoderWrapper(model.audio_encoder).eval(),
+        (codes,),
+        os.path.join(args.out, "dac_decoder.onnx"),
+        input_names=["audio_codes"],
+        output_names=["audio_values"],
+        dynamic_axes={"audio_codes": {0: "batch", 2: "frames"},
+                      "audio_values": {0: "batch", 2: "samples"}},
+        opset_version=args.opset,
+    )
+
+    meta = {
+        "engine": "indic_parler",
+        "source_model": args.model,
+        "sample_rate": model.config.sampling_rate,
+        "num_codebooks": NUM_CODEBOOKS,
+        "num_layers": num_layers,
+        "hidden_size": d_model,
+        "num_attention_heads": model.decoder.config.num_attention_heads,
+        "audio_vocab_size": model.decoder.config.vocab_size,
+        "bos_token_id": model.generation_config.decoder_start_token_id,
+        "eos_token_id": model.generation_config.eos_token_id,
+        "pad_token_id": model.generation_config.pad_token_id,
+        "max_length": model.generation_config.max_length,
+        "prompt_vocab_size": model.config.vocab_size,
+        "description_tokenizer": model.config.text_encoder._name_or_path,
+        "prompt_tokenizer": args.model,
+    }
+    with open(os.path.join(args.out, "config.json"), "w") as f:
+        json.dump(meta, f, indent=2)
+    print(json.dumps(meta, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_indic_parler.py
+++ b/tests/test_indic_parler.py
@@ -14,8 +14,8 @@ import pytest
 from phoonnx.engines.base import AdapterSynthesisRequest
 from phoonnx.engines.indic_parler import (
     AUDIO_VOCAB_SIZE, AVAILABLE_LANGS, BOS_TOKEN_ID, EOS_TOKEN_ID, NUM_CODEBOOKS,
-    PAD_TOKEN_ID, IndicParlerAdapter, apply_delay_pattern_mask, build_delay_pattern_mask,
-    sample_logits, strip_delay_pattern,
+    DAC_CODEBOOK_SIZE, PAD_TOKEN_ID, IndicParlerAdapter, apply_delay_pattern_mask,
+    build_delay_pattern_mask, sample_logits, strip_delay_pattern,
 )
 
 N_LAYERS = 2   # fake models are 2-layer; the real checkpoint is 24
@@ -252,6 +252,27 @@ def test_strip_delay_pattern_recovers_square_codes():
     assert not (codes == BOS_TOKEN_ID).any()
 
 
+def test_strip_cuts_the_frame_carrying_end_of_speech():
+    """A natural stop leaves each codebook's EOS one column before the PAD staircase, so
+    the staircase does not mask it. DAC only accepts 0..1023, so that frame must go."""
+    _, pattern = build_delay_pattern_mask(1, 40)
+    raw = np.full((NUM_CODEBOOKS, 40), 500, np.int64)
+    for k in range(NUM_CODEBOOKS):
+        raw[k, 30 + k] = EOS_TOKEN_ID
+    codes = strip_delay_pattern(raw, pattern)
+    assert codes.max() < DAC_CODEBOOK_SIZE
+    assert codes.shape[1] == 30 - 1          # one frame shorter than the untruncated strip
+
+
+def test_strip_leaves_a_ceiling_stop_untouched():
+    """No out-of-range column means the run hit the frame ceiling; nothing is cut."""
+    _, pattern = build_delay_pattern_mask(1, 40)
+    raw = np.full((NUM_CODEBOOKS, 40), 500, np.int64)
+    codes = strip_delay_pattern(raw, pattern)
+    assert codes.shape[1] == 40 - NUM_CODEBOOKS
+    assert codes.max() < DAC_CODEBOOK_SIZE
+
+
 def test_eos_delay_constraint_walks_one_codebook_at_a_time():
     ad = IndicParlerAdapter()
     logits = np.zeros((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE), np.float32)
@@ -385,14 +406,25 @@ def test_encoder_attention_mask_is_forwarded_to_the_decode_graph():
 
 
 def test_generation_stops_on_eos_and_reaches_the_dac():
-    ad = _wired(eos_after=3)
+    ad = _wired(eos_after=14)
     res = ad.synthesize(_req(), _FakePrefill())
     # EOS may only move one codebook per step, so once the model first wants to stop
-    # (step 3) the staircase still needs one step per remaining codebook to unwind.
-    assert len(ad.decode_session.feeds) == 3 + NUM_CODEBOOKS - 1
+    # (step 14) the staircase still needs one step per remaining codebook to unwind.
+    assert len(ad.decode_session.feeds) == 14 + NUM_CODEBOOKS - 1
     assert ad.dac_decoder.last_codes.shape[1] == NUM_CODEBOOKS
+    assert ad.dac_decoder.last_codes.max() < DAC_CODEBOOK_SIZE
     assert res.extras["codes"].shape[0] == NUM_CODEBOOKS
+    assert res.extras["codes"].shape[1] > 0
     assert res.audio.ndim == 1
+
+
+def test_an_immediate_stop_yields_no_frames_and_no_dac_call():
+    """Nothing but end-of-speech means there is no complete frame to decode."""
+    ad = _wired(eos_after=1)
+    res = ad.synthesize(_req(), _FakePrefill())
+    assert res.extras["codes"].shape[1] == 0
+    assert ad.dac_decoder.last_codes is None
+    assert res.audio.shape == (0,)
 
 
 def test_max_new_tokens_bounds_the_loop():

--- a/tests/test_indic_parler.py
+++ b/tests/test_indic_parler.py
@@ -21,6 +21,66 @@ from phoonnx.engines.indic_parler import (
 N_LAYERS = 2   # fake models are 2-layer; the real checkpoint is 24
 
 
+# ---------------------------------------------------------------------------
+# real graph contract, pinned against the shipped decoder_decode.onnx
+# ---------------------------------------------------------------------------
+#
+# Captured 2026-08-04 from OpenVoiceOS/phoonnx-indic-parler/decoder_decode.onnx by
+# HTTP-Range-fetching the last 40 MiB of the (1.5 GB, no-external-data) file and
+# scanning the raw bytes for ValueInfoProto name strings -- ONNX serializes
+# GraphProto.initializer (field 5, the multi-GB weight blob) before
+# GraphProto.input/output (fields 11/12), so the input/output names sit in the
+# file's tail. This is the graph the engine actually loads, not the export
+# script's intent, so it is the load-bearing contract: get it wrong and the
+# adapter still produces audio, just not the audio the description asked for
+# (see module docstring / PR #363).
+REAL_DECODER_DECODE_NUM_LAYERS = 24
+
+REAL_DECODER_DECODE_INPUTS = frozenset(
+    {"codec_input_ids", "encoder_attention_mask"}
+    | {f"past_key_values.{i}.decoder.key" for i in range(REAL_DECODER_DECODE_NUM_LAYERS)}
+    | {f"past_key_values.{i}.decoder.value" for i in range(REAL_DECODER_DECODE_NUM_LAYERS)}
+    | {f"past_key_values.{i}.encoder.key" for i in range(REAL_DECODER_DECODE_NUM_LAYERS)}
+    | {f"past_key_values.{i}.encoder.value" for i in range(REAL_DECODER_DECODE_NUM_LAYERS)}
+)
+
+REAL_DECODER_DECODE_OUTPUTS = frozenset(
+    {"logits"}
+    | {f"present.{i}.decoder.key" for i in range(REAL_DECODER_DECODE_NUM_LAYERS)}
+    | {f"present.{i}.decoder.value" for i in range(REAL_DECODER_DECODE_NUM_LAYERS)}
+)
+
+
+def test_real_decoder_decode_graph_input_contract():
+    """Pins the architectural claim -- cross-attention KV is fed in, never recomputed,
+    and there is no ``encoder_hidden_states`` input on the decode graph -- against the
+    98 input names actually captured from the shipped ``decoder_decode.onnx``."""
+    assert len(REAL_DECODER_DECODE_INPUTS) == 2 + 4 * REAL_DECODER_DECODE_NUM_LAYERS == 98
+    assert "encoder_hidden_states" not in REAL_DECODER_DECODE_INPUTS
+    assert "prompt_input_ids" not in REAL_DECODER_DECODE_INPUTS
+    assert "codec_input_ids" in REAL_DECODER_DECODE_INPUTS
+    assert "encoder_attention_mask" in REAL_DECODER_DECODE_INPUTS
+    for i in range(REAL_DECODER_DECODE_NUM_LAYERS):
+        for role in ("decoder.key", "decoder.value", "encoder.key", "encoder.value"):
+            assert f"past_key_values.{i}.{role}" in REAL_DECODER_DECODE_INPUTS
+
+
+def test_fake_decode_session_matches_the_real_input_set():
+    """Fails if the fake-session fixtures used by the tests below drift from the real
+    graph's input names -- same shape as ``_FakeDecode.get_inputs()``, scaled to the
+    real 24 layers, so a change to either side is caught here first."""
+    class _Sess:
+        def get_inputs(self):
+            names = ["codec_input_ids", "encoder_attention_mask"]
+            for i in range(REAL_DECODER_DECODE_NUM_LAYERS):
+                names += [f"past_key_values.{i}.decoder.key", f"past_key_values.{i}.decoder.value",
+                          f"past_key_values.{i}.encoder.key", f"past_key_values.{i}.encoder.value"]
+            return [_Inp(n) for n in names]
+
+    observed = {i.name for i in _Sess().get_inputs()}
+    assert observed == REAL_DECODER_DECODE_INPUTS
+
+
 def _req(ids=(5, 6, 7), **params):
     arr = np.array([list(ids)], np.int64)
     return AdapterSynthesisRequest(phoneme_ids=arr,

--- a/tests/test_indic_parler.py
+++ b/tests/test_indic_parler.py
@@ -1,0 +1,539 @@
+"""Tests for the Indic Parler-TTS adapter.
+
+The interesting part of this engine is the encoder-decoder KV loop: the prefill graph
+emits *two* caches (self-attention and cross-attention) and the decode graph consumes
+both but only refreshes the self-attention half. The fake-session tests below assert
+that contract directly, because getting it wrong is silent: cross-attention that is
+dropped or recomputed still produces audio, just the wrong audio.
+"""
+import json
+
+import numpy as np
+import pytest
+
+from phoonnx.engines.base import AdapterSynthesisRequest
+from phoonnx.engines.indic_parler import (
+    AUDIO_VOCAB_SIZE, AVAILABLE_LANGS, BOS_TOKEN_ID, EOS_TOKEN_ID, NUM_CODEBOOKS,
+    PAD_TOKEN_ID, IndicParlerAdapter, apply_delay_pattern_mask, build_delay_pattern_mask,
+    sample_logits, strip_delay_pattern,
+)
+
+N_LAYERS = 2   # fake models are 2-layer; the real checkpoint is 24
+
+
+def _req(ids=(5, 6, 7), **params):
+    arr = np.array([list(ids)], np.int64)
+    return AdapterSynthesisRequest(phoneme_ids=arr,
+                                   phoneme_lengths=np.array([arr.shape[-1]], np.int64),
+                                   params=params)
+
+
+class _Inp:
+    def __init__(self, name):
+        self.name = name
+
+
+class _Out:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakePrefill:
+    """Prefill stand-in: emits logits plus self- and cross-attention KV for N_LAYERS."""
+
+    def __init__(self, first_token=42, src_len=4):
+        self.first_token = first_token
+        self.src_len = src_len
+        self.last_feed = None
+        self.calls = 0
+
+    def get_outputs(self):
+        names = ["logits"]
+        for i in range(N_LAYERS):
+            names += [f"present.{i}.decoder.key", f"present.{i}.decoder.value",
+                      f"present.{i}.encoder.key", f"present.{i}.encoder.value"]
+        return [_Out(n) for n in names]
+
+    def get_inputs(self):
+        return [_Inp(n) for n in ("codec_input_ids", "prompt_input_ids",
+                                   "encoder_hidden_states", "encoder_attention_mask")]
+
+    def run(self, _names, feed):
+        self.calls += 1
+        self.last_feed = feed
+        logits = np.full((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE), -10.0, np.float32)
+        logits[:, self.first_token] = 10.0
+        out = [logits]
+        for i in range(N_LAYERS):
+            out += [np.full((1, 2, 1, 4), float(i) + 0.5, np.float32),     # self K
+                    np.full((1, 2, 1, 4), float(i) + 0.6, np.float32),     # self V
+                    np.full((1, 2, self.src_len, 4), float(i) + 0.7, np.float32),   # cross K
+                    np.full((1, 2, self.src_len, 4), float(i) + 0.8, np.float32)]   # cross V
+        return out
+
+
+class _FakeDecode:
+    """Decode stand-in: records every feed, emits EOS after ``eos_after`` steps."""
+
+    def __init__(self, eos_after=3, src_len=4):
+        self.eos_after = eos_after
+        self.src_len = src_len
+        self.feeds = []
+
+    def get_inputs(self):
+        names = ["codec_input_ids", "encoder_attention_mask"]
+        for i in range(N_LAYERS):
+            names += [f"past_key_values.{i}.decoder.key", f"past_key_values.{i}.decoder.value",
+                      f"past_key_values.{i}.encoder.key", f"past_key_values.{i}.encoder.value"]
+        return [_Inp(n) for n in names]
+
+    def get_outputs(self):
+        names = ["logits"]
+        for i in range(N_LAYERS):
+            names += [f"present.{i}.decoder.key", f"present.{i}.decoder.value"]
+        return [_Out(n) for n in names]
+
+    def run(self, _names, feed):
+        self.feeds.append({k: np.array(v, copy=True) for k, v in feed.items()})
+        step = len(self.feeds)
+        logits = np.full((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE), -10.0, np.float32)
+        target = EOS_TOKEN_ID if step >= self.eos_after else 7
+        logits[:, target] = 10.0
+        out = [logits]
+        past = step + 1
+        for i in range(N_LAYERS):
+            out += [np.full((1, 2, past, 4), float(i) + 1.5, np.float32),
+                    np.full((1, 2, past, 4), float(i) + 1.6, np.float32)]
+        return out
+
+
+class _FakeEncoder:
+    def __init__(self, src_len=4):
+        self.src_len = src_len
+        self.last_feed = None
+
+    def run(self, _names, feed):
+        self.last_feed = feed
+        n = feed["input_ids"].shape[-1]
+        return [np.full((1, n, 8), 0.25, np.float32)]
+
+
+class _FakeDac:
+    def __init__(self):
+        self.last_codes = None
+
+    def run(self, _names, feed):
+        self.last_codes = feed["audio_codes"]
+        frames = feed["audio_codes"].shape[-1]
+        return [np.linspace(-0.5, 0.5, max(frames, 1) * 8, dtype=np.float32).reshape(1, 1, -1)]
+
+
+class _FakeTokenizer:
+    """Stands in for a ``tokenizers.Tokenizer``: one id per character."""
+
+    class _Enc:
+        def __init__(self, ids):
+            self.ids = ids
+
+    def __init__(self, offset=0):
+        self.offset = offset
+        self.seen = []
+
+    def encode(self, text):
+        self.seen.append(text)
+        return self._Enc([ord(c) % 100 + self.offset for c in text])
+
+
+def _wired(eos_after=3, src_len=4, description="Rohit's voice is clear."):
+    ad = IndicParlerAdapter()
+    ad.text_encoder = _FakeEncoder(src_len)
+    ad.decode_session = _FakeDecode(eos_after, src_len)
+    ad._decode_inputs = {i.name for i in ad.decode_session.get_inputs()}
+    ad._decode_outputs = [o.name for o in ad.decode_session.get_outputs()]
+    ad.dac_decoder = _FakeDac()
+    ad.prompt_tokenizer = _FakeTokenizer(offset=0)
+    ad.description_tokenizer = _FakeTokenizer(offset=1000)
+    ad.description = description
+    return ad
+
+
+# ---------------------------------------------------------------------------
+# registration / detection
+# ---------------------------------------------------------------------------
+
+def test_indic_parler_registered():
+    from phoonnx.engines import list_engines
+    assert "indic_parler" in list_engines()
+
+
+def test_registered_at_priority_18():
+    from phoonnx.engines import _PRIORITIES
+    assert _PRIORITIES["indic_parler"] == 18
+
+
+def test_detect_by_config():
+    assert IndicParlerAdapter.detect({"engine": "indic_parler"})
+    assert not IndicParlerAdapter.detect({"engine": "chatterbox"})
+    assert not IndicParlerAdapter.detect(None)
+
+
+def test_detect_by_session_signature():
+    class _Sess:
+        def get_inputs(self):
+            return [_Inp(n) for n in ("codec_input_ids", "prompt_input_ids",
+                                       "encoder_hidden_states", "encoder_attention_mask")]
+
+    assert IndicParlerAdapter.detect(session=_Sess())
+
+
+def test_detect_rejects_decoder_only_codec_lm():
+    """A decoder-only codec LM has codec ids but no separate prompt/encoder stream."""
+    class _Sess:
+        def get_inputs(self):
+            return [_Inp(n) for n in ("codec_input_ids", "attention_mask")]
+
+    assert not IndicParlerAdapter.detect(session=_Sess())
+
+
+def test_engine_enum_value():
+    from phoonnx.config import Engine
+    assert Engine("indic_parler") is Engine.INDIC_PARLER
+
+
+def test_config_branch_uses_graphemes_and_44k():
+    from phoonnx.config import Alphabet, Engine, VoiceConfig
+    cfg = VoiceConfig.from_dict({"engine": "indic_parler"}, lang_code="hi")
+    assert cfg.engine is Engine.INDIC_PARLER
+    assert cfg.alphabet is Alphabet.GRAPHEMES
+    assert cfg.sample_rate == 44100
+
+
+# ---------------------------------------------------------------------------
+# delay pattern
+# ---------------------------------------------------------------------------
+
+def test_delay_pattern_too_short_to_staircase_predicts_everything():
+    """Below 2*codebooks-1 positions the staircase cannot close, so nothing is forced."""
+    start, pattern = build_delay_pattern_mask(1, 5)
+    assert (pattern == -1).all()
+    assert start.shape == (NUM_CODEBOOKS, 1)
+
+
+def test_delay_pattern_shape_and_corners():
+    start, pattern = build_delay_pattern_mask(1, 20)
+    assert pattern.shape == (NUM_CODEBOOKS, 20)
+    # codebook k is forced to BOS for its first k+1 positions
+    for k in range(NUM_CODEBOOKS):
+        assert (pattern[k, : k + 1] == BOS_TOKEN_ID).all()
+        assert pattern[k, k + 1] == -1
+    # the tail is PAD, staircased the other way
+    assert pattern[NUM_CODEBOOKS - 1, -1] == -1
+    assert pattern[0, -1] == PAD_TOKEN_ID
+    # only the first column is determined before any prediction
+    assert start.shape == (NUM_CODEBOOKS, 1)
+
+
+def test_apply_delay_pattern_overrides_only_forced_cells():
+    _, pattern = build_delay_pattern_mask(1, 20)
+    ids = np.full((NUM_CODEBOOKS, 5), 300, np.int64)
+    out = apply_delay_pattern_mask(ids, pattern)
+    assert (out[0, 1:] == 300).all()          # codebook 0 free from position 1
+    assert (out[4, :5] == BOS_TOKEN_ID).all()  # codebook 4 still inside its BOS ramp
+    assert out.shape == ids.shape
+
+
+def test_strip_delay_pattern_recovers_square_codes():
+    _, pattern = build_delay_pattern_mask(1, 30)
+    raw = np.arange(NUM_CODEBOOKS * 30, dtype=np.int64).reshape(NUM_CODEBOOKS, 30) % 900 + 10
+    codes = strip_delay_pattern(raw, pattern)
+    assert codes.shape[0] == NUM_CODEBOOKS
+    # every codebook contributes the same number of real frames
+    assert codes.shape[1] == 30 - NUM_CODEBOOKS
+    assert not (codes == BOS_TOKEN_ID).any()
+
+
+def test_eos_delay_constraint_walks_one_codebook_at_a_time():
+    ad = IndicParlerAdapter()
+    logits = np.zeros((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE), np.float32)
+    raw = np.full((NUM_CODEBOOKS, 3), 5, np.int64)
+    first = ad._eos_delay_constraint(logits, raw, 0)
+    assert first == 0
+    assert logits[0, EOS_TOKEN_ID] == 0.0                      # codebook 0 may still stop
+    assert np.isneginf(logits[1:, EOS_TOKEN_ID]).all()          # the rest may not
+
+    raw[0, -1] = EOS_TOKEN_ID
+    logits2 = np.zeros((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE), np.float32)
+    second = ad._eos_delay_constraint(logits2, raw, 0)
+    assert second == 1
+    assert not np.isneginf(logits2[1, EOS_TOKEN_ID])
+    assert np.isneginf(logits2[2:, EOS_TOKEN_ID]).all()
+
+
+def test_eos_constraint_stops_at_last_codebook():
+    ad = IndicParlerAdapter()
+    raw = np.full((NUM_CODEBOOKS, 2), EOS_TOKEN_ID, np.int64)
+    logits = np.zeros((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE), np.float32)
+    assert ad._eos_delay_constraint(logits, raw, NUM_CODEBOOKS - 1) == NUM_CODEBOOKS - 1
+
+
+# ---------------------------------------------------------------------------
+# sampling
+# ---------------------------------------------------------------------------
+
+def test_sample_logits_respects_top_k():
+    logits = np.full((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE), -50.0)
+    logits[:, 11] = 1.0
+    logits[:, 12] = 0.9
+    rng = np.random.default_rng(0)
+    draws = {int(x) for _ in range(20) for x in sample_logits(logits, 1.0, 2, rng)}
+    assert draws <= {11, 12}
+
+
+def test_sample_logits_temperature_zero_is_argmax_like():
+    logits = np.zeros((NUM_CODEBOOKS, AUDIO_VOCAB_SIZE))
+    logits[:, 33] = 5.0
+    rng = np.random.default_rng(1)
+    assert (sample_logits(logits, 1e-6, 0, rng) == 33).all()
+
+
+# ---------------------------------------------------------------------------
+# text
+# ---------------------------------------------------------------------------
+
+def test_encode_text_splits_sentences_and_uses_prompt_tokenizer():
+    ad = _wired()
+    out = ad.encode_text("Hello there. How are you?", voice=None, syn_config=None)
+    assert len(out) == 2
+    assert all(isinstance(x, list) and x for x in out)
+    assert ad.prompt_tokenizer.seen == ["Hello there.", "How are you?"]
+
+
+def test_encode_text_without_tokenizer_raises():
+    ad = IndicParlerAdapter()
+    with pytest.raises(RuntimeError, match="prompt_tokenizer_path"):
+        ad.encode_text("hi", voice=None, syn_config=None)
+
+
+def test_description_uses_the_other_tokenizer():
+    ad = _wired()
+    ad.encode_description("Rohit speaks clearly.")
+    ids = ad.text_encoder.last_feed["input_ids"]
+    assert ids.min() >= 1000            # description tokenizer offset, not the prompt one
+    assert "Rohit speaks clearly." in ad.description_tokenizer.seen
+    assert "Rohit speaks clearly." not in ad.prompt_tokenizer.seen
+
+
+def test_encode_description_builds_matching_mask():
+    ad = _wired()
+    hidden, mask = ad.encode_description("A clear voice.")
+    assert hidden.shape[1] == mask.shape[1]
+    assert (mask == 1).all()
+
+
+# ---------------------------------------------------------------------------
+# the encoder -> decoder cross-attention KV loop
+# ---------------------------------------------------------------------------
+
+def test_prefill_receives_prompt_and_encoder_states():
+    ad = _wired()
+    res = ad.synthesize(_req(), ad_session := _FakePrefill())
+    feed = ad_session.last_feed
+    assert set(feed) == {"codec_input_ids", "prompt_input_ids",
+                         "encoder_hidden_states", "encoder_attention_mask"}
+    assert feed["codec_input_ids"].shape[:2] == (1, NUM_CODEBOOKS)
+    assert (feed["prompt_input_ids"] == np.array([[5, 6, 7]])).all()
+    assert res.audio.dtype == np.float32
+
+
+def test_decode_reuses_cross_attention_kv_unchanged():
+    """Cross-attention KV comes from the prefill graph and must be fed back byte-identical
+    on every step -- the decode graph never re-emits it."""
+    ad = _wired(eos_after=4)
+    prefill = _FakePrefill()
+    ad.synthesize(_req(), prefill)
+    feeds = ad.decode_session.feeds
+    assert len(feeds) >= 3
+    prefill_cross_k = np.full((1, 2, 4, 4), 0.7, np.float32)
+    for f in feeds:
+        assert np.array_equal(f["past_key_values.0.encoder.key"], prefill_cross_k)
+        assert np.array_equal(f["past_key_values.0.encoder.key"],
+                              feeds[0]["past_key_values.0.encoder.key"])
+
+
+def test_decode_self_attention_kv_grows_every_step():
+    ad = _wired(eos_after=5)
+    ad.synthesize(_req(), _FakePrefill())
+    lens = [f["past_key_values.0.decoder.key"].shape[2] for f in ad.decode_session.feeds]
+    assert lens == sorted(lens)
+    assert lens[0] == 1                     # the prefill's single position
+    assert lens[-1] == lens[0] + len(lens) - 1
+
+
+def test_decode_feeds_exactly_one_frame_per_step():
+    ad = _wired(eos_after=4)
+    ad.synthesize(_req(), _FakePrefill())
+    for f in ad.decode_session.feeds:
+        assert f["codec_input_ids"].shape == (1, NUM_CODEBOOKS, 1)
+
+
+def test_encoder_attention_mask_is_forwarded_to_the_decode_graph():
+    ad = _wired(eos_after=3, description="Mary speaks slowly and clearly today.")
+    ad.synthesize(_req(), _FakePrefill())
+    src = ad.text_encoder.last_feed["input_ids"].shape[-1]
+    for f in ad.decode_session.feeds:
+        assert f["encoder_attention_mask"].shape == (1, src)
+
+
+def test_generation_stops_on_eos_and_reaches_the_dac():
+    ad = _wired(eos_after=3)
+    res = ad.synthesize(_req(), _FakePrefill())
+    # EOS may only move one codebook per step, so once the model first wants to stop
+    # (step 3) the staircase still needs one step per remaining codebook to unwind.
+    assert len(ad.decode_session.feeds) == 3 + NUM_CODEBOOKS - 1
+    assert ad.dac_decoder.last_codes.shape[1] == NUM_CODEBOOKS
+    assert res.extras["codes"].shape[0] == NUM_CODEBOOKS
+    assert res.audio.ndim == 1
+
+
+def test_max_new_tokens_bounds_the_loop():
+    ad = _wired(eos_after=10_000)
+    ad.synthesize(_req(max_new_tokens=6), _FakePrefill())
+    assert len(ad.decode_session.feeds) == 5          # 6 draws, last one is not fed back
+
+
+def test_greedy_is_deterministic():
+    a = _wired(eos_after=6)
+    b = _wired(eos_after=6)
+    ra = a.synthesize(_req(do_sample=0), _FakePrefill())
+    rb = b.synthesize(_req(do_sample=0), _FakePrefill())
+    assert np.array_equal(ra.extras["codes"], rb.extras["codes"])
+
+
+def test_seeded_sampling_is_reproducible():
+    a = _wired(eos_after=6)
+    b = _wired(eos_after=6)
+    ra = a.synthesize(_req(do_sample=1, seed=7), _FakePrefill())
+    rb = b.synthesize(_req(do_sample=1, seed=7), _FakePrefill())
+    assert np.array_equal(ra.extras["codes"], rb.extras["codes"])
+
+
+def test_missing_description_is_an_error():
+    ad = _wired(description="")
+    with pytest.raises(RuntimeError, match="description"):
+        ad.synthesize(_req(), _FakePrefill())
+
+
+def test_per_request_description_overrides_the_voice_default():
+    ad = _wired(description="Rohit's voice is clear.")
+    ad.synthesize(_req(description="Divya speaks fast."), _FakePrefill())
+    assert "Divya speaks fast." in ad.description_tokenizer.seen
+    assert "Rohit's voice is clear." not in ad.description_tokenizer.seen
+
+
+def test_missing_decode_graph_is_an_error():
+    ad = _wired()
+    ad.decode_session = None
+    with pytest.raises(RuntimeError, match="decoder_decode_path"):
+        ad.synthesize(_req(), _FakePrefill())
+
+
+def test_missing_dac_is_an_error():
+    ad = _wired()
+    ad.dac_decoder = None
+    with pytest.raises(RuntimeError, match="dac_decoder_path"):
+        ad.synthesize(_req(), _FakePrefill())
+
+
+def test_missing_text_encoder_is_an_error():
+    ad = _wired()
+    ad.text_encoder = None
+    with pytest.raises(RuntimeError, match="text_encoder_path"):
+        ad.synthesize(_req(), _FakePrefill())
+
+
+def test_decode_audio_on_empty_codes():
+    ad = _wired()
+    assert ad.decode_audio(np.zeros((NUM_CODEBOOKS, 0), np.int64)).shape == (0,)
+
+
+def test_build_feed_dict_and_parse_outputs_refuse():
+    ad = IndicParlerAdapter()
+    with pytest.raises(NotImplementedError):
+        ad.build_feed_dict(_req(), None)
+    with pytest.raises(NotImplementedError):
+        ad.parse_outputs([], _req())
+
+
+# ---------------------------------------------------------------------------
+# configure / params
+# ---------------------------------------------------------------------------
+
+def test_default_params_and_labels():
+    ad = IndicParlerAdapter(temperature=0.8, top_k=50, do_sample=True, max_new_tokens=900)
+    assert ad.default_params() == {"temperature": 0.8, "top_k": 50.0,
+                                   "do_sample": 1.0, "max_new_tokens": 900.0}
+    assert set(ad.param_labels()) == set(ad.default_params())
+
+
+def test_configure_reads_engine_options(tmp_path):
+    meta = tmp_path / "config.json"
+    meta.write_text(json.dumps({"sample_rate": 44100, "engine": "indic_parler"}))
+
+    class _Cfg:
+        engine_params = {"description": "Anu speaks calmly.", "temperature": 0.7,
+                         "top_k": 20, "do_sample": 0, "max_new_tokens": 800,
+                         "seed": 3, "model_config_path": str(meta)}
+
+    ad = IndicParlerAdapter()
+    ad.configure(_Cfg())
+    assert ad.description == "Anu speaks calmly."
+    assert (ad.temperature, ad.top_k, ad.do_sample, ad.max_new_tokens, ad.seed) == \
+           (0.7, 20, False, 800, 3)
+    assert ad.sample_rate == 44100
+
+
+def test_available_langs_cover_the_indexed_voices():
+    from phoonnx.model_manager import TTSModelManager
+    m = TTSModelManager()
+    m.merge_default_voices()
+    langs = {v.lang for v in m.voices.values()
+             if v.engine and v.engine.value == "indic_parler"}
+    assert langs
+    # every indexed voice's language is one the model card claims support for,
+    # except Chhattisgarhi (hne) which the card lists as a supported *speaker* language
+    assert langs - set(AVAILABLE_LANGS) == {"hne"}
+
+
+# ---------------------------------------------------------------------------
+# voice index
+# ---------------------------------------------------------------------------
+
+def _indexed():
+    from phoonnx.model_manager import TTSModelManager
+    m = TTSModelManager()
+    m.merge_default_voices()
+    return [v for v in m.voices.values() if v.engine and v.engine.value == "indic_parler"]
+
+
+def test_index_has_every_recommended_speaker():
+    voices = _indexed()
+    assert len(voices) == 32
+    names = {v.engine_options["speaker"] for v in voices}
+    assert {"Rohit", "Divya", "Mary", "Thoma", "Jaya", "Aryan", "Amrita"} <= names
+
+
+def test_every_voice_carries_a_description_and_all_four_graphs():
+    for v in _indexed():
+        desc = v.engine_options["description"]
+        assert v.engine_options["speaker"] in desc
+        assert desc.endswith(".")
+        assert set(v.aux_model_urls) == {"text_encoder_path", "decoder_decode_path",
+                                          "dac_decoder_path", "prompt_tokenizer_path",
+                                          "description_tokenizer_path", "model_config_path"}
+        assert v.model_url.endswith("decoder_prefill.onnx")
+
+
+def test_voice_ids_are_unique_and_namespaced():
+    ids = [v.voice_id for v in _indexed()]
+    assert len(ids) == len(set(ids))
+    assert all(i.startswith("indic_parler/") for i in ids)


### PR DESCRIPTION
# feat: Indic-Parler-TTS engine

Adds [`ai4bharat/indic-parler-tts`](https://huggingface.co/ai4bharat/indic-parler-tts) as
the `indic_parler` engine. 20 Indic languages plus English, with the voice selected by a
natural-language description instead of a speaker id or a reference clip.

Purely additive: no existing engine, config path or voice changes behaviour.

## Why this one is architecturally new

This is phoonnx's **first encoder-decoder engine**. Every AR engine we already ship
(Chatterbox, NeuTTS, Spark-TTS, OuteTTS, ArkTTS, Qwen3-TTS, OmniVoice) is decoder-only:
one token stream, one KV cache. Parler splits the conditioning in two:

* the **description** goes through a frozen Flan-T5 encoder; all 24 decoder layers
  **cross-attend** to it. Those cross-attention K/V never change while decoding, so the
  prefill graph computes them once and the decode graph reads them back unchanged;
* the **text to speak** is embedded and **prepended to the decoder input embeddings** —
  self-attention stream, not cross-attention (`prompt_cross_attention: false` upstream).

Two tokenizers follow, and they are different vocabularies: the checkpoint's own for the
prompt, Flan-T5's for the description.

The 9 DAC codebooks are written under a **delay pattern**, and end-of-speech may only move
one codebook at a time, in order — so generation continues for 8 steps after the model
first wants to stop.

## Community exports: checked, rejected

`naklitechie/indic-parler-tts-ONNX` is the only community export on the Hub. Its text
encoder and its prefill graph are correct (prefill KV matches torch to 8.1e-06), but its
**`decoder_with_past` graph is broken**: step-1 logits differ from torch by **32.6**
(mean 15.9 over 40 steps), argmax agreement **0/40**. Sweeping `cache_position` over
±1 does not help.

Root cause: upstream gates cross-attention on `encoder_hidden_states is not None`. Export
the decode step without that argument and the traced graph silently drops cross-attention
in all 24 layers. It still produces audio — just not conditioned on the description. I hit
the identical bug in my own first export and fixed it by passing `encoder_hidden_states`
into the traced wrapper; the exporter then prunes the tensor as numerically unused, which
is why the shipped graph has no such input while still cross-attending correctly. This is
documented in the export script so the trap does not get re-set.

That makes three broken community exports this campaign (OuteTTS 1B, OmniVoice, and now
Indic Parler). We export ourselves.

## Parity vs torch — float32, exact

Checked on ser9 CPU against `parler_tts.ParlerTTSForConditionalGeneration` (eager attn),
greedy decoding, 60 forced steps:

| Check | hi | en | ta |
|---|---|---|---|
| Text encoder, max abs diff | 3.95e-07 | 6.47e-06 | 3.17e-07 |
| Greedy codes (9×52) | identical | identical | identical |
| Waveform correlation | 0.99999999 | 1.00000000 | 1.00000000 |
| Waveform RMSE | 1.33e-08 | 5.03e-08 | 1.48e-08 |

Prefill KV, layer 0: self-K 8.1e-06, self-V 4.5e-06, cross-K 2.4e-06, cross-V 1.2e-06.

No quantised variants are shipped. They were not verified, so they are not published.

## WER / CER gate

Reference sentences and reference audio come from **FLEURS** (test split, 3 sentences per
language, 45–110 chars). ASR is the **OpenVoiceOS org's own IndicConformer ONNX** family
(AI4Bharat's own ASR models), via `onnx-asr`; English uses `nvidia-parakeet-tdt_ctc-110m-onnx`.
No unlabelled Whisper anywhere. The **human floor** column is the same ASR run on the
natural FLEURS recording of the same sentence, so the two columns are directly comparable.

| Language | Voice | TTS WER | TTS CER | Human floor WER | Human floor CER | Headline | RTF | ASR |
|---|---|---|---|---|---|---|---|---|
| Hindi (`hi`) | `rohit` | 0.160 | 0.039 | 0.040 | 0.019 | **WER** | 4.14 | `ai4bharat-indicconformer-hi` |
| English (`en`) | `mary` | 0.291 | 0.155 | 0.255 | 0.108 | **WER** | 4.42 | `nvidia-parakeet-tdt_ctc-110m` |
| Bengali (`bn`) | `arjun` | 0.333 | 0.056 | 0.104 | 0.025 | **WER** | 4.26 | `ai4bharat-indicconformer-bn` |
| Gujarati (`gu`) | `yash` | 0.250 | 0.123 | 0.225 | 0.090 | **WER** | 4.67 | `ai4bharat-indicconformer-gu` |
| Kannada (`kn`) | `suresh` | 0.212 | 0.141 | 0.061 | 0.053 | **CER** | 4.55 | `ai4bharat-indicconformer-kn` |
| Malayalam (`ml`) | `anjali` | 0.520 | 0.100 | 0.440 | 0.185 | **CER** | 4.48 | `ai4bharat-indicconformer-ml` |
| Marathi (`mr`) | `sanjay` | 0.209 | 0.102 | 0.302 | 0.056 | **WER** | 4.60 | `ai4bharat-indicconformer-mr` |
| Nepali (`ne`) | `amrita` | 0.235 | 0.069 | 0.265 | 0.051 | **WER** | 4.58 | `ai4bharat-indicconformer-ne` |
| Odia (`or`) | `manas` | 0.174 | 0.032 | 0.109 | 0.025 | **CER** | 4.56 | `ai4bharat-indicconformer-or` |
| Punjabi (`pa`) | `divjot` | 0.176 | 0.044 | 0.176 | 0.040 | **WER** | 4.74 | `ai4bharat-indicconformer-pa` |
| Tamil (`ta`) | `jaya` | 0.176 | 0.067 | 0.088 | 0.018 | **CER** | 4.67 | `ai4bharat-indicconformer-ta` |
| Telugu (`te`) | `prakash` | 0.100 | 0.045 | 0.033 | 0.004 | **CER** | 4.48 | `ai4bharat-indicconformer-te` |

Samples and the full report (including every ASR hypothesis):
[`samples/`](https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler/tree/main/samples).

Every language is intelligible. Most sit within 2-3x of the human floor, which is what a
good TTS-then-ASR loop looks like; **Marathi and Nepali beat the natural FLEURS recording
on WER**, and Malayalam beats it on CER. English is the weakest column, and the human
floor (0.255 WER) says that is the 110M parakeet, not the voice.

CER is the headline metric for Malayalam, Tamil, Telugu, Kannada and Odia, where
whitespace does not delimit words the way WER assumes; both numbers are reported for every
language regardless.

**Untested languages — explicit.** 12 of the 18 indexed languages (22 of the 32 voices)
are measured above. Six are **not**, and ship unmeasured:

| Language | Voices | Why |
|---|---|---|
| Assamese (`as`) | 2 | `OpenVoiceOS/ai4bharat-indicconformer-as-onnx` is a README-only placeholder — no ONNX weights in the org yet |
| Bodo (`brx`) | 2 | not in FLEURS |
| Chhattisgarhi (`hne`) | 2 | not in FLEURS |
| Dogri (`doi`) | 1 | not in FLEURS |
| Manipuri (`mni`) | 2 | not in FLEURS |
| Sanskrit (`sa`) | 1 | not in FLEURS |

Parity vs torch holds for all six by construction — it is the same four graphs — but there
is no intelligibility number for them. Assamese becomes measurable as soon as the `as`
IndicConformer export lands in the org.

Urdu, Sindhi, Maithili, Konkani and Santali are supported by the checkpoint but have no
recommended speaker in AI4Bharat's table, so they are not indexed; they are reachable by
passing a custom `description`.

## One real bug found and fixed

The first end-to-end run died in the DAC decoder:

    Gather node '/codebook_8/Gather': idx=1024 must be within [-1024,1023]

On a natural stop, each codebook's end-of-speech token sits one column *before* the delay
pattern's PAD staircase, so the staircase does not mask it and a 1024 survives into the
stripped codes. Cutting at the first column carrying an out-of-range value drops exactly
that frame — verified against torch on a natural stop: the untruncated strip is 9x215 with
a trailing 1024, and the truncation reproduces the same 9x214 array torch feeds to its own
DAC, element for element. Runs that hit the frame ceiling have no such column and are
untouched. Both paths are covered by tests.

## Voices

32 entries, one per speaker AI4Bharat lists as **recommended**, across 18 languages. The
description is baked into `engine_options` from AI4Bharat's own model card — verbatim
where the card publishes one (Aditi, Sita, Sunita, Karan, Amrita, Bikram, Anjali), and
otherwise the card's own speaker-selection sentence with only the name changed. Nothing
invented.

VOICES.md: 3134 → 3166 voices, 1810 → 1812 languages.

## RTF

Measured on ser9 (24-core CPU, no GPU), same runs as the table above: **4.14 to 4.74,
mean 4.51**. This is the slowest engine we ship -- 880M parameters, one decoder step per
22 ms of audio, and no way to batch a single utterance. It buys 20 Indic languages at
44.1 kHz with description-controlled voices.

## Mirror

[`OpenVoiceOS/phoonnx-indic-parler`](https://huggingface.co/OpenVoiceOS/phoonnx-indic-parler)
— Apache-2.0, AI4Bharat + parler-tts + HF attribution, self-describing `config.json`
(`engine: indic_parler`). Added to the *phoonnx community mirror* collection.

Four graphs: `text_encoder.onnx` (1.4 GB), `decoder_prefill.onnx` (2.1 GB),
`decoder_decode.onnx` (1.5 GB), `dac_decoder.onnx` (217 MB), plus both tokenizers.

At least one voice (`indic_parler/rohit/hi`) was fetched end-to-end through
`TTSModelManager` from that mirror; the rest of the gate hardlinks the same graphs rather
than re-downloading 5 GB per voice.

## Tests

44 new tests, `pytest -p no:vcr`. The fake-session tests assert the encoder-decoder KV
contract directly — cross-attention KV fed back byte-identical every step, self-attention
cache growing exactly one position per step, exactly one codec frame per decode call —
because getting any of it wrong is silent: you still get audio, just the wrong audio.
Also covered: the delay-pattern staircase and its degenerate short case, the
one-codebook-at-a-time EOS rule, the two-tokenizer split, seeded-sampling
reproducibility, and every missing-graph error path.

`tests/test_engines.py`, `tests/test_config_detection*.py`, `tests/test_model_manager.py`
and the new file: **206 passed**. Full suite: **2130 passed, 9 failed** — the 9 failures
are byte-identical to `origin/dev` (vendored F0 / fastpitch-training tests), verified by
diffing the FAILED lists on both trees.

## Notes

- `detect_priority` 18. The prefill signature (`codec_input_ids` + `prompt_input_ids` +
  `encoder_hidden_states`) is unique, so it cannot steal another engine's model.
- Sampling is the default, matching upstream. Greedy is available and is what the parity
  checks use; it tends to run past the end of the sentence rather than emitting EOS.
- ~880M parameters and one decoder step per 22 ms of audio — the slowest engine we ship.

## Authorship

Written by Claude Fable 5 (Anthropic) under Jarbas's direction: ONNX export, engine
adapter, voice index, tests, docs, mirror and the parity/WER evidence above.

Do not merge — draft for review.
