### PR TITLE
fix: fetch onnx_data sidecars for auxiliary graphs

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -485,13 +485,21 @@ class TTSModelInfo:
         return enc_path
 
     def download_aux_models(self) -> Dict[str, Path]:
-        """Download the auxiliary ONNX graphs of multi-graph engines (F5-TTS),
-        if any. Returns {engine_params_key: local_path}."""
+        """Download the auxiliary graphs and assets of multi-graph engines.
+
+        Returns {engine_params_key: local_path}. An ``.onnx`` entry goes through
+        :meth:`_fetch_onnx`, so a graph with external weights gets its
+        ``<name>.onnx_data`` sidecar too; without it the graph loads only until
+        onnxruntime looks for the weights. Non-ONNX assets (tokenizer JSON, speaker
+        embeddings) are plain downloads.
+        """
         paths: Dict[str, Path] = {}
         for key, url in (self.aux_model_urls or {}).items():
             fname = url.rsplit("/", 1)[-1] or f"{key}.onnx"
             aux_path = self.voice_path / fname
-            if not _is_cached(aux_path):
+            if fname.endswith(".onnx"):
+                self._fetch_onnx(url, aux_path)
+            elif not _is_cached(aux_path):
                 _stream_to_file(url, aux_path)
             paths[key] = aux_path
         return paths

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -223,6 +223,61 @@ class TestDownloadHelpers(VoicePathTestCase):
         for p in paths.values():
             self.assertTrue(p.is_file())
 
+    @patch("phoonnx.model_manager.requests.get")
+    def test_download_aux_models_fetches_onnx_data_sidecar(self, mock_get):
+        """Regression test: an auxiliary graph with external weights must have its
+        <name>.onnx_data sidecar fetched too, exactly like the primary graph does
+        via _fetch_onnx. Before the fix, download_aux_models called _stream_to_file
+        directly and never looked for a sidecar, so a multi-graph engine whose aux
+        graph carries external data would download a graph that onnxruntime could
+        not load."""
+        info = self.make_info(aux_model_urls={
+            "decode_path": "https://example.com/decode.onnx",
+        })
+        graph_resp = _mock_response(200, content=b"graph")
+        sidecar_resp = _mock_response(200, content=b"sidecar-weights")
+
+        def side_effect(url, timeout=None, stream=None):
+            cm = MagicMock()
+            if url.endswith("_data"):
+                cm.__enter__.return_value = sidecar_resp
+            else:
+                cm.__enter__.return_value = graph_resp
+            return cm
+
+        mock_get.side_effect = side_effect
+        paths = info.download_aux_models()
+
+        graph_path = paths["decode_path"]
+        sidecar_path = graph_path.parent / (graph_path.name + "_data")
+        self.assertTrue(graph_path.is_file())
+        self.assertTrue(
+            sidecar_path.is_file(),
+            "download_aux_models must fetch the .onnx_data sidecar of an "
+            "auxiliary graph, the same way download_model does via _fetch_onnx",
+        )
+        self.assertEqual(sidecar_path.read_bytes(), b"sidecar-weights")
+
+    @patch("phoonnx.model_manager.requests.get")
+    def test_download_aux_models_routes_onnx_entries_through_fetch_onnx(self, mock_get):
+        """An .onnx aux entry must go through _fetch_onnx (not a plain stream), so
+        it gets the same sidecar-probing behavior as the primary graph."""
+        info = self.make_info(aux_model_urls={
+            "decode_path": "https://example.com/decode.onnx",
+            "speakers_path": "https://example.com/speakers.json",
+        })
+        resp = _mock_response(200, content=b"data")
+        cm = MagicMock()
+        cm.__enter__.return_value = resp
+        mock_get.return_value = cm
+
+        with patch.object(info, "_fetch_onnx", wraps=info._fetch_onnx) as fetch:
+            paths = info.download_aux_models()
+            fetch.assert_called_once_with(
+                "https://example.com/decode.onnx", paths["decode_path"]
+            )
+        self.assertTrue(paths["speakers_path"].is_file())
+
     def test_download_bpe_tokenizer_none_without_url(self):
         info = self.make_info()
         self.assertIsNone(info.download_bpe_tokenizer())


### PR DESCRIPTION
## What

`download_aux_models` fetched only the `.onnx` file for auxiliary graphs of multi-graph engines. A graph with external weights then downloaded, but onnxruntime could not load it: it looks for `<name>.onnx_data` next to the graph, and that sidecar was never fetched. `download_model` already handled this correctly via `_fetch_onnx`; the auxiliary path did not. Every multi-graph engine whose aux graphs carry external data was affected.

## Fix

Routes `.onnx` aux entries through `_fetch_onnx`, which downloads the graph and then probes for `<name>.onnx_data`, treating a 404 (or offline/connection error) as "no sidecar here" — same behavior as the primary-graph path. Non-ONNX aux assets (tokenizer JSON, speaker embeddings) keep the plain-download path.

## Test evidence (red → green)

Two new regression tests in `tests/test_model_manager.py::TestDownloadHelpers`:
- `test_download_aux_models_fetches_onnx_data_sidecar`
- `test_download_aux_models_routes_onnx_entries_through_fetch_onnx`

Verified explicitly:
- **Red**: against `phoonnx/model_manager.py` on `dev` (unfixed), both tests fail — no sidecar file is written, and `_fetch_onnx` is never called.
- **Green**: after the fix, both pass, and the full `test_model_manager.py` suite (71 tests) stays green.

```
$ python -m unittest tests.test_model_manager -v   # before fix
FAIL: test_download_aux_models_fetches_onnx_data_sidecar
FAIL: test_download_aux_models_routes_onnx_entries_through_fetch_onnx
...
Ran 71 tests in 0.380s
FAILED (failures=2)

$ python -m unittest tests.test_model_manager -v   # after fix
Ran 71 tests in 0.380s
OK
```

## Origin

Extracted from feat/magpie-tts (#362), where this fix was discovered while wiring up the Magpie engine (a multi-graph engine with external-data aux graphs) but is a pre-existing bug affecting any multi-graph engine, not Magpie-specific. #362 will rebase to drop its copy of this change and depend on this PR landing first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved downloading of auxiliary ONNX models, including required external data files.
  * Added safer caching for multi-graph model assets.
  * Preserved existing download behavior for non-ONNX auxiliary files.

* **Tests**
  * Added coverage verifying ONNX sidecar retrieval and download routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->