### PR TITLE
feat: universal voice conversion post-stage (voiceclonnx)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ For anyone extending phoonnx or debugging a voice.
 ## Task guides
 
 - [Voice cloning](cloning.md) — zero-shot cloning from a reference clip
+- [Voice conversion](voice_conversion.md) — convert any voice's output to a target speaker
 - [Streaming](streaming.md) — low-latency streaming for VITS voices
 - [Phoneme alignment](alignment.md) — per-phoneme timing for visemes, karaoke, subtitles
 - [OVOS plugin](ovos_plugin.md) — the `ovos-tts-plugin-phoonnx` TTS plugin

--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -18,6 +18,10 @@ for chunk in voice.synthesize(
     ...  # chunk.audio_float_array — see Usage for the full AudioChunk API
 ```
 
+Cloning happens **during** generation. If your voice is not a cloning engine, see
+[Voice conversion](voice_conversion.md) — it converts the waveform **after**
+generation and works with every engine.
+
 ## Two cloning paradigms
 
 Cloning engines fall into two families, which differ in what the reference clip is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,8 @@ syn_config = SynthesisConfig(
 | `exaggeration` | `float` \| `None` | `None` | Expressiveness/intensity for engines that support it (Chatterbox, ~0.5) |
 | `temperature` | `float` \| `None` | `None` | Sampling temperature for autoregressive engines (Chatterbox, ~0.8; `0` = greedy) |
 | `top_p` | `float` \| `None` | `None` | Nucleus sampling cutoff for autoregressive engines (Chatterbox, ~0.95) |
+| `vc_reference` | `str` \| `(audio, sr)` \| `None` | `None` | Target-speaker clip for post-synthesis [voice conversion](voice_conversion.md); works with every engine |
+| `vc_engine` | `str` \| `None` | `None` | voiceclonnx engine for `vc_reference`; `None` selects `"openvoice"` |
 | `extra_params` | `dict` | `{}` | Engine-specific per-call parameters (e.g. `d_factor`, `p_factor`, `e_factor`) |
 
 ## model.json Format

--- a/docs/voice_conversion.md
+++ b/docs/voice_conversion.md
@@ -1,0 +1,136 @@
+# Voice Conversion
+
+Voice conversion changes **who** the audio sounds like, after it has been
+synthesized. Because it runs on the waveform, it works with every phoonnx engine —
+including single-speaker models that have no cloning support of their own. One
+model therefore gives you an unlimited number of voices.
+
+```python
+from phoonnx.voice import TTSVoice
+from phoonnx.config import SynthesisConfig
+
+voice = TTSVoice.load("model.onnx", "model.json")
+for chunk in voice.synthesize(
+    "This sentence comes out in the target speaker's voice.",
+    SynthesisConfig(vc_reference="target_speaker.wav"),
+):
+    ...  # chunk.audio_float_array — see Usage for the full AudioChunk API
+```
+
+Conversion is powered by [voiceclonnx](https://github.com/TigreGotico/voiceclonnx),
+a pure-ONNX library. Install it with the extra:
+
+```bash
+pip install phoonnx[vc]
+```
+
+## Voice conversion or native cloning?
+
+phoonnx has two ways to make a voice sound like somebody else, and they are not
+interchangeable.
+
+| | `speaker_reference` (native cloning) | `vc_reference` (voice conversion) |
+|---|---|---|
+| When it happens | during generation | after generation, on the waveform |
+| What it changes | timbre **and** prosody — the model is conditioned on the reference | timbre only — the source voice's rhythm and intonation stay |
+| Which engines | cloning engines only (YourTTS, StyleTTS2, ZipVoice, F5-TTS, Chatterbox, …) | **all** of them |
+| Quality | higher — nothing is re-synthesized from an already-lossy waveform | good, but it is a second pass over generated audio |
+| Cost | none beyond the engine's own inference | one extra ONNX pass per sentence |
+
+**Prefer `speaker_reference` when the voice supports it.** Reach for
+`vc_reference` when it does not — a piper VITS voice, a kokoro voice, a kittentts
+voice — or when you want one target speaker applied uniformly across several
+different engines.
+
+The two are independent and may be combined, though there is rarely a reason to:
+native cloning already puts you at the target speaker, and a conversion pass on
+top only adds loss.
+
+## Configuration
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `vc_reference` | `str` path or URL, or `(audio, sample_rate)` | `None` | target-speaker clip; `None` disables the stage entirely |
+| `vc_engine` | `str` | `"openvoice"` | which voiceclonnx engine to use |
+
+`None` is a strict no-op: `voiceclonnx` is never imported and the audio is
+bit-for-bit the engine's own output.
+
+The reference clip should be 5–30 seconds of clean speech from one speaker. Paths,
+URLs and in-memory `(audio, sample_rate)` tuples are all accepted — the same shapes
+`speaker_reference` takes, loaded by the same guarded loader, so remote clips are
+subject to its address and size limits. Whatever you pass is decoded and written to
+a temporary WAV, which is what voiceclonnx reads.
+
+The loaded engine is cached against the reference's **samples**, not against the
+path or URL you named, so rewriting a reference file in place gives you the new
+speaker rather than the previous one. The cost is that the reference is read —
+and, for a URL, fetched — once per `synthesize()` call. Pass an
+`(audio, sample_rate)` tuple if you want to do that reading yourself.
+
+### Choosing an engine
+
+`openvoice` is the default because it is the only engine tested here that transfers
+the voice **and** keeps the words intact. `knnvc` transfers harder but costs about
+9 percentage points of word error rate — pick it only if you care more about timbre
+than about being understood, and measure it on your own material first. The full
+engine list is in the voiceclonnx README.
+
+```python
+SynthesisConfig(vc_reference="target.wav", vc_engine="knnvc")
+```
+
+## What to expect
+
+Measured on 5 utterances × 3 source voices × 2 target speakers, with
+`wespeaker-resnet34` for similarity and parakeet for word error rate:
+
+* Speaker similarity to the target rises **+0.24 cosine** on average over the
+  unconverted floor, on every source/target pair.
+* Word error rate rises **+2.5 pp** on average — conversion is close to
+  intelligibility-neutral but not free.
+* Prosody does not move. A flat source voice stays flat; converting it to an
+  expressive speaker's timbre will not make it expressive.
+
+Reproduce it all with:
+
+```bash
+python scripts/vc_gate.py --out vc-run.json
+```
+
+The script exits non-zero when a gate fails.
+
+## How it fits in the pipeline
+
+Conversion is applied **per chunk** — one sentence at a time — not to the whole
+utterance. Every voiceclonnx engine is stateless across calls and conditions only
+on the reference, so per-sentence conversion gives the same result as converting
+the whole utterance while keeping synthesis streaming. Sentences under roughly
+0.3 s carry too little content for the engines' content encoders and pass through
+unconverted rather than becoming artefacts.
+
+The converted audio comes back at the VC engine's own sample rate (22 050 Hz for
+OpenVoice), and the `AudioChunk` reports that rate — not the voice's native one.
+`synthesize_wav()` takes the header from the chunk, so files come out correct
+without any extra work on your side.
+
+When [super-resolution](usage.md) is also enabled, conversion runs **first**, so
+the upscaler works on the final timbre.
+
+## Errors
+
+Voice conversion fails loudly, unlike super-resolution. Returning the source
+speaker after you asked for a different one is a wrong answer, not a degraded one,
+so:
+
+* `vc_reference` set without `voiceclonnx` installed raises `ImportError` naming
+  the `phoonnx[vc]` extra.
+* A reference path that is not a readable file raises `FileNotFoundError`.
+* A conversion failure mid-stream propagates instead of yielding the source voice.
+
+## Models
+
+voiceclonnx downloads its own weights from Hugging Face on first use
+(`TigreGotico/voiceclonnx-openvoice-v2` for the default engine) and caches them.
+phoonnx does not mirror or manage them — there is one mirror, owned by the project
+that runs the models.

--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -475,6 +475,29 @@ class SynthesisConfig:
     # ``super_resolution`` is True.
     super_resolution_model: Optional[str] = None
 
+    # post-synthesis universal voice conversion via ``voiceclonnx`` (pure-ONNX).
+    # ``None`` (the default) is a strict no-op: ``voiceclonnx`` is never imported and
+    # the audio is bit-for-bit the engine's own output. When set, every synthesized
+    # chunk is converted to the target speaker *after* generation, so any voice —
+    # including single-speaker models with no cloning support of their own — can speak
+    # with an arbitrary target timbre.
+    #
+    # Value: a path or URL to a short (5–30 s) target-speaker clip, or an
+    # ``(audio, sample_rate)`` tuple — the same shapes ``speaker_reference`` accepts.
+    #
+    # ``vc_reference`` vs ``speaker_reference``: ``speaker_reference`` is engine-native
+    # cloning at generation time, so the model is conditioned on the reference and
+    # prosody follows it as well as timbre, but only cloning-capable engines support
+    # it. ``vc_reference`` is post-hoc conversion on the waveform: it works with every
+    # engine, but prosody stays the source voice's and only the timbre moves. Prefer
+    # ``speaker_reference`` when the voice supports it.
+    vc_reference: Optional[Any] = None
+
+    # voiceclonnx engine alias used for ``vc_reference`` (e.g. ``"openvoice"``,
+    # ``"knnvc"``, ``"focalcodec"``). ``None`` (the default) selects ``"openvoice"``.
+    # Ignored unless ``vc_reference`` is set.
+    vc_engine: Optional[str] = None
+
     # Engine-specific per-call params (d_factor, p_factor, e_factor, …)
     extra_params: Dict[str, Any] = field(default_factory=dict)
 

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -6,10 +6,15 @@ all ONNX-specific I/O to an engine adapter (``phoonnx.engines``),
 which means the same TTSVoice class works for VITS or
 any future architecture without code changes here.
 """
+import hashlib
 import json
 import os.path
 import re
+import shutil
+import tempfile
 import wave
+import weakref
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union, Dict
@@ -53,6 +58,43 @@ def _phonemic_chunks(text: str, alphabet: Optional[Alphabet]) -> PhonemizedChunk
     if alphabet == Alphabet.ARPA:
         return [chunk.split() for chunk, _, _ in chunks if chunk.strip()]
     return [[c for c in chunk] for chunk, _, _ in chunks if chunk]
+
+
+def _write_wav(path: str, audio: np.ndarray, sample_rate: int) -> str:
+    """Write mono float32 ``audio`` to ``path`` as 16-bit PCM WAV.
+
+    voiceclonnx is a file-in/file-out API, so the in-memory chunks have to land on
+    disk for the conversion hop.
+    """
+    pcm = np.clip(np.asarray(audio, dtype=np.float32).reshape(-1), -1.0, 1.0)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(int(sample_rate))
+        w.writeframes((pcm * 32767.0).astype("<i2").tobytes())
+    return path
+
+
+def _unlink(path: str) -> None:
+    with suppress(OSError):
+        os.unlink(path)
+
+
+class _VoiceConversion:
+    """A loaded voiceclonnx cloner together with the reference WAV it reads.
+
+    The two are one resource. voiceclonnx re-reads the reference file on every
+    ``clone_voice`` call, so the file has to outlive every request still holding
+    this object — and no longer. Tying its lifetime to the object rather than to
+    the voice's cache slot means a later call for a different speaker can replace
+    the cache without pulling the file out from under a synthesis already
+    streaming, and the file still goes away once nobody is converting to it.
+    """
+
+    def __init__(self, cloner, ref_path: str):
+        self.cloner = cloner
+        self.ref_path = ref_path
+        weakref.finalize(self, _unlink, ref_path)
 
 
 @dataclass
@@ -169,6 +211,13 @@ class TTSVoice:
 
     _sr_engine: Any = field(default=None, init=False, repr=False)
     _sr_loaded: bool = field(default=False, init=False, repr=False)
+    # Post-synthesis voice-conversion state (``SynthesisConfig.vc_reference``).
+    # ``_vc_key`` is the (engine, reference content) the cached ``_VoiceConversion``
+    # was built for, so a later call naming a different engine or target speaker —
+    # or the same path holding a different recording — rebuilds instead of silently
+    # reusing the wrong voice.
+    _vc: Optional[_VoiceConversion] = field(default=None, init=False, repr=False)
+    _vc_key: Any = field(default=None, init=False, repr=False)
     # Path to the ONNX model file backing ``session``, kept so a later
     # ``include_alignments=True`` call can locate-and-patch a model that was
     # exported without the alignment output (see ``_ensure_alignment_session``).
@@ -558,6 +607,115 @@ class TTSVoice:
                         f"{in_sr} Hz audio instead")
             return audio, in_sr
 
+    def _load_voice_conversion(
+            self, syn_config: SynthesisConfig) -> Optional[_VoiceConversion]:
+        """
+        Lazily build the ``voiceclonnx`` cloner for ``syn_config.vc_reference``.
+
+        Disabled — ``vc_reference is None``, the default — is a strict no-op:
+        ``voiceclonnx`` is never imported and synthesis is untouched. When enabled,
+        the cloner and its materialized reference WAV are cached as one
+        :class:`_VoiceConversion`, so repeated calls naming the same target speaker
+        do not reload the ONNX sessions. The object is handed to the caller, which
+        holds it for the whole of its synthesis; a later call for a different
+        speaker replaces the cache slot without disturbing it.
+
+        The reference is normalised by
+        :func:`phoonnx.reference_audio.load_reference_audio`, the same guarded
+        loader ``speaker_reference`` uses, so URLs are fetched under its address and
+        size limits and non-WAV clips are decoded rather than handed to voiceclonnx
+        raw. The cache is keyed on the resulting *samples*, not on the path or URL
+        that produced them, because a path is not a stable identity for a
+        recording: a reference rewritten in place under the same name is a
+        different speaker, and serving the previous one would be a wrong answer.
+        The cost of that is reading — and for a URL, fetching — the reference once
+        per synthesis call.
+
+        A missing install raises an ImportError naming the extra. A missing or
+        unreadable reference raises rather than degrading: skipping the conversion
+        would emit the *source* speaker, which is a wrong answer, not a
+        reduced-quality one.
+
+        Returns:
+            The :class:`_VoiceConversion` to convert with, or None when disabled.
+        """
+        ref = syn_config.vc_reference
+        if ref is None:
+            return None
+
+        engine = syn_config.vc_engine or "openvoice"
+        if isinstance(ref, (str, Path)) and not str(ref).lower().startswith(
+                ("http://", "https://")) and not os.path.isfile(str(ref)):
+            raise FileNotFoundError(
+                f"vc_reference points at no readable file: {str(ref)!r}")
+
+        audio, sr = load_reference_audio(ref)
+        key = (engine, hashlib.sha1(audio.tobytes()).hexdigest(), int(sr))
+        if self._vc is not None and self._vc_key == key:
+            return self._vc
+
+        try:
+            from voiceclonnx import VoiceCloner
+        except ImportError as e:
+            raise ImportError(
+                "vc_reference is set but 'voiceclonnx' is not installed; "
+                "install it with `pip install phoonnx[vc]` (or set "
+                "vc_reference=None)") from e
+
+        cloner = VoiceCloner(engine=engine)
+        fd, ref_path = tempfile.mkstemp(prefix="phoonnx_vc_ref_", suffix=".wav")
+        os.close(fd)
+        try:
+            _write_wav(ref_path, audio, sr)
+        except BaseException:
+            _unlink(ref_path)
+            raise
+
+        self._vc = _VoiceConversion(cloner, ref_path)
+        self._vc_key = key
+        LOG.info(f"Voice conversion enabled (engine={engine}); output will be "
+                 f"converted to the reference speaker at {cloner.sample_rate} Hz")
+        return self._vc
+
+    @staticmethod
+    def _maybe_convert(audio: np.ndarray, vc: Optional[_VoiceConversion],
+                       in_sr: int) -> Tuple[np.ndarray, int]:
+        """
+        Convert ``audio`` to the target speaker, if a conversion is loaded.
+
+        Returns ``(audio, sample_rate)`` — untouched when ``vc`` is None, and the
+        converted audio at the VC engine's own rate otherwise, so the caller always
+        emits a sample rate that matches the samples it got. Nothing is resampled on
+        the way in: voiceclonnx accepts any input rate and resamples internally, so
+        the chunk reaches it at the voice's native rate.
+
+        Conversion is applied per chunk, not per utterance: every voiceclonnx engine
+        is stateless across calls and conditions only on the reference, so a
+        per-sentence application is equivalent to a whole-utterance one while keeping
+        synthesis streaming. Sentences shorter than roughly 0.3 s carry too little
+        content for the content encoders and pass through unconverted rather than
+        turning into artefacts.
+
+        Unlike super-resolution, a runtime failure is not swallowed: returning the
+        source speaker after the caller asked for a different one is a wrong answer,
+        not a degraded one.
+        """
+        if vc is None:
+            return audio, in_sr
+        if audio.size < int(0.3 * in_sr):
+            LOG.debug("chunk too short for voice conversion; passing through")
+            return audio, in_sr
+
+        tmpdir = tempfile.mkdtemp(prefix="phoonnx_vc_")
+        try:
+            src = os.path.join(tmpdir, "src.wav")
+            dst = os.path.join(tmpdir, "out.wav")
+            _write_wav(src, audio, in_sr)
+            vc.cloner.clone_voice(src, vc.ref_path, dst)
+            return load_reference_audio(dst)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
     def synthesize(
             self,
             text: str,
@@ -592,6 +750,12 @@ class TTSVoice:
         # optional post-synthesis super-resolution; disabled (the default) means the
         # loop below is bit-for-bit the native path and audiosronnx is not imported
         sr_engine = self._load_super_resolution(syn_config)
+
+        # optional post-synthesis voice conversion; disabled (the default) means the
+        # loop below is bit-for-bit the native path and voiceclonnx is not imported.
+        # VC runs before SR so the upscaler sees the final timbre and the 48 kHz rate
+        # is what actually reaches the caller.
+        vc = self._load_voice_conversion(syn_config)
 
         # Text preprocessing — engine-agnostic, applied to the whole text before
         # any conversion: user pronunciation overrides.
@@ -670,10 +834,11 @@ class TTSVoice:
                 _idx2char, _blank_id, _bos_id, _eos_id,
             ) if phoneme_id_samples is not None else None
 
-            # SR changes the rate of the samples, so the chunk must report the
-            # rate that came back with them, not the voice's native one
-            audio, chunk_sr = self._maybe_upscale(
-                audio, sr_engine, self.config.sample_rate)
+            # VC and SR each change the rate of the samples, so the chunk must
+            # report the rate that came back with them, not the voice's native one
+            audio, chunk_sr = self._maybe_convert(
+                audio, vc, self.config.sample_rate)
+            audio, chunk_sr = self._maybe_upscale(audio, sr_engine, chunk_sr)
 
             yield AudioChunk(
                 sample_rate=chunk_sr,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ test = [
     "sentencepiece",
     "ahotts-g2p>=0.1.0",
     "espyak>=0.0.3a1",
+    # the voice-conversion post-stage's end-to-end test runs the real engine;
+    # pure-ONNX with no torch of its own, so it is cheap to have here.
+    "voiceclonnx>=0.0.3a3",
     "orthography2ipa",
     "arbtok",
     "euskaphone",
@@ -287,6 +290,10 @@ cloning = ["soundfile", "scipy"]
 # pure-ONNX, no torch at runtime. off by default (see the super_resolution field
 # block); models fetch from HuggingFace on first use.
 audiosr = ["audiosronnx"]
+# optional post-synthesis universal voice conversion: convert any voice's output to an
+# arbitrary target speaker. pure-ONNX, no torch at runtime. off by default (see the
+# vc_reference field block); models fetch from HuggingFace on first use.
+vc = ["voiceclonnx>=0.0.3a3"]
 # Chatterbox multilingual per-language script transforms. ja/zh below; ko is pure-Python
 # (built in). he/ru degrade gracefully unless `dicta_onnx` / `russian_text_stresser` are
 # also installed (not on clean PyPI, so left out of the extra).
@@ -352,6 +359,8 @@ all = [
     "onnx<1.18",
     # optional post-synthesis audio super-resolution (phoonnx/voice.py).
     "audiosronnx",
+    # optional post-synthesis voice conversion (phoonnx/voice.py).
+    "voiceclonnx>=0.0.3a3",
 ]
 
 [tool.setuptools.dynamic]

--- a/scripts/vc_gate.py
+++ b/scripts/vc_gate.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Self-gating benchmark for the ``vc_reference`` voice-conversion post-stage.
+
+Runs the full matrix (utterances x source voices x target speakers), scores it,
+writes a run JSON plus a markdown table, and exits non-zero when a gate fails.
+
+What it measures
+----------------
+speaker similarity
+    Cosine between speakeronnx embeddings.  Three numbers per pair:
+
+    * ``sim_to_target`` — converted output vs the target-speaker reference.
+      This is the number the feature exists for.
+    * ``sim_to_source`` — converted output vs the same sentence in the source
+      voice.  The **negative control**.  A pass-through "conversion" scores ~1.0
+      here (see the mimi/quickvc failure mode), so this has to fall well below
+      1.0.  Note it does **not** have to fall below ``sim_to_target``: when the
+      source and the target are already similar speakers (same sex, similar
+      pitch) the converted audio legitimately resembles both.
+    * ``floor`` — source vs target with no conversion at all.  The baseline any
+      real conversion has to beat.
+
+intelligibility
+    WER of an ASR pass (parakeet) against the reference text, before and after
+    conversion.  Conversion may not wreck the words.
+
+Gates
+-----
+1. Every (source voice, target speaker) pair moves toward the target: its mean
+   ``sim_to_target - floor`` margin is positive, and the margin over the whole
+   matrix is >= 0.10.  Aggregating per pair rather than per utterance is
+   deliberate — the acoustic models are stochastic, so a single utterance can
+   sit at the floor by chance without the pair being broken.
+2. ``sim_to_source`` <= 0.85 for every pair — no source leakage.  A stage that
+   silently passed audio through would score ~1.0.
+3. Mean WER degradation <= 5 percentage points absolute.
+
+Usage
+-----
+::
+
+    python scripts/vc_gate.py --out vc-run.json
+
+Everything is CPU-only and offline after the first model download.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+import wave
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+# --- matrix -----------------------------------------------------------------
+
+UTTERANCES = [
+    "The quick brown fox jumps over the lazy dog near the river bank.",
+    "Please turn on the kitchen lights and set the thermostat to twenty degrees.",
+    "She sold seashells by the seashore every summer morning without fail.",
+    "Recording the weather forecast for tomorrow afternoon in central Portugal.",
+    "An open source voice assistant should never send your speech to the cloud.",
+]
+
+# Three fast, architecturally different sources: a piper VITS voice, a kokoro
+# StyleTTS2 voice, and a kittentts nano voice.
+SOURCE_VOICES = [
+    "piper/en_US-amy-low",
+    "kokoro/af_heart",
+    "kittentts/nano-0.2-expr-voice-2-m",
+]
+
+# Two target speakers, deliberately far apart (male / female) and from engines
+# that are not in the source set, so no source-target pair is trivially close.
+TARGET_VOICES = {
+    "target_male": "piper/en_US-ryan-medium",
+    "target_female": "supertonic/F1/en",
+}
+
+# The target reference clip: long enough for every VC engine's speaker encoder.
+TARGET_REF_TEXT = (
+    "This is a reference recording of my voice. I am speaking clearly and at a "
+    "steady pace so that the speaker encoder has enough material to work with. "
+    "The weather today is mild, with a light breeze from the north."
+)
+
+SIM_MARGIN_GATE = 0.10   # mean (sim_to_target - floor)
+LEAKAGE_GATE = 0.85      # max sim_to_source; a pass-through scores ~1.0
+WER_DELTA_GATE = 5.0     # percentage points absolute
+
+
+# --- helpers ----------------------------------------------------------------
+
+def _pkg_version(name: str) -> str:
+    from importlib.metadata import PackageNotFoundError, version
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _norm(text: str) -> list[str]:
+    return re.sub(r"[^a-z0-9 ]+", " ", text.lower()).split()
+
+
+def wer(reference: str, hypothesis: str) -> float:
+    """Word error rate in percent (Levenshtein over words)."""
+    r, h = _norm(reference), _norm(hypothesis)
+    if not r:
+        return 0.0
+    prev = list(range(len(h) + 1))
+    for i, rw in enumerate(r, 1):
+        cur = [i]
+        for j, hw in enumerate(h, 1):
+            cur.append(min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (rw != hw)))
+        prev = cur
+    return 100.0 * prev[-1] / len(r)
+
+
+def write_wav(path: str, audio: np.ndarray, sr: int) -> str:
+    pcm = np.clip(np.asarray(audio, np.float32).reshape(-1), -1.0, 1.0)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(int(sr))
+        w.writeframes((pcm * 32767.0).astype("<i2").tobytes())
+    return path
+
+
+def load_voice(voice_id: str):
+    from phoonnx.model_manager import TTSModelManager
+
+    mgr = TTSModelManager()
+    mgr.merge_default_voices()
+    for info in mgr.all_voices:
+        if info.voice_id == voice_id:
+            return info.load()
+    raise SystemExit(f"unknown voice id: {voice_id}")
+
+
+def synth(voice, text, syn_config=None) -> tuple[np.ndarray, int]:
+    """Concatenate every chunk of one synthesis call into a single waveform."""
+    from phoonnx.config import SynthesisConfig
+
+    parts, sr = [], None
+    for chunk in voice.synthesize(text, syn_config=syn_config or SynthesisConfig()):
+        parts.append(chunk.audio_float_array)
+        sr = chunk.sample_rate
+    if not parts:
+        raise RuntimeError(f"no audio for {text!r}")
+    return np.concatenate(parts).astype(np.float32), sr
+
+
+# --- run --------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="vc-run.json")
+    ap.add_argument("--vc-engine", default="openvoice")
+    ap.add_argument("--speaker-model", default="wespeaker-resnet34")
+    ap.add_argument("--asr-model", default="nemo-parakeet-tdt-0.6b-v2")
+    ap.add_argument("--audio-dir", default=None,
+                    help="keep the generated WAVs here instead of a temp dir")
+    args = ap.parse_args()
+
+    import onnx_asr
+    import speakeronnx
+    from phoonnx.config import SynthesisConfig
+    from phoonnx.version import VERSION_STR
+
+    embedder = speakeronnx.SpeakerEmbedder(args.speaker_model)
+    asr = onnx_asr.load_model(args.asr_model)
+
+    workdir = Path(args.audio_dir) if args.audio_dir else Path(tempfile.mkdtemp(prefix="vc_gate_"))
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    def embed(path: str) -> np.ndarray:
+        return np.asarray(embedder.embed(path)).reshape(-1)
+
+    def transcribe(path: str) -> str:
+        return asr.recognize(path)
+
+    # 1. Build the target-speaker reference clips.
+    refs = {}
+    for name, voice_id in TARGET_VOICES.items():
+        print(f"[ref] {name} <- {voice_id}", flush=True)
+        voice = load_voice(voice_id)
+        audio, sr = synth(voice, TARGET_REF_TEXT)
+        refs[name] = {
+            "voice_id": voice_id,
+            "path": write_wav(str(workdir / f"ref_{name}.wav"), audio, sr),
+            "sample_rate": sr,
+        }
+        refs[name]["embedding"] = embed(refs[name]["path"])
+        del voice
+
+    # 2. The matrix.
+    rows = []
+    for source_id in SOURCE_VOICES:
+        print(f"[source] {source_id}", flush=True)
+        voice = load_voice(source_id)
+        for u_idx, text in enumerate(UTTERANCES):
+            base_audio, base_sr = synth(voice, text)
+            base_path = write_wav(
+                str(workdir / f"base_{u_idx}_{source_id.replace('/', '_')}.wav"),
+                base_audio, base_sr)
+            base_emb = embed(base_path)
+            base_hyp = transcribe(base_path)
+            base_wer = wer(text, base_hyp)
+
+            for tgt_name, ref in refs.items():
+                cfg = SynthesisConfig(vc_reference=ref["path"],
+                                      vc_engine=args.vc_engine)
+                t0 = time.time()
+                conv_audio, conv_sr = synth(voice, text, cfg)
+                elapsed = time.time() - t0
+                conv_path = write_wav(
+                    str(workdir /
+                        f"conv_{u_idx}_{source_id.replace('/', '_')}_{tgt_name}.wav"),
+                    conv_audio, conv_sr)
+                conv_emb = embed(conv_path)
+                conv_hyp = transcribe(conv_path)
+                conv_wer = wer(text, conv_hyp)
+
+                rows.append({
+                    "utterance_index": u_idx,
+                    "text": text,
+                    "source_voice": source_id,
+                    "target_speaker": tgt_name,
+                    "target_voice": ref["voice_id"],
+                    "sim_to_target": float(speakeronnx.cosine(conv_emb, ref["embedding"])),
+                    "sim_to_source": float(speakeronnx.cosine(conv_emb, base_emb)),
+                    "floor": float(speakeronnx.cosine(base_emb, ref["embedding"])),
+                    "wer_before": base_wer,
+                    "wer_after": conv_wer,
+                    "asr_before": base_hyp,
+                    "asr_after": conv_hyp,
+                    "source_sample_rate": base_sr,
+                    "converted_sample_rate": conv_sr,
+                    "rtf_seconds": elapsed,
+                    "audio_before": os.path.basename(base_path),
+                    "audio_after": os.path.basename(conv_path),
+                })
+                print(f"  {source_id} -> {tgt_name} [{u_idx}] "
+                      f"tgt={rows[-1]['sim_to_target']:.3f} "
+                      f"src={rows[-1]['sim_to_source']:.3f} "
+                      f"floor={rows[-1]['floor']:.3f} "
+                      f"wer {base_wer:.1f} -> {conv_wer:.1f}", flush=True)
+        del voice
+
+    # 3. Gates.
+    margins = [r["sim_to_target"] - r["floor"] for r in rows]
+    pair_margins = {}
+    for r in rows:
+        pair_margins.setdefault((r["source_voice"], r["target_speaker"]), []).append(
+            r["sim_to_target"] - r["floor"])
+    pair_means = {f"{k[0]} -> {k[1]}": float(np.mean(v)) for k, v in pair_margins.items()}
+    leakage = [r["sim_to_source"] for r in rows]
+    wer_deltas = [r["wer_after"] - r["wer_before"] for r in rows]
+
+    gates = {
+        "similarity_beats_floor": {
+            "pass": (all(m > 0 for m in pair_means.values())
+                     and float(np.mean(margins)) >= SIM_MARGIN_GATE),
+            "mean_margin": float(np.mean(margins)),
+            "min_pair_mean_margin": float(min(pair_means.values())),
+            "min_utterance_margin": float(np.min(margins)),
+            "pair_mean_margins": pair_means,
+            "threshold": SIM_MARGIN_GATE,
+        },
+        "no_source_leakage": {
+            "pass": float(np.max(leakage)) <= LEAKAGE_GATE,
+            "max_sim_to_source": float(np.max(leakage)),
+            "mean_sim_to_source": float(np.mean(leakage)),
+            "threshold": LEAKAGE_GATE,
+        },
+        "intelligibility_preserved": {
+            "pass": float(np.mean(wer_deltas)) <= WER_DELTA_GATE,
+            "mean_wer_delta_pp": float(np.mean(wer_deltas)),
+            "max_wer_delta_pp": float(np.max(wer_deltas)),
+            "threshold_pp": WER_DELTA_GATE,
+        },
+    }
+
+    report = {
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "phoonnx_version": VERSION_STR,
+        "voiceclonnx_version": _pkg_version("voiceclonnx"),
+        "speakeronnx_version": _pkg_version("speakeronnx"),
+        "onnx_asr_version": _pkg_version("onnx-asr"),
+        "vc_engine": args.vc_engine,
+        "speaker_model": args.speaker_model,
+        "asr_model": args.asr_model,
+        "n_utterances": len(UTTERANCES),
+        "source_voices": SOURCE_VOICES,
+        "target_voices": TARGET_VOICES,
+        "rows": rows,
+        "gates": gates,
+        "pass": all(g["pass"] for g in gates.values()),
+    }
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    _write_markdown(report, out.with_suffix(".md"))
+
+    print(json.dumps(gates, indent=2))
+    print(f"\nwrote {out} and {out.with_suffix('.md')}")
+    if not args.audio_dir:
+        print(f"(audio in {workdir} — delete when done)")
+    return 0 if report["pass"] else 1
+
+
+def _write_markdown(report: dict, path: Path) -> None:
+    rows = report["rows"]
+    lines = [
+        f"# Voice-conversion gate — {report['vc_engine']}",
+        "",
+        f"phoonnx {report['phoonnx_version']} · voiceclonnx {report['voiceclonnx_version']} · "
+        f"speaker model {report['speaker_model']} · ASR {report['asr_model']}",
+        f"Generated {report['generated_utc']}",
+        "",
+        "## Speaker similarity (cosine)",
+        "",
+        "| source voice | target | sim to target | sim to source | floor (no VC) | margin |",
+        "|---|---|---|---|---|---|",
+    ]
+    by_pair: dict = {}
+    for r in rows:
+        by_pair.setdefault((r["source_voice"], r["target_speaker"]), []).append(r)
+    for (src, tgt), rs in by_pair.items():
+        lines.append(
+            f"| `{src}` | {tgt} | {np.mean([r['sim_to_target'] for r in rs]):.3f} "
+            f"| {np.mean([r['sim_to_source'] for r in rs]):.3f} "
+            f"| {np.mean([r['floor'] for r in rs]):.3f} "
+            f"| **{np.mean([r['sim_to_target'] - r['floor'] for r in rs]):+.3f}** |")
+    lines += [
+        "",
+        "## Intelligibility (WER %, parakeet)",
+        "",
+        "| source voice | target | WER before | WER after | delta (pp) |",
+        "|---|---|---|---|---|",
+    ]
+    for (src, tgt), rs in by_pair.items():
+        b = np.mean([r["wer_before"] for r in rs])
+        a = np.mean([r["wer_after"] for r in rs])
+        lines.append(f"| `{src}` | {tgt} | {b:.1f} | {a:.1f} | {a - b:+.1f} |")
+    lines += ["", "## Gates", ""]
+    for name, g in report["gates"].items():
+        lines.append(f"- **{name}**: {'PASS' if g['pass'] else 'FAIL'} — "
+                     + ", ".join(f"{k}={v}" for k, v in g.items() if k != "pass"))
+    lines += ["", f"Overall: **{'PASS' if report['pass'] else 'FAIL'}**", ""]
+    path.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_voice_conversion.py
+++ b/tests/test_voice_conversion.py
@@ -1,0 +1,492 @@
+"""Universal voice-conversion post-stage wiring on TTSVoice (engine-agnostic).
+
+Covers the lazy cloner loader, the per-chunk conversion helper, the WAV
+round-trip helpers and the no-op guarantee, without constructing a full ONNX
+voice. A gated end-to-end test exercises the real voiceclonnx pipeline when the
+package (and its weights) are available.
+"""
+import gc
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from phoonnx.config import SynthesisConfig
+from phoonnx.reference_audio import load_reference_audio
+from phoonnx.voice import TTSVoice, _VoiceConversion, _write_wav
+
+
+def _vc(cloner, ref_path):
+    """A loaded conversion built straight from a fake cloner and a path."""
+    return _VoiceConversion(cloner, ref_path)
+
+
+def _bare_voice(testcase=None):
+    """A TTSVoice instance with only the VC-cache fields set (no ONNX session)."""
+    v = TTSVoice.__new__(TTSVoice)
+    v._vc = None
+    v._vc_key = None
+    return v
+
+
+def _ref_wav(tmpdir, sr=16000, seconds=1.0):
+    path = os.path.join(tmpdir, "ref.wav")
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False, dtype=np.float32)
+    return _write_wav(path, 0.2 * np.sin(2 * np.pi * 180 * t), sr)
+
+
+def _fake_voiceclonnx(testcase, sample_rate=22050):
+    cloner = MagicMock(name="cloner")
+    cloner.sample_rate = sample_rate
+    module = types.ModuleType("voiceclonnx")
+    module.VoiceCloner = MagicMock(name="VoiceCloner", return_value=cloner)
+    patcher = patch.dict(sys.modules, {"voiceclonnx": module})
+    patcher.start()
+    testcase.addCleanup(patcher.stop)
+    return module, cloner
+
+
+class TestWavHelpers(unittest.TestCase):
+    """The disk hop must not change the signal beyond 16-bit quantisation."""
+
+    def test_round_trip_preserves_audio_and_rate(self):
+        sr = 22050
+        t = np.linspace(0, 0.5, sr // 2, endpoint=False, dtype=np.float32)
+        audio = (0.4 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        with tempfile.TemporaryDirectory() as d:
+            p = _write_wav(os.path.join(d, "a.wav"), audio, sr)
+            back, got_sr = load_reference_audio(p)
+        self.assertEqual(got_sr, sr)
+        self.assertEqual(back.shape, audio.shape)
+        self.assertEqual(back.dtype, np.float32)
+        # 16-bit PCM: one LSB is 1/32768
+        self.assertLess(np.max(np.abs(back - audio)), 2.0 / 32768.0)
+
+    def test_clips_out_of_range_samples(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = _write_wav(os.path.join(d, "a.wav"),
+                           np.array([2.0, -2.0], dtype=np.float32), 8000)
+            back, _ = load_reference_audio(p)
+        self.assertLessEqual(back.max(), 1.0)
+        self.assertGreaterEqual(back.min(), -1.0)
+
+    def test_empty_audio_round_trips(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = _write_wav(os.path.join(d, "a.wav"),
+                           np.zeros(0, dtype=np.float32), 16000)
+            back, sr = load_reference_audio(p)
+        self.assertEqual(back.shape[0], 0)
+        self.assertEqual(sr, 16000)
+
+
+class TestLoadVoiceConversion(unittest.TestCase):
+    def test_disabled_when_unset(self):
+        self.assertIsNone(
+            _bare_voice(self)._load_voice_conversion(SynthesisConfig()))
+
+    def test_defaults_to_disabled(self):
+        """The runtime knob is off unless a caller explicitly turns it on."""
+        cfg = SynthesisConfig()
+        self.assertIsNone(cfg.vc_reference)
+        self.assertIsNone(cfg.vc_engine)
+
+    def test_disabled_path_never_imports_voiceclonnx(self):
+        """The default path must not touch the optional dependency at all."""
+        with patch.dict(sys.modules):
+            sys.modules.pop("voiceclonnx", None)
+            self.assertIsNone(
+                _bare_voice(self)._load_voice_conversion(SynthesisConfig()))
+            self.assertNotIn("voiceclonnx", sys.modules)
+
+    def test_enabled_but_not_installed_raises_actionable_import_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            cfg = SynthesisConfig(vc_reference=_ref_wav(d))
+            with patch.dict(sys.modules, {"voiceclonnx": None}):
+                with self.assertRaises(ImportError) as ctx:
+                    _bare_voice(self)._load_voice_conversion(cfg)
+        self.assertIn("phoonnx[vc]", str(ctx.exception))
+
+    def test_enabled_loads_named_engine(self):
+        module, cloner = _fake_voiceclonnx(self)
+        with tempfile.TemporaryDirectory() as d:
+            ref = _ref_wav(d)
+            vc = _bare_voice(self)._load_voice_conversion(
+                SynthesisConfig(vc_reference=ref, vc_engine="knnvc"))
+            want, want_sr = load_reference_audio(ref)
+            self.assertIs(vc.cloner, cloner)
+            module.VoiceCloner.assert_called_once_with(engine="knnvc")
+            # the reference is materialized through the guarded loader, so what
+            # voiceclonnx reads is a decoded copy rather than the caller's file
+            self.assertNotEqual(vc.ref_path, ref)
+            got_audio, got_sr = load_reference_audio(vc.ref_path)
+            self.assertEqual(got_sr, want_sr)
+            np.testing.assert_allclose(got_audio, want, atol=2.0 / 32768.0)
+
+    def test_defaults_to_openvoice(self):
+        module, _ = _fake_voiceclonnx(self)
+        with tempfile.TemporaryDirectory() as d:
+            _bare_voice(self)._load_voice_conversion(
+                SynthesisConfig(vc_reference=_ref_wav(d)))
+        module.VoiceCloner.assert_called_once_with(engine="openvoice")
+
+    def test_loaded_once_and_cached(self):
+        module, cloner = _fake_voiceclonnx(self)
+        v = _bare_voice(self)
+        with tempfile.TemporaryDirectory() as d:
+            cfg = SynthesisConfig(vc_reference=_ref_wav(d))
+            self.assertIs(v._load_voice_conversion(cfg).cloner, cloner)
+            self.assertIs(v._load_voice_conversion(cfg).cloner, cloner)
+        module.VoiceCloner.assert_called_once()
+
+    def test_changing_target_speaker_rebuilds(self):
+        """A cached cloner must never be reused for a different reference —
+        that would emit the previous speaker."""
+        module, _ = _fake_voiceclonnx(self)
+        v = _bare_voice(self)
+        with tempfile.TemporaryDirectory() as d:
+            a = _ref_wav(d)
+            b = _write_wav(os.path.join(d, "b.wav"),
+                           np.full(16000, 0.3, dtype=np.float32), 16000)
+            vc_a = v._load_voice_conversion(SynthesisConfig(vc_reference=a))
+            vc_b = v._load_voice_conversion(SynthesisConfig(vc_reference=b))
+            self.assertEqual(module.VoiceCloner.call_count, 2)
+            self.assertIsNot(vc_a, vc_b)
+            self.assertNotEqual(vc_a.ref_path, vc_b.ref_path)
+            np.testing.assert_allclose(load_reference_audio(vc_b.ref_path)[0],
+                                       load_reference_audio(b)[0],
+                                       atol=2.0 / 32768.0)
+
+    def test_rewriting_a_reference_path_rebuilds(self):
+        """A path is not a stable identity for a recording. If the file at the
+        same path now holds a different speaker, serving the cached one is the
+        wrong answer the fail-loud contract exists to avoid."""
+        module, _ = _fake_voiceclonnx(self)
+        v = _bare_voice(self)
+        with tempfile.TemporaryDirectory() as d:
+            ref = _ref_wav(d)
+            cfg = SynthesisConfig(vc_reference=ref)
+            first = v._load_voice_conversion(cfg)
+            _write_wav(ref, np.full(16000, 0.4, dtype=np.float32), 16000)
+            second = v._load_voice_conversion(cfg)
+            self.assertEqual(module.VoiceCloner.call_count, 2)
+            self.assertIsNot(first, second)
+            # the cloner now reads the speaker that is on disk now
+            np.testing.assert_allclose(load_reference_audio(second.ref_path)[0],
+                                       load_reference_audio(ref)[0],
+                                       atol=2.0 / 32768.0)
+
+    def test_in_memory_references_with_equal_content_share_a_cloner(self):
+        """The cache key is the reference's content, not its object identity —
+        two equal arrays must not each pay for a fresh ONNX load, and two
+        different ones must never collide."""
+        module, _ = _fake_voiceclonnx(self)
+        v = _bare_voice(self)
+        audio = np.linspace(-0.5, 0.5, 16000, dtype=np.float32)
+        v._load_voice_conversion(SynthesisConfig(vc_reference=(audio, 16000)))
+        v._load_voice_conversion(SynthesisConfig(vc_reference=(audio.copy(), 16000)))
+        module.VoiceCloner.assert_called_once()
+        v._load_voice_conversion(SynthesisConfig(vc_reference=(audio * -1, 16000)))
+        self.assertEqual(module.VoiceCloner.call_count, 2)
+
+    def test_url_reference_goes_through_the_guarded_fetcher(self):
+        """A remote reference must be fetched by phoonnx.reference_audio, whose
+        address and size limits are the only thing standing between a caller's
+        URL and an internal service."""
+        _fake_voiceclonnx(self)
+        with tempfile.TemporaryDirectory() as d:
+            local = _ref_wav(d)
+            with patch("phoonnx.reference_audio.fetch_reference_audio",
+                       return_value=local) as fetch:
+                vc = _bare_voice(self)._load_voice_conversion(
+                    SynthesisConfig(vc_reference="https://example.invalid/a.wav"))
+            fetch.assert_called_once_with("https://example.invalid/a.wav")
+            self.assertTrue(os.path.isfile(vc.ref_path))
+
+    def test_changing_engine_rebuilds(self):
+        module, _ = _fake_voiceclonnx(self)
+        v = _bare_voice(self)
+        with tempfile.TemporaryDirectory() as d:
+            ref = _ref_wav(d)
+            v._load_voice_conversion(SynthesisConfig(vc_reference=ref))
+            v._load_voice_conversion(
+                SynthesisConfig(vc_reference=ref, vc_engine="focalcodec"))
+        self.assertEqual(module.VoiceCloner.call_count, 2)
+
+    def test_per_call_disable_wins_over_a_loaded_cloner(self):
+        """vc_reference is a per-synthesis runtime knob: a voice that already
+        loaded a cloner still yields native audio when the caller's config says
+        off."""
+        _fake_voiceclonnx(self)
+        v = _bare_voice(self)
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNotNone(
+                v._load_voice_conversion(SynthesisConfig(vc_reference=_ref_wav(d))))
+        self.assertIsNone(v._load_voice_conversion(SynthesisConfig()))
+
+    def test_missing_reference_file_raises(self):
+        _fake_voiceclonnx(self)
+        cfg = SynthesisConfig(vc_reference="/nope/does/not/exist.wav")
+        with self.assertRaises(FileNotFoundError) as ctx:
+            _bare_voice(self)._load_voice_conversion(cfg)
+        self.assertIn("does/not/exist.wav", str(ctx.exception))
+
+    def test_in_memory_reference_is_materialized_to_a_wav(self):
+        _fake_voiceclonnx(self)
+        audio = np.linspace(-0.5, 0.5, 16000, dtype=np.float32)
+        vc = _bare_voice(self)._load_voice_conversion(
+            SynthesisConfig(vc_reference=(audio, 16000)))
+        self.assertTrue(os.path.isfile(vc.ref_path))
+        back, sr = load_reference_audio(vc.ref_path)
+        self.assertEqual(sr, 16000)
+        self.assertEqual(back.shape, audio.shape)
+
+    def test_reference_wav_dies_with_the_voice(self):
+        """The materialized copy is owned by the loaded conversion, so dropping
+        the voice takes the temp file with it rather than orphaning it."""
+        _fake_voiceclonnx(self)
+        v = _bare_voice(self)
+        audio = np.linspace(-0.5, 0.5, 16000, dtype=np.float32)
+        ref_path = v._load_voice_conversion(
+            SynthesisConfig(vc_reference=(audio, 16000))).ref_path
+        self.assertTrue(os.path.isfile(ref_path))
+        del v
+        gc.collect()
+        self.assertFalse(os.path.exists(ref_path))
+
+    def test_load_failure_propagates(self):
+        module, _ = _fake_voiceclonnx(self)
+        module.VoiceCloner.side_effect = RuntimeError("bad weights")
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(RuntimeError):
+                _bare_voice(self)._load_voice_conversion(
+                    SynthesisConfig(vc_reference=_ref_wav(d)))
+
+
+class TestMaybeConvert(unittest.TestCase):
+    def test_none_cloner_is_passthrough(self):
+        audio = np.zeros(16000, dtype=np.float32)
+        out, sr = TTSVoice._maybe_convert(audio, None, 22050)
+        self.assertIs(out, audio)
+        self.assertEqual(sr, 22050)
+
+    def test_converts_and_returns_engine_sr(self):
+        cloner = MagicMock()
+        cloner.sample_rate = 22050
+
+        def fake_clone(src, ref, dst):
+            _write_wav(dst, np.zeros(11025, dtype=np.float32), 22050)
+            return dst
+
+        cloner.clone_voice.side_effect = fake_clone
+        audio = np.linspace(-0.5, 0.5, 16000, dtype=np.float32)
+        out, sr = TTSVoice._maybe_convert(audio, _vc(cloner, "/ref.wav"), 16000)
+        self.assertEqual(sr, 22050)
+        self.assertEqual(out.dtype, np.float32)
+        self.assertEqual(out.shape[0], 11025)
+
+    def test_source_written_at_the_engine_native_rate(self):
+        """The chunk goes to disk at the voice's own rate — voiceclonnx accepts
+        any input rate and resamples internally, so no lossy pre-resample."""
+        seen = {}
+        cloner = MagicMock()
+
+        def fake_clone(src, ref, dst):
+            seen["audio"], seen["sr"] = load_reference_audio(src)
+            seen["ref"] = ref
+            _write_wav(dst, np.zeros(100, dtype=np.float32), 24000)
+            return dst
+
+        cloner.clone_voice.side_effect = fake_clone
+        audio = np.linspace(-0.5, 0.5, 22050, dtype=np.float32)
+        TTSVoice._maybe_convert(audio, _vc(cloner, "/tgt.wav"), 22050)
+        self.assertEqual(seen["sr"], 22050)
+        self.assertEqual(seen["ref"], "/tgt.wav")
+        self.assertLess(np.max(np.abs(seen["audio"] - audio)), 2.0 / 32768.0)
+
+    def test_very_short_chunk_passes_through_unconverted(self):
+        cloner = MagicMock()
+        audio = np.zeros(1000, dtype=np.float32)  # 62 ms at 16 kHz
+        out, sr = TTSVoice._maybe_convert(audio, _vc(cloner, "/ref.wav"), 16000)
+        self.assertIs(out, audio)
+        self.assertEqual(sr, 16000)
+        cloner.clone_voice.assert_not_called()
+
+    def test_conversion_failure_propagates(self):
+        """Unlike super-resolution, a VC failure must not silently fall back:
+        emitting the source speaker is a wrong answer, not a degraded one."""
+        cloner = MagicMock()
+        cloner.clone_voice.side_effect = RuntimeError("boom")
+        with self.assertRaises(RuntimeError):
+            TTSVoice._maybe_convert(np.zeros(16000, dtype=np.float32),
+                                    _vc(cloner, "/ref.wav"), 16000)
+
+    def test_temp_files_are_cleaned_up_even_on_failure(self):
+        cloner = MagicMock()
+        before = set(os.listdir(tempfile.gettempdir()))
+        cloner.clone_voice.side_effect = RuntimeError("boom")
+        with self.assertRaises(RuntimeError):
+            TTSVoice._maybe_convert(np.zeros(16000, dtype=np.float32),
+                                    _vc(cloner, "/ref.wav"), 16000)
+        leaked = [n for n in set(os.listdir(tempfile.gettempdir())) - before
+                  if n.startswith("phoonnx_vc_")]
+        self.assertEqual(leaked, [])
+
+
+class TestSynthesisPipelineWiring(unittest.TestCase):
+    """The stage must be invisible when off, and ordered VC -> SR when on."""
+
+    def _voice(self):
+        from phoonnx.config import Alphabet
+
+        v = TTSVoice.__new__(TTSVoice)
+        v.config = MagicMock(sample_rate=22050, alphabet=Alphabet.IPA)
+        v.phonetic_spellings = None
+        v._sr_engine = None
+        v._sr_loaded = False
+        v._vc = None
+        v._vc_key = None
+        return v
+
+    def _run(self, cfg):
+        v = self._voice()
+        audio = np.linspace(-0.5, 0.5, 22050, dtype=np.float32)
+        with patch.object(TTSVoice, "_iter_synthesis_ids",
+                          return_value=iter([(["a"], [1, 2, 3])])), \
+                patch.object(TTSVoice, "phoneme_ids_to_audio", return_value=audio):
+            return list(TTSVoice.synthesize(v, "hello", syn_config=cfg))
+
+    def test_unset_is_byte_identical_to_the_native_path(self):
+        """The no-op guarantee, pinned in both directions."""
+        with patch.dict(sys.modules):
+            sys.modules.pop("voiceclonnx", None)
+            baseline = self._run(SynthesisConfig())
+            explicit_off = self._run(SynthesisConfig(vc_reference=None))
+            self.assertNotIn("voiceclonnx", sys.modules)
+        self.assertEqual(len(baseline), 1)
+        self.assertEqual(baseline[0].sample_rate, 22050)
+        np.testing.assert_array_equal(baseline[0].audio_float_array,
+                                      explicit_off[0].audio_float_array)
+        self.assertEqual(baseline[0].audio_int16_bytes,
+                         explicit_off[0].audio_int16_bytes)
+
+    def test_set_converts_the_chunk_and_reports_the_vc_rate(self):
+        _, cloner = _fake_voiceclonnx(self, sample_rate=24000)
+
+        def fake_clone(src, ref, dst):
+            _write_wav(dst, np.full(12000, 0.25, dtype=np.float32), 24000)
+            return dst
+
+        cloner.clone_voice.side_effect = fake_clone
+        with tempfile.TemporaryDirectory() as d:
+            chunks = self._run(SynthesisConfig(vc_reference=_ref_wav(d)))
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].sample_rate, 24000)
+        self.assertEqual(chunks[0].audio_float_array.shape[0], 12000)
+        cloner.clone_voice.assert_called_once()
+
+    def test_in_flight_synthesis_keeps_its_own_speaker(self):
+        """One voice serves every caller. A synthesis already streaming must keep
+        converting with the cloner and reference file it started on, even when a
+        genuine second load for a different speaker replaces the voice's cache
+        underneath it — including the reference WAV, which the engine re-reads on
+        every chunk."""
+        cloners = [MagicMock(name="a"), MagicMock(name="b")]
+        for c in cloners:
+            c.sample_rate = 16000
+        module = types.ModuleType("voiceclonnx")
+        module.VoiceCloner = MagicMock(side_effect=cloners)
+        patcher = patch.dict(sys.modules, {"voiceclonnx": module})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        seen = []
+
+        def fake_clone(src, ref, dst):
+            seen.append((ref, os.path.isfile(ref)))
+            _write_wav(dst, np.zeros(8000, dtype=np.float32), 16000)
+            return dst
+
+        for c in cloners:
+            c.clone_voice.side_effect = fake_clone
+
+        v = self._voice()
+        audio = np.linspace(-0.5, 0.5, 22050, dtype=np.float32)
+        with tempfile.TemporaryDirectory() as d, \
+                patch.object(TTSVoice, "_iter_synthesis_ids",
+                             return_value=iter([(["a"], [1]), (["b"], [2]),
+                                                (["c"], [3])])), \
+                patch.object(TTSVoice, "phoneme_ids_to_audio", return_value=audio):
+            mine = _ref_wav(d)
+            theirs = _write_wav(os.path.join(d, "theirs.wav"),
+                                np.full(16000, 0.3, dtype=np.float32), 16000)
+            stream = TTSVoice.synthesize(
+                v, "one. two. three.",
+                syn_config=SynthesisConfig(vc_reference=mine))
+            chunks = [next(stream)]
+            # a real second request for a different speaker, not a poked attribute
+            other = v._load_voice_conversion(SynthesisConfig(vc_reference=theirs))
+            self.assertIs(other.cloner, cloners[1])
+            chunks.extend(stream)
+
+        self.assertEqual(len(chunks), 3)
+        self.assertEqual(cloners[0].clone_voice.call_count, 3)
+        cloners[1].clone_voice.assert_not_called()
+        # all three chunks used one reference file, and it was readable each time
+        self.assertEqual(len({ref for ref, _ in seen}), 1)
+        self.assertTrue(all(existed for _, existed in seen))
+
+    def test_vc_runs_before_super_resolution(self):
+        """SR must upscale the converted timbre, and see the VC output rate."""
+        _, cloner = _fake_voiceclonnx(self, sample_rate=16000)
+
+        def fake_clone(src, ref, dst):
+            _write_wav(dst, np.zeros(8000, dtype=np.float32), 16000)
+            return dst
+
+        cloner.clone_voice.side_effect = fake_clone
+        sr_engine = MagicMock()
+        sr_engine.upscale.return_value = (np.zeros(24000, dtype=np.float32), 48000)
+        sr_module = types.ModuleType("audiosronnx")
+        sr_module.load_sr = MagicMock(return_value=sr_engine)
+        with patch.dict(sys.modules, {"audiosronnx": sr_module}), \
+                tempfile.TemporaryDirectory() as d:
+            chunks = self._run(SynthesisConfig(vc_reference=_ref_wav(d),
+                                               super_resolution=True))
+        self.assertEqual(chunks[0].sample_rate, 48000)
+        # the upscaler was handed the VC engine's rate, not the voice's native one
+        self.assertEqual(sr_engine.upscale.call_args.args[1], 16000)
+
+
+class TestVoiceConversionE2E(unittest.TestCase):
+    """Runs only when voiceclonnx and its weights are actually available."""
+
+    def test_real_conversion_changes_the_waveform_and_keeps_length(self):
+        try:
+            from voiceclonnx import VoiceCloner
+        except ImportError:
+            self.skipTest("voiceclonnx not installed")
+        try:
+            cloner = VoiceCloner(engine="openvoice")
+        except Exception as exc:  # weights download / runtime unavailable
+            self.skipTest(f"voice-conversion engine unavailable: {exc}")
+
+        sr = 22050
+        t = np.linspace(0, 2.0, 2 * sr, endpoint=False, dtype=np.float32)
+        audio = (0.3 * np.sin(2 * np.pi * 150 * t)
+                 * (1 + 0.5 * np.sin(2 * np.pi * 3 * t))).astype(np.float32)
+        with tempfile.TemporaryDirectory() as d:
+            ref = _ref_wav(d, sr=sr, seconds=3.0)
+            out, out_sr = TTSVoice._maybe_convert(audio, _vc(cloner, ref), sr)
+        self.assertEqual(out_sr, cloner.sample_rate)
+        self.assertEqual(out.dtype, np.float32)
+        self.assertGreater(out.shape[0], 0)
+        # duration is preserved within 15% (VC is not a duration model)
+        self.assertLess(abs(out.shape[0] / out_sr - audio.shape[0] / sr), 0.3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 via Claude Code — NOT human-reviewed. Verify before acting.

`SynthesisConfig` gains a voice-conversion post-stage. Set `vc_reference` to a target-speaker clip and every synthesized chunk is converted to that speaker after generation. Because it runs on the waveform it works with every phoonnx engine, including single-speaker models that have no cloning of their own, so one model gives you an unlimited number of voices. Conversion is done by [voiceclonnx](https://github.com/TigreGotico/voiceclonnx) — pure ONNX, no torch — shipped as the new `phoonnx[vc]` extra.

```python
SynthesisConfig(vc_reference="target_speaker.wav")            # default engine
SynthesisConfig(vc_reference="target.wav", vc_engine="knnvc") # explicit engine
```

This is a complement to native cloning, not an alternative. `speaker_reference` conditions the *model* on the reference and moves timbre and prosody together, but only cloning engines can do it; conversion is a second pass over the finished waveform that moves timbre only and is engine-agnostic. `docs/voice_conversion.md` says plainly when to prefer each — native cloning first, conversion when the voice cannot clone.

The stage is shaped like the existing super-resolution hook: `None` off by default, lazy import, engine cached on the voice, and the chunk reports the rate that came back with its samples. VC runs before SR so the upscaler sees the final timbre. The one deliberate divergence is that VC does not swallow failures — a super-resolution failure degrades quality, while a conversion failure emits the *wrong speaker*, which is a wrong answer. Missing package, missing reference and mid-stream conversion errors all raise. Conversion is applied per sentence rather than per utterance: every voiceclonnx engine is stateless across calls and conditions only on the reference, so the two are equivalent and per-sentence keeps synthesis streaming. Chunks under roughly 0.3 s pass through unconverted rather than becoming artefacts. Nothing is resampled on our side — voiceclonnx accepts any input rate and resamples internally — and no model management is added, because voiceclonnx downloads and caches its own weights from its own mirrors.

References go through `phoonnx.reference_audio.load_reference_audio`, the same guarded loader `speaker_reference` uses, so a URL reference is fetched under its address and size limits and non-WAV clips are decoded rather than handed to voiceclonnx raw. The cache is keyed on the engine plus the reference's *samples*, not on the path or URL that produced them, because a path is not a stable identity for a recording: a reference rewritten in place under the same name is a different speaker, and serving the previous one would be exactly the wrong answer the fail-loud contract exists to avoid. The cost is reading — and for a URL fetching — the reference once per `synthesize()` call, which the docs say plainly, with the in-memory tuple form as the way out.

The cloner and the materialized reference WAV it reads are one object rather than two cache slots, because voiceclonnx re-reads that file on every chunk. A request takes the pair as a local and holds it for its whole synthesis; a later call for a different speaker replaces the voice's cache slot without touching it, and the file is released by a `weakref.finalize` once nobody is converting to it. So a concurrent request can only cost a rebuild, never finish somebody's utterance in the wrong voice or with a reference deleted mid-stream, and the temp copy dies with the voice instead of being orphaned.

`vc_reference=None`, the default, is a strict no-op pinned in both directions: the yielded audio is byte-identical (`audio_int16_bytes`) to the native path and `voiceclonnx` is asserted absent from `sys.modules` afterwards.

Benchmarked over 5 utterances × 3 source engines (piper VITS, kokoro, kittentts) × 2 target speakers, with cosine similarity over `speakeronnx` `wespeaker-resnet34` and WER from `onnx-asr` `nemo-parakeet-tdt-0.6b-v2`. With the default `openvoice` engine, speaker similarity to the target beats the no-conversion floor on every pair — mean margin +0.24 cosine, worst pair +0.08 — while the negative control (similarity back to the *source*, which a pass-through would score ~1.0) peaks at 0.76. Word error rate rises +2.5 pp on average. `knnvc` transfers harder (mean margin +0.32, worst source leakage 0.43) but costs +9.3 pp mean WER and fails the intelligibility gate, so OpenVoice v2 is the default and kNN-VC stays one keyword away. `scripts/vc_gate.py` reproduces the whole matrix and exits non-zero when a gate fails; the audio under test is synthesized by phoonnx itself, so the run is offline and reproducible after the model downloads, and WER is word-level Levenshtein computed in-script rather than delegated to a library.

`tests/test_voice_conversion.py` carries 31 tests covering WAV round-trip fidelity, the lazy loader (default engine, content-keyed caching, rebuild on a changed speaker, a changed engine or a reference rewritten in place, per-call disable, actionable `ImportError` naming `phoonnx[vc]`, missing-reference `FileNotFoundError`, URL references routed through the guarded fetcher, in-memory reference materialisation, load-failure propagation), the conversion helper (rate reporting, source written at the native rate, short-chunk passthrough, no silent fallback, temp-file cleanup on failure), pipeline wiring (unset ⇒ byte-identical output with `voiceclonnx` never imported; VC ordered before SR and SR handed the VC rate; an in-flight synthesis completing all its chunks with its own cloner and a still-readable reference while a genuine second load for another speaker replaces the cache underneath it) a reference copy that dies with the voice, and a real-weights end-to-end run — voiceclonnx is in the `test` extra, so that last one executes in CI rather than skipping. All 31 fail before the change. The full non-training suite goes from 2606 passing on `dev` to 2637 here with a byte-identical failure set (28 pre-existing failures, all optional-dependency `ImportError`s for pandas/pyarrow, pyworld, speechonnxmetrics and transformers in this environment).

New `docs/voice_conversion.md`, linked from the docs index, `docs/cloning.md` and the `SynthesisConfig` reference in `docs/configuration.md`. `VOICES.md` is untouched — conversion is not a voice-index entry.

This touches `phoonnx/config.py` (`SynthesisConfig`) and `phoonnx/voice.py` (the synthesis loop), both shared across every engine, so it needs human review before merge. The no-op guarantee is test-pinned; the review should confirm the VC-before-SR ordering and the fail-loudly error contract are the calls we want.
