### PR TITLE
fix: fetch voice files through the shared HuggingFace cache

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -118,7 +118,11 @@ falls back to the bundled indexes, so a single voice can be fetched without runn
 phoonnx-voices download OpenVoiceOS/pipertts_es-ES_dii
 ```
 
-Files are saved to the XDG cache directory: `~/.cache/phoonnx/voices/<voice_id>/`
+Files are fetched with `huggingface_hub` straight into the shared HuggingFace
+cache (`~/.cache/huggingface/hub/` by default, or wherever `HF_HOME`/`HF_HUB_CACHE`
+points), the same place any other program on the machine keeps hub files. A model
+named by more than one voice, or already pulled by another tool, is stored once
+and reused, not downloaded again.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,13 +25,10 @@ phoonnx-voices download OpenVoiceOS/phoonnx_pt-PT_miro_tugaphone
 ```
 
 `update-cache` prints how many voices and languages are now available. `download` fetches the
-model into the per-voice cache directory:
-
-```
-~/.cache/phoonnx/voices/OpenVoiceOS/phoonnx_pt-PT_miro_tugaphone/
-├── model.onnx     # the ONNX voice
-└── model.json     # its configuration
-```
+model with `huggingface_hub`, straight into the shared HuggingFace cache
+(`~/.cache/huggingface/hub/` by default) — the model and its config land together in the
+voice's hub snapshot directory, alongside anything else on the machine that has already
+pulled the same files.
 
 The full command set is in the [CLI reference](cli.md); browsing and caching is covered in the
 [Voice manager](voice_manager.md) guide.

--- a/docs/voice_manager.md
+++ b/docs/voice_manager.md
@@ -99,21 +99,30 @@ the on-disk cache; `save()` writes the current in-memory voices back out.
 
 ## Cache Location
 
-Downloaded files for a voice are cached per voice under the XDG cache directory:
+Voice files are not kept in a phoonnx-owned directory. They are fetched with
+`huggingface_hub` and used exactly where it puts them: the shared HuggingFace hub
+cache (`~/.cache/huggingface/hub/` by default, or wherever `HF_HOME`/`HF_HUB_CACHE`
+points). A model named by many voices, or already pulled by another program on the
+machine, is stored once and reused rather than downloaded again — the model file,
+its config, tokenizer artifacts and any vocoder/style/speaker-encoder/auxiliary
+graphs all land in the same hub snapshot directory.
 
-```
-~/.cache/phoonnx/voices/<voice_id>/
-    model.onnx
-    model.json             (if the voice has a config_url)
-    tokens.txt             (Mimic3/Sherpa style, if applicable)
-    vocab.json             (Transformers style, if applicable)
-    tokenizer_config.json  (if applicable)
-    vocoder.onnx           (two-stage engines, if applicable)
-```
+A voice whose URL is not a HuggingFace file URL (a self-hosted or mirrored voice)
+cannot be served by the hub client, so it still gets a private copy under the hub
+cache instead; it just does not get the sharing/dedup benefit.
 
-`TTSModelInfo.voice_path` returns this directory
-(`~/.cache/phoonnx/voices/<voice_id>`). The voice catalog cache itself is a separate
-`JsonStorageXDG` under `phoonnx/voices`.
+`TTSModelInfo.voice_path` returns the directory the voice's primary graph lives in
+— the hub snapshot directory, or the private-copy directory for a non-hub URL.
+
+If you upgraded from an older phoonnx, voices already downloaded under the old
+`~/.cache/phoonnx/voices/<voice_id>/` layout are not reused; each voice is fetched
+once more into the hub cache. That old directory is safe to delete if you want the
+space back.
+
+The voice catalog cache is a separate thing from these model files: it is a
+`JsonStorageXDG` under `phoonnx/voices` in the XDG cache directory (see
+[`Basic Usage`](#basic-usage) above), and only holds the voice index, not any
+downloaded model.
 
 ## TTSModelInfo
 

--- a/phoonnx/cli.py
+++ b/phoonnx/cli.py
@@ -1,6 +1,7 @@
 import click
 from phoonnx.model_manager import TTSModelManager, TTSModelInfo
 import requests
+from huggingface_hub.errors import HfHubHTTPError
 
 
 # --- Helper Function for CLI Output ---
@@ -153,7 +154,10 @@ def download_voice(voice_id):
                 return
             click.echo(f"\nDownload complete.")
 
-    except requests.exceptions.RequestException as e:
+    except (HfHubHTTPError, requests.exceptions.RequestException) as e:
+        # Voice files come from the HuggingFace hub, so a network failure now
+        # surfaces as a hub error; a self-hosted voice still raises the
+        # requests error from the direct download path.
         click.echo(f"\nDownload failed due to network error: {e}", err=True)
     except Exception as e:
         click.echo(f"\nAn unexpected error occurred during download: {e}", err=True)

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -1,11 +1,17 @@
+import hashlib
 import onnxruntime
 import json
 import os
+import re
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Dict, List, Any, Sequence
 import requests
+from huggingface_hub import hf_hub_download
+from huggingface_hub.constants import HF_HUB_CACHE
+from huggingface_hub.errors import (EntryNotFoundError, LocalEntryNotFoundError,
+                                    OfflineModeIsEnabled)
 from json_database import JsonStorageXDG, JsonStorage
 
 from phoonnx.config import PhonemeType, get_phonemizer, VoiceConfig, Engine, Alphabet
@@ -33,12 +39,44 @@ def _is_cached(path: Path) -> bool:
         return False
 
 
+# The hub is asked for a file's metadata before its body. That call is one
+# small request, so it should give up long before the body timeout would: a
+# blackholed network otherwise stalls the caller for the full body budget
+# before the download it is blocking has even started.
+_ETAG_TIMEOUT = 10
+
+
+def _sidecar_url(url: str) -> str:
+    """The external-weights URL for ``url``, keeping any query intact.
+
+    The suffix belongs on the path, not on the end of the string: appending it
+    to ``model.onnx?download=true`` yields ``download=true_data``, a query the
+    hub ignores, so the request comes back as the graph itself. The sidecar
+    then looks like it was fetched when it never was, and the graph is handed
+    to onnxruntime with its weights missing.
+    """
+    head, sep, tail = url.partition("?")
+    return f"{head}_data{sep}{tail}"
+
+
 def _expected_size(response) -> Optional[int]:
-    """Content-Length of a response, or None when absent/unusable."""
+    """Content-Length of a response, or None when absent/unusable.
+
+    A compressed response is a deliberate ``None``: ``Content-Length`` then
+    counts the bytes on the wire, while the stream below yields the decoded
+    body, so comparing the two condemns a download that arrived intact.
+    """
     try:
-        raw = response.headers.get("Content-Length")
+        headers = response.headers
     except AttributeError:
         return None
+    try:
+        encoding = (headers.get("Content-Encoding") or "").strip().lower()
+    except AttributeError:
+        encoding = ""
+    if encoding and encoding != "identity":
+        return None
+    raw = headers.get("Content-Length")
     if not isinstance(raw, (str, int)) or isinstance(raw, bool):
         return None
     try:
@@ -47,14 +85,18 @@ def _expected_size(response) -> Optional[int]:
         return None
 
 
-def _stream_to_file(url: str, dest: Path, timeout: int = 120) -> Path:
-    """Stream ``url`` into ``dest`` atomically.
+
+def _direct_stream(url: str, dest: Path, timeout: int = 120) -> Path:
+    """Stream ``url`` into ``dest`` atomically, outside the shared cache.
 
     The body is written to a sibling ``.part`` file and only renamed onto
     ``dest`` once it has been fully received (and matches ``Content-Length``,
     when the server sends one). An interrupted download therefore leaves at
     most a stale ``.part`` file, never a truncated artifact that later runs
     would mistake for a complete one.
+
+    This is the path for a self-hosted or mirrored voice, which the hub client
+    cannot serve. It gets a private copy.
     """
     tmp = _tmp_path(dest)
     written = 0
@@ -77,51 +119,97 @@ def _stream_to_file(url: str, dest: Path, timeout: int = 120) -> Path:
     return dest
 
 
-def _write_bytes_atomic(dest: Path, data: bytes) -> Path:
-    """Write ``data`` to ``dest`` via a sibling ``.part`` file + rename."""
-    tmp = _tmp_path(dest)
-    try:
-        tmp.write_bytes(data)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
-    os.replace(tmp, dest)
-    return dest
+def _direct_dir(url: str) -> Path:
+    """Where a file the hub cannot serve is kept.
 
+    Self-hosted and mirrored voices still have to land somewhere, and that
+    somewhere has the same requirement as a hub snapshot: a graph and the
+    external-data sidecar it names must share one directory, or onnxruntime
+    refuses to follow the reference. The directory is keyed by the URL's own
+    directory, so files published together stay together.
 
-def _write_json_atomic(dest: Path, data: Any) -> Path:
-    """Serialize ``data`` to ``dest`` via a sibling ``.part`` file + rename."""
-    tmp = _tmp_path(dest)
-    try:
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=4)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
-    os.replace(tmp, dest)
-    return dest
-
-
-def _load_cached_json(path: Path) -> Optional[Dict[str, Any]]:
-    """Load a cached JSON file, self-healing a corrupt one.
-
-    Returns ``None`` when the file is missing, empty or undecodable; in the
-    corrupt case the file is unlinked so the caller re-downloads it once
-    instead of failing forever on a bad cache entry.
+    It lives inside the HuggingFace cache, not in a phoonnx-owned one. There is
+    exactly one place voice files are kept, and ``HF_HOME`` moves all of it.
     """
-    if not _is_cached(path):
-        path.unlink(missing_ok=True)
+    base = url.split("?")[0].rsplit("/", 1)[0]
+    digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:32]
+    return Path(HF_HUB_CACHE) / "phoonnx-direct" / digest
+
+
+def _resolve(url: str, timeout: int = 120) -> Path:
+    """Give the local path of ``url``, downloading it once.
+
+    Hub files are fetched with the hub client and used exactly where it puts
+    them: one copy per file and revision, in the cache the rest of the machine
+    already shares, so a model named by hundreds of voices is stored once and a
+    model another program has already pulled is not pulled again. Nothing is
+    copied or linked out of it — a graph that names an external-data sidecar
+    only loads from the directory that holds both, and that is the hub's.
+
+    A URL the hub cannot serve is streamed into :func:`_direct_dir` instead,
+    with a warning, because breaking self-hosted voices costs more than the
+    duplicate copy they keep.
+
+    Raises:
+        huggingface_hub.errors.EntryNotFoundError: no such file on the hub.
+        requests.exceptions.RequestException: the direct download failed.
+    """
+    cached = _hf_fetch(url, timeout)
+    if cached is not None:
+        return cached
+    _warn_offhub(url)
+    dest = _direct_dir(url) / (url.split("?")[0].rsplit("/", 1)[-1] or "artifact")
+    if _is_cached(dest):
+        return dest
+    return _direct_stream(url, dest, timeout)
+
+
+_HF_URL = re.compile(
+    r"https?://huggingface\.co/(?P<repo>[^/]+/[^/]+)/(?:resolve|raw)/(?P<rev>[^/]+)/(?P<path>.+)")
+
+# Raised by the hub client when the file, not the network, is the problem, and
+# when the client is offline with nothing cached. Both mean "no file here".
+_NO_SUCH_FILE = (EntryNotFoundError, OfflineModeIsEnabled, LocalEntryNotFoundError)
+
+
+def _hf_fetch(url: str, timeout: int = 120) -> Optional[Path]:
+    """Give the shared HuggingFace cache path for ``url``, downloading it once.
+
+    Both hub file forms are understood: ``/resolve/<rev>/`` (the form the voice
+    index uses) and ``/raw/<rev>/``, which serves the same bytes for the small
+    text artifacts.
+
+    Returns ``None`` for a URL the hub cannot serve — a self-hosted or mirrored
+    voice. Those are rare but legitimate, so the caller downloads them
+    directly; they just do not get the deduplication.
+    """
+    match = _HF_URL.match(url.split("?")[0])
+    if not match:
         return None
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
-        LOG.warning(f"discarding corrupt cached json '{path}': {e}")
-        path.unlink(missing_ok=True)
-        return None
+    return Path(hf_hub_download(repo_id=match["repo"],
+                                filename=match["path"],
+                                revision=match["rev"],
+                                etag_timeout=min(timeout, _ETAG_TIMEOUT)))
+
+
+def _warn_offhub(url: str) -> None:
+    LOG.warning(f"not a HuggingFace file URL, so this download is a private copy "
+                f"that no other voice or program can share: {url}")
+
+
+def _read_json(path: Path) -> Any:
+    """Parse the JSON at ``path``."""
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _hub_json(url: str) -> Any:
+    """Give the parsed JSON at ``url``, from the shared cache."""
+    return _read_json(_resolve(url))
 
 
 @dataclass
+
 class TTSModelInfo:
     voice_id: str
     lang: str  # not always present in config.json and often wrong if present
@@ -260,7 +348,7 @@ class TTSModelInfo:
                                                      alphabet=alphabet,
                                                      phoneme_type=phoneme_type,
                                                      engine=engine,
-                                                     tokens_txt=str(self.voice_path / "tokens.txt"),
+                                                     tokens_txt=str(self.hub_path(self.tokens_url) or ""),
                                                      lang_code=lang_code)
             else:
                 self._config = VoiceConfig.from_dict(config,
@@ -305,216 +393,119 @@ class TTSModelInfo:
             except (AttributeError, KeyError):
                 LOG.warning(f"Could not format display_name for {self.voice_id}.")
 
+    def hub_path(self, url: Optional[str]) -> Optional[Path]:
+        """Give the local path of ``url``, downloading it if needed.
+
+        The path is the one the file already lives at — the hub's, or the
+        directory a self-hosted voice was streamed into. Nothing is copied out
+        of either, because a graph only loads from the directory that also
+        holds the sidecar it names.
+
+        ``None`` only when there is no URL to fetch.
+        """
+        if not url:
+            return None
+        return _resolve(url)
+
     @property
     def voice_path(self) -> Path:
-        return Path(os.path.expanduser("~")) / ".cache" / "phoonnx" / "voices" / self.voice_id
+        """The directory this voice's graph lives in.
+
+        The hub's snapshot directory, or the direct-download directory for a
+        voice the hub cannot serve. phoonnx owns neither: there is no
+        phoonnx-managed voice cache any more, so nothing here is a copy.
+        """
+        return self.download_model().parent
 
     def download_config(self) -> Dict[str, Any]:
-        """
-        Ensure the model configuration file exists locally and return its parsed contents.
-        
-        If the configuration file is not present in the voice cache directory, download it from the instance's configured URL and save it as model.json; otherwise load the existing file.
-        
-        Returns:
-            dict: Parsed JSON configuration for the TTS model.
-        """
-        config_path = self.voice_path / "model.json"
-        cached = _load_cached_json(config_path)
-        if cached is not None:
-            return cached
-        r = requests.get(self.config_url, timeout=30)
-        r.raise_for_status()
-        cfg = r.json()  # validate received json
-        _write_json_atomic(config_path, cfg)
-        return cfg
+        """Give the voice's model configuration, from the hub cache."""
+        path = self.hub_path(self.config_url)
+        return _read_json(path) if path else {}
 
     def download_tokenizer_config(self) -> Dict[str, Any]:
-        """
-        Download and cache the tokenizer configuration for this voice, returning it as a parsed dictionary.
-        
-        If a local cached file exists, it is loaded and returned; otherwise the configuration is fetched from the configured URL, saved to the voice cache, and returned.
-        
-        Returns:
-            dict: The tokenizer configuration parsed from JSON.
-        
-        Raises:
-            requests.HTTPError: If the HTTP request for the tokenizer configuration returns an error status.
-            json.JSONDecodeError: If a retrieved or cached file contains invalid JSON.
-        """
-        config_path = self.voice_path / "tokenizer_config.json"
-        cached = _load_cached_json(config_path)
-        if cached is not None:
-            return cached
-        r = requests.get(self.tokenizer_config_url, timeout=30)
-        r.raise_for_status()
-        cfg = r.json()  # validate received json
-        _write_json_atomic(config_path, cfg)
-        return cfg
+        """Give the tokenizer configuration, from the hub cache."""
+        path = self.hub_path(self.tokenizer_config_url)
+        return _read_json(path) if path else {}
 
     def download_vocab(self) -> Dict[str, Any]:
-        """
-        Load the voice vocabulary from the local cache or download it from the configured URL.
-        
-        If a cached vocab.json exists in the voice's cache directory, it is read and returned.
-        If no cached file exists and `vocab_url` is set, the vocabulary JSON is fetched from that URL,
-        saved to the cache as vocab.json (UTF-8), and the parsed dictionary is returned.
-        
-        Returns:
-            dict: The vocabulary mapping loaded from vocab.json.
-        
-        Raises:
-            requests.RequestException: On network errors or non-success HTTP responses.
-            OSError: On file read/write errors.
-        """
-        vocab_path = self.voice_path / "vocab.json"
-        cached = _load_cached_json(vocab_path)
-        if cached is not None:
-            return cached
-        if not self.vocab_url:
-            # preserve the historical error for a missing, un-downloadable vocab
-            with open(vocab_path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        r = requests.get(self.vocab_url, timeout=30)
-        r.raise_for_status()
-        cfg = r.json()
-        _write_json_atomic(vocab_path, cfg)
-        return cfg
+        """Give the vocabulary, from the cache or from the index entry."""
+        if self.vocab_override:
+            return self.vocab_override
+        path = self.hub_path(self.vocab_url)
+        return _read_json(path) if path else {}
 
     def download_tokens_txt(self) -> str:
-        """
-        Ensure a local tokens.txt exists for this voice and return its contents.
-        
-        If `tokens_url` is set and the file does not exist in the voice cache directory, download the tokens file, save it to the cache using UTF-8 encoding, and return its text. If the file already exists, read and return its contents.
-        
-        Returns:
-            str: Contents of the tokens file.
-        
-        Raises:
-            requests.exceptions.RequestException: If the HTTP request to `tokens_url` fails or the response status is not successful.
-        """
-        tokens_path = self.voice_path / "tokens.txt"
-        if self.tokens_url and not _is_cached(tokens_path):
-            tokens_path.unlink(missing_ok=True)  # discard an empty/partial cache
-            r = requests.get(self.tokens_url, timeout=30)
-            r.raise_for_status()
-            tokens = r.text
-            _write_bytes_atomic(tokens_path, tokens.encode("utf-8"))
-            return tokens
-        with open(tokens_path, "r", encoding="utf-8") as f:
-            return f.read()
+        """Give the token list, from the hub cache."""
+        path = self.hub_path(self.tokens_url)
+        return path.read_text(encoding="utf-8") if path else ""
 
-    def _fetch_onnx(self, url: str, dest: Path) -> Path:
-        """Download an ONNX graph (and its external-data sidecar, if present) into the
-        voice cache.
+    def _fetch_onnx(self, url: str) -> Path:
+        """Give the local path of an ONNX graph, with its sidecar alongside.
 
-        A graph with external weights references them by the original
-        ``<name>.onnx_data`` filename, so that sidecar is saved under exactly that name
-        next to the graph for the reference to resolve. Chatterbox's four graphs all use
-        external data; single-file graphs (piper/vits exports) simply have no sidecar.
+        A graph with external weights names its sidecar by filename and
+        onnxruntime resolves that name against the directory the graph itself
+        resolves to, so the two must share a directory. Fetching the sidecar
+        from the same source puts it there, and the graph loads where it lies.
+        Single-file graphs (piper/vits exports) simply have no sidecar.
 
-        A missing sidecar may surface as an HTTP 404 (online) or as a connection
-        error (offline); both mean "no sidecar here", so a fully-cached voice loads
-        without the probe crashing when there is no network.
+        "No sidecar" and "the sidecar failed to arrive" are not the same
+        answer. The sidecar carries the weights, so a failure that is mistaken
+        for absence produces a graph that loads and then synthesizes silence.
+        Only a 404, and being offline with nothing cached, count as absence.
         """
-        if not _is_cached(dest):
-            _stream_to_file(url, dest)
-        data_dest = dest.parent / (url.split("/")[-1] + "_data")   # e.g. model_q4.onnx_data
-        if not _is_cached(data_dest):
-            try:
-                with requests.get(url + "_data", timeout=600, stream=True) as r:
-                    if r.status_code != 404:
-                        r.raise_for_status()
-                        tmp = _tmp_path(data_dest)
-                        try:
-                            with open(tmp, "wb") as f:
-                                for chunk in r.iter_content(chunk_size=8192):
-                                    if chunk:
-                                        f.write(chunk)
-                        except BaseException:
-                            tmp.unlink(missing_ok=True)
-                            raise
-                        os.replace(tmp, data_dest)
-            except requests.exceptions.RequestException as e:
-                # Offline/DNS/timeout: treat like a 404 (sidecar simply absent) so a
-                # fully-cached voice still loads; a genuinely needed sidecar surfaces
-                # later when the graph is loaded.
-                LOG.debug(f"external-data sidecar unavailable for '{url}': {e}")
-        return dest
+        path = _resolve(url)
+        try:
+            _resolve(_sidecar_url(url))
+        except _NO_SUCH_FILE as e:
+            # There is no sidecar at that URL, or we are offline and have never
+            # seen one; a single-file graph loads fine either way.
+            LOG.debug(f"external-data sidecar unavailable for '{url}': {e}")
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout) as e:
+            # Offline/DNS/timeout on the direct (non-hub) path.
+            LOG.debug(f"external-data sidecar unavailable for '{url}': {e}")
+        except requests.exceptions.HTTPError as e:
+            # Only a 404 means "no sidecar here". Anything else — a 500, a 403,
+            # a status we cannot read — is a real failure and must not be
+            # swallowed.
+            if getattr(getattr(e, "response", None), "status_code", None) != 404:
+                raise
+            LOG.debug(f"external-data sidecar unavailable for '{url}': {e}")
+        return path
 
     def download_model(self) -> Path:
-        """Download the primary ONNX graph (+ external-data sidecar, if any)."""
-        return self._fetch_onnx(self.model_url, self.voice_path / "model.onnx")
+        """Give the ONNX graph's path in the hub cache."""
+        return self._fetch_onnx(self.model_url)
 
     def download_vocoder(self) -> Optional[Path]:
-        """
-        Download the separate vocoder ONNX (and optional config) for two-stage
-        engines such as Matcha-TTS into the voice cache directory.
-
-        Returns the local vocoder path, or ``None`` if this voice has no
-        ``vocoder_url``.
-        """
+        """Give the vocoder graph's path, for two-stage engines."""
         if not self.vocoder_url:
             return None
-        vocoder_path = self.voice_path / "vocoder.onnx"
-        if not _is_cached(vocoder_path):
-            _stream_to_file(self.vocoder_url, vocoder_path)
-        if self.vocoder_config_url:
-            vocoder_cfg_path = self.voice_path / "vocoder.json"
-            if _load_cached_json(vocoder_cfg_path) is None:
-                r = requests.get(self.vocoder_config_url, timeout=30)
-                r.raise_for_status()
-                _write_json_atomic(vocoder_cfg_path, r.json())
-        return vocoder_path
+        return self._fetch_onnx(self.vocoder_url)
 
     def download_style(self) -> Optional[Path]:
-        """Download the per-voice StyleTTS2/Kokoro style embedding, if any."""
-        if not self.style_url:
-            return None
-        style_path = self.voice_path / "style.bin"
-        if not _is_cached(style_path):
-            _stream_to_file(self.style_url, style_path)
-        return style_path
+        """Give the style embedding's path, if this voice has one."""
+        return self.hub_path(self.style_url)
 
     def download_speaker_encoder(self) -> Optional[Path]:
-        """Download the speaker-encoder ONNX (cloning models), if any."""
+        """Give the speaker encoder's path, if this voice has one."""
         if not self.speaker_encoder_url:
             return None
-        enc_path = self.voice_path / "speaker_encoder.onnx"
-        if not _is_cached(enc_path):
-            _stream_to_file(self.speaker_encoder_url, enc_path)
-        return enc_path
+        return self._fetch_onnx(self.speaker_encoder_url)
 
     def download_aux_models(self) -> Dict[str, Path]:
-        """Download the auxiliary graphs and assets of multi-graph engines.
-
-        Returns {engine_params_key: local_path}. An ``.onnx`` entry goes through
-        :meth:`_fetch_onnx`, so a graph with external weights gets its
-        ``<name>.onnx_data`` sidecar too; without it the graph loads only until
-        onnxruntime looks for the weights. Non-ONNX assets (tokenizer JSON, speaker
-        embeddings) are plain downloads.
-        """
-        paths: Dict[str, Path] = {}
+        """Give the auxiliary graphs' paths, keyed as the engine expects."""
+        out: Dict[str, Path] = {}
         for key, url in (self.aux_model_urls or {}).items():
-            fname = url.rsplit("/", 1)[-1] or f"{key}.onnx"
-            aux_path = self.voice_path / fname
-            if fname.endswith(".onnx"):
-                self._fetch_onnx(url, aux_path)
-            elif not _is_cached(aux_path):
-                _stream_to_file(url, aux_path)
-            paths[key] = aux_path
-        return paths
+            if not url:
+                continue
+            out[key] = (self._fetch_onnx(url) if str(url).endswith(".onnx")
+                        else _resolve(url))
+        return out
 
     def download_bpe_tokenizer(self) -> Optional[Path]:
-        """Download the HF ``tokenizer.json`` (Chatterbox subword BPE) from
-        ``tokenizer_config_url``, if any."""
-        if not self.tokenizer_config_url:
-            return None
-        path = self.voice_path / "tokenizer.json"
-        if _load_cached_json(path) is None:
-            r = requests.get(self.tokenizer_config_url, timeout=60)
-            r.raise_for_status()
-            _write_bytes_atomic(path, r.content)
-        return path
+        """Give the BPE tokenizer's path in the hub cache."""
+        return self.hub_path(self.tokenizer_config_url)
 
     def engine_params(self) -> Dict[str, Any]:
         """
@@ -537,23 +528,13 @@ class TTSModelInfo:
             params["vocoder_path"] = str(vocoder_path)
             if self.vocoder_type:
                 params["vocoder_type"] = self.vocoder_type
-            vocoder_cfg_path = self.voice_path / "vocoder.json"
-            if vocoder_cfg_path.is_file():
-                with open(vocoder_cfg_path, "r", encoding="utf-8") as f:
-                    params["vocoder_config"] = json.load(f)
+            if self.vocoder_config_url:
+                params["vocoder_config"] = _hub_json(self.vocoder_config_url)
         elif self.vocoder_type:
             # Parametric vocoder (e.g. Griffin-Lim) — no model file, just config.
             params["vocoder_type"] = self.vocoder_type
             if self.vocoder_config_url:
-                cfg_path = self.voice_path / "vocoder.json"
-                cached = _load_cached_json(cfg_path)
-                if cached is None:
-                    r = requests.get(self.vocoder_config_url, timeout=30)
-                    r.raise_for_status()
-                    _write_bytes_atomic(cfg_path, r.content)
-                    with open(cfg_path, "r", encoding="utf-8") as f:
-                        cached = json.load(f)
-                params["vocoder_config"] = cached
+                params["vocoder_config"] = _hub_json(self.vocoder_config_url)
 
         # Chatterbox's three auxiliary graphs (the language_model is the primary model).
         for url, key, fname in (
@@ -562,7 +543,7 @@ class TTSModelInfo:
             (self.conditional_decoder_url, "conditional_decoder_path", "conditional_decoder.onnx"),
         ):
             if url:
-                params[key] = str(self._fetch_onnx(url, self.voice_path / fname))
+                params[key] = str(self._fetch_onnx(url))
         return params
 
     def download_all(self) -> Path:
@@ -612,12 +593,11 @@ class TTSModelInfo:
         Returns:
             TTSVoice: The configured TTSVoice instance ready for synthesis.
         """
-        model_path = self.voice_path / "model.onnx"
-        config_path = self.voice_path / "model.json"
-        vocab_path = self.voice_path / "vocab.json"
-        tokenizer_config_path = self.voice_path / "tokenizer_config.json"
-        tokens_path = self.voice_path / "tokens.txt"
-        self.download_model()
+        model_path = self.download_model()
+        config_path = self.hub_path(self.config_url)
+        vocab_path = self.hub_path(self.vocab_url)
+        tokenizer_config_path = self.hub_path(self.tokenizer_config_url)
+        tokens_path = self.hub_path(self.tokens_url)
 
         # Voices without a published config.json (Chatterbox) can't be engine-detected
         # from files on disk — build the voice from the index-derived VoiceConfig, which

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "unicode_rbnf",
     "click",
     "requests",
+    "huggingface_hub",
     "json_database",
     "ovos-plugin-manager>=2.1.0",
     "ovos-utils",

--- a/tests/test_f5tts.py
+++ b/tests/test_f5tts.py
@@ -267,8 +267,11 @@ def test_aux_model_urls_resolved_in_engine_params(tmp_path, monkeypatch):
         engine="f5tts",
         aux_model_urls={"preprocess_path": "https://example.com/F5_Preprocess.onnx",
                         "decode_path": "https://example.com/F5_Decode.onnx"})
-    monkeypatch.setattr(type(info), "voice_path",
-                        property(lambda self: tmp_path))
+    # these graphs are self-hosted, so they take the direct-download path;
+    # keep it inside the test's own cache root
+    import phoonnx.model_manager as mm
+    monkeypatch.setattr(mm, "HF_HUB_CACHE", str(tmp_path))
+    expected = mm._direct_dir("https://example.com/F5_Preprocess.onnx")
 
     class _Resp:
         status_code = 200
@@ -277,13 +280,12 @@ def test_aux_model_urls_resolved_in_engine_params(tmp_path, monkeypatch):
         def __enter__(self): return self
         def __exit__(self, *a): return False
 
-    import phoonnx.model_manager as mm
     monkeypatch.setattr(mm.requests, "get", lambda *a, **k: _Resp())
 
     params = info.engine_params()
-    assert params["preprocess_path"] == str(tmp_path / "F5_Preprocess.onnx")
-    assert params["decode_path"] == str(tmp_path / "F5_Decode.onnx")
-    assert (tmp_path / "F5_Preprocess.onnx").read_bytes() == b"onnx-bytes"
+    assert params["preprocess_path"] == str(expected / "F5_Preprocess.onnx")
+    assert params["decode_path"] == str(expected / "F5_Decode.onnx")
+    assert (expected / "F5_Preprocess.onnx").read_bytes() == b"onnx-bytes"
 
 
 def test_f5tts_resample():

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import tempfile
@@ -5,10 +6,17 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import onnxruntime
 import requests
 
-from phoonnx.model_manager import TTSModelInfo, TTSModelManager
+from huggingface_hub.errors import (EntryNotFoundError, HfHubHTTPError,
+                                    LocalEntryNotFoundError)
+
+from phoonnx.model_manager import (TTSModelInfo, TTSModelManager, _direct_dir,
+                                   _hf_fetch)
 from phoonnx.config import Engine, PhonemeType, Alphabet
+
+HUB = "https://huggingface.co/an-org/a-repo/resolve/main"
 
 
 def _mock_response(status_code=200, json_data=None, content=b"", text=""):
@@ -17,552 +25,554 @@ def _mock_response(status_code=200, json_data=None, content=b"", text=""):
     resp.content = content
     resp.text = text
     resp.iter_content.return_value = [content] if content else []
+    resp.headers = {}
     if json_data is not None:
         resp.json.return_value = json_data
     else:
         resp.json.side_effect = ValueError("No JSON")
     if status_code >= 400:
-        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(f"{status_code} error")
+        # requests attaches the response to the error; the sidecar handler
+        # reads its status to tell "absent" from "failed"
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            f"{status_code} error", response=resp)
     else:
         resp.raise_for_status.return_value = None
     return resp
 
 
-class VoicePathTestCase(unittest.TestCase):
-    """Base class that redirects TTSModelInfo.voice_path into a tmp dir."""
+def _hub_500():
+    """The hub client wraps a server error, keeping the response on it."""
+    return HfHubHTTPError("500 Server Error", response=MagicMock(status_code=500))
+
+
+class FakeHub:
+    """A stand-in for ``huggingface_hub.hf_hub_download``.
+
+    It copies the real cache layout, which is the whole point of this change:
+    content-addressed blobs in one flat directory, and a snapshot directory of
+    links named after the files in the repo. onnxruntime resolves an
+    external-data reference against the directory the graph itself resolves to,
+    so a fixture that puts every file in one plain directory would pass for
+    layouts the real cache rejects.
+    """
+
+    def __init__(self, root: Path, files=None):
+        self.root = root
+        self.files = dict(files or {})   # "path/in/repo" -> bytes
+        self.downloads = []              # every call, in order
+        self.errors = {}                 # "path/in/repo" -> exception to raise
+
+    def __call__(self, repo_id, filename, revision, **kwargs):
+        self.downloads.append((repo_id, filename, revision))
+        if filename in self.errors:
+            raise self.errors[filename]
+        if filename not in self.files:
+            raise EntryNotFoundError(f"404 for {filename}")
+        data = self.files[filename]
+        blobs = self.root / repo_id / "blobs"
+        blobs.mkdir(parents=True, exist_ok=True)
+        blob = blobs / hashlib.sha256(data).hexdigest()
+        if not blob.exists():
+            blob.write_bytes(data)
+        link = self.root / repo_id / "snapshots" / revision / filename
+        link.parent.mkdir(parents=True, exist_ok=True)
+        if not link.is_symlink():
+            os.symlink(blob, link)
+        return str(link)
+
+    def stage(self, url: str, content) -> None:
+        """Publish ``content`` at ``url`` on this fake hub."""
+        if isinstance(content, (dict, list)):
+            content = json.dumps(content).encode("utf-8")
+        elif isinstance(content, str):
+            content = content.encode("utf-8")
+        self.files[url.split("/resolve/")[-1].split("/", 1)[-1]
+                   if "/resolve/" in url
+                   else url.split("/raw/")[-1].split("/", 1)[-1]] = content
+
+    @property
+    def unique_downloads(self):
+        return set(self.downloads)
+
+
+class HubTestCase(unittest.TestCase):
+    """Every artifact comes from the hub cache, and nothing is copied out of it.
+
+    A voice directory owned by phoonnx no longer exists, so these tests assert
+    on what the hub returns and on what reaches onnxruntime — not on files in a
+    directory phoonnx manages.
+    """
 
     def setUp(self):
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self.addCleanup(self._tmpdir.cleanup)
-        patcher = patch("phoonnx.model_manager.os.path.expanduser", return_value=self._tmpdir.name)
+        self._hubdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._hubdir.cleanup)
+        self.hub_root = Path(self._hubdir.name)
+        self.hub = FakeHub(self.hub_root)
+        patcher = patch("phoonnx.model_manager.hf_hub_download", self.hub)
         self.addCleanup(patcher.stop)
         patcher.start()
+        # a non-hub download must not land in the developer's real cache
+        self._directdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._directdir.cleanup)
+        dpatch = patch("phoonnx.model_manager.HF_HUB_CACHE", self._directdir.name)
+        self.addCleanup(dpatch.stop)
+        dpatch.start()
 
     def make_info(self, **kwargs):
-        defaults = dict(
-            voice_id="test/voice",
-            lang="en-US",
-            model_url="https://example.com/model.onnx",
-        )
+        defaults = dict(voice_id="test/voice", lang="en-US",
+                        model_url=f"{HUB}/model.onnx")
         defaults.update(kwargs)
-        info = TTSModelInfo(**defaults)
-        # these tests seed cached artifacts into the voice directory; creating it
-        # is the fixture's job, since constructing a catalog entry deliberately
-        # does not touch the disk
-        info.voice_path.mkdir(parents=True, exist_ok=True)
-        return info
+        return TTSModelInfo(**defaults)
 
-
-class TestFetchOnnx(VoicePathTestCase):
-    @patch("phoonnx.model_manager.requests.get")
-    def test_downloads_model_and_sidecar_missing_is_404(self, mock_get):
-        info = self.make_info()
-        model_resp = _mock_response(200, content=b"onnxdata")
-        sidecar_resp = _mock_response(404)
-
+    def stream(self, bodies):
+        """Patch ``requests.get`` to serve ``{url_suffix: response}``."""
         def side_effect(url, timeout=None, stream=None):
-            if url == info.model_url:
-                cm = MagicMock()
-                cm.__enter__.return_value = model_resp
-                return cm
-            cm = MagicMock()
-            cm.__enter__.return_value = sidecar_resp
-            return cm
+            for suffix, resp in bodies.items():
+                if url.endswith(suffix):
+                    cm = MagicMock()
+                    cm.__enter__.return_value = resp
+                    return cm
+            raise AssertionError(f"unexpected request for {url}")
+        return patch("phoonnx.model_manager.requests.get", side_effect=side_effect)
 
-        mock_get.side_effect = side_effect
-        dest = info.voice_path / "model.onnx"
-        result = info._fetch_onnx(info.model_url, dest)
-        self.assertTrue(dest.is_file())
-        self.assertEqual(dest.read_bytes(), b"onnxdata")
-        self.assertEqual(result, dest)
-        self.assertFalse((info.voice_path / "model.onnx_data").is_file())
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_http_404_on_primary_download_raises(self, mock_get):
+class TestArtifactsComeFromTheHub(HubTestCase):
+    def test_the_graph_path_is_the_hub_s_own(self):
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
         info = self.make_info()
-        resp = _mock_response(404)
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        dest = info.voice_path / "model.onnx"
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info._fetch_onnx(info.model_url, dest)
+        path = info.download_model()
+        self.assertEqual(path.read_bytes(), b"onnxdata")
+        self.assertTrue(str(path).startswith(str(self.hub_root)),
+                        f"{path} is not in the shared cache")
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_http_500_on_primary_download_raises(self, mock_get):
+    def test_nothing_is_copied_into_a_phoonnx_directory(self):
+        """The voice cache phoonnx used to own is gone. ``voice_path`` answers
+        with the directory the hub keeps the graph in."""
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
         info = self.make_info()
-        resp = _mock_response(500)
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        dest = info.voice_path / "model.onnx"
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info._fetch_onnx(info.model_url, dest)
+        self.assertEqual(info.voice_path, info.download_model().parent)
+        self.assertTrue(str(info.voice_path).startswith(str(self.hub_root)))
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_sidecar_network_failure_treated_as_absent(self, mock_get):
-        info = self.make_info()
-        model_resp = _mock_response(200, content=b"data")
+    def test_two_voices_naming_one_model_share_one_file(self):
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
+        url = f"{HUB}/model.onnx"
+        a = self.make_info(voice_id="org/first", model_url=url).download_model()
+        b = self.make_info(voice_id="org/second", model_url=url).download_model()
+        self.assertEqual(a, b, "both voices resolve to the one cached file")
+        self.assertEqual(len({os.path.realpath(p) for p in
+                              self.hub_root.rglob("model.onnx")}), 1,
+                         "one physical copy in the cache")
 
-        def side_effect(url, timeout=None, stream=None):
-            if url == info.model_url:
-                cm = MagicMock()
-                cm.__enter__.return_value = model_resp
-                return cm
-            raise requests.exceptions.ConnectionError("offline")
-
-        mock_get.side_effect = side_effect
-        dest = info.voice_path / "model.onnx"
-        result = info._fetch_onnx(info.model_url, dest)
-        self.assertEqual(result, dest)
-        self.assertTrue(dest.is_file())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_already_cached_skips_download(self, mock_get):
-        info = self.make_info()
-        dest = info.voice_path / "model.onnx"
-        dest.write_bytes(b"cached")
-        data_dest = info.voice_path / (info.model_url.split("/")[-1] + "_data")
-        data_dest.write_bytes(b"cached-data")
-        result = info._fetch_onnx(info.model_url, dest)
-        mock_get.assert_not_called()
-        self.assertEqual(result, dest)
-
-
-class TestDownloadHelpers(VoicePathTestCase):
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_model_delegates_to_fetch_onnx(self, mock_get):
-        info = self.make_info()
-        resp = _mock_response(200, content=b"x")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        with patch.object(info, "_fetch_onnx", wraps=info._fetch_onnx) as fetch:
-            path = info.download_model()
-            fetch.assert_called_once_with(info.model_url, info.voice_path / "model.onnx")
-        self.assertTrue(path.is_file())
-
-    def test_download_vocoder_none_when_no_url(self):
-        info = self.make_info()
-        self.assertIsNone(info.download_vocoder())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_vocoder_with_config(self, mock_get):
-        info = self.make_info(vocoder_url="https://example.com/vocoder.onnx",
-                               vocoder_config_url="https://example.com/vocoder.json")
-        vocoder_resp = _mock_response(200, content=b"vdata")
-        config_resp = _mock_response(200, json_data={"a": 1})
-
-        def side_effect(url, timeout=None, stream=None):
-            if stream:
-                cm = MagicMock()
-                cm.__enter__.return_value = vocoder_resp
-                return cm
-            return config_resp
-
-        mock_get.side_effect = side_effect
-        path = info.download_vocoder()
-        self.assertTrue(path.is_file())
-        self.assertTrue((info.voice_path / "vocoder.json").is_file())
-
-    def test_download_style_none_when_no_url(self):
-        info = self.make_info()
-        self.assertIsNone(info.download_style())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_style_downloads(self, mock_get):
-        info = self.make_info(style_url="https://example.com/style.bin")
-        resp = _mock_response(200, content=b"styledata")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        path = info.download_style()
-        self.assertTrue(path.is_file())
-        self.assertEqual(path.read_bytes(), b"styledata")
-
-    def test_download_speaker_encoder_none_when_no_url(self):
-        info = self.make_info()
-        self.assertIsNone(info.download_speaker_encoder())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_speaker_encoder_downloads(self, mock_get):
-        info = self.make_info(speaker_encoder_url="https://example.com/enc.onnx")
-        resp = _mock_response(200, content=b"encdata")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        path = info.download_speaker_encoder()
-        self.assertTrue(path.is_file())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_speaker_encoder_http_500(self, mock_get):
-        info = self.make_info(speaker_encoder_url="https://example.com/enc.onnx")
-        resp = _mock_response(500)
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info.download_speaker_encoder()
-
-    def test_download_aux_models_empty(self):
-        info = self.make_info()
-        self.assertEqual(info.download_aux_models(), {})
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_aux_models_downloads_each(self, mock_get):
-        info = self.make_info(aux_model_urls={
-            "preprocess_path": "https://example.com/preprocess.onnx",
-            "decode_path": "https://example.com/decode.onnx",
-        })
-        resp = _mock_response(200, content=b"aux")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        paths = info.download_aux_models()
-        self.assertEqual(set(paths.keys()), {"preprocess_path", "decode_path"})
-        for p in paths.values():
-            self.assertTrue(p.is_file())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_aux_models_fetches_onnx_data_sidecar(self, mock_get):
-        """Regression test: an auxiliary graph with external weights must have its
-        <name>.onnx_data sidecar fetched too, exactly like the primary graph does
-        via _fetch_onnx. Before the fix, download_aux_models called _stream_to_file
-        directly and never looked for a sidecar, so a multi-graph engine whose aux
-        graph carries external data would download a graph that onnxruntime could
-        not load."""
-        info = self.make_info(aux_model_urls={
-            "decode_path": "https://example.com/decode.onnx",
-        })
-        graph_resp = _mock_response(200, content=b"graph")
-        sidecar_resp = _mock_response(200, content=b"sidecar-weights")
-
-        def side_effect(url, timeout=None, stream=None):
-            cm = MagicMock()
-            if url.endswith("_data"):
-                cm.__enter__.return_value = sidecar_resp
-            else:
-                cm.__enter__.return_value = graph_resp
-            return cm
-
-        mock_get.side_effect = side_effect
-        paths = info.download_aux_models()
-
-        graph_path = paths["decode_path"]
-        sidecar_path = graph_path.parent / (graph_path.name + "_data")
-        self.assertTrue(graph_path.is_file())
-        self.assertTrue(
-            sidecar_path.is_file(),
-            "download_aux_models must fetch the .onnx_data sidecar of an "
-            "auxiliary graph, the same way download_model does via _fetch_onnx",
-        )
-        self.assertEqual(sidecar_path.read_bytes(), b"sidecar-weights")
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_aux_models_routes_onnx_entries_through_fetch_onnx(self, mock_get):
-        """An .onnx aux entry must go through _fetch_onnx (not a plain stream), so
-        it gets the same sidecar-probing behavior as the primary graph."""
-        info = self.make_info(aux_model_urls={
-            "decode_path": "https://example.com/decode.onnx",
-            "speakers_path": "https://example.com/speakers.json",
-        })
-        resp = _mock_response(200, content=b"data")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-
-        with patch.object(info, "_fetch_onnx", wraps=info._fetch_onnx) as fetch:
-            paths = info.download_aux_models()
-            fetch.assert_called_once_with(
-                "https://example.com/decode.onnx", paths["decode_path"]
-            )
-        self.assertTrue(paths["speakers_path"].is_file())
-
-    def test_download_bpe_tokenizer_none_without_url(self):
-        info = self.make_info()
-        self.assertIsNone(info.download_bpe_tokenizer())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_bpe_tokenizer_downloads(self, mock_get):
-        info = self.make_info(tokenizer_config_url="https://example.com/tokenizer.json")
-        resp = _mock_response(200, content=b'{"vocab": {}}')
-        mock_get.return_value = resp
-        path = info.download_bpe_tokenizer()
-        self.assertTrue(path.is_file())
-        self.assertEqual(path.read_bytes(), b'{"vocab": {}}')
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_bpe_tokenizer_http_404(self, mock_get):
-        info = self.make_info(tokenizer_config_url="https://example.com/tokenizer.json")
-        resp = _mock_response(404)
-        mock_get.return_value = resp
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info.download_bpe_tokenizer()
-
-
-class TestDownloadConfig(VoicePathTestCase):
-    @patch("phoonnx.model_manager.requests.get")
-    def test_truncated_json_response_raises(self, mock_get):
-        info = self.make_info(config_url="https://example.com/config.json")
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.raise_for_status.return_value = None
-        resp.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
-        mock_get.return_value = resp
-        with self.assertRaises(json.JSONDecodeError):
-            info.download_config()
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_http_404_raises(self, mock_get):
-        info = self.make_info(config_url="https://example.com/config.json")
-        resp = _mock_response(404)
-        mock_get.return_value = resp
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info.download_config()
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_corrupt_cached_file_self_heals(self, mock_get):
-        info = self.make_info(config_url="https://example.com/config.json")
-        config_path = info.voice_path / "model.json"
-        config_path.write_text("{not valid json", encoding="utf-8")
-        mock_get.return_value = _mock_response(200, json_data={"fresh": True})
-        self.assertEqual(info.download_config(), {"fresh": True})
-        mock_get.assert_called_once()
-        # the healed cache is now valid and used on the next call
-        mock_get.reset_mock()
-        self.assertEqual(info.download_config(), {"fresh": True})
-        mock_get.assert_not_called()
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_empty_cached_file_self_heals(self, mock_get):
-        info = self.make_info(config_url="https://example.com/config.json")
-        (info.voice_path / "model.json").write_text("", encoding="utf-8")
-        mock_get.return_value = _mock_response(200, json_data={"fresh": True})
-        self.assertEqual(info.download_config(), {"fresh": True})
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_uses_cache_when_present(self, mock_get):
-        info = self.make_info(config_url="https://example.com/config.json")
-        config_path = info.voice_path / "model.json"
-        config_path.write_text(json.dumps({"cached": True}), encoding="utf-8")
-        result = info.download_config()
-        mock_get.assert_not_called()
-        self.assertEqual(result, {"cached": True})
-
-
-class TestConfigProperty(VoicePathTestCase):
-    @patch("phoonnx.model_manager.requests.get")
-    def test_config_with_vocab_override(self, mock_get):
+    def test_raw_urls_are_served_by_the_hub_too(self):
+        """``/raw/<rev>/`` serves the same bytes as ``/resolve/<rev>/``, so it
+        must not be pushed onto the private download path."""
+        self.hub.files["tokens.txt"] = b"a\nb\n"
         info = self.make_info(
-            config_url="https://example.com/config.json",
-            vocab_override={"a": 1, "b": 2},
-            phoneme_type="graphemes",
-            alphabet="unicode",
-        )
-        mock_get.return_value = _mock_response(200, json_data={"blank": "a"})
-        config = info.config
-        self.assertIsNotNone(config)
-        self.assertIs(info.config, config)
+            tokens_url="https://huggingface.co/an-org/a-repo/raw/main/tokens.txt")
+        with patch("phoonnx.model_manager.requests.get") as mock_get:
+            self.assertEqual(info.download_tokens_txt(), "a\nb\n")
+        mock_get.assert_not_called()
+        self.assertEqual(self.hub.downloads,
+                         [("an-org/a-repo", "tokens.txt", "main")])
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_config_with_vocab_url_and_tokenizer_config(self, mock_get):
+    def test_json_artifacts_are_read_from_the_cache(self):
+        self.hub.stage(f"{HUB}/config.json", {"sample_rate": 22050})
+        self.hub.stage(f"{HUB}/vocab.json", {"a": 1})
+        self.hub.stage(f"{HUB}/tokenizer_config.json", {"unk_token": "<unk>"})
+        info = self.make_info(config_url=f"{HUB}/config.json",
+                              vocab_url=f"{HUB}/vocab.json",
+                              tokenizer_config_url=f"{HUB}/tokenizer_config.json")
+        with patch("phoonnx.model_manager.requests.get") as mock_get:
+            self.assertEqual(info.download_config(), {"sample_rate": 22050})
+            self.assertEqual(info.download_vocab(), {"a": 1})
+            self.assertEqual(info.download_tokenizer_config(),
+                             {"unk_token": "<unk>"})
+        mock_get.assert_not_called()
+
+    def test_a_vocab_shipped_in_the_index_entry_is_used_as_is(self):
+        """``vocab_override`` carries the vocabulary inside the catalog entry;
+        there is nothing to download."""
+        info = self.make_info(vocab_override={"x": 3})
+        self.assertEqual(info.download_vocab(), {"x": 3})
+        self.assertEqual(self.hub.downloads, [])
+
+    def test_a_missing_graph_propagates(self):
+        info = self.make_info()
+        with self.assertRaises(EntryNotFoundError):
+            info.download_model()
+
+    def test_hub_failure_on_the_primary_graph_propagates(self):
+        self.hub.errors["model.onnx"] = _hub_500()
+        with self.assertRaises(HfHubHTTPError):
+            self.make_info().download_model()
+
+    def test_aux_and_auxiliary_graphs_resolve(self):
+        for name in ("speech_encoder.onnx", "embed_tokens.onnx",
+                     "conditional_decoder.onnx", "extra.onnx", "speaker.bin"):
+            self.hub.stage(f"{HUB}/{name}", b"payload-" + name.encode())
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
         info = self.make_info(
-            config_url="https://example.com/config.json",
-            vocab_url="https://example.com/vocab.json",
-            tokenizer_config_url="https://example.com/tokenizer_config.json",
-            phoneme_type="graphemes",
-            alphabet="unicode",
-        )
-
-        def side_effect(url, timeout=None):
-            if url == info.vocab_url:
-                return _mock_response(200, json_data={"a": 0, "b": 1})
-            if url == info.tokenizer_config_url:
-                return _mock_response(200, json_data={"add_blank": True, "language": "en", "pad_token": "a"})
-            return _mock_response(200, json_data={"blank": "a"})
-
-        mock_get.side_effect = side_effect
-        config = info.config
-        self.assertIsNotNone(config)
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_config_with_tokens_url(self, mock_get):
-        info = self.make_info(tokens_url="https://example.com/tokens.txt", phoneme_type="graphemes", alphabet="unicode")
-        mock_get.return_value = _mock_response(200, text="a\nb\nc\n")
-        config = info.config
-        self.assertIsNotNone(config)
-        self.assertTrue((info.voice_path / "tokens.txt").is_file())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_config_espeak_phoneme_type_hack(self, mock_get):
-        info = self.make_info(config_url="https://example.com/config.json")
-        mock_get.return_value = _mock_response(200, json_data={"phoneme_type": "PhonemeType.ESPEAK", "alphabet": "ipa"})
-        config = info.config
-        self.assertIsNotNone(config)
+            aux_model_urls={"extra_path": f"{HUB}/extra.onnx",
+                            "speaker_path": f"{HUB}/speaker.bin"},
+            speech_encoder_url=f"{HUB}/speech_encoder.onnx",
+            embed_tokens_url=f"{HUB}/embed_tokens.onnx",
+            conditional_decoder_url=f"{HUB}/conditional_decoder.onnx")
+        params = info.engine_params()
+        for key in ("extra_path", "speaker_path", "speech_encoder_path",
+                    "embed_tokens_path", "conditional_decoder_path"):
+            self.assertTrue(str(params[key]).startswith(str(self.hub_root)),
+                            f"{key} left the cache: {params[key]}")
 
 
-class TestVocabAndTokenizerDownloads(VoicePathTestCase):
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_tokenizer_config_downloads_and_caches(self, mock_get):
-        info = self.make_info(tokenizer_config_url="https://example.com/tokenizer_config.json")
-        mock_get.return_value = _mock_response(200, json_data={"model_max_length": 64})
-        result = info.download_tokenizer_config()
-        self.assertEqual(result, {"model_max_length": 64})
-        mock_get.reset_mock()
-        result2 = info.download_tokenizer_config()
-        mock_get.assert_not_called()
-        self.assertEqual(result2, {"model_max_length": 64})
+class TestNonHubVoices(HubTestCase):
+    """Self-hosted and mirrored voices are rare but legitimate. They lose the
+    deduplication, not the ability to load."""
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_tokenizer_config_http_500(self, mock_get):
-        info = self.make_info(tokenizer_config_url="https://example.com/tokenizer_config.json")
-        mock_get.return_value = _mock_response(500)
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info.download_tokenizer_config()
+    URL = "https://mirror.example.org/v/model.onnx"
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_vocab_downloads_and_caches(self, mock_get):
-        info = self.make_info(vocab_url="https://example.com/vocab.json")
-        mock_get.return_value = _mock_response(200, json_data={"a": 0})
-        result = info.download_vocab()
-        self.assertEqual(result, {"a": 0})
+    def test_a_non_hub_url_is_downloaded_not_dropped(self):
+        with self.stream({"model.onnx_data": _mock_response(404),
+                          "model.onnx": _mock_response(200, content=b"selfhosted")}), \
+                patch("phoonnx.model_manager.LOG") as mock_log:
+            path = self.make_info(model_url=self.URL).download_model()
+        self.assertIsNotNone(path, "a non-hub voice must not resolve to None")
+        self.assertEqual(path.read_bytes(), b"selfhosted")
+        self.assertTrue(mock_log.warning.called,
+                        "the private copy must be announced")
+        self.assertEqual(self.hub.downloads, [], "the hub was never asked")
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_vocab_http_404(self, mock_get):
-        info = self.make_info(vocab_url="https://example.com/vocab.json")
-        mock_get.return_value = _mock_response(404)
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info.download_vocab()
+    def test_the_graph_and_its_sidecar_share_one_directory(self):
+        """The reason a private download still needs a directory of its own:
+        onnxruntime resolves the sidecar against the graph's directory."""
+        with self.stream({"model.onnx_data": _mock_response(200, content=b"weights"),
+                          "model.onnx": _mock_response(200, content=b"graph")}):
+            path = self.make_info(model_url=self.URL).download_model()
+        self.assertEqual((path.parent / "model.onnx_data").read_bytes(), b"weights")
+        self.assertEqual(path.parent, _direct_dir(self.URL))
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_tokens_txt_downloads_and_caches(self, mock_get):
-        info = self.make_info(tokens_url="https://example.com/tokens.txt")
-        mock_get.return_value = _mock_response(200, text="a\nb\n")
-        result = info.download_tokens_txt()
-        self.assertEqual(result, "a\nb\n")
-        mock_get.reset_mock()
-        result2 = info.download_tokens_txt()
-        mock_get.assert_not_called()
-        self.assertEqual(result2, "a\nb\n")
+    def test_files_published_together_land_together(self):
+        self.assertEqual(_direct_dir("https://m.example/v/model.onnx"),
+                         _direct_dir("https://m.example/v/vocab.json"))
+        self.assertNotEqual(_direct_dir("https://m.example/v/model.onnx"),
+                            _direct_dir("https://m.example/w/model.onnx"))
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_tokens_txt_http_500(self, mock_get):
-        info = self.make_info(tokens_url="https://example.com/tokens.txt")
-        mock_get.return_value = _mock_response(500)
-        with self.assertRaises(requests.exceptions.HTTPError):
-            info.download_tokens_txt()
+    def test_a_second_call_does_not_download_again(self):
+        bodies = {"model.onnx_data": _mock_response(404),
+                  "model.onnx": _mock_response(200, content=b"selfhosted")}
+        info = self.make_info(model_url=self.URL)
+        with self.stream(bodies) as mock_get:
+            info.download_model()
+            first = mock_get.call_count
+            info.download_model()
+        self.assertEqual(mock_get.call_count, first + 1,
+                         "only the sidecar is re-probed, the graph is cached")
+
+    def test_a_compressed_download_is_not_mistaken_for_truncated(self):
+        """A gzipped response is complete even though it is shorter on the wire.
+
+        ``Content-Length`` counts the compressed bytes while the stream yields
+        the decoded body, so comparing them rejects a download that arrived
+        perfectly intact. Transfer compression is the server's choice, not
+        ours, so this is a voice that simply refuses to install.
+        """
+        body = b"a decoded body that is longer than its compressed length"
+        resp = _mock_response(200, content=body)
+        resp.headers = {"Content-Length": "12", "Content-Encoding": "gzip"}
+        with self.stream({"model.onnx_data": _mock_response(404),
+                          "model.onnx": resp}):
+            path = self.make_info(model_url=self.URL).download_model()
+        self.assertEqual(path.read_bytes(), body)
+
+    def test_identity_encoding_still_catches_truncation(self):
+        # The exemption above must not become a way to skip the size check.
+        resp = _mock_response(200, content=b"partial")
+        resp.headers = {"Content-Length": "999", "Content-Encoding": "identity"}
+        with self.stream({"model.onnx_data": _mock_response(404),
+                          "model.onnx": resp}):
+            with self.assertRaises(IOError):
+                self.make_info(model_url=self.URL).download_model()
+
+    def test_a_truncated_download_is_not_left_behind(self):
+        resp = _mock_response(200, content=b"partial")
+        resp.headers = {"Content-Length": "999"}
+        with self.stream({"model.onnx_data": _mock_response(404),
+                          "model.onnx": resp}):
+            with self.assertRaises(IOError):
+                self.make_info(model_url=self.URL).download_model()
+        self.assertFalse((_direct_dir(self.URL) / "model.onnx").exists())
 
 
-class TestEngineParams(VoicePathTestCase):
+class TestMetadataTimeout(unittest.TestCase):
+    """The metadata lookup must give up long before the body budget.
+
+    ``hf_hub_download`` asks the hub about the file before fetching it. If that
+    call inherits the body timeout, a blackholed network stalls the caller for
+    the whole budget before the download it blocks has even begun — and the
+    request in front of it has usually timed out by then anyway.
+    """
+
+    def test_metadata_lookup_does_not_inherit_the_body_timeout(self):
+        from phoonnx import model_manager as mm
+        seen = {}
+
+        def fake(**kwargs):
+            seen.update(kwargs)
+            return "/tmp/x"
+
+        with patch.object(mm, "hf_hub_download", side_effect=fake):
+            mm._hf_fetch(f"{HUB}/model.onnx",
+                         timeout=120)
+        self.assertLessEqual(seen["etag_timeout"], 30,
+                             "a metadata call must not wait out the body timeout")
+
+
+class TestSidecarUrlKeepsTheQuery(HubTestCase):
+    """A query on the model URL must not swallow the sidecar suffix.
+
+    HuggingFace's own download links carry ``?download=true``, so this is the
+    URL form an index entry most easily picks up. Appending ``_data`` to the
+    whole string puts the suffix inside the query, which the hub ignores — the
+    request returns the graph again, the "no sidecar" branch is never entered,
+    and onnxruntime is handed a graph whose weights are missing.
+    """
+
+    def test_the_suffix_goes_on_the_path_not_the_query(self):
+        from phoonnx.model_manager import _sidecar_url
+        self.assertEqual(_sidecar_url(f"{HUB}/model.onnx?download=true"),
+                         f"{HUB}/model.onnx_data?download=true")
+        self.assertEqual(_sidecar_url(f"{HUB}/model.onnx"),
+                         f"{HUB}/model.onnx_data")
+
+    def test_a_query_url_still_fetches_the_real_sidecar(self):
+        self.hub.stage(f"{HUB}/model.onnx", b"graph")
+        self.hub.stage(f"{HUB}/model.onnx_data", b"weights")
+        info = self.make_info(model_url=f"{HUB}/model.onnx?download=true")
+        path = info.download_model()
+        sidecar = path.parent / "model.onnx_data"
+        self.assertTrue(sidecar.is_file(),
+                        "the sidecar must land beside the graph")
+        self.assertEqual(sidecar.read_bytes(), b"weights",
+                         "the sidecar must be the weights, not the graph again")
+
+
+class TestSidecarErrors(HubTestCase):
+    """The external-weights sidecar is the biggest file a voice pulls (2.45 GB
+    for the omnivoice backbone). "Absent" must stay distinguishable from
+    "failed", or a graph loads with its weights missing and synthesizes
+    silence."""
+
+    def setUp(self):
+        super().setUp()
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
+        self.info = self.make_info()
+
+    def test_absent_sidecar_is_tolerated(self):
+        # a single-file graph (piper/vits) simply has no <name>.onnx_data
+        path = self.info.download_model()
+        self.assertTrue(path.is_file())
+        self.assertFalse((path.parent / "model.onnx_data").exists())
+
+    def test_offline_with_nothing_cached_is_tolerated(self):
+        self.hub.errors["model.onnx_data"] = LocalEntryNotFoundError("offline")
+        self.assertTrue(self.info.download_model().is_file())
+
+    def test_a_full_disk_is_not_mistaken_for_an_absent_sidecar(self):
+        self.hub.errors["model.onnx_data"] = OSError(28, "No space left on device")
+        with self.assertRaises(OSError):
+            self.info.download_model()
+
+    def test_a_permission_error_is_not_mistaken_for_an_absent_sidecar(self):
+        self.hub.errors["model.onnx_data"] = PermissionError(13, "Permission denied")
+        with self.assertRaises(PermissionError):
+            self.info.download_model()
+
+    def test_a_server_error_is_not_mistaken_for_an_absent_sidecar(self):
+        self.hub.errors["model.onnx_data"] = _hub_500()
+        with self.assertRaises(HfHubHTTPError):
+            self.info.download_model()
+
+    def test_a_404_on_a_non_hub_sidecar_is_still_tolerated(self):
+        url = "https://mirror.example.org/v/model.onnx"
+        with self.stream({"model.onnx_data": _mock_response(404),
+                          "model.onnx": _mock_response(200, content=b"data")}):
+            path = self.make_info(model_url=url).download_model()
+        self.assertTrue(path.is_file())
+        self.assertFalse((path.parent / "model.onnx_data").exists())
+
+    def test_a_500_on_a_non_hub_sidecar_is_not_tolerated(self):
+        url = "https://mirror.example.org/v/model.onnx"
+        with self.stream({"model.onnx_data": _mock_response(500),
+                          "model.onnx": _mock_response(200, content=b"data")}):
+            with self.assertRaises(requests.exceptions.HTTPError):
+                self.make_info(model_url=url).download_model()
+
+
+class TestExternalDataGraphLoads(HubTestCase):
+    """An external-data graph must load through onnxruntime, end to end.
+
+    The graph names its weights by a relative path, and onnxruntime refuses to
+    follow that reference outside the directory the graph itself resolves to.
+    Every other test here stops at "the bytes arrived", which is why a layout
+    onnxruntime rejects shipped: a real graph beside a linked sidecar reads as
+    complete on disk and fails at load, with
+
+        FAIL : External data path validation failed for initializer: W.
+        Error: External data path escapes model directory.
+
+    and every voice built that way answered with HTTP 500. This test loads it.
+    """
+
+    def _external_data_model(self):
+        """Build a tiny graph whose one initializer lives in a sidecar."""
+        import numpy as np
+        import onnx
+        from onnx import helper, numpy_helper, TensorProto
+
+        build = Path(tempfile.mkdtemp())
+        self.addCleanup(
+            lambda: __import__("shutil").rmtree(build, ignore_errors=True))
+        weight = numpy_helper.from_array(
+            np.ones((1024, 16), dtype=np.float32), name="W")
+        graph = helper.make_graph(
+            [helper.make_node("Add", ["X", "W"], ["Y"])], "g",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1024, 16])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1024, 16])],
+            [weight])
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 13)])
+        onnx.save(model, str(build / "model.onnx"), save_as_external_data=True,
+                  location="model.onnx_data", all_tensors_to_one_file=True,
+                  size_threshold=0)
+        return ((build / "model.onnx").read_bytes(),
+                (build / "model.onnx_data").read_bytes())
+
+    def _stage_external_data_voice(self):
+        graph, weights = self._external_data_model()
+        self.hub.stage(f"{HUB}/model.onnx", graph)
+        self.hub.stage(f"{HUB}/model.onnx_data", weights)
+        return self.make_info()
+
+    def test_the_graph_the_engine_is_handed_loads(self):
+        info = self._stage_external_data_voice()
+        session = onnxruntime.InferenceSession(
+            str(info.download_model()), providers=["CPUExecutionProvider"])
+        self.assertEqual([i.name for i in session.get_inputs()], ["X"])
+
+    def test_a_copy_outside_the_cache_would_not_load(self):
+        """The property under test, stated as its own failure.
+
+        Copying the graph anywhere else — which is what phoonnx used to do —
+        leaves the sidecar behind in the cache, and onnxruntime rejects it.
+
+        The rejection is onnxruntime's, and older builds load the escaping
+        path without complaint, so this control is skipped there rather than
+        failing: it would otherwise report a missing guard in a dependency as
+        a fault in phoonnx.
+        """
+        import shutil
+        info = self._stage_external_data_voice()
+        cached = info.download_model()
+        elsewhere = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(elsewhere, ignore_errors=True))
+        shutil.copy2(cached, elsewhere / "model.onnx")
+        os.symlink(cached.parent / "model.onnx_data",
+                   elsewhere / "model.onnx_data")
+
+        try:
+            onnxruntime.InferenceSession(
+                str(elsewhere / "model.onnx"),
+                providers=["CPUExecutionProvider"])
+        except Exception as exc:
+            self.assertIn("escapes model directory", str(exc))
+        else:
+            self.skipTest(
+                f"onnxruntime {onnxruntime.__version__} does not enforce "
+                "external-data path containment; the control cannot run")
+
+    def test_a_self_hosted_external_data_graph_loads_too(self):
+        graph, weights = self._external_data_model()
+        url = "https://mirror.example.org/v/model.onnx"
+        with self.stream({"model.onnx_data": _mock_response(200, content=weights),
+                          "model.onnx": _mock_response(200, content=graph)}):
+            path = self.make_info(model_url=url).download_model()
+        session = onnxruntime.InferenceSession(
+            str(path), providers=["CPUExecutionProvider"])
+        self.assertEqual([i.name for i in session.get_inputs()], ["X"])
+
+    def test_load_opens_a_real_session_on_an_external_data_graph(self):
+        """``load()`` itself opens the session for a voice with no published
+        config.json, so this exercises the whole path with real onnxruntime."""
+        info = self._stage_external_data_voice()
+        info.engine = Engine.PHOONNX
+        with patch("phoonnx.model_manager.TTSVoice") as voice_cls:
+            info.load()
+        session = voice_cls.call_args.kwargs["session"]
+        self.assertEqual([i.name for i in session.get_inputs()], ["X"])
+
+
+class TestLoad(HubTestCase):
+    def test_load_hands_every_artifact_path_to_ttsvoice(self):
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
+        self.hub.stage(f"{HUB}/config.json", {"sample_rate": 22050})
+        self.hub.stage(f"{HUB}/tokens.txt", "a\nb\n")
+        info = self.make_info(config_url=f"{HUB}/config.json",
+                              tokens_url=f"{HUB}/tokens.txt")
+        with patch("phoonnx.model_manager.TTSVoice") as voice_cls, \
+                patch("phoonnx.model_manager.get_phonemizer"):
+            info.load()
+        kwargs = voice_cls.load.call_args.kwargs
+        self.assertEqual(Path(kwargs["model_path"]).read_bytes(), b"onnxdata")
+        self.assertEqual(json.loads(Path(kwargs["config_path"]).read_text()),
+                         {"sample_rate": 22050})
+        self.assertIsNone(kwargs["vocab_path"], "this voice has no vocab.json")
+
+
+class TestEngineParams(HubTestCase):
     def test_empty_for_single_stage_engine(self):
-        info = self.make_info()
-        self.assertEqual(info.engine_params(), {})
+        self.assertEqual(self.make_info().engine_params(), {})
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_combines_vocoder_style_speaker_encoder(self, mock_get):
-        info = self.make_info(
-            vocoder_url="https://example.com/vocoder.onnx",
-            vocoder_type="hifigan",
-            style_url="https://example.com/style.bin",
-            speaker_encoder_url="https://example.com/enc.onnx",
-            speaker_encoder_type="dvector",
-        )
-        resp = _mock_response(200, content=b"data")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
+    def test_vocoder_style_and_speaker_encoder_resolve(self):
+        for name in ("vocoder.onnx", "style.bin", "speaker_encoder.onnx"):
+            self.hub.stage(f"{HUB}/{name}", b"payload")
+        self.hub.stage(f"{HUB}/vocoder.json", {"hop": 256})
+        info = self.make_info(vocoder_url=f"{HUB}/vocoder.onnx",
+                              vocoder_config_url=f"{HUB}/vocoder.json",
+                              vocoder_type="hifigan",
+                              style_url=f"{HUB}/style.bin",
+                              speaker_encoder_url=f"{HUB}/speaker_encoder.onnx")
         params = info.engine_params()
         self.assertEqual(params["vocoder_type"], "hifigan")
-        self.assertEqual(params["speaker_encoder_type"], "dvector")
-        self.assertIn("style_path", params)
-        self.assertIn("vocoder_path", params)
-        self.assertIn("speaker_encoder_path", params)
+        self.assertEqual(params["vocoder_config"], {"hop": 256})
+        for key in ("vocoder_path", "style_path", "speaker_encoder_path"):
+            self.assertTrue(str(params[key]).startswith(str(self.hub_root)))
 
-    @patch("phoonnx.model_manager.requests.get")
-    def test_parametric_vocoder_no_model_file(self, mock_get):
-        info = self.make_info(vocoder_type="griffinlim", vocoder_config_url="https://example.com/vocoder.json")
-        mock_get.return_value = _mock_response(200, content=b'{"n_fft": 1024}')
+    def test_a_parametric_vocoder_needs_no_model_file(self):
+        self.hub.stage(f"{HUB}/vocoder.json", {"n_fft": 1024})
+        info = self.make_info(vocoder_type="griffin_lim",
+                              vocoder_config_url=f"{HUB}/vocoder.json")
         params = info.engine_params()
-        self.assertEqual(params["vocoder_type"], "griffinlim")
-        self.assertIn("vocoder_config", params)
+        self.assertEqual(params["vocoder_type"], "griffin_lim")
         self.assertEqual(params["vocoder_config"], {"n_fft": 1024})
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_aux_model_url_without_filename_uses_key(self, mock_get):
-        info = self.make_info(aux_model_urls={"weird_path": "https://example.com/graphs/"})
-        resp = _mock_response(200, content=b"data")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        paths = info.download_aux_models()
-        self.assertTrue(str(paths["weird_path"]).endswith("weird_path.onnx"))
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_chatterbox_aux_graphs(self, mock_get):
-        info = self.make_info(
-            speech_encoder_url="https://example.com/speech_encoder.onnx",
-            embed_tokens_url="https://example.com/embed_tokens.onnx",
-            conditional_decoder_url="https://example.com/conditional_decoder.onnx",
-        )
-        resp = _mock_response(200, content=b"data")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        params = info.engine_params()
-        self.assertIn("speech_encoder_path", params)
-        self.assertIn("embed_tokens_path", params)
-        self.assertIn("conditional_decoder_path", params)
+        self.assertNotIn("vocoder_path", params)
 
 
-class TestLoad(VoicePathTestCase):
-    @patch("phoonnx.model_manager.TTSVoice")
-    @patch("phoonnx.model_manager.requests.get")
-    def test_load_downloads_model_then_builds_voice(self, mock_get, mock_ttsvoice_cls):
-        info = self.make_info(config_url="https://example.com/config.json")
-        resp = _mock_response(200, content=b"data")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        info.voice_path.joinpath("model.json").write_text(
-            json.dumps({"phoneme_type": "graphemes", "alphabet": "unicode"}), encoding="utf-8"
-        )
-        fake_voice = MagicMock()
-        fake_voice.config.phoneme_type = info.config.phoneme_type
-        fake_voice.config.alphabet = info.config.alphabet
-        mock_ttsvoice_cls.load.return_value = fake_voice
-        result = info.load()
-        mock_ttsvoice_cls.load.assert_called_once()
-        self.assertEqual(result, fake_voice)
-
-    @patch("phoonnx.model_manager.VoiceConfig")
-    @patch("phoonnx.model_manager.onnxruntime")
-    @patch("phoonnx.model_manager.TTSVoice")
-    @patch("phoonnx.model_manager.requests.get")
-    def test_load_engine_without_config_url_uses_session(self, mock_get, mock_ttsvoice_cls, mock_ort, mock_voiceconfig_cls):
-        info = self.make_info(engine=Engine.CHATTERBOX, tokenizer_config_url="https://example.com/tokenizer.json")
-
-        def side_effect(url, timeout=None, stream=None):
-            if stream:
-                resp = _mock_response(200, content=b"data")
-                cm = MagicMock()
-                cm.__enter__.return_value = resp
-                return cm
-            return _mock_response(200, content=b'{"vocab": {}}')
-
-        mock_get.side_effect = side_effect
-        fake_config = MagicMock()
-        fake_config.engine_params = {}
-        mock_voiceconfig_cls.from_dict.return_value = fake_config
-        session = MagicMock()
-        mock_ort.InferenceSession.return_value = session
-        fake_voice = MagicMock()
-        mock_ttsvoice_cls.return_value = fake_voice
-        result = info.load()
-        mock_ort.InferenceSession.assert_called_once()
-        self.assertEqual(result, fake_voice)
+class TestDownloadAll(HubTestCase):
+    def test_every_artifact_a_voice_needs_is_fetched(self):
+        self.hub.stage(f"{HUB}/model.onnx", b"onnxdata")
+        self.hub.stage(f"{HUB}/config.json", {"sample_rate": 22050})
+        self.hub.stage(f"{HUB}/vocab.json", {"a": 1})
+        self.hub.stage(f"{HUB}/tokenizer_config.json", {"unk_token": "<unk>"})
+        info = self.make_info(config_url=f"{HUB}/config.json",
+                              vocab_url=f"{HUB}/vocab.json",
+                              tokenizer_config_url=f"{HUB}/tokenizer_config.json")
+        model_path = info.download_all()
+        self.assertEqual(model_path.read_bytes(), b"onnxdata")
+        pulled = {name for _, name, _ in self.hub.downloads}
+        self.assertLessEqual({"model.onnx", "config.json", "vocab.json",
+                              "tokenizer_config.json"}, pulled)
 
 
-class TestTTSModelInfoStringEnumCoercion(VoicePathTestCase):
+class TestTTSModelInfoStringEnumCoercion(HubTestCase):
     def test_string_engine_alphabet_phoneme_type_coerced(self):
         info = self.make_info(engine="piper", alphabet="ipa", phoneme_type="espeak")
         self.assertEqual(info.engine, Engine.PIPER)
@@ -794,192 +804,6 @@ class TestFullSerializationRoundTrip(ManagerTestCase):
         json.dumps(d)
 
 
-class TestLoadPhonemeTypeOverrideAppliesToConfig(VoicePathTestCase):
-    @patch("phoonnx.model_manager.TTSVoice")
-    @patch("phoonnx.model_manager.requests.get")
-    def test_override_sets_config_phoneme_type_not_voice_attribute(self, mock_get, mock_ttsvoice_cls):
-        info = self.make_info(config_url="https://example.com/config.json", phoneme_type="graphemes", alphabet="unicode")
-        resp = _mock_response(200, content=b"data")
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        info.voice_path.joinpath("model.json").write_text(
-            json.dumps({"phoneme_type": "espeak", "alphabet": "ipa"}), encoding="utf-8"
-        )
-        fake_voice = MagicMock()
-        fake_voice.config.phoneme_type = PhonemeType.ESPEAK
-        fake_voice.config.alphabet = Alphabet.IPA
-        mock_ttsvoice_cls.load.return_value = fake_voice
-
-        with patch("phoonnx.model_manager.get_phonemizer") as mock_get_phonemizer:
-            result = info.load()
-
-        # the override must land on voice.config.phoneme_type, not a dead
-        # voice.phoneme_type attribute
-        self.assertEqual(fake_voice.config.phoneme_type, info.phoneme_type)
-        self.assertEqual(fake_voice.config.alphabet, info.alphabet)
-        mock_get_phonemizer.assert_called_once()
-        self.assertEqual(result, fake_voice)
-
-
-class TestUnwritableCachePath(unittest.TestCase):
-    def test_unwritable_cache_dir_raises_clear_error(self):
-        tmpdir = tempfile.mkdtemp()
-        self.addCleanup(lambda: (os.chmod(tmpdir, 0o700), __import__("shutil").rmtree(tmpdir)))
-        os.chmod(tmpdir, 0o500)
-        bad_path = os.path.join(tmpdir, "sub", "cache.json")
-        with self.assertRaises(PermissionError):
-            TTSModelManager(cache_path=bad_path)
-
-
-class TestAtomicDownloads(VoicePathTestCase):
-    """An interrupted download must never leave a file later runs trust."""
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_interrupted_stream_leaves_no_usable_file(self, mock_get):
-        info = self.make_info()
-        dest = info.voice_path / "model.onnx"
-
-        broken = MagicMock()
-        broken.status_code = 200
-        broken.raise_for_status.return_value = None
-        broken.headers = {}
-
-        def _explode(chunk_size=None):
-            yield b"012345678"  # 9 bytes, then the connection drops
-            raise requests.exceptions.ConnectionError("connection reset")
-
-        broken.iter_content.side_effect = _explode
-        cm = MagicMock()
-        cm.__enter__.return_value = broken
-        mock_get.return_value = cm
-
-        with self.assertRaises(requests.exceptions.ConnectionError):
-            info._fetch_onnx(info.model_url, dest)
-        self.assertFalse(dest.exists())
-        self.assertFalse((info.voice_path / "model.onnx.part").exists())
-
-        # a later run must actually re-download, not trust the leftovers
-        good = _mock_response(200, content=b"complete-onnx-graph")
-        good.headers = {}
-        sidecar = _mock_response(404)
-
-        def side_effect(url, timeout=None, stream=None):
-            resp = good if url == info.model_url else sidecar
-            cm2 = MagicMock()
-            cm2.__enter__.return_value = resp
-            return cm2
-
-        mock_get.side_effect = side_effect
-        mock_get.return_value = None
-        info._fetch_onnx(info.model_url, dest)
-        self.assertEqual(dest.read_bytes(), b"complete-onnx-graph")
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_short_body_vs_content_length_is_rejected(self, mock_get):
-        info = self.make_info(style_url="https://example.com/style.bin")
-        resp = _mock_response(200, content=b"123456789")  # 9 bytes
-        resp.headers = {"Content-Length": "4096"}
-        cm = MagicMock()
-        cm.__enter__.return_value = resp
-        mock_get.return_value = cm
-        with self.assertRaises(IOError):
-            info.download_style()
-        self.assertFalse((info.voice_path / "style.bin").exists())
-        self.assertFalse((info.voice_path / "style.bin.part").exists())
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_zero_byte_cached_model_is_redownloaded(self, mock_get):
-        info = self.make_info()
-        dest = info.voice_path / "model.onnx"
-        dest.write_bytes(b"")
-        good = _mock_response(200, content=b"real-graph")
-        good.headers = {}
-        sidecar = _mock_response(404)
-
-        def side_effect(url, timeout=None, stream=None):
-            resp = good if url == info.model_url else sidecar
-            cm = MagicMock()
-            cm.__enter__.return_value = resp
-            return cm
-
-        mock_get.side_effect = side_effect
-        info._fetch_onnx(info.model_url, dest)
-        self.assertEqual(dest.read_bytes(), b"real-graph")
-
-
-class TestDownloadAll(VoicePathTestCase):
-    """A downloaded voice must be usable offline: side files included."""
-
-    def _recording_get(self, requested):
-        def side_effect(url, timeout=None, stream=None):
-            requested.append(url)
-            if url.endswith("_data"):
-                resp = _mock_response(404)
-            elif url.endswith(".json"):
-                resp = _mock_response(200, json_data={"phoneme_type": "graphemes",
-                                                      "alphabet": "unicode"})
-            elif url.endswith(".txt"):
-                resp = _mock_response(200, text="a\nb\n")
-            else:
-                resp = _mock_response(200, content=b"binarydata")
-            resp.headers = {}
-            if stream:
-                cm = MagicMock()
-                cm.__enter__.return_value = resp
-                return cm
-            return resp
-
-        return side_effect
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_all_fetches_every_side_file(self, mock_get):
-        info = self.make_info(
-            config_url="https://example.com/config.json",
-            tokens_url="https://example.com/tokens.txt",
-            vocoder_url="https://example.com/vocoder.onnx",
-            vocoder_config_url="https://example.com/vocoder_config.json",
-            vocoder_type="hifigan",
-            style_url="https://example.com/style.bin",
-            speaker_encoder_url="https://example.com/enc.onnx",
-            aux_model_urls={"decode_path": "https://example.com/decode.onnx"},
-        )
-        requested = []
-        mock_get.side_effect = self._recording_get(requested)
-
-        info.download_all()
-
-        for url in (info.model_url, info.config_url, info.tokens_url,
-                    info.vocoder_url, info.vocoder_config_url, info.style_url,
-                    info.speaker_encoder_url,
-                    info.aux_model_urls["decode_path"]):
-            self.assertIn(url, requested)
-        for fname in ("model.onnx", "model.json", "tokens.txt", "vocoder.onnx",
-                      "vocoder.json", "style.bin", "speaker_encoder.onnx",
-                      "decode.onnx"):
-            self.assertTrue((info.voice_path / fname).is_file(), fname)
-
-    @patch("phoonnx.model_manager.requests.get")
-    def test_download_voice_by_id_uses_download_all(self, mock_get):
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
-        manager = TTSModelManager(cache_path=os.path.join(tmp.name, "cache.json"))
-        info = self.make_info(
-            voice_id="aux/voice",
-            config_url="https://example.com/config.json",
-            vocoder_url="https://example.com/vocoder.onnx",
-            style_url="https://example.com/style.bin",
-        )
-        manager.voices = {"aux/voice": info}
-        requested = []
-        mock_get.side_effect = self._recording_get(requested)
-
-        self.assertTrue(manager.download_voice_by_id("aux/voice"))
-        self.assertIn(info.config_url, requested)
-        self.assertIn(info.vocoder_url, requested)
-        self.assertIn(info.style_url, requested)
-
-
 class TestVoiceIndexSources(unittest.TestCase):
     def test_every_bundled_index_is_listed(self):
         tmp = tempfile.TemporaryDirectory()
@@ -1013,3 +837,59 @@ class TestCatalogDoesNotTouchDisk(unittest.TestCase):
                 self.assertTrue(mm.voices, "expected a populated catalog")
                 created = [p for p in Path(home).rglob("*") if p.is_dir()]
                 self.assertEqual(created, [], f"catalog created {len(created)} dirs")
+
+
+# ---------------------------------------------------------------------------
+# The shared HuggingFace cache
+# ---------------------------------------------------------------------------
+
+HUB = "https://huggingface.co/an-org/a-repo/resolve/main"
+
+
+def _hub_500():
+    """The hub client wraps a server error, keeping the response on it."""
+    return HfHubHTTPError("500 Server Error", response=MagicMock(status_code=500))
+
+
+class TestHfUrlParsing(unittest.TestCase):
+    def test_non_hub_urls_are_declined(self):
+        for url in ["https://example.com/model.onnx",
+                    "https://huggingface.co/an-org/a-repo",
+                    "https://not-huggingface.co/a/b/resolve/main/f.onnx"]:
+            self.assertIsNone(_hf_fetch(url), url)
+
+    def test_query_strings_are_ignored(self):
+        with patch("phoonnx.model_manager.hf_hub_download",
+                   return_value="/cache/f.onnx") as dl:
+            _hf_fetch(f"{HUB}/model.onnx?download=true")
+        dl.assert_called_once()
+        self.assertEqual(dl.call_args.kwargs["filename"], "model.onnx")
+
+    def test_nested_paths_survive(self):
+        with patch("phoonnx.model_manager.hf_hub_download",
+                   return_value="/cache/f.onnx") as dl:
+            _hf_fetch(f"{HUB}/onnx/sub/model.onnx")
+        self.assertEqual(dl.call_args.kwargs["filename"], "onnx/sub/model.onnx")
+
+
+class TestHubImportedEagerly(unittest.TestCase):
+    def test_the_hub_client_is_imported_at_module_scope(self):
+        """Importing it inside the download call meant the first voice download
+        decided where the hub cache and token live. Anything that had redirected
+        ``expanduser`` by then — a test, a sandbox — got baked in for the life of
+        the process."""
+        import phoonnx.model_manager as mm
+        self.assertTrue(callable(mm.hf_hub_download))
+        from huggingface_hub import constants
+        self.assertTrue(Path(constants.HF_TOKEN_PATH).parent.name,
+                        "the token path must be resolved, not empty")
+
+
+class TestUnwritableCachePath(unittest.TestCase):
+    def test_unwritable_cache_dir_raises_clear_error(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(lambda: (os.chmod(tmpdir, 0o700), __import__("shutil").rmtree(tmpdir)))
+        os.chmod(tmpdir, 0o500)
+        bad_path = os.path.join(tmpdir, "sub", "cache.json")
+        with self.assertRaises(PermissionError):
+            TTSModelManager(cache_path=bad_path)

--- a/tests/test_offline_model_load.py
+++ b/tests/test_offline_model_load.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 
 import requests
 
-from phoonnx.model_manager import TTSModelInfo
+from phoonnx.model_manager import TTSModelInfo, _direct_dir
 
 
 class _FakeResponse:
@@ -39,25 +39,24 @@ class _FakeResponse:
 
 
 class TestOfflineModelLoad(unittest.TestCase):
+    """This voice is self-hosted, so it takes the direct-download path. The hub
+    client is never involved, and the sidecar probe behaves exactly as it does
+    for a hub voice."""
+
+    URL = "https://example.test/v/model.onnx"
+
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()
-        self.tmp = Path(self._tmpdir.name)
-        self.info = TTSModelInfo(
-            voice_id="test/offline",
-            lang="en",
-            model_url="https://example.test/model.onnx",
-        )
-        # redirect the cache dir away from the real ~/.cache
-        self._patcher = patch.object(
-            type(self.info), "voice_path",
-            property(lambda _self: self.tmp),
-        )
-        self._patcher.start()
+        self.addCleanup(self._tmpdir.cleanup)
+        # keep every download inside the test's own cache root
+        patcher = patch("phoonnx.model_manager.HF_HUB_CACHE", self._tmpdir.name)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+        self.info = TTSModelInfo(voice_id="test/offline", lang="en",
+                                 model_url=self.URL)
+        self.tmp = _direct_dir(self.URL)
+        self.tmp.mkdir(parents=True, exist_ok=True)
         self.model_path = self.tmp / "model.onnx"
-
-    def tearDown(self):
-        self._patcher.stop()
-        self._tmpdir.cleanup()
 
     def test_sidecar_connection_error_does_not_propagate(self):
         """An offline sidecar probe must not crash a voice that has its graph."""
@@ -89,7 +88,7 @@ class TestOfflineModelLoad(unittest.TestCase):
         def fake_get(url, *a, **kw):
             if url.endswith("_data"):
                 return _FakeResponse(status_code=200, content=b"weights")
-            raise AssertionError(f"unexpected url {url}")
+            return _FakeResponse(status_code=200, content=b"onnx-graph")
 
         with patch("phoonnx.model_manager.requests.get", side_effect=fake_get):
             self.info.download_model()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Voice files were downloaded with a plain HTTP GET into a directory named after the voice. Two consequences:

1. **Every voice that names the same file stored its own copy.** The catalog has **3227 voices behind 1740 distinct model URLs**. One model serves **646 omnivoice** voices and its files come to ~3 GB — about **1.9 TB of identical bytes**. Another serves **310 supertonic** voices.
2. **The copy was private.** The HuggingFace cache the rest of the machine already uses — onnx-asr, transformers, anything else — was neither read nor written, so a file already on disk was downloaded again.

## The change

Every URL in the voice index resolves to `huggingface.co` (verified: **5289 of 5289**), so downloads go through `huggingface_hub`, which keeps one copy per file and revision. The voice directory holds a symlink to it, so the layout every caller sees is unchanged.

`_stream_to_file` is the single choke point every artifact passes through — the graph, its external-weights sidecar, vocoders, aux encoders, tokenizers — so wrapping it there covers all of them. The sidecar previously had its own inline request and is now routed the same way; it is the largest file (2.45 GB for the omnivoice backbone), so it was the bulk of the waste.

`huggingface_hub` is now a declared dependency, and it is imported at module scope rather than inside the download call. Importing it lazily let the first download decide where the hub cache and token live, so anything that had redirected `expanduser` by then got baked in for the life of the process.

## A URL the hub cannot serve

The first version of this raised on any non-`huggingface.co` URL. That is wrong: `add_voice` is public, and a self-hosted or mirrored voice is rare but legitimate — refusing it turns "no deduplication" into "does not work". Hub `/raw/<rev>/` URLs were refused too, although they serve the same bytes as `/resolve/<rev>/`.

So both hub forms are accepted, and a URL the hub cannot serve is streamed directly into the voice directory as before, with a warning naming the URL. It loses the sharing, not the ability to load.

## Sharing a cache means never writing into it

`dest` is a link into a cache shared by every voice and by every other program on the machine, and dozens of download workers run at once. `_point_at` links under a temporary name and `os.replace`s it over `dest`, because rename is atomic: racing callers end up with the same link instead of one of them failing. A dangling link — the hub cache can be pruned from under us — is unlinked and replaced rather than tripped over forever. The copy fallback, for a filesystem without symlinks, is never allowed to write *through* an existing link into the shared blob.

The temporary name carries a uuid, not just the pid: the workers are threads as often as they are processes, and the concurrency test caught two threads colliding on a pid-only name.

## The sidecar must not swallow real errors

The external-data sidecar is probed speculatively, because a single-file graph (piper/vits) simply has none. That probe caught bare `Exception`, so a full disk or a permission error on the 2.45 GB weights file was silently treated as "no sidecar" — and the graph then loads without its weights, which makes silence rather than an error.

Now only "there is no file here" is tolerated: the hub's `EntryNotFoundError` (which covers both the remote 404 and the offline-with-nothing-cached case) and `OfflineModeIsEnabled`, plus a connection error or a **404** on the direct path. A 500, a 403, a disk full, a permission error, or an HTTP error whose status cannot be read all propagate.

## Tests

`tests/test_model_manager.py`: **71 → 95 passing**. The 71 pre-existing tests cover the direct download path, which is still reachable, and three were updated where the artifact changed shape (a tokenizer.json is streamed now, and a vocoder config is parsed as JSON rather than as raw bytes).

24 new tests cover the hub contract with `hf_hub_download` stubbed by a fake cache: symlinking into the cache, two voices sharing one physical file for one download, `/raw/` URLs, JSON and text through the cache, the non-hub fallback and its warning, error propagation, and the sidecar matrix above. `TestPointAt` covers the concurrency rules: 8 threads × 50 calls with no errors and no leftover temp links, the shared blob unmodified when the copy fallback fires on a path that is already a link, and a dangling link healed without resurrecting its dead target.

Every new test was checked to **fail against the code before this change** and pass after — including the pid-only race, which is why the uuid is there.

Whole suite, minimal venv: `origin/dev` **1862 passed / 115 failed**, this branch **1886 passed / 115 failed**, with the `FAILED` lists diffed and identical. The pre-existing failures are missing optional/training dependencies.

## Evidence

- Two voices naming one model: one download, one physical file (`a.resolve() == b.resolve()`), a distinct URL still downloads.
- All file types, not just the graph: after fetching an aux encoder for two voices, the hub cache holds 12 MB and the voice directories hold ~0.
- 8 concurrent workers against one destination: no errors, shared blob unmodified, dangling link healed, no leftover temp links.
- On the live deployment, deleting the duplicated omnivoice directories reclaimed **40 GB from 22 voices**.

## Not covered

Per-language models are unaffected and cannot be deduplicated: the 1165 `facebook/mms-tts-*` voices are 1165 genuinely distinct checkpoints, not a base model plus adapters.

Model usage: implemented by Claude Opus 5 via Claude Code.
