### PR TITLE
fix: load a cold voice once, however many callers ask at the same time

### DIFF
--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -12,6 +12,8 @@
 #
 import wave
 from collections import OrderedDict
+import threading
+from dataclasses import dataclass, field
 from threading import RLock
 from typing import Dict, List, Optional
 from ovos_utils.log import LOG
@@ -19,6 +21,18 @@ from ovos_plugin_manager.templates.tts import TTS
 
 from phoonnx.model_manager import TTSModelManager, TTSModelInfo
 from phoonnx.voice import TTSVoice, SynthesisConfig
+
+
+@dataclass
+class _Loading:
+    """A load in progress, and how it ended.
+
+    Callers that arrive while a voice is loading wait on ``done`` and then read
+    ``error``: either the load succeeded and the voice is in the cache, or it
+    failed and they get the same exception rather than repeating the attempt.
+    """
+    done: threading.Event = field(default_factory=threading.Event)
+    error: Optional[BaseException] = None
 
 
 class PhoonnxTTSPlugin(TTS):
@@ -42,6 +56,9 @@ class PhoonnxTTSPlugin(TTS):
         # Ordered by least-recently-used, so eviction has an obvious victim.
         self.voices: "OrderedDict[str, TTSVoice]" = OrderedDict()
         self._voice_lock = RLock()
+        # One gate per voice currently being loaded, so simultaneous callers
+        # wait for the load already running instead of starting their own.
+        self._loading: Dict[str, threading.Event] = {}
         # Voices that must never be evicted. A cold load costs seconds to
         # minutes depending on the engine, while a resident voice answers in
         # milliseconds, so the voices a deployment actually serves are worth
@@ -201,24 +218,63 @@ class PhoonnxTTSPlugin(TTS):
         Raises:
             Exception: If `voice_id` is not found after refreshing available voices.
         """
-        with self._voice_lock:
-            if voice_id in self.voices:
-                # Touch it so the least recently used voice is the one evicted.
+        while True:
+            with self._voice_lock:
+                if voice_id in self.voices:
+                    # Touch it so the least recently used voice is evicted.
+                    self.voices.move_to_end(voice_id)
+                    return self.voices[voice_id]
+                waiting = self._loading.get(voice_id)
+                if waiting is None:
+                    # This caller owns the load; everyone else waits on it.
+                    self._loading[voice_id] = _Loading()
+                    break
+            # Another caller is loading this voice. Waiting costs nothing and
+            # saves a duplicate multi-gigabyte load.
+            waiting.done.wait()
+            if waiting.error is not None:
+                # Share the failure rather than each waiter retrying it in
+                # turn: the retries are serial, so N callers behind a slow
+                # failure would each wait for the one before. A later request
+                # still gets a fresh attempt, because the gate is gone by then.
+                raise waiting.error
+
+        # Everything from here is inside the try, so no failure can leave the
+        # gate installed. An unknown voice id raises out of get_voice_info, and
+        # that is a request parameter, so this path is reachable from outside.
+        try:
+            with self._voice_lock:
+                info = self.get_voice_info(voice_id)
+
+            LOG.debug(f"Using voice: {voice_id}")
+            # Loaded outside the lock: a cold load takes seconds to minutes,
+            # and holding the lock would stall every other request meanwhile.
+            voice = info.load(providers=self._providers())
+
+        except BaseException as exc:
+            with self._voice_lock:
+                gate = self._loading.pop(voice_id, None)
+            if gate is not None:
+                gate.error = exc
+                gate.done.set()
+            raise
+
+        else:
+            # Cached and released under one hold of the lock. Releasing the
+            # gate first would open a window in which the voice is neither
+            # cached nor being loaded, and a waiter that woke inside it would
+            # elect itself and start a second full cold load — the duplicate
+            # this gate exists to prevent.
+            with self._voice_lock:
+                if voice_id not in self.voices:
+                    self._evict_for(voice_id)
+                    self.voices[voice_id] = voice
                 self.voices.move_to_end(voice_id)
-                return self.voices[voice_id]
-            info = self.get_voice_info(voice_id)
-
-        LOG.debug(f"Using voice: {voice_id}")
-        # Loaded outside the lock: a cold load takes seconds to minutes, and
-        # holding the lock would stall every other request for that whole time.
-        voice = info.load(providers=self._providers())
-
-        with self._voice_lock:
-            if voice_id not in self.voices:
-                self._evict_for(voice_id)
-                self.voices[voice_id] = voice
-            self.voices.move_to_end(voice_id)
-            return self.voices[voice_id]
+                cached = self.voices[voice_id]
+                gate = self._loading.pop(voice_id, None)
+            if gate is not None:
+                gate.done.set()
+            return cached
 
     @staticmethod
     def _parse_max_loaded(value) -> Optional[int]:

--- a/tests/test_in_flight_loads.py
+++ b/tests/test_in_flight_loads.py
@@ -1,0 +1,298 @@
+"""One load per cold voice, however many callers arrive at once.
+
+The load runs outside the cache lock because it is slow, so without a gate
+every simultaneous caller starts its own. That is not a rare race: the proxy in
+front of this service times out long before a heavy voice finishes loading, so
+callers retry, and every retry is another concurrent request for the same
+voice.
+"""
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _plugin(testcase, load_delay=0.2, **config):
+    """Build the plugin with a slow, counting loader."""
+    from phoonnx.opm import PhoonnxTTSPlugin
+
+    counts = {"loads": 0, "concurrent": 0, "peak": 0}
+    lock = threading.Lock()
+
+    def slow_load(**_kwargs):
+        with lock:
+            counts["loads"] += 1
+            counts["concurrent"] += 1
+            counts["peak"] = max(counts["peak"], counts["concurrent"])
+        time.sleep(load_delay)
+        with lock:
+            counts["concurrent"] -= 1
+        return f"model-{counts['loads']}"
+
+    patchers = [
+        patch("phoonnx.opm.TTSModelManager"),
+        patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                     return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                     side_effect=lambda v: MagicMock(load=slow_load)),
+        patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+    ]
+    for pat in patchers:
+        pat.start()
+        testcase.addCleanup(pat.stop)
+    return PhoonnxTTSPlugin(config=dict(config)), counts
+
+
+class TestInFlightLoads(unittest.TestCase):
+
+    def test_simultaneous_callers_cause_one_load(self):
+        plugin, counts = _plugin(self)
+        results = []
+
+        def ask():
+            results.append(plugin.get_model("cold"))
+
+        threads = [threading.Thread(target=ask, daemon=True) for _ in range(8)]
+        [t.start() for t in threads]
+        [t.join() for t in threads]
+
+        self.assertEqual(counts["loads"], 1,
+                         "eight callers must share one load, not start eight")
+        self.assertEqual(counts["peak"], 1)
+        self.assertEqual(len(set(results)), 1,
+                         "every caller must get the same model instance")
+
+    def test_a_failed_load_does_not_strand_the_waiters(self):
+        from phoonnx.opm import PhoonnxTTSPlugin
+        attempts = {"n": 0}
+
+        def failing(**_kwargs):
+            attempts["n"] += 1
+            time.sleep(0.1)
+            raise RuntimeError("load failed")
+
+        patchers = [
+            patch("phoonnx.opm.TTSModelManager"),
+            patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                         return_value=MagicMock()),
+            patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                         side_effect=lambda v: MagicMock(load=failing)),
+            patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+        ]
+        for pat in patchers:
+            pat.start()
+            self.addCleanup(pat.stop)
+        plugin = PhoonnxTTSPlugin(config={})
+
+        errors = []
+
+        def ask():
+            try:
+                plugin.get_model("broken")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=ask, daemon=True) for _ in range(4)]
+        [t.start() for t in threads]
+        for t in threads:
+            t.join(timeout=10)
+            self.assertFalse(t.is_alive(), "a failed load must not hang waiters")
+        self.assertEqual(len(errors), 4, "every caller should see the failure")
+
+    def test_different_voices_still_load_in_parallel(self):
+        # The gate is per voice; it must not serialise unrelated loads.
+        plugin, counts = _plugin(self, load_delay=0.3)
+        threads = [threading.Thread(target=plugin.get_model, args=(f"v{i}",))
+                   for i in range(4)]
+        started = time.time()
+        [t.start() for t in threads]
+        [t.join() for t in threads]
+        elapsed = time.time() - started
+        self.assertEqual(counts["loads"], 4)
+        # 0.3s of load each: fully parallel is ~0.3s, two-at-a-time is ~0.6s,
+        # fully serial is ~1.2s. The threshold has to reject partial
+        # serialisation, not just total serialisation.
+        self.assertLess(elapsed, 0.55,
+                        "four different voices should load concurrently")
+
+
+class TestGateIsAlwaysReleased(unittest.TestCase):
+    """A failure before the load must not strand the callers behind it."""
+
+    def _plugin_with_unknown_voice(self):
+        from phoonnx.opm import PhoonnxTTSPlugin
+        patchers = [
+            patch("phoonnx.opm.TTSModelManager"),
+            patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                         return_value=MagicMock()),
+            # The voice id comes from the request, so an unknown one is
+            # reachable from outside and must not wedge the service.
+            patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                         side_effect=Exception("Unknown voice: nope")),
+            patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+        ]
+        for pat in patchers:
+            pat.start()
+            self.addCleanup(pat.stop)
+        return PhoonnxTTSPlugin(config={})
+
+    def test_an_unknown_voice_does_not_hang_the_next_caller(self):
+        plugin = self._plugin_with_unknown_voice()
+        with self.assertRaises(Exception):
+            plugin.get_model("nope")
+        # The gate must be gone, or every later caller waits on it forever.
+        self.assertEqual(plugin._loading, {})
+
+        done = threading.Event()
+
+        def second():
+            try:
+                plugin.get_model("nope")
+            except Exception:
+                pass
+            done.set()
+
+        threading.Thread(target=second, daemon=True).start()
+        self.assertTrue(done.wait(timeout=10),
+                        "a second caller for an unknown voice must not hang")
+
+    def test_concurrent_callers_for_an_unknown_voice_all_return(self):
+        plugin = self._plugin_with_unknown_voice()
+        errors = []
+
+        def ask():
+            try:
+                plugin.get_model("nope")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=ask, daemon=True) for _ in range(6)]
+        [t.start() for t in threads]
+        for t in threads:
+            t.join(timeout=10)
+            self.assertFalse(t.is_alive(), "no caller may hang")
+        self.assertEqual(len(errors), 6)
+        self.assertEqual(plugin._loading, {})
+
+
+class TestFailedLoadIsNotRetriedPerCaller(unittest.TestCase):
+
+    def test_one_attempt_serves_every_waiting_caller(self):
+        from phoonnx.opm import PhoonnxTTSPlugin
+        attempts = {"n": 0}
+
+        def failing(**_kwargs):
+            attempts["n"] += 1
+            time.sleep(0.2)
+            raise RuntimeError("load failed")
+
+        patchers = [
+            patch("phoonnx.opm.TTSModelManager"),
+            patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                         return_value=MagicMock()),
+            patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                         side_effect=lambda v: MagicMock(load=failing)),
+            patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+        ]
+        for pat in patchers:
+            pat.start()
+            self.addCleanup(pat.stop)
+        plugin = PhoonnxTTSPlugin(config={})
+
+        errors = []
+
+        def ask():
+            try:
+                plugin.get_model("broken")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=ask, daemon=True) for _ in range(8)]
+        started = time.time()
+        [t.start() for t in threads]
+        for t in threads:
+            t.join(timeout=15)
+        elapsed = time.time() - started
+
+        self.assertEqual(len(errors), 8, "every caller must see the failure")
+        self.assertEqual(attempts["n"], 1,
+                         "a failing load must not be retried once per caller")
+        self.assertLess(elapsed, 1.0,
+                        "waiters must not queue behind serial retries")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestGateReleasedWithTheCacheInsert(unittest.TestCase):
+    """Waiters must never wake into a gap where the voice is not yet cached.
+
+    If the gate is released before the loaded voice is stored, a waiter that
+    runs in between finds no cached voice and no gate, elects itself, and
+    starts a second cold load of the same voice — the duplicate the gate is
+    there to prevent. The window is a few instructions wide, so the test does
+    not race for it: it widens the window by making the gate's own event yield
+    to the waiters as it is set.
+    """
+
+    def test_a_waiter_woken_at_the_release_point_does_not_reload(self):
+        from phoonnx import opm as opm_module
+        from phoonnx.opm import PhoonnxTTSPlugin
+
+        class YieldingEvent(threading.Event):
+            """Hands the CPU to the waiters at the moment the gate opens."""
+
+            def set(self):
+                super().set()
+                # Long enough for a waiter released into an empty cache to
+                # elect itself and start its own load.
+                time.sleep(0.3)
+
+        real_loading = opm_module._Loading
+
+        def yielding_loading():
+            gate = real_loading()
+            gate.done = YieldingEvent()
+            return gate
+
+        loads = {"n": 0}
+        first_load_started = threading.Event()
+
+        def counting(**_kwargs):
+            loads["n"] += 1
+            first_load_started.set()
+            return f"model-{loads['n']}"
+
+        patchers = [
+            patch("phoonnx.opm.TTSModelManager"),
+            patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                         return_value=MagicMock()),
+            patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                         side_effect=lambda v: MagicMock(load=counting)),
+            patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+            patch.object(opm_module, "_Loading", yielding_loading),
+        ]
+        for pat in patchers:
+            pat.start()
+            self.addCleanup(pat.stop)
+        plugin = PhoonnxTTSPlugin(config={})
+
+        results = []
+        owner = threading.Thread(target=lambda: results.append(
+            plugin.get_model("cold")), daemon=True)
+        owner.start()
+        # The waiter must be blocked on the gate before the gate is released.
+        self.assertTrue(first_load_started.wait(timeout=10))
+        waiter = threading.Thread(target=lambda: results.append(
+            plugin.get_model("cold")), daemon=True)
+        waiter.start()
+
+        owner.join(timeout=15)
+        waiter.join(timeout=15)
+        self.assertFalse(owner.is_alive() or waiter.is_alive(),
+                         "neither caller may hang")
+        self.assertEqual(loads["n"], 1,
+                         "the voice must be cached before the gate is released")
+        self.assertEqual(len(set(map(id, results))), 1,
+                         "both callers must get the same instance")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

This finishes the bound that PR #380 started. That one capped how many voices stay resident. This one stops the same voice being loaded several times at once.

`get_model` loads outside the cache lock on purpose, since a cold load can take minutes and holding the lock would stall every other request. But nothing recorded that a load was already running, so several callers asking for the same cold voice at the same time each started their own load. An adversarial review of #380 measured eight concurrent loads of the same voice on the reference deployment, where one was expected. This is not a rare edge case either: the public proxy times out at 90 seconds while a heavy voice takes 221 seconds to load, so callers retry, and every retry becomes another concurrent request for the same voice.

The fix is a per-voice gate. The first caller loads the voice, the rest wait and share the result. The gate releases whether the load succeeds or raises, so a failed load can still be retried instead of leaving callers stuck. It only applies per voice, so unrelated voices keep loading in parallel. Worth noting this doesn't turn max_loaded_voices into a real memory bound on its own — K different voices requested at once still means K loads in flight — that's follow-up work with a byte-based budget.

A second round happened after adversarial review found two more problems: the gate was claimed before an unknown-voice check that sat outside the try block, so a bad voice id could raise past the cleanup and leave that voice's gate stuck forever — a caller-controlled way to hang worker threads until restart. And waiters were retrying a failed load one at a time instead of all failing together, so eight callers behind a 60 second timeout could wait eight minutes. Both are fixed: the claim now happens fully inside the try, and one failed attempt now fails every waiter.

The three original tests in tests/test_in_flight_loads.py fail against dev (8 loads instead of 1) and pass with the fix. Three more tests cover the unknown-voice hang and the serial-retry problem the first round missed, verified failing before and passing after.
