### PR TITLE
feat: bound the loaded-voice cache by bytes, not by voice count

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -197,6 +197,42 @@ def _warn_offhub(url: str) -> None:
                 f"that no other voice or program can share: {url}")
 
 
+def _cached_path(url: str) -> Optional[Path]:
+    """Local path of ``url`` if it is already downloaded, else None.
+
+    Never touches the network: this answers "how big is what we already
+    fetched", and a size question must not be able to start a download or
+    block on a hub that is slow to answer.
+    """
+    if not url:
+        return None
+    match = _HF_URL.match(url.split("?")[0])
+    if match:
+        try:
+            return Path(hf_hub_download(repo_id=match["repo"],
+                                        filename=match["path"],
+                                        revision=match["rev"],
+                                        local_files_only=True))
+        except Exception:
+            return None
+    dest = _direct_dir(url) / (url.split("?")[0].rsplit("/", 1)[-1] or "artifact")
+    return dest if _is_cached(dest) else None
+
+
+def _file_bytes(url: str) -> int:
+    """On-disk size of ``url``'s cached copy, plus its weights sidecar."""
+    total = 0
+    for candidate in (url, _sidecar_url(url)):
+        path = _cached_path(candidate)
+        if path is None:
+            continue
+        try:
+            total += path.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
 def _read_json(path: Path) -> Any:
     """Parse the JSON at ``path``."""
     with open(path, "r", encoding="utf-8") as handle:
@@ -578,6 +614,39 @@ class TTSModelInfo:
         # vocoder / style / speaker-encoder / aux graphs
         self.engine_params()
         return model_path
+
+    def disk_size(self) -> int:
+        """Total on-disk size, in bytes, of this voice's downloaded artifacts.
+
+        Sums every graph the voice loads — the primary ONNX model, its
+        external-weights sidecar when it has one, the vocoder, the style
+        embedding, the speaker encoder and any auxiliary graphs — as they lie
+        in the shared cache.
+
+        This is a *proxy* for how much memory the loaded voice occupies, not a
+        measurement of it. It is the honest one available without an optional
+        dependency, and the weights dominate both numbers, so the ordering it
+        gives between a 60 MB piper voice and a 2.2 GB omnivoice voice is the
+        ordering that matters. What it does NOT account for:
+
+        - onnxruntime arena allocations, activation buffers and per-session
+          overhead, which grow with the graph and with sequence length;
+        - weights the runtime materializes larger than they are stored (a
+          quantized graph dequantized at load, for instance);
+        - memory shared between voices that name the same file;
+        - anything the voice allocates later, during synthesis;
+        - artifacts that are not yet downloaded, which count as zero.
+
+        Returns:
+            int: bytes, or 0 when nothing is cached locally.
+        """
+        urls = [self.model_url, self.vocoder_url, self.style_url,
+                self.speaker_encoder_url, self.speech_encoder_url,
+                self.embed_tokens_url, self.conditional_decoder_url]
+        urls += [u for u in (self.aux_model_urls or {}).values() if u]
+        # One file may be named by several fields (and several voices); count
+        # each distinct file once.
+        return sum(_file_bytes(u) for u in dict.fromkeys(u for u in urls if u))
 
     def load(self, providers: Optional[Sequence[ProviderSpec]] = None) -> TTSVoice:
         """

--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -11,7 +11,9 @@
 # limitations under the License.
 #
 import hashlib
+import math
 import os
+import re
 import tempfile
 import wave
 from contextlib import suppress
@@ -67,6 +69,13 @@ class PhoonnxTTSPlugin(TTS):
         # One gate per voice currently being loaded, so simultaneous callers
         # wait for the load already running instead of starting their own.
         self._loading: Dict[str, threading.Event] = {}
+        # Bytes promised to loads that are running right now. A load allocates
+        # its memory before the cache ever sees it, so the budget has to be
+        # spent when the load starts, not when it finishes.
+        self._reserved_bytes = 0
+        # Signalled whenever a reservation is released, so a waiting loader
+        # can re-check whether it fits.
+        self._budget_free = threading.Condition(self._voice_lock)
         # Voices that must never be evicted. A cold load costs seconds to
         # minutes depending on the engine, while a resident voice answers in
         # milliseconds, so the voices a deployment actually serves are worth
@@ -90,6 +99,14 @@ class PhoonnxTTSPlugin(TTS):
                 f"max_loaded_voices is {self.max_loaded_voices}; raising the "
                 f"limit to fit them, because a pinned voice is a promise")
             self.max_loaded_voices = len(self.pinned_voices)
+        # How many bytes of voice may be resident at once. A count cannot bound
+        # memory on a mixed catalog: a piper voice is ~60 MB and an omnivoice
+        # voice is ~2.2 GB, so the count that is safe for the big one wastes
+        # the cache for the small ones. Unset keeps the previous behaviour.
+        self.max_loaded_bytes = self._parse_max_bytes(
+            self.config.get("max_loaded_bytes"))
+        # Measured size of each resident voice, keyed as ``self.voices`` is.
+        self._voice_bytes: Dict[str, int] = {}
         # Resolve the configured voice now, but do not load it. A voice that was
         # named explicitly and does not exist is a configuration error and still
         # raises here; an unset voice (or "default") resolves to the language's
@@ -108,6 +125,15 @@ class PhoonnxTTSPlugin(TTS):
                 # A pinned voice that cannot load must not stop the service
                 # from starting; it simply is not resident.
                 LOG.error(f"pinned voice '{voice_id}' failed to load: {e}")
+        if (self.max_loaded_bytes is not None
+                and self._resident_bytes() > self.max_loaded_bytes):
+            # Said once, at startup, the way a too-small max_loaded_voices is.
+            # The pins win either way, so this is the only warning an operator
+            # gets that the budget they set is not the memory they will use.
+            LOG.error(
+                f"the pinned voices need {self._resident_bytes()} bytes, more "
+                f"than max_loaded_bytes ({self.max_loaded_bytes}); the pins "
+                f"win, so memory use will exceed the budget")
 
     def _cfg_opt(self, default, *keys):
         """
@@ -250,17 +276,25 @@ class PhoonnxTTSPlugin(TTS):
         # Everything from here is inside the try, so no failure can leave the
         # gate installed. An unknown voice id raises out of get_voice_info, and
         # that is a request parameter, so this path is reachable from outside.
+        reserved = 0
         try:
             with self._voice_lock:
                 info = self.get_voice_info(voice_id)
 
             LOG.debug(f"Using voice: {voice_id}")
+            # Room is claimed BEFORE the load allocates anything. Evicting
+            # after the fact bounds the steady state and nothing else: four
+            # concurrent 2.2 GB loads each evicted the one before and the
+            # cache looked healthy, after the OOM killer had already taken
+            # the process.
+            reserved, measured = self._reserve(voice_id, info)
             # Loaded outside the lock: a cold load takes seconds to minutes,
             # and holding the lock would stall every other request meanwhile.
             voice = info.load(providers=self._providers())
 
         except BaseException as exc:
             with self._voice_lock:
+                self._release(reserved)
                 gate = self._loading.pop(voice_id, None)
             if gate is not None:
                 gate.error = exc
@@ -274,18 +308,29 @@ class PhoonnxTTSPlugin(TTS):
             # elect itself and start a second full cold load — the duplicate
             # this gate exists to prevent.
             #
-            # The try covers the caching too. An exception raised here is not
-            # caught by the except above it — that is what `else` means — so
-            # anything that failed while storing the voice used to leave the
-            # gate installed with nothing to ever set it, and every later
-            # caller for that voice id waited on it forever. The voice id
-            # comes from the request, so that is one wedged voice per failure,
-            # until the process restarts.
+            # The try covers the measuring and the caching too. An exception
+            # raised here is not caught by the except above it — that is what
+            # `else` means — so anything that failed while storing the voice
+            # used to leave the gate installed with nothing to ever set it,
+            # and every later caller for that voice id waited on it forever.
             try:
+                # Measured outside the lock: it only stats files, but it stats
+                # one per artifact and there is no reason to hold up every
+                # other request for it. A voice that could be measured before
+                # the load is not measured twice; one that could not (its
+                # files were not downloaded yet) now can be.
+                size = measured if measured else self._measure(voice_id, info)
+
                 with self._voice_lock:
+                    self._release(reserved)
+                    # Released exactly once: the failure path below runs the
+                    # same call, and releasing twice would shrink the budget
+                    # by a voice that was never holding it.
+                    reserved = 0
                     if voice_id not in self.voices:
-                        self._evict_for(voice_id)
+                        self._evict_for(voice_id, size)
                         self.voices[voice_id] = voice
+                        self._voice_bytes[voice_id] = size
                     self.voices.move_to_end(voice_id)
                     cached = self.voices[voice_id]
                     gate = self._loading.pop(voice_id, None)
@@ -295,6 +340,7 @@ class PhoonnxTTSPlugin(TTS):
 
             except BaseException as exc:
                 with self._voice_lock:
+                    self._release(reserved)
                     gate = self._loading.pop(voice_id, None)
                 if gate is not None:
                     gate.error = exc
@@ -317,22 +363,178 @@ class PhoonnxTTSPlugin(TTS):
             return None
         return parsed
 
-    def _evict_for(self, incoming: str) -> None:
-        """Make room for ``incoming``, never dropping a pinned voice."""
-        if self.max_loaded_voices is None:
+    @staticmethod
+    def _parse_max_bytes(value) -> Optional[int]:
+        """Normalize ``max_loaded_bytes``; None means no budget.
+
+        Accepts a plain number of bytes (``6000000000``) or a human-friendly
+        size (``"6GB"``, ``"512 MB"``, ``"1.5GiB"``). ``KB/MB/GB/TB`` are
+        powers of 1000, ``KiB/MiB/GiB/TiB`` powers of 1024, as those suffixes
+        are defined.
+
+        An unusable value is rejected and the budget stays unset. It must never
+        end up as zero: a zero budget evicts every voice on every request, and
+        an unbounded cache is a far better answer to a typo than a cache that
+        cold-loads a multi-gigabyte model for each call.
+        """
+        if value in (None, "", 0):
+            return None
+        units = {"": 1, "B": 1,
+                 "KB": 10 ** 3, "MB": 10 ** 6, "GB": 10 ** 9, "TB": 10 ** 12,
+                 "KIB": 2 ** 10, "MIB": 2 ** 20, "GIB": 2 ** 30, "TIB": 2 ** 40}
+        if isinstance(value, bool):  # bools are ints in python
+            LOG.error(f"ignoring invalid max_loaded_bytes: {value!r}")
+            return None
+        if isinstance(value, (int, float)):
+            number, unit = float(value), ""
+        else:
+            text = str(value).strip().replace(" ", "")
+            match = re.fullmatch(r"([0-9]*\.?[0-9]+)([a-zA-Z]*)", text)
+            if not match:
+                LOG.error(f"ignoring invalid max_loaded_bytes: {value!r}")
+                return None
+            number, unit = float(match.group(1)), match.group(2).upper()
+        if unit not in units:
+            LOG.error(f"ignoring max_loaded_bytes={value!r}: unknown unit "
+                      f"'{unit}', expected one of {sorted(units)}")
+            return None
+        if not math.isfinite(number):
+            # YAML writes infinity as ``.inf`` and json.loads accepts
+            # ``Infinity``/``NaN``; int() raises on all three, and this is
+            # called from __init__, so an uncaught raise here is a plugin that
+            # will not start.
+            LOG.error(f"ignoring max_loaded_bytes={value!r}: not a finite "
+                      f"size")
+            return None
+        parsed = int(number * units[unit])
+        if parsed < 1:
+            LOG.error(f"ignoring max_loaded_bytes={value!r}, it must be at "
+                      f"least 1 byte")
+            return None
+        return parsed
+
+    def _measure(self, voice_id: str, info: TTSModelInfo) -> int:
+        """Size of a loaded voice in bytes, as a proxy: its files on disk.
+
+        See :meth:`TTSModelInfo.disk_size` for what that proxy does and does
+        not account for. Nothing is measured unless a budget is set, so a
+        deployment that does not use one pays nothing for this.
+
+        A voice that cannot be measured counts as free rather than as
+        infinite: refusing to cache a voice because its size is unknown would
+        turn a measurement problem into a synthesis problem.
+        """
+        if self.max_loaded_bytes is None:
+            return 0
+        try:
+            return int(info.disk_size())
+        except Exception as exc:
+            LOG.error(f"could not measure the size of voice '{voice_id}', "
+                      f"counting it as free: {exc}")
+            return 0
+
+    def _reserve(self, voice_id: str, info: TTSModelInfo) -> "tuple[int, int]":
+        """Claim budget for a load that has not started yet.
+
+        Returns ``(reserved, measured)``: the bytes claimed, and the size the
+        voice could be measured at before loading (0 when it could not be).
+
+        Waits until the voice fits beside what is resident and what other
+        loads have already claimed, evicting to make room. Two rules keep this
+        from ever becoming a hang:
+
+        - a loader that finds no other load in flight always proceeds, so a
+          voice bigger than the whole budget still loads (evicting everything
+          evictable first, and warning) instead of waiting for room that can
+          never appear;
+        - every reservation is released on both the success and the failure
+          path, and each release wakes the waiters.
+
+        A voice whose files are not downloaded yet cannot be measured, and an
+        unknown size is treated as the whole budget: it loads alone. That
+        costs the cache once per voice, the first time it is ever fetched,
+        and it is the only honest way to keep an unknown allocation inside a
+        known bound.
+        """
+        if self.max_loaded_bytes is None:
+            return 0, 0
+        measured = self._measure(voice_id, info)
+        need = measured if measured > 0 else self.max_loaded_bytes
+        with self._budget_free:
+            while (self._reserved_bytes
+                   and self._resident_bytes() + self._reserved_bytes + need
+                   > self.max_loaded_bytes):
+                self._budget_free.wait()
+            # Make the room now, so the bytes are free when the load takes
+            # them rather than after it already has.
+            self._evict_for(voice_id, need)
+            self._reserved_bytes += need
+        return need, measured
+
+    def _release(self, reserved: int) -> None:
+        """Give back a reservation and wake whoever is waiting for room.
+
+        Called with ``self._voice_lock`` held.
+        """
+        if not reserved:
             return
-        while len(self.voices) >= self.max_loaded_voices:
-            victim = next((v for v in self.voices if v not in self.pinned_voices),
-                          None)
+        self._reserved_bytes = max(0, self._reserved_bytes - reserved)
+        self._budget_free.notify_all()
+
+    def _resident_bytes(self) -> int:
+        """Total measured size of the voices currently cached."""
+        return sum(self._voice_bytes.get(v, 0) for v in self.voices)
+
+    def _drop(self, victim: str) -> None:
+        self.voices.pop(victim, None)
+        self._voice_bytes.pop(victim, None)
+        LOG.debug(f"evicted least recently used voice: {victim}")
+
+    def _lru_victim(self) -> Optional[str]:
+        """The least recently used voice that may be evicted, if any."""
+        return next((v for v in self.voices if v not in self.pinned_voices),
+                    None)
+
+    def _evict_for(self, incoming: str, size: int = 0) -> None:
+        """Make room for ``incoming``, never dropping a pinned voice.
+
+        Both bounds apply when both are set: a voice is evicted when either the
+        count or the byte budget would be exceeded.
+        """
+        if self.max_loaded_voices is not None:
+            while len(self.voices) >= self.max_loaded_voices:
+                victim = self._lru_victim()
+                if victim is None:
+                    # Everything resident is pinned: serve the request anyway
+                    # rather than evict a voice an operator asked us to keep.
+                    LOG.warning(
+                        f"all {len(self.voices)} loaded voices are pinned; "
+                        f"loading '{incoming}' above max_loaded_voices")
+                    break
+                self._drop(victim)
+
+        if self.max_loaded_bytes is None:
+            return
+
+        if size > self.max_loaded_bytes:
+            # Serving it is still better than not serving it. Everything
+            # evictable goes first, so the overshoot is as small as it can be.
+            LOG.warning(
+                f"voice '{incoming}' needs {size} bytes on disk, more than the "
+                f"whole max_loaded_bytes budget of {self.max_loaded_bytes}; "
+                f"loading it anyway, so memory use will exceed the budget")
+
+        while (self.voices
+               and self._resident_bytes() + self._reserved_bytes + size
+               > self.max_loaded_bytes):
+            victim = self._lru_victim()
             if victim is None:
-                # Everything resident is pinned: serve the request anyway
-                # rather than evict a voice an operator asked us to keep.
                 LOG.warning(
-                    f"all {len(self.voices)} loaded voices are pinned; "
-                    f"loading '{incoming}' above max_loaded_voices")
-                return
-            self.voices.pop(victim, None)
-            LOG.debug(f"evicted least recently used voice: {victim}")
+                    f"all {len(self.voices)} loaded voices are pinned "
+                    f"({self._resident_bytes()} bytes); loading '{incoming}' "
+                    f"above max_loaded_bytes")
+                break
+            self._drop(victim)
 
     def get_voice_info(self, voice_id: str) -> TTSModelInfo:
         """

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -893,3 +893,140 @@ class TestUnwritableCachePath(unittest.TestCase):
         bad_path = os.path.join(tmpdir, "sub", "cache.json")
         with self.assertRaises(PermissionError):
             TTSModelManager(cache_path=bad_path)
+
+
+class TestDiskSize(unittest.TestCase):
+    """Measuring a voice, against a real hub cache layout on disk.
+
+    The byte budget is only as good as this measurement: a ``disk_size`` that
+    silently returns 0 does not fail loudly, it disables the budget and lets
+    memory run unbounded. So these tests build the cache the hub actually
+    writes — blobs, refs, and a snapshot of symlinks into the blobs — and read
+    it back through the real ``huggingface_hub`` resolver rather than a stub.
+    """
+
+    REPO = "an-org/a-repo"
+    URL = "https://huggingface.co/an-org/a-repo/resolve/main/"
+
+    def setUp(self):
+        from huggingface_hub import constants
+        self._cache = tempfile.TemporaryDirectory(dir=os.environ.get("TMPDIR"))
+        self.addCleanup(self._cache.cleanup)
+        self.cache = Path(self._cache.name)
+        patcher = patch.object(constants, "HF_HUB_CACHE", str(self.cache))
+        self.addCleanup(patcher.stop)
+        patcher.start()
+        # a direct (non-hub) download must not touch the developer's cache
+        dpatch = patch("phoonnx.model_manager.HF_HUB_CACHE", str(self.cache))
+        self.addCleanup(dpatch.stop)
+        dpatch.start()
+
+        self.root = self.cache / "models--an-org--a-repo"
+        (self.root / "blobs").mkdir(parents=True)
+        (self.root / "refs").mkdir()
+        (self.root / "refs" / "main").write_text("cafebabe")
+        self.snapshot = self.root / "snapshots" / "cafebabe"
+        self.snapshot.mkdir(parents=True)
+
+    def add(self, name, size):
+        """Write ``name`` into the cache exactly as the hub would: a blob,
+        with the snapshot entry a symlink pointing at it."""
+        blob = self.root / "blobs" / f"{name}-sha"
+        blob.write_bytes(b"x" * size)
+        link = self.snapshot / name
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(blob)
+        return blob
+
+    def test_a_cached_file_resolves_to_the_blob_it_links_to(self):
+        from phoonnx.model_manager import _cached_path
+        blob = self.add("model.onnx", 1000)
+        path = _cached_path(f"{self.URL}model.onnx")
+        self.assertIsNotNone(path)
+        self.assertTrue(Path(path).is_symlink())
+        self.assertEqual(Path(path).resolve(), blob.resolve())
+        self.assertEqual(Path(path).stat().st_size, 1000,
+                         "stat must follow the link to the blob, not measure "
+                         "the link itself")
+
+    def test_the_weights_sidecar_is_counted_with_its_graph(self):
+        # An omnivoice graph is a few MB and its .onnx_data is gigabytes;
+        # missing the sidecar is the difference between a budget and a lie.
+        from phoonnx.model_manager import _file_bytes
+        self.add("model.onnx", 1000)
+        self.add("model.onnx_data", 5000)
+        self.assertEqual(_file_bytes(f"{self.URL}model.onnx"), 6000)
+
+    def test_a_graph_without_a_sidecar_is_just_the_graph(self):
+        from phoonnx.model_manager import _file_bytes
+        self.add("vocoder.onnx", 2000)
+        self.assertEqual(_file_bytes(f"{self.URL}vocoder.onnx"), 2000)
+
+    def test_the_download_query_form_measures_the_same_file(self):
+        from phoonnx.model_manager import _file_bytes
+        self.add("model.onnx", 1000)
+        self.add("model.onnx_data", 5000)
+        self.assertEqual(_file_bytes(f"{self.URL}model.onnx?download=true"),
+                         6000)
+
+    def test_a_file_that_was_never_downloaded_measures_zero(self):
+        from phoonnx.model_manager import _cached_path, _file_bytes
+        self.assertIsNone(_cached_path(f"{self.URL}absent.onnx"))
+        self.assertEqual(_file_bytes(f"{self.URL}absent.onnx"), 0)
+        self.assertEqual(_file_bytes(""), 0)
+
+    def test_never_goes_to_the_network(self):
+        # A size question that can start a download, or block on a hub that is
+        # slow to answer, is a size question that can hang synthesis.
+        from phoonnx.model_manager import _file_bytes
+        with patch("requests.get", side_effect=AssertionError("network!")), \
+                patch("requests.head", side_effect=AssertionError("network!")):
+            self.assertEqual(_file_bytes(f"{self.URL}absent.onnx"), 0)
+
+    def test_every_graph_a_voice_loads_is_summed(self):
+        self.add("model.onnx", 1000)
+        self.add("model.onnx_data", 5000)
+        self.add("vocoder.onnx", 2000)
+        self.add("speaker.onnx", 400)
+        self.add("aux.onnx", 100)
+        info = TTSModelInfo(voice_id="v", lang="en-US",
+                            model_url=f"{self.URL}model.onnx",
+                            vocoder_url=f"{self.URL}vocoder.onnx",
+                            speaker_encoder_url=f"{self.URL}speaker.onnx",
+                            aux_model_urls={"extra": f"{self.URL}aux.onnx"})
+        self.assertEqual(info.disk_size(), 8500)
+
+    def test_one_file_named_by_two_fields_is_counted_once(self):
+        self.add("model.onnx", 1000)
+        self.add("model.onnx_data", 5000)
+        info = TTSModelInfo(voice_id="v", lang="en-US",
+                            model_url=f"{self.URL}model.onnx",
+                            vocoder_url=f"{self.URL}model.onnx")
+        self.assertEqual(info.disk_size(), 6000)
+
+    def test_a_voice_that_was_never_fetched_measures_zero(self):
+        info = TTSModelInfo(voice_id="v", lang="en-US",
+                            model_url=f"{self.URL}cold.onnx")
+        self.assertEqual(info.disk_size(), 0)
+
+    def test_a_voice_hosted_outside_the_hub_is_measured_too(self):
+        from phoonnx.model_manager import _file_bytes
+        url = "https://models.example/voice/model.onnx"
+        dest = _direct_dir(url)
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "model.onnx").write_bytes(b"x" * 777)
+        self.assertEqual(_file_bytes(url), 777)
+        self.assertEqual(
+            TTSModelInfo(voice_id="v", lang="en-US",
+                         model_url=url).disk_size(), 777)
+
+    def test_an_empty_off_hub_file_is_not_reported_as_downloaded(self):
+        # ``_is_cached`` treats a zero-byte file as absent: an interrupted
+        # download leaves one behind, and calling it cached would both skip the
+        # refetch and measure a multi-gigabyte voice as free.
+        from phoonnx.model_manager import _cached_path
+        url = "https://models.example/voice/model.onnx"
+        dest = _direct_dir(url)
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "model.onnx").write_bytes(b"")
+        self.assertIsNone(_cached_path(url))

--- a/tests/test_voice_cache_budget.py
+++ b/tests/test_voice_cache_budget.py
@@ -1,0 +1,430 @@
+"""A memory budget for the loaded-voice cache, in bytes rather than voices.
+
+A count cannot bound memory on a mixed catalog. Measured on a server with an
+8 GiB limit and ``max_loaded_voices: 3``: four concurrent omnivoice requests
+pinned the container at 8 GiB / 8 GiB and left 6.479 GiB resident, and a
+five-worker sweep killed the process.
+
+The budget bounds *peak* memory, not only the steady state, because peak is
+what the OOM killer reads. A cold load reserves its bytes before it allocates
+them, so concurrent loads of different voices are admitted only while they fit.
+The guarantee is:
+
+    peak resident bytes <= max(budget, pinned bytes + the largest single voice)
+
+A single voice larger than the whole budget still loads, because refusing to
+serve it is worse; it is the only way to exceed the budget, and it does so
+alone. These tests pin that bound, and that the count bound still works exactly
+as before.
+"""
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+MB = 10 ** 6
+GB = 10 ** 9
+
+
+def _plugin(testcase, sizes=None, load_hook=None, **config):
+    """Build the plugin with its model manager and loading stubbed out.
+
+    ``sizes`` maps voice id -> on-disk bytes; anything not listed is 10 MB, the
+    order of a small piper voice.
+    """
+    from phoonnx.opm import PhoonnxTTSPlugin
+
+    sizes = sizes or {}
+
+    def info_for(voice_id):
+        def load(**_kwargs):
+            if load_hook is not None:
+                load_hook(voice_id)
+            return f"model:{voice_id}"
+
+        return MagicMock(load=load,
+                         disk_size=MagicMock(
+                             return_value=sizes.get(voice_id, 10 * MB)))
+
+    patchers = [
+        patch("phoonnx.opm.TTSModelManager"),
+        patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                     return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "get_voice_info", side_effect=info_for),
+        patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+    ]
+    for pat in patchers:
+        pat.start()
+        testcase.addCleanup(pat.stop)
+    return PhoonnxTTSPlugin(config=dict(config))
+
+
+class TestSizeParsing(unittest.TestCase):
+
+    def test_human_friendly_sizes(self):
+        from phoonnx.opm import PhoonnxTTSPlugin as P
+        cases = {
+            "6GB": 6 * 10 ** 9,
+            "512MB": 512 * 10 ** 6,
+            "1.5GB": 1_500_000_000,
+            "2GiB": 2 * 2 ** 30,
+            "512 MiB": 512 * 2 ** 20,
+            "1024": 1024,
+            1024: 1024,
+            "900KB": 900_000,
+            "4TB": 4 * 10 ** 12,
+        }
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(P._parse_max_bytes(value), expected)
+
+    def test_infinite_and_nan_budgets_are_rejected_not_crashes(self):
+        # YAML ".inf" and json.loads("Infinity"/"NaN") both land here as
+        # floats, and int(inf) raises out of __init__, killing plugin startup.
+        from phoonnx.opm import PhoonnxTTSPlugin as P
+        for value in (float("inf"), float("-inf"), float("nan"),
+                      "1e400", 1e400):
+            with self.subTest(value=value):
+                self.assertIsNone(P._parse_max_bytes(value))
+
+    def test_an_infinite_budget_does_not_break_startup(self):
+        plugin = _plugin(self, max_loaded_bytes=float("inf"))
+        self.assertIsNone(plugin.max_loaded_bytes)
+        plugin.get_model("v")
+        self.assertIn("v", plugin.voices)
+
+    def test_unset_means_no_budget(self):
+        from phoonnx.opm import PhoonnxTTSPlugin as P
+        for value in (None, "", 0):
+            with self.subTest(value=value):
+                self.assertIsNone(P._parse_max_bytes(value))
+
+    def test_invalid_sizes_are_rejected_not_read_as_zero(self):
+        # A zero budget would evict every voice on every request, so a typo
+        # must leave the cache unbounded rather than unusable.
+        from phoonnx.opm import PhoonnxTTSPlugin as P
+        for value in ("nonsense", "6 gigabytes", "GB", "-1", -1, "1.2.3",
+                      "6GBB", "0.4", True, [1], "12PB"):
+            with self.subTest(value=value):
+                self.assertIsNone(P._parse_max_bytes(value))
+
+    def test_an_invalid_budget_leaves_the_cache_unbounded(self):
+        plugin = _plugin(self, max_loaded_bytes="nonsense")
+        self.assertIsNone(plugin.max_loaded_bytes)
+        for i in range(4):
+            plugin.get_model(f"v{i}")
+        self.assertEqual(len(plugin.voices), 4)
+
+
+class TestByteBudget(unittest.TestCase):
+
+    def test_a_voice_over_the_remaining_budget_evicts_the_lru(self):
+        plugin = _plugin(self, sizes={"a": 200 * MB, "b": 200 * MB,
+                                      "big": 700 * MB},
+                         max_loaded_bytes="1GB")
+        plugin.get_model("a")
+        plugin.get_model("b")
+        plugin.get_model("a")       # touch: "b" is now the oldest
+        plugin.get_model("big")
+        self.assertIn("big", plugin.voices)
+        self.assertNotIn("b", plugin.voices)
+        self.assertIn("a", plugin.voices)
+
+    def test_many_small_voices_but_only_one_big_one(self):
+        # The case a count gets wrong: with max_loaded_voices=3 these small
+        # voices would evict for no reason, and three big ones would fit and
+        # kill the server.
+        plugin = _plugin(self, sizes={"omni": 2200 * MB},
+                         max_loaded_bytes="3GB")
+        for i in range(20):
+            plugin.get_model(f"small{i}")   # 10 MB each -> 200 MB resident
+        self.assertEqual(len(plugin.voices), 20)
+
+        plugin.get_model("omni")
+        self.assertIn("omni", plugin.voices)
+        self.assertLessEqual(sum(plugin._voice_bytes[v] for v in plugin.voices),
+                             3 * GB)
+
+        # Another small voice still fits alongside it; the budget is never
+        # exceeded by voices that could have been evicted.
+        plugin.get_model("small20")
+        self.assertIn("omni", plugin.voices)
+        self.assertLessEqual(sum(plugin._voice_bytes[v] for v in plugin.voices),
+                             3 * GB)
+
+    def test_two_big_voices_cannot_be_resident_together(self):
+        plugin = _plugin(self, sizes={"omniA": 2200 * MB, "omniB": 2200 * MB},
+                         max_loaded_bytes="3GB")
+        plugin.get_model("omniA")
+        plugin.get_model("omniB")
+        self.assertIn("omniB", plugin.voices)
+        self.assertNotIn("omniA", plugin.voices)
+
+    def test_a_voice_bigger_than_the_whole_budget_still_loads_and_warns(self):
+        plugin = _plugin(self, sizes={"huge": 8 * GB}, max_loaded_bytes="1GB")
+        plugin.get_model("small")
+        with patch("phoonnx.opm.LOG") as log:
+            model = plugin.get_model("huge")
+        self.assertEqual(model, "model:huge")
+        self.assertIn("huge", plugin.voices)
+        self.assertNotIn("small", plugin.voices,
+                         "everything evictable goes before overshooting")
+        warned = " ".join(str(c) for c in log.warning.call_args_list)
+        self.assertIn("huge", warned)
+        self.assertIn(str(8 * GB), warned)
+        self.assertIn(str(10 ** 9), warned)
+
+    def test_no_budget_means_no_measuring(self):
+        # Deployments that set neither bound must be untouched, and must not
+        # pay for a measurement they never asked for.
+        info = MagicMock(disk_size=MagicMock(return_value=1))
+        plugin = _plugin(self)
+        with patch.object(plugin, "get_voice_info", return_value=info):
+            plugin.get_model("v")
+        info.disk_size.assert_not_called()
+
+    def test_an_unmeasurable_voice_is_still_served(self):
+        plugin = _plugin(self, max_loaded_bytes="1GB")
+        broken = MagicMock(load=lambda **_k: "model:broken",
+                           disk_size=MagicMock(side_effect=OSError("no")))
+        with patch.object(plugin, "get_voice_info", return_value=broken):
+            self.assertEqual(plugin.get_model("broken"), "model:broken")
+        self.assertIn("broken", plugin.voices)
+
+
+class TestBothBoundsTogether(unittest.TestCase):
+
+    def test_the_count_still_evicts_when_the_budget_is_roomy(self):
+        plugin = _plugin(self, max_loaded_voices=2, max_loaded_bytes="100GB")
+        for name in ("a", "b", "c"):
+            plugin.get_model(name)
+        self.assertEqual(set(plugin.voices), {"b", "c"})
+
+    def test_the_budget_still_evicts_when_the_count_is_roomy(self):
+        sizes = {f"small{i}": 20 * MB for i in range(10)}
+        sizes["big"] = 900 * MB
+        plugin = _plugin(self, max_loaded_voices=50,
+                         sizes=sizes, max_loaded_bytes="1GB")
+        for i in range(10):
+            plugin.get_model(f"small{i}")
+        plugin.get_model("big")
+        self.assertIn("big", plugin.voices)
+        self.assertLess(len(plugin.voices), 11)
+        self.assertLessEqual(sum(plugin._voice_bytes[v] for v in plugin.voices),
+                             GB)
+
+
+class TestPinningUnderBudgetPressure(unittest.TestCase):
+
+    def test_a_pinned_voice_is_never_evicted_by_the_budget(self):
+        plugin = _plugin(self, pinned_voices=["keeper"],
+                         sizes={"keeper": 900 * MB, "big": 900 * MB},
+                         max_loaded_bytes="1GB")
+        self.assertIn("keeper", plugin.voices)
+        for i in range(5):
+            plugin.get_model(f"big{i}" if i else "big")
+        self.assertIn("keeper", plugin.voices,
+                      "a pinned voice must never be evicted")
+
+    def test_pins_raise_the_effective_ceiling(self):
+        # Three pins of 900 MB against a 1 GB budget: the pins win, exactly as
+        # they win against a too-small max_loaded_voices.
+        plugin = _plugin(self, pinned_voices=["p1", "p2", "p3"],
+                         sizes={"p1": 900 * MB, "p2": 900 * MB,
+                                "p3": 900 * MB},
+                         max_loaded_bytes="1GB")
+        for pin in ("p1", "p2", "p3"):
+            self.assertIn(pin, plugin.voices)
+        self.assertGreater(plugin._resident_bytes(), GB)
+
+    def test_pins_over_the_budget_are_reported_at_startup(self):
+        with patch("phoonnx.opm.LOG") as log:
+            _plugin(self, pinned_voices=["p1", "p2"],
+                    sizes={"p1": 900 * MB, "p2": 900 * MB},
+                    max_loaded_bytes="1GB")
+        logged = " ".join(str(c) for c in log.error.call_args_list)
+        self.assertIn("max_loaded_bytes", logged)
+        self.assertIn(str(1800 * MB), logged)
+
+    def test_an_all_pinned_cache_serves_a_new_voice_anyway(self):
+        plugin = _plugin(self, pinned_voices=["p1"],
+                         sizes={"p1": 900 * MB, "extra": 900 * MB},
+                         max_loaded_bytes="1GB")
+        self.assertEqual(plugin.get_model("extra"), "model:extra")
+        self.assertIn("p1", plugin.voices)
+        self.assertIn("extra", plugin.voices)
+
+
+class TestConcurrentEviction(unittest.TestCase):
+
+    def test_eviction_under_concurrent_loads_keeps_the_cache_consistent(self):
+        # Eviction runs in the same critical section that installs a voice and
+        # releases its loading gate. If it corrupted either, callers would hang
+        # or the size bookkeeping would drift away from the cache contents.
+        # Three of these 30 MB voices fit in the 100 MB budget at once, so
+        # three loads may overlap; a fourth waits for room. The barrier is
+        # sized to what admission control admits together.
+        barrier = threading.Barrier(3, timeout=10)
+        started = []
+        lock = threading.Lock()
+
+        def hook(voice_id):
+            with lock:
+                started.append(voice_id)
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                pass
+
+        plugin = _plugin(self, load_hook=hook, max_loaded_bytes="100MB",
+                         sizes={f"v{i}": 30 * MB for i in range(8)})
+
+        results = {}
+
+        def ask(i):
+            results[i] = plugin.get_model(f"v{i}")
+
+        threads = [threading.Thread(target=ask, args=(i,), daemon=True)
+                   for i in range(8)]
+        [t.start() for t in threads]
+        [t.join(timeout=20) for t in threads]
+
+        self.assertFalse([t for t in threads if t.is_alive()],
+                         "a stranded loading gate hangs callers forever")
+        self.assertEqual(len(results), 8)
+        self.assertEqual(plugin._loading, {},
+                         "every loading gate must be released")
+        self.assertEqual(set(plugin._voice_bytes), set(plugin.voices),
+                         "size bookkeeping must match the cache exactly")
+        self.assertLessEqual(plugin._resident_bytes(), 100 * MB)
+
+    def test_repeated_concurrent_requests_for_an_evicted_voice(self):
+        plugin = _plugin(self, max_loaded_bytes="50MB",
+                         sizes={"a": 30 * MB, "b": 30 * MB})
+
+        def hammer():
+            for _ in range(20):
+                plugin.get_model("a")
+                plugin.get_model("b")
+
+        threads = [threading.Thread(target=hammer, daemon=True)
+                   for _ in range(4)]
+        [t.start() for t in threads]
+        [t.join(timeout=30) for t in threads]
+        self.assertFalse([t for t in threads if t.is_alive()])
+        self.assertEqual(plugin._loading, {})
+        self.assertEqual(set(plugin._voice_bytes), set(plugin.voices))
+
+
+class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
+    """The bound that matters: what is resident at the worst instant.
+
+    Bounding only the steady state is no protection at all. The live incident
+    this budget exists for was four concurrent omnivoice loads: each one ended
+    up evicting the previous, so the cache looked well behaved afterwards while
+    the process had already been killed at the peak.
+    """
+
+    def _run(self, voices, sizes, budget, threads=None):
+        """Load ``voices`` concurrently and return the peak bytes observed.
+
+        Peak is sampled as (bytes being loaded right now) + (bytes resident),
+        counting a voice once: a voice that has become resident is dropped from
+        the in-flight side of the sum.
+        """
+        lock = threading.Lock()
+        live = {}
+        peak = [0]
+        plugin = None
+
+        def sample():
+            if plugin is None:   # a pinned voice loading from __init__
+                return
+            with lock:
+                inflight = sum(size for v, size in live.items()
+                               if v not in plugin.voices)
+                total = inflight + plugin._resident_bytes()
+                peak[0] = max(peak[0], total)
+
+        def hook(voice_id):
+            with lock:
+                live[voice_id] = sizes.get(voice_id, 10 * MB)
+            sample()
+            # Long enough that any admitted-together loads genuinely overlap.
+            time.sleep(0.2)
+            sample()
+
+        plugin = _plugin(self, sizes=sizes, load_hook=hook,
+                         max_loaded_bytes=budget,
+                         **(threads or {}))
+
+        errors = []
+
+        def ask(voice_id):
+            try:
+                plugin.get_model(voice_id)
+            except BaseException as exc:  # pragma: no cover - a failure is the report
+                errors.append(exc)
+            finally:
+                sample()
+                with lock:
+                    live.pop(voice_id, None)
+
+        workers = [threading.Thread(target=ask, args=(v,), daemon=True)
+                   for v in voices]
+        [t.start() for t in workers]
+        [t.join(timeout=60) for t in workers]
+        self.assertFalse([t for t in workers if t.is_alive()],
+                         "admission control must never deadlock")
+        self.assertFalse(errors, f"loads failed: {errors}")
+        self.assertEqual(plugin._loading, {})
+        self.assertEqual(set(plugin._voice_bytes), set(plugin.voices))
+        return plugin, peak[0]
+
+    def test_four_concurrent_omnivoice_loads_stay_within_the_budget(self):
+        # The reviewer's repro: without reservation this peaks at 4 x 2.2 GB.
+        sizes = {f"omni{i}": 2200 * MB for i in range(4)}
+        plugin, peak = self._run(list(sizes), sizes, "3GB")
+        self.assertLessEqual(peak, 3 * GB,
+                             f"peak {peak} bytes exceeded the 3 GB budget")
+        # No two of these fit together, so the peak is one voice, not four.
+        self.assertLessEqual(peak, 2200 * MB)
+        self.assertLessEqual(plugin._resident_bytes(), 3 * GB)
+
+    def test_voices_that_fit_together_still_load_together(self):
+        # Admission control must not serialise loads that the budget allows;
+        # that would trade an OOM for a queue.
+        barrier = threading.Barrier(3, timeout=15)
+        plugin = _plugin(self, load_hook=lambda _v: barrier.wait(),
+                         sizes={f"v{i}": 30 * MB for i in range(3)},
+                         max_loaded_bytes="100MB")
+        threads = [threading.Thread(target=plugin.get_model, args=(f"v{i}",),
+                                    daemon=True) for i in range(3)]
+        [t.start() for t in threads]
+        [t.join(timeout=20) for t in threads]
+        self.assertFalse([t for t in threads if t.is_alive()])
+        self.assertEqual(len(plugin.voices), 3)
+
+    def test_a_voice_larger_than_the_budget_still_loads_under_concurrency(self):
+        # It cannot fit by definition, so it must be let through alone rather
+        # than wait forever for room that will never appear.
+        sizes = {f"huge{i}": 4 * GB for i in range(3)}
+        plugin, peak = self._run(list(sizes), sizes, "1GB")
+        self.assertEqual(len(plugin.voices), 1)
+        self.assertLessEqual(peak, 4 * GB,
+                             "one oversized voice may exceed the budget, "
+                             "three at once may not")
+
+    def test_pinned_voices_raise_the_peak_ceiling_but_only_by_themselves(self):
+        sizes = {"keeper": 2 * GB, "a": 900 * MB, "b": 900 * MB,
+                 "c": 900 * MB}
+        plugin, peak = self._run(["a", "b", "c"], sizes, "1GB",
+                                 threads={"pinned_voices": ["keeper"]})
+        self.assertIn("keeper", plugin.voices)
+        self.assertLessEqual(peak, 2 * GB + 900 * MB,
+                             "pins raise the ceiling by their own size, "
+                             "not by one voice per concurrent request")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

The loaded-voice cache was bounded by counting voices, and that doesn't work on a mixed catalog. A piper voice is around 60 MB, an omnivoice voice is around 2.2 GB — a 40x gap. Whatever count is safe for the big voices wastes the cache on the small ones, and whatever count is generous for the small ones can kill the server on the big ones. On an 8 GiB container with max_loaded_voices set to 3, four concurrent omnivoice requests pinned the container at its full 8 GiB and a five-worker sweep killed the process outright.

This adds a new config option, max_loaded_bytes, that bounds the cache by actual size instead of voice count (accepts plain numbers, "6GB", "512 MB", "1.5GiB", etc). Size is measured from the voice's downloaded files in the shared cache — the model graphs plus the .onnx_data weights sidecar — which is a proxy for resident memory, not a direct measurement, and the docstring says so.

The important part is that the budget bounds peak memory, not just the steady state, because peak is what actually gets a process killed. Evicting only after a load finishes doesn't help here — four concurrent 2.2 GB loads would each evict the one before it, so the cache would look healthy right after the process had already been OOM-killed at the peak. So a load now claims its bytes before it starts, and other loads wait if there isn't room, woken up as claims free up. A single voice bigger than the whole budget still loads rather than being refused — it evicts everything evictable first and logs a warning, but a caller is never left waiting for room that will never exist. Pinned voices raise the ceiling by their own size just like they already do for max_loaded_voices, and pins that don't fit are now flagged with a startup error. A voice whose files aren't downloaded yet can't be sized ahead of time, so it's assumed to need the whole budget and loads alone — a one-time cost the first time each voice is fetched.

Everything from before still works: max_loaded_voices behaves the same and both bounds apply together if both are set; a config with no byte budget behaves exactly as before; pinned voices are never evicted; and a bad max_loaded_bytes value (including things like .inf or NaN) leaves the cache unbounded rather than accidentally becoming zero, which would have evicted every voice on every request.

tests/test_voice_cache_budget.py covers size parsing, eviction, both bounds together, pinning under pressure, and concurrency — four concurrent 2.2 GB loads against a 3 GB budget now peak at 2.2 GB instead of the 8.8 GB they hit before this change. tests/test_model_manager.py adds real coverage of the size-measurement code against a hand-built cache directory, covering sidecars, symlinks, missing files, and off-hub voices, with no network access anywhere in the path.
