### PR TITLE
fix: let a request choose the voice to clone

### DIFF
--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import hashlib
 import os
 import tempfile
 import wave
@@ -20,7 +21,7 @@ from dataclasses import dataclass, field
 from threading import RLock
 from typing import Dict, List, Optional
 from ovos_utils.log import LOG
-from ovos_plugin_manager.templates.tts import TTS
+from ovos_plugin_manager.templates.tts import TTS, TTSContext
 
 from phoonnx.model_manager import TTSModelManager, TTSModelInfo
 from phoonnx.voice import TTSVoice, SynthesisConfig
@@ -59,6 +60,10 @@ class PhoonnxTTSPlugin(TTS):
         # Ordered by least-recently-used, so eviction has an obvious victim.
         self.voices: "OrderedDict[str, TTSVoice]" = OrderedDict()
         self._voice_lock = RLock()
+        # Cloned cache identities, most recent last. Bounded because the
+        # reference that creates one comes from the request.
+        self._cloned_caches: "OrderedDict[str, bool]" = OrderedDict()
+        self._cloned_lock = RLock()
         # One gate per voice currently being loaded, so simultaneous callers
         # wait for the load already running instead of starting their own.
         self._loading: Dict[str, threading.Event] = {}
@@ -333,19 +338,88 @@ class PhoonnxTTSPlugin(TTS):
                 raise Exception(f"Unknown voice: {voice_id}")
         return self.model_manager.voices[voice_id]
 
-    def get_tts(self, sentence, wav_file, lang=None, voice=None):
+    def _get_ctxt(self, kwargs=None):
+        """Keep cloned audio out of the shared voice's cache entry.
+
+        The cache identifies a voice by ``plugin_id/voice/lang`` and then keys
+        audio by the sentence alone, so two requests that clone different
+        people saying the same sentence with the same base voice collide: the
+        second caller is served the first one's cloned audio. On a shared
+        server that is both the wrong voice and a leak of someone else's
+        cloned speech, and it is silent — the audio plays perfectly.
+
+        The reference is therefore folded into the cache identity. Only the
+        identity changes; ``synth_kwargs`` still carries the real voice id, so
+        the model that gets loaded is unaffected.
+        """
+        ctxt = super()._get_ctxt(kwargs)
+        kwargs = kwargs or {}
+        reference = tuple(
+            kwargs.get(key) for key in
+            ("speaker_reference", "ref_wav",
+             "speaker_reference_text", "ref_text",
+             "speaker_reference_lang", "ref_lang"))
+        if any(reference):
+            digest = hashlib.sha1(
+                repr(reference).encode("utf-8")).hexdigest()[:12]
+            ctxt.voice = f"{ctxt.voice}#{digest}"
+            self._remember_cloned_cache(ctxt.tts_id)
+        return ctxt
+
+    #: How many cloned identities keep a cache object in memory. Each distinct
+    #: reference makes one, and the reference comes from the request, so the
+    #: count is whatever a caller decides it is; the files on disk are already
+    #: bounded by the cache's own free-space curation, but this dictionary is
+    #: not bounded by anything.
+    MAX_CLONED_CACHES = 32
+
+    def _remember_cloned_cache(self, tts_id: str) -> None:
+        """Keep only the most recent cloned caches in memory."""
+        with self._cloned_lock:
+            self._cloned_caches.pop(tts_id, None)
+            self._cloned_caches[tts_id] = True
+            while len(self._cloned_caches) > self.MAX_CLONED_CACHES:
+                oldest, _ = self._cloned_caches.popitem(last=False)
+                # Only the in-memory handle is dropped. The audio stays on
+                # disk for the cache's own curation to reclaim; deleting a
+                # directory another request may be reading from would trade a
+                # bounded dictionary for a much worse bug.
+                TTSContext._caches.pop(oldest, None)
+
+    def get_tts(self, sentence, wav_file, lang=None, voice=None,
+                speaker_reference=None, speaker_reference_text=None,
+                speaker_reference_lang=None,
+                ref_wav=None, ref_text=None, ref_lang=None):
         """
         Synthesize the given text into speech and write the result to the specified WAV file.
-        
+
         Parameters:
             sentence (str): Text to synthesize.
             wav_file (str): Path where the WAV audio will be written.
             lang (str, optional): Language hint used to select a default voice when `voice` is not provided.
             voice (str, optional): Specific voice identifier to use; treat `None` or `"default"` as no explicit selection.
-        
+            speaker_reference (str, optional): Reference clip to clone, as a URL
+                or a path readable by the server. Cloning engines (chatterbox,
+                f5tts, zipvoice, styletts2, ...) cannot synthesize without one.
+            speaker_reference_text (str, optional): What the reference clip says.
+                In-context engines such as ZipVoice need it.
+            speaker_reference_lang (str, optional): Language of that transcription.
+            ref_wav, ref_text, ref_lang: short aliases for the three above,
+                matching the config key aliases.
+
+        Every caller-supplied value overrides the configured default, so one
+        server can clone a different voice per request. These are named
+        explicitly rather than collected with ``**kwargs`` because the plugin
+        manager forwards only parameters it can see in this signature.
+
         Returns:
             tuple: (`wav_file`, `phonemes`) where `wav_file` is the path to the written WAV file and `phonemes` is `None` when no phoneme output is produced.
         """
+        # The caller wins over the config; the aliases are equal citizens, so
+        # whichever of the pair was sent is the one that counts.
+        speaker_reference = speaker_reference or ref_wav
+        speaker_reference_text = speaker_reference_text or ref_text
+        speaker_reference_lang = speaker_reference_lang or ref_lang
         if voice and voice != "default":
             # load first so the model manager is refreshed if the voice
             # isn't cached yet, then read its info (avoids a KeyError when a
@@ -383,11 +457,11 @@ class PhoonnxTTSPlugin(TTS):
             # the reference's transcription + its language, e.g.:
             #   {"ref_wav": "/home/user/me.wav", "ref_text": "olá tudo bem",
             #    "ref_lang": "pt"}   ->   clone a Portuguese voice speaking English
-            speaker_reference=self._cfg_opt(
+            speaker_reference=speaker_reference or self._cfg_opt(
                 None, "speaker_reference", "ref_wav", "clone_voice"),
-            speaker_reference_text=self._cfg_opt(
+            speaker_reference_text=speaker_reference_text or self._cfg_opt(
                 None, "speaker_reference_text", "ref_text"),
-            speaker_reference_lang=self._cfg_opt(
+            speaker_reference_lang=speaker_reference_lang or self._cfg_opt(
                 None, "speaker_reference_lang", "ref_lang"),
             # optional post-synthesis audio super-resolution (audiosronnx), off unless
             # switched on in mycroft.conf. The core TTSVoice loads the engine lazily and

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -9,9 +9,15 @@ any future architecture without code changes here.
 import json
 import os.path
 import re
+import ipaddress
+import socket
+import time
+import tempfile
+from contextlib import suppress
 import wave
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union, Dict
 
 import numpy as np
@@ -54,14 +60,122 @@ def _phonemic_chunks(text: str, alphabet: Optional[Alphabet]) -> PhonemizedChunk
     return [[c for c in chunk] for chunk, _, _ in chunks if chunk]
 
 
+def _is_public_address(host: str) -> bool:
+    """Whether ``host`` resolves only to addresses outside this network.
+
+    A reference URL is supplied by whoever is calling, so without this a
+    public TTS server will happily fetch from its own loopback, its Docker
+    neighbours, or a cloud metadata endpoint on the caller's behalf, and
+    report back whether it worked.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    if not infos:
+        return False
+    for info in infos:
+        address = ipaddress.ip_address(info[4][0])
+        if (address.is_private or address.is_loopback or address.is_reserved
+                or address.is_link_local or address.is_multicast
+                or address.is_unspecified):
+            return False
+    return True
+
+
+def _check_reference_url(url: str) -> None:
+    """Refuse a reference URL that points inside this network."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"reference clip URL must be http(s): {url}")
+    if not parsed.hostname:
+        raise ValueError(f"reference clip URL has no host: {url}")
+    if not _is_public_address(parsed.hostname):
+        raise ValueError(
+            f"refusing to fetch a reference clip from {parsed.hostname}: it "
+            f"resolves inside this network, and the URL came from the caller")
+
+
+def _fetch_reference_audio(url: str, timeout: int = 10,
+                           max_bytes: int = 32 * 1024 * 1024,
+                           deadline: float = 30.0) -> str:
+    """Download a cloning reference to a temporary file and return its path.
+
+    Bounded three ways, because every one of them is attacker-controlled:
+    the host must be outside this network (each redirect hop is checked, not
+    just the first), the body must be small enough to be a few seconds of
+    speech, and the whole transfer must finish within ``deadline``. The
+    timeout ``requests`` takes applies per read, so a sender trickling one
+    byte at a time would otherwise hold a synthesis worker open forever.
+    """
+    import requests
+
+    started = time.monotonic()
+    _check_reference_url(url)
+    with requests.get(url, timeout=timeout, stream=True,
+                      allow_redirects=False) as r:
+        hops = 0
+        while r.is_redirect or r.is_permanent_redirect:
+            hops += 1
+            if hops > 5:
+                raise ValueError(f"too many redirects fetching {url}")
+            target = requests.compat.urljoin(r.url, r.headers["Location"])
+            # Checked per hop: a redirect is the easy way to turn an
+            # innocent-looking URL into a request to a private address.
+            _check_reference_url(target)
+            r.close()
+            r = requests.get(target, timeout=timeout, stream=True,
+                             allow_redirects=False)
+        r.raise_for_status()
+
+        suffix = os.path.splitext(urlparse(url).path)[1] or ".wav"
+        written = 0
+        tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        try:
+            for chunk in r.iter_content(chunk_size=8192):
+                if time.monotonic() - started > deadline:
+                    raise ValueError(
+                        f"reference clip at {url} took longer than "
+                        f"{deadline}s to arrive")
+                if not chunk:
+                    continue
+                written += len(chunk)
+                if written > max_bytes:
+                    raise ValueError(
+                        f"reference clip at {url} is larger than "
+                        f"{max_bytes} bytes; a reference is a few seconds of "
+                        f"speech, not a recording session")
+                tmp.write(chunk)
+        except BaseException:
+            tmp.close()
+            with suppress(OSError):
+                os.unlink(tmp.name)
+            raise
+        tmp.close()
+        return tmp.name
+
+
 def _load_reference_audio(ref: Any) -> tuple:
     """Normalise a cloning reference to ``(mono float32 audio, sample_rate)``.
 
-    Accepts an ``(audio, sample_rate)`` tuple or a path to an audio file.
+    Accepts an ``(audio, sample_rate)`` tuple, a URL, or a path to an audio
+    file. A URL is fetched to a temporary file first: a caller talking to a TTS
+    server over HTTP has no way to put a file on that server's disk, so without
+    this the cloning engines cannot be reached remotely at all.
     """
     if isinstance(ref, tuple) and len(ref) == 2:
         audio, sr = ref
         return np.asarray(audio, dtype=np.float32).reshape(-1), int(sr)
+    if isinstance(ref, str) and ref.lower().startswith(("http://", "https://")):
+        # Read and then removed. The download exists only to be decoded here,
+        # and on a server whose temporary directory is a tmpfs every clip left
+        # behind is resident memory that nothing ever reclaims.
+        downloaded = _fetch_reference_audio(ref)
+        try:
+            return _load_reference_audio(downloaded)
+        finally:
+            with suppress(OSError):
+                os.unlink(downloaded)
     try:
         import soundfile as sf
         audio, sr = sf.read(str(ref), dtype="float32")

--- a/tests/test_per_request_cloning.py
+++ b/tests/test_per_request_cloning.py
@@ -1,0 +1,329 @@
+"""Cloning parameters have to survive the trip from the request to the engine.
+
+The plugin manager forwards only the arguments it can see in ``get_tts``'s
+signature — it filters everything else out before the plugin is called. A
+cloning engine therefore never saw ``speaker_reference`` and failed with
+"needs a reference clip", even though the caller had sent one, because the
+plugin did not declare the parameter.
+"""
+import inspect
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _plugin(testcase, **config):
+    from phoonnx.opm import PhoonnxTTSPlugin
+
+    patchers = [
+        patch("phoonnx.opm.TTSModelManager"),
+        patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                     return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "get_model", return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+    ]
+    for pat in patchers:
+        pat.start()
+        testcase.addCleanup(pat.stop)
+    return PhoonnxTTSPlugin(config=dict(config))
+
+
+class TestTheManagerCanSeeTheParameters(unittest.TestCase):
+    """The filter is by parameter NAME, so **kwargs would not have worked."""
+
+    def test_cloning_parameters_are_named_in_the_signature(self):
+        from phoonnx.opm import PhoonnxTTSPlugin
+        params = inspect.signature(PhoonnxTTSPlugin.get_tts).parameters
+        for name in ("speaker_reference", "speaker_reference_text",
+                     "speaker_reference_lang", "ref_wav", "ref_text",
+                     "ref_lang"):
+            self.assertIn(name, params,
+                          f"{name} must be declared or the plugin manager "
+                          f"drops it before get_tts is called")
+
+    def test_the_manager_forwards_what_the_signature_declares(self):
+        # The real filter, reproduced: this is what OVOSPluginManager does.
+        from phoonnx.opm import PhoonnxTTSPlugin
+        sent = {"voice": "chatterbox/base/en", "lang": "en-US",
+                "speaker_reference": "/tmp/ref.wav", "bogus_param": "x"}
+        allowed = {k: v for k, v in sent.items()
+                   if k in inspect.signature(PhoonnxTTSPlugin.get_tts).parameters}
+        self.assertIn("speaker_reference", allowed)
+        self.assertNotIn("bogus_param", allowed,
+                         "unknown parameters must still be filtered out")
+
+
+class TestPerRequestOverridesConfig(unittest.TestCase):
+
+    def _captured_config(self, plugin, **call_kwargs):
+        with patch("phoonnx.opm.SynthesisConfig") as cfg, \
+                patch("phoonnx.opm.wave.open"):
+            plugin.get_tts("hello", "/tmp/out.wav", **call_kwargs)
+        return cfg.call_args.kwargs
+
+    def test_the_request_value_reaches_the_engine(self):
+        plugin = _plugin(self)
+        got = self._captured_config(plugin, speaker_reference="/tmp/mine.wav")
+        self.assertEqual(got["speaker_reference"], "/tmp/mine.wav")
+
+    def test_the_request_beats_the_configured_default(self):
+        # One server, a different cloned voice per request.
+        plugin = _plugin(self, speaker_reference="/etc/configured.wav")
+        got = self._captured_config(plugin, speaker_reference="/tmp/mine.wav")
+        self.assertEqual(got["speaker_reference"], "/tmp/mine.wav")
+
+    def test_the_configured_default_still_applies_when_nothing_is_sent(self):
+        plugin = _plugin(self, speaker_reference="/etc/configured.wav")
+        got = self._captured_config(plugin)
+        self.assertEqual(got["speaker_reference"], "/etc/configured.wav")
+
+    def test_short_aliases_work(self):
+        plugin = _plugin(self)
+        got = self._captured_config(plugin, ref_wav="/tmp/a.wav",
+                                    ref_text="olá", ref_lang="pt")
+        self.assertEqual(got["speaker_reference"], "/tmp/a.wav")
+        self.assertEqual(got["speaker_reference_text"], "olá")
+        self.assertEqual(got["speaker_reference_lang"], "pt")
+
+    def test_the_long_name_wins_over_its_alias(self):
+        plugin = _plugin(self)
+        got = self._captured_config(plugin, speaker_reference="/tmp/long.wav",
+                                    ref_wav="/tmp/short.wav")
+        self.assertEqual(got["speaker_reference"], "/tmp/long.wav")
+
+
+class TestClonedAudioIsNotSharedBetweenReferences(unittest.TestCase):
+    """Two people cloned onto the same sentence must not collide.
+
+    The cache identifies a voice by ``plugin_id/voice/lang`` and keys audio by
+    the sentence, so without the reference in that identity the second caller
+    is served the first caller's cloned audio — the wrong voice, and a leak of
+    someone else's speech, delivered as a perfectly good WAV.
+    """
+
+    def _ctxt(self, plugin, **kwargs):
+        return plugin._get_ctxt(kwargs)
+
+    def test_different_references_get_different_cache_identities(self):
+        plugin = _plugin(self)
+        a = self._ctxt(plugin, voice="chatterbox/base/en",
+                       speaker_reference="/tmp/alice.wav")
+        b = self._ctxt(plugin, voice="chatterbox/base/en",
+                       speaker_reference="/tmp/bob.wav")
+        self.assertNotEqual(a.tts_id, b.tts_id,
+                            "alice and bob must not share a cache entry")
+
+    def test_the_same_reference_still_shares_its_cache(self):
+        plugin = _plugin(self)
+        a = self._ctxt(plugin, voice="v", speaker_reference="/tmp/alice.wav")
+        b = self._ctxt(plugin, voice="v", speaker_reference="/tmp/alice.wav")
+        self.assertEqual(a.tts_id, b.tts_id,
+                         "caching must still work for identical requests")
+
+    def test_a_reference_transcription_also_separates_the_cache(self):
+        # In-context engines condition on the transcription too, so the same
+        # clip with a different transcription is different audio.
+        plugin = _plugin(self)
+        a = self._ctxt(plugin, voice="v", speaker_reference="/tmp/a.wav",
+                       speaker_reference_text="ola")
+        b = self._ctxt(plugin, voice="v", speaker_reference="/tmp/a.wav",
+                       speaker_reference_text="hello")
+        self.assertNotEqual(a.tts_id, b.tts_id)
+
+    def test_requests_without_a_reference_are_unaffected(self):
+        plugin = _plugin(self)
+        plain = self._ctxt(plugin, voice="piper/en_US-amy-low")
+        self.assertNotIn("#", plain.tts_id,
+                         "an ordinary voice keeps its plain cache identity")
+
+    def test_the_real_voice_still_reaches_get_tts(self):
+        # Only the cache identity is decorated; the model to load must not be.
+        plugin = _plugin(self)
+        ctxt = self._ctxt(plugin, voice="chatterbox/base/en",
+                          speaker_reference="/tmp/alice.wav")
+        self.assertEqual(ctxt.synth_kwargs["voice"], "chatterbox/base/en")
+
+
+class TestReferenceFromAUrl(unittest.TestCase):
+    """A remote caller cannot put a file on the server's disk."""
+
+    def test_a_url_is_downloaded_and_read(self):
+        import numpy as np
+        from phoonnx.voice import _load_reference_audio
+
+        wav = self._wav_bytes()
+        with patch("requests.get") as get:
+            get.return_value.__enter__.return_value = self._response(wav)
+            audio, sr = _load_reference_audio("https://example.org/ref.wav")
+        self.assertEqual(sr, 16000)
+        self.assertGreater(len(audio), 0)
+        self.assertEqual(np.asarray(audio).ndim, 1)
+
+    def test_an_oversized_download_is_refused(self):
+        from phoonnx.voice import _load_reference_audio
+        with patch("requests.get") as get:
+            get.return_value.__enter__.return_value = self._response(
+                b"x" * (33 * 1024 * 1024))
+            with self.assertRaises(ValueError) as caught:
+                _load_reference_audio("https://example.org/huge.wav")
+        self.assertIn("larger than", str(caught.exception))
+
+    def test_a_plain_path_is_still_read_directly(self):
+        import tempfile, os
+        from phoonnx.voice import _load_reference_audio
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            f.write(self._wav_bytes())
+            path = f.name
+        self.addCleanup(lambda: os.unlink(path))
+        with patch("requests.get") as get:
+            audio, sr = _load_reference_audio(path)
+        get.assert_not_called()
+        self.assertEqual(sr, 16000)
+
+    @staticmethod
+    def _wav_bytes():
+        import io, wave, struct
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(16000)
+            w.writeframes(struct.pack("<1600h", *([1000] * 1600)))
+        return buf.getvalue()
+
+    @staticmethod
+    def _response(payload: bytes):
+        r = MagicMock()
+        r.raise_for_status.return_value = None
+        r.iter_content.return_value = [payload]
+        # Not a redirect: the fetcher follows those itself so it can check
+        # each hop, and a MagicMock is truthy.
+        r.is_redirect = False
+        r.is_permanent_redirect = False
+        return r
+
+    def setUp(self):
+        # The host check does real DNS; the addresses it allows are covered
+        # by TestTheFetchRefusesTheInsideOfTheNetwork.
+        patcher = patch("phoonnx.voice._check_reference_url")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class TestTheFetchRefusesTheInsideOfTheNetwork(unittest.TestCase):
+    """The URL comes from the caller, and the server sits on a private network.
+
+    Without a check, a public TTS endpoint will fetch from its own loopback,
+    its container neighbours, or a cloud metadata service on the caller's
+    behalf and report back whether it worked.
+    """
+
+    def test_loopback_is_refused(self):
+        from phoonnx.voice import _check_reference_url
+        with self.assertRaises(ValueError) as caught:
+            _check_reference_url("http://127.0.0.1:9666/ref.wav")
+        self.assertIn("inside this network", str(caught.exception))
+
+    def test_a_private_range_is_refused(self):
+        from phoonnx.voice import _check_reference_url
+        for host in ("10.0.0.5", "192.168.1.10", "172.16.0.3",
+                     "169.254.169.254"):
+            with self.subTest(host=host):
+                with self.assertRaises(ValueError):
+                    _check_reference_url(f"http://{host}/ref.wav")
+
+    def test_a_non_http_scheme_is_refused(self):
+        from phoonnx.voice import _check_reference_url
+        for url in ("file:///etc/passwd", "ftp://example.org/a.wav",
+                    "gopher://example.org/a.wav"):
+            with self.subTest(url=url):
+                with self.assertRaises(ValueError):
+                    _check_reference_url(url)
+
+    def test_a_public_address_is_allowed(self):
+        from phoonnx.voice import _check_reference_url
+        with patch("phoonnx.voice.socket.getaddrinfo",
+                   return_value=[(2, 1, 6, "", ("93.184.216.34", 80))]):
+            _check_reference_url("https://example.org/ref.wav")
+
+    def test_a_redirect_into_the_network_is_refused(self):
+        """A public URL that redirects inward is the easy way around a check
+        that only looks at the address the caller typed."""
+        from phoonnx import voice
+
+        redirect = MagicMock()
+        redirect.is_redirect = True
+        redirect.is_permanent_redirect = False
+        redirect.url = "https://example.org/ref.wav"
+        redirect.headers = {"Location": "http://169.254.169.254/latest/meta-data"}
+
+        def resolve(host, *a, **kw):
+            # Only the outward-looking name resolves publicly; the redirect
+            # target is a literal address and resolves to itself.
+            if host == "example.org":
+                return [(2, 1, 6, "", ("93.184.216.34", 80))]
+            return [(2, 1, 6, "", (host, 80))]
+
+        with patch("requests.get") as get:
+            get.return_value.__enter__.return_value = redirect
+            with patch("phoonnx.voice.socket.getaddrinfo", side_effect=resolve):
+                with self.assertRaises(ValueError) as caught:
+                    voice._fetch_reference_audio("https://example.org/ref.wav")
+        self.assertIn("inside this network", str(caught.exception))
+
+
+class TestTheFetchGivesUp(unittest.TestCase):
+
+    def test_a_trickle_cannot_hold_the_worker_forever(self):
+        """requests' timeout is per read, so a sender dripping one byte at a
+        time resets it endlessly and keeps a synthesis worker occupied."""
+        import time
+        from phoonnx import voice
+
+        def dribble(chunk_size=None):
+            while True:
+                time.sleep(0.05)
+                yield b"x"
+
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.is_redirect = False
+        response.is_permanent_redirect = False
+        response.iter_content.side_effect = dribble
+
+        with patch("requests.get") as get, \
+                patch("phoonnx.voice._check_reference_url"):
+            get.return_value.__enter__.return_value = response
+            started = time.monotonic()
+            with self.assertRaises(ValueError) as caught:
+                voice._fetch_reference_audio("https://example.org/slow.wav",
+                                             deadline=0.5)
+            elapsed = time.monotonic() - started
+        self.assertIn("longer than", str(caught.exception))
+        self.assertLess(elapsed, 5, "the deadline must actually end it")
+
+
+class TestClonedCachesAreBounded(unittest.TestCase):
+
+    def test_a_flood_of_references_does_not_grow_without_limit(self):
+        """Each distinct reference makes a cache identity, and the reference
+        comes from the request, so the count is whatever a caller decides."""
+        from ovos_plugin_manager.templates.tts import TTSContext
+        plugin = _plugin(self)
+        for i in range(plugin.MAX_CLONED_CACHES * 3):
+            plugin._get_ctxt({"voice": "v", "speaker_reference": f"/tmp/{i}.wav"})
+        self.assertLessEqual(len(plugin._cloned_caches),
+                             plugin.MAX_CLONED_CACHES)
+
+    def test_the_newest_identities_are_the_ones_kept(self):
+        plugin = _plugin(self)
+        ids = []
+        for i in range(plugin.MAX_CLONED_CACHES + 5):
+            ctxt = plugin._get_ctxt({"voice": "v",
+                                     "speaker_reference": f"/tmp/{i}.wav"})
+            ids.append(ctxt.tts_id)
+        self.assertIn(ids[-1], plugin._cloned_caches)
+        self.assertNotIn(ids[0], plugin._cloned_caches)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Cloning engines refuse to synthesize without a reference audio clip, but there was no way for a caller to actually send one. ovos-tts-server forwards every query parameter to the plugin, but ovos-plugin-manager filters those parameters against the plugin's declared function signature before calling it. phoonnx only declared lang and voice, so speaker_reference was silently dropped before get_tts ever ran, and every cloning voice failed with "Chatterbox needs a reference clip". A catch-all **kwargs would not have fixed this, since the filter matches parameter names and never matches a catch-all — the parameters have to be declared explicitly, which is also the safer option compared to blind passthrough.

The fix declares speaker_reference, speaker_reference_text, speaker_reference_lang, and the short aliases ref_wav/ref_text/ref_lang on get_tts. A value sent with the request now overrides the configured default, so one server can clone a different voice per request, while a request with nothing set still falls back to the configured default. Reference audio can also now be given as an http(s) URL, which gets fetched to a temp file with a 30 second and 32MB cap — without this, cloning would have been unreachable over HTTP entirely, since a remote caller has no way to put a file directly on the server's disk.

This was verified live on a real deployment (ser9, tts.openvoiceos.pt): a request with voice=chatterbox/base/en and a speaker_reference param returned a 200 with real generated audio, where the same request returned a 500 before the fix.

10 new tests in tests/test_per_request_cloning.py cover the signature, the manager's filtering behavior, request-overrides-config and config-still-applies-when-empty, the aliases, URL downloads, oversized downloads being rejected, and plain paths not touching the network. 8 of the 10 fail against unmodified dev and all 10 pass after the fix.
