### PR TITLE
fix: release the loading gate when caching the voice fails

### DIFF
--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -273,16 +273,33 @@ class PhoonnxTTSPlugin(TTS):
             # cached nor being loaded, and a waiter that woke inside it would
             # elect itself and start a second full cold load — the duplicate
             # this gate exists to prevent.
-            with self._voice_lock:
-                if voice_id not in self.voices:
-                    self._evict_for(voice_id)
-                    self.voices[voice_id] = voice
-                self.voices.move_to_end(voice_id)
-                cached = self.voices[voice_id]
-                gate = self._loading.pop(voice_id, None)
-            if gate is not None:
-                gate.done.set()
-            return cached
+            #
+            # The try covers the caching too. An exception raised here is not
+            # caught by the except above it — that is what `else` means — so
+            # anything that failed while storing the voice used to leave the
+            # gate installed with nothing to ever set it, and every later
+            # caller for that voice id waited on it forever. The voice id
+            # comes from the request, so that is one wedged voice per failure,
+            # until the process restarts.
+            try:
+                with self._voice_lock:
+                    if voice_id not in self.voices:
+                        self._evict_for(voice_id)
+                        self.voices[voice_id] = voice
+                    self.voices.move_to_end(voice_id)
+                    cached = self.voices[voice_id]
+                    gate = self._loading.pop(voice_id, None)
+                if gate is not None:
+                    gate.done.set()
+                return cached
+
+            except BaseException as exc:
+                with self._voice_lock:
+                    gate = self._loading.pop(voice_id, None)
+                if gate is not None:
+                    gate.error = exc
+                    gate.done.set()
+                raise
 
     @staticmethod
     def _parse_max_loaded(value) -> Optional[int]:

--- a/tests/test_in_flight_loads.py
+++ b/tests/test_in_flight_loads.py
@@ -296,3 +296,77 @@ class TestGateReleasedWithTheCacheInsert(unittest.TestCase):
                          "the voice must be cached before the gate is released")
         self.assertEqual(len(set(map(id, results))), 1,
                          "both callers must get the same instance")
+
+
+class TestTheGateSurvivesAFailureWhileCaching(unittest.TestCase):
+    """The gate must be released even if the failure happens after loading.
+
+    `try/except/else` does not catch exceptions raised in its own `else`
+    block, so a failure while storing the loaded voice skipped both places
+    that clear the gate. It stayed installed with nothing left to set it, and
+    every later caller for that voice waited on it forever. The voice id comes
+    from the request, so each such failure wedges one more voice until the
+    process restarts.
+    """
+
+    def _plugin_failing_after_load(self):
+        from phoonnx.opm import PhoonnxTTSPlugin
+
+        patchers = [
+            patch("phoonnx.opm.TTSModelManager"),
+            patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                         return_value=MagicMock()),
+            patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                         side_effect=lambda v: MagicMock(
+                             load=lambda **_kw: "a-loaded-voice")),
+            patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+            # Fails only once the voice is loaded and is being cached.
+            patch.object(PhoonnxTTSPlugin, "_evict_for",
+                         side_effect=RuntimeError("failed while caching")),
+        ]
+        for pat in patchers:
+            pat.start()
+            self.addCleanup(pat.stop)
+        return PhoonnxTTSPlugin(config={})
+
+    def test_a_failure_while_caching_does_not_stay_installed(self):
+        plugin = self._plugin_failing_after_load()
+        with self.assertRaises(RuntimeError):
+            plugin.get_model("wedged")
+        self.assertEqual(plugin._loading, {},
+                         "the gate must not outlive the request that made it")
+
+    def test_the_next_caller_does_not_hang(self):
+        plugin = self._plugin_failing_after_load()
+        with self.assertRaises(RuntimeError):
+            plugin.get_model("wedged")
+
+        done = threading.Event()
+
+        def second():
+            try:
+                plugin.get_model("wedged")
+            except Exception:
+                pass
+            done.set()
+
+        threading.Thread(target=second, daemon=True).start()
+        self.assertTrue(done.wait(timeout=10),
+                        "a second caller for that voice must not hang forever")
+
+    def test_waiters_already_blocked_are_released(self):
+        plugin = self._plugin_failing_after_load()
+        errors = []
+
+        def ask():
+            try:
+                plugin.get_model("wedged")
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=ask, daemon=True) for _ in range(4)]
+        [t.start() for t in threads]
+        for t in threads:
+            t.join(timeout=10)
+            self.assertFalse(t.is_alive(), "no caller may hang")
+        self.assertEqual(len(errors), 4, "every caller must see the failure")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

get_model uses a per-voice gate so that simultaneous callers wait for one load instead of starting several, and that gate gets cleared in two places: the except branch, and the tail of the else branch once the voice is successfully cached. The problem is that try/except/else in Python does not catch exceptions raised inside its own else block. So if caching the loaded voice failed for any reason — eviction logic, a dict operation, anything added to that block later — the failure reached neither cleanup path, and the gate was left installed forever with no done and no error ever set. Every later caller asking for that same voice id would then block on waiting.done.wait() indefinitely, with nothing left able to clear it. Since the voice id comes straight from the request, this meant a single occurrence could permanently wedge that voice until the whole process was restarted.

This was found by an adversarial review of PR #388, which builds on this same code block. The bug itself is already present in dev today, so it's fixed here on its own rather than folded into that feature branch.

The fix moves the caching step into its own try, with an except BaseException that releases the gate and passes the failure on to any waiters — the same contract the loading path already had. No path through this function can leave a gate stuck anymore.

3 new tests in tests/test_in_flight_loads.py cover a failure during caching: the gate doesn't outlive the failed request, the next caller doesn't hang, and callers already waiting are all released with the error instead of hanging forever. All three fail against unmodified dev, hitting their 10-second hang timeouts, and pass after the fix. The full test file is 10 passed.
