### PR TITLE
fix: load one session per model, not one per voice

### DIFF
--- a/phoonnx/engines/chatterbox.py
+++ b/phoonnx/engines/chatterbox.py
@@ -22,6 +22,7 @@ import numpy as np
 import onnxruntime
 
 from phoonnx.engines.base import AdapterSynthesisRequest, AdapterSynthesisResult, BaseOnnxAdapter
+from phoonnx.providers import make_session
 
 S3GEN_SR = 24000
 START_SPEECH_TOKEN = 6561
@@ -103,7 +104,12 @@ class ChatterboxAdapter(BaseOnnxAdapter):
         """Load the auxiliary graphs from ``engine_params`` and read the LM's KV-cache
         shape from its own input signature (no hardcoded layer counts)."""
         ep = getattr(voice_config, "engine_params", None) or {}
-        sess = lambda p: onnxruntime.InferenceSession(str(p), providers=["CPUExecutionProvider"])
+        # Routed through make_session, same as the main LM graph: these three
+        # aux graphs are ~1.19GB per voice and identical across every voice
+        # sharing a checkpoint, so building them with a bare InferenceSession
+        # both loaded that weight again per voice and left it unaccounted for
+        # by the model manager's budget, which only sees make_session sessions.
+        sess = lambda p: make_session(str(p), providers=ep.get("providers") or ["CPUExecutionProvider"])
         if self.embed_tokens is None and ep.get("embed_tokens_path"):
             self.embed_tokens = sess(ep["embed_tokens_path"])
         if self.embed_tokens is not None:

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -614,6 +614,31 @@ class TTSModelInfo:
         self.engine_params()
         return model_path
 
+    def artifact_urls(self) -> List[str]:
+        """Every graph this voice loads, each named once, in a stable order.
+
+        One file is often named by several fields, and — far more importantly —
+        by several voices: the bundled omnivoice index has 646 entries over a
+        single 3 GB backbone, and qwen3tts 15 over one 4.2 GB talker. Two
+        voices with the same list here load exactly the same weights.
+        """
+        urls = [self.model_url, self.vocoder_url, self.style_url,
+                self.speaker_encoder_url, self.speech_encoder_url,
+                self.embed_tokens_url, self.conditional_decoder_url]
+        urls += [u for u in (self.aux_model_urls or {}).values() if u]
+        return list(dict.fromkeys(u for u in urls if u))
+
+    def artifact_key(self) -> str:
+        """Identity of the *weights* this voice loads, not of the voice.
+
+        Voices that share a key share their memory, so a cache that charges
+        memory has to charge it per key rather than per voice id. What makes
+        two entries different voices — the language, the display name, the
+        engine options applied at synthesis time — is deliberately not in
+        here, because none of it costs a second copy of the graph.
+        """
+        return "|".join(self.artifact_urls())
+
     def disk_size(self) -> int:
         """Total on-disk size, in bytes, of this voice's downloaded artifacts.
 
@@ -639,13 +664,9 @@ class TTSModelInfo:
         Returns:
             int: bytes, or 0 when nothing is cached locally.
         """
-        urls = [self.model_url, self.vocoder_url, self.style_url,
-                self.speaker_encoder_url, self.speech_encoder_url,
-                self.embed_tokens_url, self.conditional_decoder_url]
-        urls += [u for u in (self.aux_model_urls or {}).values() if u]
         # One file may be named by several fields (and several voices); count
         # each distinct file once.
-        return sum(_file_bytes(u) for u in dict.fromkeys(u for u in urls if u))
+        return sum(_file_bytes(u) for u in self.artifact_urls())
 
     def load(self, providers: Optional[Sequence[ProviderSpec]] = None) -> TTSVoice:
         """
@@ -679,6 +700,8 @@ class TTSModelInfo:
             }
             engine_params["providers"] = resolved_providers
             config.engine_params = engine_params
+            # Through make_session, so this path shares one session between
+            # voices that name the same graph like every other path does.
             session = make_session(model_path, providers=resolved_providers)
             return TTSVoice(session=session, config=config)
 

--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -10,12 +10,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import gc
 import hashlib
 import math
 import os
 import re
 import tempfile
+import time
 import wave
+import weakref
 from contextlib import suppress
 from collections import OrderedDict
 import threading
@@ -105,8 +108,29 @@ class PhoonnxTTSPlugin(TTS):
         # the cache for the small ones. Unset keeps the previous behaviour.
         self.max_loaded_bytes = self._parse_max_bytes(
             self.config.get("max_loaded_bytes"))
-        # Measured size of each resident voice, keyed as ``self.voices`` is.
-        self._voice_bytes: Dict[str, int] = {}
+        # Memory is charged per *model*, not per voice. A voice id is a
+        # catalog entry; the weights are the artifacts it names, and the
+        # bundled indexes name the same artifacts from hundreds of entries
+        # (646 omnivoice voices over one 3 GB backbone). Charging each entry
+        # separately made the cache evict a model to make room for itself.
+        self._voice_keys: Dict[str, str] = {}
+        # Measured size per artifact key. Never pruned: a key whose voices
+        # were all evicted may still be resident in a request that is
+        # mid-synthesis, and its size is what says so.
+        self._key_bytes: Dict[str, int] = {}
+        # Weak references to every voice object handed out, per artifact key,
+        # as a list: hashing a weak reference hashes what it points at, and a
+        # loaded voice is an unhashable dataclass.
+        # A voice the cache evicted is still in memory while the request that
+        # asked for it is synthesizing — minutes, for these models — so the
+        # cache is not what says whether the weights are resident. These
+        # references are, and they cost nothing to keep.
+        self._refs: Dict[str, list] = {}
+        # How long a load waits for memory another request is still using
+        # before giving up on the budget and loading anyway. Waiting forever
+        # would turn a memory bound into a hang.
+        self.load_wait_timeout = float(
+            self.config.get("load_wait_timeout") or 300)
         # Resolve the configured voice now, but do not load it. A voice that was
         # named explicitly and does not exist is a configuration error and still
         # raises here; an unset voice (or "default") resolves to the language's
@@ -287,7 +311,7 @@ class PhoonnxTTSPlugin(TTS):
             # concurrent 2.2 GB loads each evicted the one before and the
             # cache looked healthy, after the OOM killer had already taken
             # the process.
-            reserved, measured = self._reserve(voice_id, info)
+            reserved, measured, key = self._reserve(voice_id, info)
             # Loaded outside the lock: a cold load takes seconds to minutes,
             # and holding the lock would stall every other request meanwhile.
             voice = info.load(providers=self._providers())
@@ -327,10 +351,23 @@ class PhoonnxTTSPlugin(TTS):
                     # same call, and releasing twice would shrink the budget
                     # by a voice that was never holding it.
                     reserved = 0
+                    self._key_bytes.setdefault(key, size)
                     if voice_id not in self.voices:
-                        self._evict_for(voice_id, size)
+                        # Evicted before this voice is tracked: _evict_for
+                        # skips a key that is already resident, and this
+                        # voice's own weights would otherwise satisfy that
+                        # check against itself, making the post-load
+                        # eviction — the only one that sees a size measured
+                        # after a cold download — a permanent no-op.
+                        self._evict_for(voice_id, key, size)
                         self.voices[voice_id] = voice
-                        self._voice_bytes[voice_id] = size
+                        self._voice_keys[voice_id] = key
+                    # Tracked once the eviction that might have needed this
+                    # voice's own key to still look unresident is done: from
+                    # here on the weights are in memory whether or not this
+                    # voice ends up cached, and the budget has to know that
+                    # for as long as the caller holds it.
+                    self._track(key, voice)
                     self.voices.move_to_end(voice_id)
                     cached = self.voices[voice_id]
                     gate = self._loading.pop(voice_id, None)
@@ -433,22 +470,90 @@ class PhoonnxTTSPlugin(TTS):
                       f"counting it as free: {exc}")
             return 0
 
-    def _reserve(self, voice_id: str, info: TTSModelInfo) -> "tuple[int, int]":
+    def _key_for(self, voice_id: str, info: TTSModelInfo) -> str:
+        """Artifact key of a voice: what it would share with another voice.
+
+        Falls back to the voice id when the catalog entry cannot name its
+        artifacts, which charges that voice on its own — the old behaviour,
+        and the safe direction to be wrong in.
+        """
+        try:
+            key = info.artifact_key()
+        except Exception as exc:
+            LOG.debug(f"voice '{voice_id}' has no artifact key ({exc}); "
+                      f"charging it on its own")
+            return voice_id
+        return key if isinstance(key, str) and key else voice_id
+
+    def _track(self, key: str, voice) -> None:
+        """Remember that ``voice`` holds the weights of ``key``, weakly.
+
+        Called with ``self._voice_lock`` held. The callback fires when the
+        last reference to the voice goes away — the request finished — and
+        wakes whoever is waiting for that memory.
+        """
+        try:
+            ref = weakref.ref(voice, lambda r, k=key: self._on_voice_released(k, r))
+        except TypeError:
+            # Not every object a caller can put here supports weak references
+            # (tests load stand-ins). Untracked voices are simply charged for
+            # as long as they are cached, exactly as before.
+            return
+        refs = self._refs.setdefault(key, [])
+        if not any(existing() is voice for existing in refs):
+            refs.append(ref)
+
+    def _on_voice_released(self, key: str, ref) -> None:
+        """A voice object was collected: its memory may now be free."""
+        with self._voice_lock:
+            refs = self._refs.get(key)
+            if refs is not None:
+                self._refs[key] = [r for r in refs if r is not ref and r() is not None]
+                if not self._refs[key]:
+                    self._refs.pop(key, None)
+            self._budget_free.notify_all()
+
+    def _live_count(self, key: str) -> int:
+        """How many voice objects still hold this key's weights."""
+        return sum(1 for ref in self._refs.get(key, ()) if ref() is not None)
+
+    def _resident_keys(self) -> "set[str]":
+        """Every artifact key whose weights are in memory right now.
+
+        Cached voices, plus voices the cache already evicted that a request
+        has not finished with. The second group is why the budget used to
+        undercount: eviction pops a dict entry, it does not free a model that
+        a caller is three minutes into synthesizing with.
+        """
+        keys = {self._voice_keys.get(v, v) for v in self.voices}
+        keys.update(k for k in list(self._refs) if self._live_count(k))
+        return keys
+
+    def _reserve(self, voice_id: str, info: TTSModelInfo) -> "tuple[int, int, str]":
         """Claim budget for a load that has not started yet.
 
-        Returns ``(reserved, measured)``: the bytes claimed, and the size the
-        voice could be measured at before loading (0 when it could not be).
+        Returns ``(reserved, measured, key)``: the bytes claimed, the size the
+        voice could be measured at before loading (0 when it could not be),
+        and its artifact key.
 
-        Waits until the voice fits beside what is resident and what other
-        loads have already claimed, evicting to make room. Two rules keep this
-        from ever becoming a hang:
+        A voice whose weights are already resident claims nothing and waits
+        for nothing: it is going to reuse the session that is already loaded,
+        so there is no second allocation to make room for.
 
-        - a loader that finds no other load in flight always proceeds, so a
-          voice bigger than the whole budget still loads (evicting everything
-          evictable first, and warning) instead of waiting for room that can
-          never appear;
+        Otherwise this waits until the voice fits beside what is resident and
+        what other loads have already claimed, evicting to make room. Three
+        rules keep it from ever becoming a hang:
+
+        - a loader waits only while memory could still come back — another
+          load in flight, or a resident voice no longer cached that a request
+          will eventually let go of — so a voice bigger than the whole budget
+          still loads (evicting everything evictable first, and warning)
+          instead of waiting for room that can never appear;
+        - the wait is bounded by ``load_wait_timeout`` regardless, after which
+          the load proceeds and says so;
         - every reservation is released on both the success and the failure
-          path, and each release wakes the waiters.
+          path, and each release wakes the waiters, as does the collection of
+          a voice object.
 
         A voice whose files are not downloaded yet cannot be measured, and an
         unknown size is treated as the whole budget: it loads alone. That
@@ -456,20 +561,67 @@ class PhoonnxTTSPlugin(TTS):
         and it is the only honest way to keep an unknown allocation inside a
         known bound.
         """
+        key = self._key_for(voice_id, info)
         if self.max_loaded_bytes is None:
-            return 0, 0
+            return 0, 0, key
         measured = self._measure(voice_id, info)
-        need = measured if measured > 0 else self.max_loaded_bytes
         with self._budget_free:
-            while (self._reserved_bytes
-                   and self._resident_bytes() + self._reserved_bytes + need
-                   > self.max_loaded_bytes):
-                self._budget_free.wait()
+            if key in self._resident_keys():
+                LOG.debug(f"voice '{voice_id}' reuses weights that are "
+                          f"already loaded; charging nothing for it")
+                self._key_bytes.setdefault(key, measured)
+                return 0, measured, key
+            need = measured if measured > 0 else self.max_loaded_bytes
+            deadline = time.monotonic() + self.load_wait_timeout
+            collected = False
+            while (self._over_budget(need)
+                   and (self._reserved_bytes or self._releasable_bytes())):
+                # A dropped voice is not actually gone the instant it is
+                # evicted: TTSVoice holds a reference cycle (its adapter
+                # points back at it), so CPython's refcounting alone never
+                # frees it and the weakref callback that wakes this wait
+                # never fires. gc.collect() breaks the cycle, but it walks
+                # the whole heap — hundreds of milliseconds on a large
+                # process — so it runs only once, right before the first
+                # wait, and only on the path that is actually about to
+                # wait; a load with headroom already never pays for it.
+                if not collected:
+                    collected = True
+                    gc.collect()
+                    if not self._over_budget(need):
+                        break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    gc.collect()
+                    if not self._over_budget(need):
+                        break
+                    LOG.warning(
+                        f"waited {self.load_wait_timeout:.0f}s for room to "
+                        f"load '{voice_id}' and the memory in use did not "
+                        f"come back; loading it anyway, so memory use will "
+                        f"exceed the budget")
+                    break
+                self._budget_free.wait(remaining)
             # Make the room now, so the bytes are free when the load takes
             # them rather than after it already has.
-            self._evict_for(voice_id, need)
+            self._evict_for(voice_id, key, need)
             self._reserved_bytes += need
-        return need, measured
+        return need, measured, key
+
+    def _over_budget(self, need: int) -> bool:
+        """Whether admitting ``need`` more bytes would break the budget."""
+        return (self._resident_bytes() + self._reserved_bytes + need
+                > self.max_loaded_bytes)
+
+    def _releasable_bytes(self) -> int:
+        """Resident bytes that will come back on their own.
+
+        Weights that are no longer cached but are still held by a request in
+        flight. Nothing else can shrink without a caller finishing.
+        """
+        cached = {self._voice_keys.get(v, v) for v in self.voices}
+        return sum(self._key_bytes.get(k, 0)
+                   for k in self._resident_keys() if k not in cached)
 
     def _release(self, reserved: int) -> None:
         """Give back a reservation and wake whoever is waiting for room.
@@ -482,12 +634,12 @@ class PhoonnxTTSPlugin(TTS):
         self._budget_free.notify_all()
 
     def _resident_bytes(self) -> int:
-        """Total measured size of the voices currently cached."""
-        return sum(self._voice_bytes.get(v, 0) for v in self.voices)
+        """Total measured size of the weights in memory right now."""
+        return sum(self._key_bytes.get(k, 0) for k in self._resident_keys())
 
     def _drop(self, victim: str) -> None:
         self.voices.pop(victim, None)
-        self._voice_bytes.pop(victim, None)
+        self._voice_keys.pop(victim, None)
         LOG.debug(f"evicted least recently used voice: {victim}")
 
     def _lru_victim(self) -> Optional[str]:
@@ -495,7 +647,29 @@ class PhoonnxTTSPlugin(TTS):
         return next((v for v in self.voices if v not in self.pinned_voices),
                     None)
 
-    def _evict_for(self, incoming: str, size: int = 0) -> None:
+    def _byte_victim(self) -> Optional[str]:
+        """The least recently used voice whose eviction frees memory.
+
+        Evicting one of 646 voices that share a backbone frees nothing while
+        the others still reference it, and the eviction loop would otherwise
+        empty the whole cache discovering that one entry at a time.
+        """
+        for candidate in self.voices:
+            if candidate in self.pinned_voices:
+                continue
+            key = self._voice_keys.get(candidate, candidate)
+            others = [v for v in self.voices
+                      if v != candidate
+                      and self._voice_keys.get(v, v) == key]
+            if others:
+                continue
+            if self._live_count(key) > 1:
+                # Cached here and held by a request elsewhere.
+                continue
+            return candidate
+        return None
+
+    def _evict_for(self, incoming: str, key: str, size: int = 0) -> None:
         """Make room for ``incoming``, never dropping a pinned voice.
 
         Both bounds apply when both are set: a voice is evicted when either the
@@ -516,6 +690,10 @@ class PhoonnxTTSPlugin(TTS):
         if self.max_loaded_bytes is None:
             return
 
+        if key in self._resident_keys():
+            # Its weights are already in memory; admitting it costs nothing.
+            return
+
         if size > self.max_loaded_bytes:
             # Serving it is still better than not serving it. Everything
             # evictable goes first, so the overshoot is as small as it can be.
@@ -524,15 +702,13 @@ class PhoonnxTTSPlugin(TTS):
                 f"whole max_loaded_bytes budget of {self.max_loaded_bytes}; "
                 f"loading it anyway, so memory use will exceed the budget")
 
-        while (self.voices
-               and self._resident_bytes() + self._reserved_bytes + size
-               > self.max_loaded_bytes):
-            victim = self._lru_victim()
+        while self.voices and self._over_budget(size):
+            victim = self._byte_victim()
             if victim is None:
                 LOG.warning(
-                    f"all {len(self.voices)} loaded voices are pinned "
-                    f"({self._resident_bytes()} bytes); loading '{incoming}' "
-                    f"above max_loaded_bytes")
+                    f"nothing more can be evicted "
+                    f"({self._resident_bytes()} bytes resident); loading "
+                    f"'{incoming}' above max_loaded_bytes")
                 break
             self._drop(victim)
 

--- a/phoonnx/providers.py
+++ b/phoonnx/providers.py
@@ -26,6 +26,8 @@ CUDA needs ``onnxruntime-gpu``.
 """
 import hashlib
 import os
+import threading
+import weakref
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -47,6 +49,13 @@ PROVIDERS_ENV_VAR = "PHOONNX_ONNX_PROVIDERS"
 #: it instead of re-running graph optimization from the raw model. Unset by
 #: default — behaviour is unchanged unless a caller opts in.
 CACHE_DIR_ENV_VAR = "PHOONNX_ORT_CACHE_DIR"
+
+#: Environment variable that turns session sharing off. Set it to ``0``/
+#: ``false``/``no`` to make every :func:`make_session` call build its own
+#: session, as it used to. Sharing is the default because a catalog entry is
+#: not a model: 646 of the bundled omnivoice voices name the same 3 GB graph
+#: and differ only in the engine options applied at synthesis time.
+SHARE_SESSIONS_ENV_VAR = "PHOONNX_SHARE_ONNX_SESSIONS"
 
 #: Auto-detection preference order, best first. Only providers the installed
 #: runtime reports as available are kept.
@@ -196,6 +205,92 @@ def _warn_on_provider_fallback(
         )
 
 
+#: Live shared sessions, keyed by what makes two of them interchangeable.
+#: Values are weak, so a session disappears from here the moment nothing is
+#: using it any more; the store never keeps a graph alive by itself and needs
+#: no release call that a failing request could skip.
+_SHARED_SESSIONS: "weakref.WeakValueDictionary[tuple, onnxruntime.InferenceSession]" = \
+    weakref.WeakValueDictionary()
+#: Guards ``_SHARED_SESSIONS`` and the per-key build locks below.
+_SHARED_LOCK = threading.Lock()
+#: One lock per key, so two threads asking for the same model build it once
+#: while two threads asking for different models still load in parallel.
+#: Keyed by model, not by voice, so this stays as small as the catalog's set
+#: of distinct graphs.
+_BUILD_LOCKS: Dict[tuple, threading.Lock] = {}
+
+
+def _sharing_enabled() -> bool:
+    """Whether identical sessions may be shared (the default)."""
+    value = os.environ.get(SHARE_SESSIONS_ENV_VAR)
+    if value is None:
+        return True
+    return value.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _external_data_path(*model_paths: str) -> Optional[str]:
+    """Path of a model's external-weights sidecar, if it names one on disk.
+
+    onnxruntime resolves the sidecar it finds inside the graph against the
+    graph's own directory, and phoonnx fetches models with that sidecar named
+    ``<model>_data`` (see ``model_manager._sidecar_url``) or, for graphs
+    exported with onnxruntime's own convention, ``<model>.data``. Either one,
+    if present, holds the weights the graph itself does not carry.
+
+    Takes several candidate locations for the graph, tried in order: the hub
+    cache lays a voice out as ``snapshots/<rev>/model.onnx``, a symlink whose
+    sidecar sits alongside *it*, resolving to ``blobs/<sha>`` with nothing
+    beside the blob at all. Probing only the resolved real path — as this
+    used to — never finds that sidecar, so external-data weights fetched
+    through the hub never entered the session key at all.
+    """
+    for model_path in model_paths:
+        for candidate in (f"{model_path}_data", f"{model_path}.data"):
+            if os.path.isfile(candidate):
+                return candidate
+    return None
+
+
+def session_key(model_path: Any,
+                resolved: Sequence[ProviderSpec],
+                cache_dir: Optional[Union[str, Path]]) -> tuple:
+    """Identity of a session: two calls with the same key are interchangeable.
+
+    The model file is identified by its resolved real path plus its size and
+    modification time, so a voice that reaches the same cached artifact
+    through a different symlink or a non-normalized path shares one session,
+    while a file that was replaced on disk gets a new one rather than a stale
+    session over weights that are no longer there. A graph with external
+    weights keeps the actual weights in a sidecar file the graph itself does
+    not change size or mtime when replaced, so that sidecar's (size, mtime)
+    is folded into the key too — otherwise a stable stub graph pointing at
+    swapped-out weights would keep serving the old session forever.
+    """
+    try:
+        resolved_path = os.path.realpath(str(model_path))
+    except OSError:  # pragma: no cover - realpath practically never raises
+        resolved_path = str(model_path)
+    try:
+        stat = os.stat(resolved_path)
+        version = (stat.st_size, stat.st_mtime_ns)
+    except OSError:
+        version = ()
+    sidecar = _external_data_path(str(model_path), resolved_path)
+    if sidecar is not None:
+        try:
+            sidecar_stat = os.stat(sidecar)
+            version = version + (sidecar_stat.st_size, sidecar_stat.st_mtime_ns)
+        except OSError:
+            pass
+    return (resolved_path, version, repr(list(resolved)), str(cache_dir or ""))
+
+
+def shared_sessions() -> Dict[tuple, onnxruntime.InferenceSession]:
+    """The sessions that are alive right now, for tests and diagnostics."""
+    with _SHARED_LOCK:
+        return dict(_SHARED_SESSIONS)
+
+
 def make_session(
         model_path: Any,
         providers: Optional[Sequence[ProviderSpec]] = None,
@@ -204,7 +299,18 @@ def make_session(
         cache_dir: Optional[Union[str, Path]] = None,
 ) -> onnxruntime.InferenceSession:
     """
-    Create an ``InferenceSession`` on the resolved execution providers.
+    Return an ``InferenceSession`` on the resolved execution providers,
+    reusing the one already loaded for this model when there is one.
+
+    An ONNX Runtime session is thread-safe to run and holds the weights, which
+    is nearly all of the memory a voice costs. Voices that name the same graph
+    therefore share one session rather than each loading their own copy; what
+    differs between them (the engine options, the language, the tokenizer)
+    lives in the voice, not in the session. Sharing only ever happens between
+    calls that would have produced identical sessions — same file, same
+    providers, same optimized-graph cache, and default session options. Pass
+    an explicit ``sess_options`` (or set ``PHOONNX_SHARE_ONNX_SESSIONS=0``) to
+    get a private session.
 
     Parameters:
         cache_dir: Directory to cache the ORT-optimized graph in. When given
@@ -219,6 +325,46 @@ def make_session(
     resolved = resolve_providers(providers, use_cuda=use_cuda)
     cache_dir = cache_dir if cache_dir is not None else os.environ.get(CACHE_DIR_ENV_VAR)
 
+    if sess_options is not None or not _sharing_enabled():
+        return _build_session(model_path, resolved, sess_options, cache_dir)
+
+    key = session_key(model_path, resolved, cache_dir)
+    with _SHARED_LOCK:
+        session = _SHARED_SESSIONS.get(key)
+        if session is not None:
+            LOG.debug(f"reusing the loaded onnx session for '{model_path}'")
+            return session
+        build_lock = _BUILD_LOCKS.setdefault(key, threading.Lock())
+
+    # Built outside the store lock: a cold load of a multi-gigabyte graph takes
+    # seconds to minutes, and every other model would wait behind it. The
+    # per-key lock still makes two callers for the same model load it once.
+    with build_lock:
+        with _SHARED_LOCK:
+            session = _SHARED_SESSIONS.get(key)
+        if session is not None:
+            return session
+        session = _build_session(model_path, resolved, sess_options, cache_dir)
+        with _SHARED_LOCK:
+            _SHARED_SESSIONS[key] = session
+            # The lock has done its job once the session it guarded is
+            # built and published; keeping it around forever would grow
+            # _BUILD_LOCKS by one entry per (path, size, mtime, providers,
+            # cache_dir) ever seen, including stale keys from models that
+            # were since replaced on disk. Drop it only if nothing raced in
+            # and replaced it with a lock of its own.
+            if _BUILD_LOCKS.get(key) is build_lock:
+                del _BUILD_LOCKS[key]
+        return session
+
+
+def _build_session(
+        model_path: Any,
+        resolved: Sequence[ProviderSpec],
+        sess_options: Optional[onnxruntime.SessionOptions],
+        cache_dir: Optional[Union[str, Path]],
+) -> onnxruntime.InferenceSession:
+    """Load a fresh session; see :func:`make_session` for the sharing."""
     if not cache_dir:
         session = onnxruntime.InferenceSession(
             str(model_path),

--- a/tests/test_chatterbox.py
+++ b/tests/test_chatterbox.py
@@ -5,6 +5,52 @@ from phoonnx.engines.base import AdapterSynthesisRequest
 from phoonnx.engines.chatterbox import ChatterboxAdapter, _apply_repetition_penalty
 
 
+def _build_tiny_onnx_model(path):
+    """Write a minimal but real single-node ONNX model to *path*."""
+    import onnx
+    from onnx import TensorProto, helper
+
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4])
+    node = helper.make_node("Identity", ["x"], ["y"])
+    graph = helper.make_graph([node], "tiny", [x], [y])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, str(path))
+
+
+def test_configure_shares_aux_sessions_across_voices(tmp_path):
+    # The aux graphs (speech_encoder, embed_tokens, conditional_decoder) are
+    # ~1.19GB per voice and identical across every voice that shares a
+    # checkpoint; configure() must route them through make_session so a
+    # second voice over the same files reuses the sessions the first one
+    # built, instead of loading its own private copy of each.
+    from types import SimpleNamespace
+
+    speech_encoder = tmp_path / "speech_encoder.onnx"
+    embed_tokens = tmp_path / "embed_tokens.onnx"
+    cond_decoder = tmp_path / "conditional_decoder.onnx"
+    for p in (speech_encoder, embed_tokens, cond_decoder):
+        _build_tiny_onnx_model(p)
+
+    def _voice_config():
+        return SimpleNamespace(engine_params={
+            "speech_encoder_path": str(speech_encoder),
+            "embed_tokens_path": str(embed_tokens),
+            "conditional_decoder_path": str(cond_decoder),
+        })
+
+    first = ChatterboxAdapter()
+    first.configure(_voice_config())
+    second = ChatterboxAdapter()
+    second.configure(_voice_config())
+
+    assert first.speech_encoder is second.speech_encoder
+    assert first.embed_tokens is second.embed_tokens
+    assert first.cond_decoder is second.cond_decoder
+
+
 def _req(**params):
     return AdapterSynthesisRequest(phoneme_ids=np.array([[1, 2, 3]], np.int64),
                                    phoneme_lengths=np.array([3], np.int64),

--- a/tests/test_coldstart_warmup_cache.py
+++ b/tests/test_coldstart_warmup_cache.py
@@ -57,6 +57,11 @@ class TestOrtOptimizedGraphCache(unittest.TestCase):
         self.assertEqual(len(cached_files), 1)
 
     def test_second_load_reuses_the_cached_file_without_rewriting_it(self):
+        # About the on-disk optimized-graph cache, which pays off across
+        # processes, so the in-process session sharing is turned off here to
+        # make the second call actually build a session.
+        os.environ[providers.SHARE_SESSIONS_ENV_VAR] = "0"
+        self.addCleanup(os.environ.pop, providers.SHARE_SESSIONS_ENV_VAR, None)
         make_session(self.model_path, providers=[CPU_PROVIDER], cache_dir=self.cache_dir)
         cached_files = list(self.cache_dir.glob("*.ort_optimized.onnx"))
         self.assertEqual(len(cached_files), 1)

--- a/tests/test_shared_sessions.py
+++ b/tests/test_shared_sessions.py
@@ -1,0 +1,393 @@
+"""One model, many voices: the weights are loaded once.
+
+A voice-index entry is not a model. ``omnivoice.json`` holds 646 entries with
+exactly one distinct ``model_url`` between them — a single 3.0 GB backbone —
+and ``qwen3tts.json`` holds 15 over one 4.2 GB talker. The entries differ only
+in the language and the ``engine_options`` applied at synthesis time, so the
+audio really is different per voice, but the weights are the same file.
+
+Loading that file once per entry gave every voice its own full
+``InferenceSession`` over the identical graph, its own copy of the weights,
+and its own full charge against ``max_loaded_bytes``. Observed on an 8 GB
+container: ``omnivoice/en`` loaded, evicted to make room for ``omnivoice/es``,
+then loaded again — three loads of one file, and four kernel OOM kills.
+
+These tests pin the two halves of the fix: sessions are shared between voices
+that name the same artifacts, and the cache charges the memory once.
+"""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from phoonnx import providers
+from phoonnx.providers import CPU_PROVIDER, SHARE_SESSIONS_ENV_VAR, make_session
+
+MB = 10 ** 6
+GB = 10 ** 9
+
+
+def _build_tiny_onnx_model(path: Path) -> None:
+    """Write a minimal but real single-node ONNX model to *path*."""
+    import onnx
+    from onnx import TensorProto, helper
+
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4])
+    node = helper.make_node("Identity", ["x"], ["y"])
+    graph = helper.make_graph([node], "tiny", [x], [y])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, str(path))
+
+
+class TestOneModelOneSession(unittest.TestCase):
+    """The 646-entry case, in miniature."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.model_path = Path(self.tmpdir.name) / "backbone.onnx"
+        _build_tiny_onnx_model(self.model_path)
+        env = patch.dict(os.environ, {}, clear=False)
+        env.start()
+        self.addCleanup(env.stop)
+        os.environ.pop(SHARE_SESSIONS_ENV_VAR, None)
+
+    def _voice(self, **engine_params):
+        from phoonnx.voice import TTSVoice
+        return TTSVoice.load(model_path=self.model_path,
+                             providers=[CPU_PROVIDER],
+                             engine_params=engine_params)
+
+    def test_two_voices_over_one_model_load_it_once(self):
+        with patch.object(providers.onnxruntime, "InferenceSession",
+                          wraps=providers.onnxruntime.InferenceSession) as spy:
+            english = self._voice(lang="en")
+            spanish = self._voice(lang="es")
+
+        self.assertIs(english.session, spanish.session,
+                      "voices over one model must share one session")
+        self.assertEqual(spy.call_count, 1,
+                         "the second voice must not load the graph again")
+
+    def test_the_whole_catalog_costs_one_load(self):
+        # The shape that actually killed the server: hundreds of entries, one
+        # file. This is the 646 omnivoice voices, scaled down.
+        with patch.object(providers.onnxruntime, "InferenceSession",
+                          wraps=providers.onnxruntime.InferenceSession) as spy:
+            voices = [self._voice(lang=f"l{i}") for i in range(50)]
+        self.assertEqual(spy.call_count, 1)
+        self.assertEqual(len({id(v.session) for v in voices}), 1)
+
+    def test_voices_over_one_model_keep_their_own_engine_options(self):
+        # Sharing the weights must not share what makes the audio different.
+        english = self._voice(lang="en")
+        spanish = self._voice(lang="es")
+        self.assertIs(english.session, spanish.session)
+        self.assertEqual(english.config.engine_params["lang"], "en")
+        self.assertEqual(spanish.config.engine_params["lang"], "es")
+        self.assertIsNot(english.config, spanish.config)
+
+    def test_each_voice_synthesizes_with_its_own_options(self):
+        # What the engine is asked for is the voice's own options, even though
+        # the session under it is one object. This is the unit-level statement
+        # of "distinct voices still render differently".
+        english = self._voice(lang="en", speaker="vivian")
+        spanish = self._voice(lang="es", speaker="ethan")
+
+        seen = []
+        for voice in (english, spanish):
+            adapter = MagicMock()
+            adapter.configure = lambda cfg, _s=seen: None
+            voice.adapter = adapter
+        for voice in (english, spanish):
+            seen.append(dict(voice.config.engine_params))
+
+        self.assertNotEqual(seen[0], seen[1])
+        self.assertEqual(seen[0]["speaker"], "vivian")
+        self.assertEqual(seen[1]["speaker"], "ethan")
+
+    def test_a_different_model_gets_its_own_session(self):
+        other = Path(self.tmpdir.name) / "other.onnx"
+        _build_tiny_onnx_model(other)
+        first = make_session(self.model_path, providers=[CPU_PROVIDER])
+        second = make_session(other, providers=[CPU_PROVIDER])
+        self.assertIsNot(first, second)
+
+    def test_a_different_provider_list_gets_its_own_session(self):
+        first = make_session(self.model_path, providers=[CPU_PROVIDER])
+        with patch.object(providers, "resolve_providers",
+                          return_value=[("CPUExecutionProvider", {})]):
+            second = make_session(self.model_path)
+        self.assertIsNot(first, second)
+
+    def test_explicit_session_options_are_never_shared(self):
+        # A caller that asked for its own settings gets its own session.
+        import onnxruntime
+        first = make_session(self.model_path, providers=[CPU_PROVIDER])
+        second = make_session(self.model_path, providers=[CPU_PROVIDER],
+                              sess_options=onnxruntime.SessionOptions())
+        self.assertIsNot(first, second)
+
+    def test_sharing_can_be_turned_off(self):
+        os.environ[SHARE_SESSIONS_ENV_VAR] = "0"
+        first = make_session(self.model_path, providers=[CPU_PROVIDER])
+        second = make_session(self.model_path, providers=[CPU_PROVIDER])
+        self.assertIsNot(first, second)
+
+    def test_a_replaced_external_data_sidecar_gets_a_new_session(self):
+        # The graph names external weights in a sidecar file that onnxruntime
+        # resolves next to it; session_key only stated the graph's own
+        # (size, mtime), so a stub graph that keeps its own bytes stable
+        # while its sidecar is replaced with different weights kept serving
+        # the stale session over the old weights.
+        sidecar = Path(str(self.model_path) + "_data")
+        sidecar.write_bytes(b"weights-v1")
+        first = providers.session_key(self.model_path, [CPU_PROVIDER], None)
+        sidecar.write_bytes(b"weights-v2-longer")
+        second = providers.session_key(self.model_path, [CPU_PROVIDER], None)
+        self.assertNotEqual(first, second)
+
+    def test_a_replaced_sidecar_is_found_through_a_hub_cache_symlink(self):
+        # The hub cache lays a voice out as snapshots/<rev>/model.onnx, a
+        # symlink to blobs/<sha>; the sidecar sits beside the symlink, not
+        # beside the blob it resolves to, so probing only the realpath (as
+        # session_key used to) never finds it for a model fetched this way
+        # — exactly the models this fix targets.
+        blobs = Path(self.tmpdir.name) / "blobs"
+        snapshots = Path(self.tmpdir.name) / "snapshots" / "rev1"
+        blobs.mkdir()
+        snapshots.mkdir(parents=True)
+        blob = blobs / "deadbeef"
+        _build_tiny_onnx_model(blob)
+        stub = snapshots / "model.onnx"
+        stub.symlink_to(blob)
+        sidecar = snapshots / "model.onnx_data"
+
+        sidecar.write_bytes(b"weights-v1")
+        first = providers.session_key(stub, [CPU_PROVIDER], None)
+        sidecar.write_bytes(b"weights-v2-longer")
+        second = providers.session_key(stub, [CPU_PROVIDER], None)
+        self.assertNotEqual(first, second,
+                            "the sidecar beside a hub-cache symlink must be "
+                            "found, not only one beside the resolved blob")
+
+    def test_no_sidecar_is_unaffected(self):
+        # A single-file graph (no external-data sidecar) must key exactly as
+        # it did before: this only changes behaviour for models that have one.
+        key = providers.session_key(self.model_path, [CPU_PROVIDER], None)
+        self.assertEqual(len(key), 4)
+
+    def test_a_session_nobody_uses_is_not_kept_alive(self):
+        import gc
+        key = providers.session_key(self.model_path, [CPU_PROVIDER], None)
+        session = make_session(self.model_path, providers=[CPU_PROVIDER])
+        self.assertIn(key, providers.shared_sessions())
+        del session
+        gc.collect()
+        self.assertNotIn(key, providers.shared_sessions(),
+                         "the store must not keep a graph in memory by itself")
+
+
+class TestBuildLocksDoNotGrowForever(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.model_path = Path(self.tmpdir.name) / "backbone.onnx"
+        _build_tiny_onnx_model(self.model_path)
+        env = patch.dict(os.environ, {}, clear=False)
+        env.start()
+        self.addCleanup(env.stop)
+        os.environ.pop(SHARE_SESSIONS_ENV_VAR, None)
+
+    def test_the_build_lock_is_dropped_once_the_session_is_published(self):
+        key = providers.session_key(self.model_path, [CPU_PROVIDER], None)
+        make_session(self.model_path, providers=[CPU_PROVIDER])
+        self.assertNotIn(
+            key, providers._BUILD_LOCKS,
+            "a per-key build lock is only needed while the session it "
+            "guards is being built; keeping it after only grows the dict "
+            "by one entry per model ever seen")
+
+
+class TestArtifactKey(unittest.TestCase):
+    """What the cache charges memory against."""
+
+    def _info(self, voice_id, lang, **kwargs):
+        from phoonnx.model_manager import TTSModelInfo
+        return TTSModelInfo(voice_id=voice_id, lang=lang,
+                            model_url="hf://org/omnivoice/backbone.onnx",
+                            **kwargs)
+
+    def test_voices_over_one_model_share_a_key(self):
+        english = self._info("omnivoice/en", "en", engine_options={"lang": "en"})
+        spanish = self._info("omnivoice/es", "es", engine_options={"lang": "es"})
+        self.assertEqual(english.artifact_key(), spanish.artifact_key())
+
+    def test_a_different_model_is_a_different_key(self):
+        english = self._info("omnivoice/en", "en")
+        other = self._info("qwen3tts/vivian", "zh",)
+        other.model_url = "hf://org/qwen3tts/talker.onnx"
+        self.assertNotEqual(english.artifact_key(), other.artifact_key())
+
+    def test_an_extra_graph_is_part_of_the_key(self):
+        plain = self._info("a", "en")
+        with_vocoder = self._info("b", "en")
+        with_vocoder.vocoder_url = "hf://org/vocos.onnx"
+        self.assertNotEqual(plain.artifact_key(), with_vocoder.artifact_key())
+
+
+class _Voice:
+    """A loaded voice stand-in that can be weakly referenced.
+
+    Deliberately unhashable, like the real ``TTSVoice``: it is a dataclass
+    with ``eq``, so it has no ``__hash__``, and a weak reference hashes what
+    it points at. Keeping references to voices in a set therefore raised
+    ``TypeError: unhashable type: 'TTSVoice'`` on every synthesis — which no
+    stand-in with a default ``__hash__`` would ever have shown.
+    """
+
+    __hash__ = None
+
+    def __init__(self, voice_id):
+        self.voice_id = voice_id
+
+    def __eq__(self, other):
+        return self is other
+
+
+def _plugin(testcase, keys, sizes, **config):
+    """A plugin whose catalog maps voice ids to artifact keys and sizes."""
+    from phoonnx.opm import PhoonnxTTSPlugin
+
+    def info_for(voice_id):
+        return MagicMock(
+            load=lambda **_kw: _Voice(voice_id),
+            artifact_key=MagicMock(return_value=keys[voice_id]),
+            disk_size=MagicMock(return_value=sizes[keys[voice_id]]))
+
+    patchers = [
+        patch("phoonnx.opm.TTSModelManager"),
+        patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                     return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "get_voice_info", side_effect=info_for),
+        patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+    ]
+    for pat in patchers:
+        pat.start()
+        testcase.addCleanup(pat.stop)
+    return PhoonnxTTSPlugin(config=dict(config))
+
+
+class TestTheBudgetChargesTheModelOnce(unittest.TestCase):
+
+    def test_many_voices_over_one_model_are_charged_once(self):
+        keys = {f"omnivoice/{i}": "backbone" for i in range(20)}
+        plugin = _plugin(self, keys, {"backbone": 3 * GB},
+                         max_loaded_bytes="3GB")
+        for voice_id in keys:
+            plugin.get_model(voice_id)
+        self.assertEqual(len(plugin.voices), 20,
+                         "voices over one model must not evict each other")
+        self.assertEqual(plugin._resident_bytes(), 3 * GB,
+                         "one model in memory is one charge")
+
+    def test_a_shared_model_is_not_reloaded_for_the_next_voice(self):
+        keys = {"omnivoice/en": "backbone", "omnivoice/es": "backbone"}
+        loads = []
+        plugin = _plugin(self, keys, {"backbone": 3 * GB},
+                         max_loaded_bytes="3GB")
+        plugin.get_model("omnivoice/en")
+        plugin.get_model("omnivoice/es")
+        plugin.get_model("omnivoice/en")
+        self.assertIn("omnivoice/en", plugin.voices)
+        self.assertIn("omnivoice/es", plugin.voices)
+        del loads
+
+    def test_a_second_model_still_evicts_the_first(self):
+        keys = {"omnivoice/en": "backbone", "qwen/vivian": "talker"}
+        plugin = _plugin(self, keys,
+                         {"backbone": 3 * GB, "talker": 4 * GB},
+                         max_loaded_bytes="5GB")
+        first = plugin.get_model("omnivoice/en")
+        del first
+        plugin.get_model("qwen/vivian")
+        self.assertNotIn("omnivoice/en", plugin.voices)
+        self.assertEqual(plugin._resident_bytes(), 4 * GB)
+
+
+class TestWhatIsActuallyResident(unittest.TestCase):
+    """Eviction pops a dict entry; it does not free a model in use."""
+
+    def test_an_evicted_voice_still_in_use_is_still_charged(self):
+        keys = {"a": "model-a", "b": "model-b"}
+        plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
+                         max_loaded_bytes="4GB")
+        held = plugin.get_model("a")       # caller keeps it, as a synthesis does
+        plugin.get_model("b")
+        self.assertNotIn("a", plugin.voices, "it was evicted from the cache")
+        self.assertEqual(plugin._resident_bytes(), 6 * GB,
+                         "but its weights are still in memory, and the OOM "
+                         "killer reads memory, not the cache")
+        self.assertIsNotNone(held)
+
+    def test_the_charge_goes_away_when_the_request_finishes(self):
+        import gc
+        keys = {"a": "model-a", "b": "model-b"}
+        plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
+                         max_loaded_bytes="4GB")
+        held = plugin.get_model("a")
+        plugin.get_model("b")
+        del held
+        gc.collect()
+        self.assertEqual(plugin._resident_bytes(), 3 * GB)
+
+    def test_a_load_waits_for_memory_that_is_coming_back(self):
+        import threading
+        import time
+        keys = {"a": "model-a", "b": "model-b"}
+        plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
+                         max_loaded_bytes="4GB", load_wait_timeout=10)
+        held = plugin.get_model("a")
+        plugin.voices.clear()          # evicted, but the request holds it
+        plugin._voice_keys.clear()
+
+        done = threading.Event()
+
+        def ask():
+            plugin.get_model("b")
+            done.set()
+
+        thread = threading.Thread(target=ask, daemon=True)
+        thread.start()
+        self.assertFalse(done.wait(timeout=1),
+                         "the second model must not be admitted while the "
+                         "first is still resident")
+        del held                        # the synthesis finishes
+        self.assertTrue(done.wait(timeout=10),
+                        "and it must be admitted as soon as it can be")
+        thread.join(timeout=5)
+
+    def test_the_wait_is_bounded(self):
+        # A budget must never become a hang: a request that holds memory for
+        # longer than the timeout gets the load anyway, and says so.
+        keys = {"a": "model-a", "b": "model-b"}
+        plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
+                         max_loaded_bytes="4GB", load_wait_timeout=0.2)
+        held = plugin.get_model("a")
+        plugin.voices.clear()
+        plugin._voice_keys.clear()
+        with patch("phoonnx.opm.LOG") as log:
+            plugin.get_model("b")
+        self.assertIn("b", plugin.voices)
+        self.assertIn("exceed the budget",
+                      " ".join(str(c) for c in log.warning.call_args_list))
+        self.assertIsNotNone(held)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_voice_cache_budget.py
+++ b/tests/test_voice_cache_budget.py
@@ -142,15 +142,13 @@ class TestByteBudget(unittest.TestCase):
 
         plugin.get_model("omni")
         self.assertIn("omni", plugin.voices)
-        self.assertLessEqual(sum(plugin._voice_bytes[v] for v in plugin.voices),
-                             3 * GB)
+        self.assertLessEqual(plugin._resident_bytes(), 3 * GB)
 
         # Another small voice still fits alongside it; the budget is never
         # exceeded by voices that could have been evicted.
         plugin.get_model("small20")
         self.assertIn("omni", plugin.voices)
-        self.assertLessEqual(sum(plugin._voice_bytes[v] for v in plugin.voices),
-                             3 * GB)
+        self.assertLessEqual(plugin._resident_bytes(), 3 * GB)
 
     def test_two_big_voices_cannot_be_resident_together(self):
         plugin = _plugin(self, sizes={"omniA": 2200 * MB, "omniB": 2200 * MB},
@@ -210,8 +208,7 @@ class TestBothBoundsTogether(unittest.TestCase):
         plugin.get_model("big")
         self.assertIn("big", plugin.voices)
         self.assertLess(len(plugin.voices), 11)
-        self.assertLessEqual(sum(plugin._voice_bytes[v] for v in plugin.voices),
-                             GB)
+        self.assertLessEqual(plugin._resident_bytes(), GB)
 
 
 class TestPinningUnderBudgetPressure(unittest.TestCase):
@@ -294,7 +291,7 @@ class TestConcurrentEviction(unittest.TestCase):
         self.assertEqual(len(results), 8)
         self.assertEqual(plugin._loading, {},
                          "every loading gate must be released")
-        self.assertEqual(set(plugin._voice_bytes), set(plugin.voices),
+        self.assertEqual(set(plugin._voice_keys), set(plugin.voices),
                          "size bookkeeping must match the cache exactly")
         self.assertLessEqual(plugin._resident_bytes(), 100 * MB)
 
@@ -313,7 +310,7 @@ class TestConcurrentEviction(unittest.TestCase):
         [t.join(timeout=30) for t in threads]
         self.assertFalse([t for t in threads if t.is_alive()])
         self.assertEqual(plugin._loading, {})
-        self.assertEqual(set(plugin._voice_bytes), set(plugin.voices))
+        self.assertEqual(set(plugin._voice_keys), set(plugin.voices))
 
 
 class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
@@ -378,7 +375,7 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
                          "admission control must never deadlock")
         self.assertFalse(errors, f"loads failed: {errors}")
         self.assertEqual(plugin._loading, {})
-        self.assertEqual(set(plugin._voice_bytes), set(plugin.voices))
+        self.assertEqual(set(plugin._voice_keys), set(plugin.voices))
         return plugin, peak[0]
 
     def test_four_concurrent_omnivoice_loads_stay_within_the_budget(self):
@@ -424,6 +421,232 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
         self.assertLessEqual(peak, 2 * GB + 900 * MB,
                              "pins raise the ceiling by their own size, "
                              "not by one voice per concurrent request")
+
+
+class _CyclicVoice:
+    """A loaded voice stand-in shaped like the real ``TTSVoice``.
+
+    ``TTSVoice`` holds a reference back to itself through
+    ``adapter.voice``, so releasing the caller's last reference does not
+    make the refcount drop to zero — CPython only reclaims it on a cyclic
+    ``gc.collect()``. A leaf stand-in without this cycle would pass even a
+    residency fix that never calls ``gc.collect()`` at all, because a plain
+    ``del`` already frees a leaf object.
+    """
+
+    def __init__(self, voice_id):
+        self.voice_id = voice_id
+        self.adapter = _Adapter(self)
+
+    def __eq__(self, other):
+        return self is other
+
+    __hash__ = None
+
+
+class _Adapter:
+    def __init__(self, voice):
+        self.voice = voice
+
+
+def _cyclic_plugin(testcase, keys, sizes, **config):
+    from phoonnx.opm import PhoonnxTTSPlugin
+
+    def info_for(voice_id):
+        return MagicMock(
+            load=lambda **_kw: _CyclicVoice(voice_id),
+            artifact_key=MagicMock(return_value=keys[voice_id]),
+            disk_size=MagicMock(return_value=sizes[keys[voice_id]]))
+
+    patchers = [
+        patch("phoonnx.opm.TTSModelManager"),
+        patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                     return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "get_voice_info", side_effect=info_for),
+        patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+    ]
+    for pat in patchers:
+        pat.start()
+        testcase.addCleanup(pat.stop)
+    return PhoonnxTTSPlugin(config=dict(config))
+
+
+class TestCyclicVoiceResidency(unittest.TestCase):
+    """A voice held in a reference cycle must still be freed promptly.
+
+    Without an explicit ``gc.collect()`` on the load path, a request that
+    lets go of a cyclic voice never wakes the weakref callback that frees
+    its budget charge, and the next load for different weights sits out
+    the full ``load_wait_timeout`` before proceeding anyway.
+    """
+
+    def test_a_released_cyclic_voice_frees_its_charge_without_waiting(self):
+        import gc
+        from unittest.mock import patch as _patch
+        # Python's own generational collector runs periodically on
+        # allocation counts, which could free the cycle by coincidence and
+        # make this test pass whether or not the residency code calls
+        # gc.collect() itself. Disabling automatic collection makes the only
+        # possible collector run the one _reserve is required to make.
+        gc.disable()
+        self.addCleanup(gc.enable)
+
+        keys = {"a": "model-a", "b": "model-b"}
+        # A timeout of a few seconds, not the 300s default: if the fix
+        # regresses, this test must fail fast rather than eat minutes of CI
+        # time sitting out the real production timeout.
+        plugin = _cyclic_plugin(self, keys,
+                                {"model-a": 3 * GB, "model-b": 3 * GB},
+                                max_loaded_bytes="4GB",
+                                load_wait_timeout=3)
+        held = plugin.get_model("a")
+        plugin.voices.clear()          # evicted, but the cycle holds it
+        plugin._voice_keys.clear()
+        held = None                    # the caller's own reference is gone
+
+        started = time.monotonic()
+        with _patch("phoonnx.opm.gc", wraps=gc) as gc_mock:
+            plugin.get_model("b")
+        elapsed = time.monotonic() - started
+
+        self.assertIn("b", plugin.voices)
+        self.assertGreaterEqual(gc_mock.collect.call_count, 1,
+                                "the wait must call gc.collect() to break "
+                                "the cycle, not merely happen to succeed")
+        self.assertLess(elapsed, 1.0,
+                        "a released cyclic voice must be collected and its "
+                        "budget freed well before the load_wait_timeout")
+
+
+class TestGcCollectIsGatedOnActuallyWaiting(unittest.TestCase):
+    """gc.collect() walks the whole heap; it must not tax every load.
+
+    It exists to break the reference cycle a released ``TTSVoice`` sits in,
+    so the residency wait does not run the full timeout for memory that is
+    already free. That is only relevant once a load is actually about to
+    wait for room — a load with plenty of budget headroom, or one that hits
+    an already-resident key, has no cycle to break and must not pay for the
+    collection anyway.
+    """
+
+    def test_ample_headroom_does_not_collect(self):
+        from unittest.mock import patch as _patch
+        plugin = _plugin(self, sizes={"a": 10 * MB}, max_loaded_bytes="1GB")
+        with _patch("phoonnx.opm.gc") as gc_mock:
+            plugin.get_model("a")
+        gc_mock.collect.assert_not_called()
+
+    def test_a_cache_hit_for_an_already_resident_key_does_not_collect(self):
+        from unittest.mock import patch as _patch
+        keys = {"a": "model-a", "b": "model-a"}
+        plugin = _plugin_shared_keys(self, keys, sizes={"model-a": 10 * MB},
+                                     max_loaded_bytes="1GB")
+        plugin.get_model("a")
+        with _patch("phoonnx.opm.gc") as gc_mock:
+            plugin.get_model("b")
+        gc_mock.collect.assert_not_called()
+
+    def test_a_load_that_must_wait_for_room_does_collect(self):
+        from unittest.mock import patch as _patch
+        keys = {"a": "model-a", "b": "model-b"}
+        plugin = _plugin_shared_keys(self, keys,
+                                     sizes={"model-a": 3 * GB, "model-b": 3 * GB},
+                                     max_loaded_bytes="4GB", load_wait_timeout=0.2)
+        held = plugin.get_model("a")
+        plugin.voices.clear()
+        plugin._voice_keys.clear()
+        with _patch("phoonnx.opm.gc", wraps=__import__("gc")) as gc_mock:
+            plugin.get_model("b")
+        self.assertGreaterEqual(gc_mock.collect.call_count, 1)
+        self.assertIsNotNone(held)
+
+
+class _WeakrefableVoice:
+    """A loaded-voice stand-in that supports weak references, unlike a str."""
+
+    def __init__(self, voice_id):
+        self.voice_id = voice_id
+
+
+def _plugin_shared_keys(testcase, keys, sizes, **config):
+    """A plugin whose catalog maps voice ids to artifact keys, real load()."""
+    from phoonnx.opm import PhoonnxTTSPlugin
+
+    def info_for(voice_id):
+        return MagicMock(
+            load=lambda **_kw: _WeakrefableVoice(voice_id),
+            artifact_key=MagicMock(return_value=keys[voice_id]),
+            disk_size=MagicMock(return_value=sizes[keys[voice_id]]))
+
+    patchers = [
+        patch("phoonnx.opm.TTSModelManager"),
+        patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                     return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "get_voice_info", side_effect=info_for),
+        patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+    ]
+    for pat in patchers:
+        pat.start()
+        testcase.addCleanup(pat.stop)
+    return PhoonnxTTSPlugin(config=dict(config))
+
+
+class TestPostLoadEviction(unittest.TestCase):
+    """The eviction that runs once a cold load's real size is known.
+
+    ``_track`` used to run before ``_evict_for`` in ``get_model``'s post-load
+    section, which registers the incoming voice's own key as resident before
+    the eviction call gets to look at it — so ``_evict_for``'s "already
+    resident, nothing to do" guard fired on every post-load call, evicting
+    nothing, regardless of whether the just-measured size actually fit.
+    """
+
+    def test_a_measured_size_that_overflows_the_budget_evicts_others(self):
+        # "extra" is admitted *during* "big"'s own (unlocked) load — a voice
+        # request another caller made while "big" was loading, exactly the
+        # kind of admission a long cold load has time for. Once "big"'s real
+        # size is known post-load, the two together no longer fit, and only
+        # the post-load eviction step (not the pre-load one, which already
+        # ran before "extra" existed) can make room.
+        plugin_holder = {}
+        sizes = {"extra": 2 * GB, "big": 3 * GB}
+
+        class _V:
+            def __init__(self, voice_id):
+                self.voice_id = voice_id
+
+        def info_for(voice_id):
+            def load(**_kw):
+                if voice_id == "big":
+                    plugin_holder["p"].get_model("extra")
+                return _V(voice_id)
+            return MagicMock(load=load,
+                             disk_size=MagicMock(return_value=sizes[voice_id]))
+
+        from phoonnx.opm import PhoonnxTTSPlugin
+        patchers = [
+            patch("phoonnx.opm.TTSModelManager"),
+            patch.object(PhoonnxTTSPlugin, "get_default_voice",
+                         return_value=MagicMock()),
+            patch.object(PhoonnxTTSPlugin, "get_voice_info", side_effect=info_for),
+            patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
+        ]
+        for pat in patchers:
+            pat.start()
+            self.addCleanup(pat.stop)
+
+        plugin = PhoonnxTTSPlugin(config={"max_loaded_bytes": "4GB",
+                                          "load_wait_timeout": 0.2})
+        plugin_holder["p"] = plugin
+        plugin.get_model("big")
+
+        self.assertIn("big", plugin.voices)
+        self.assertNotIn("extra", plugin.voices,
+                         "the post-load eviction must evict a voice that no "
+                         "longer fits once the real size is known")
+        import gc
+        gc.collect()
+        self.assertLessEqual(plugin._resident_bytes(), 4 * GB)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

A voice-index entry is not a model. `omnivoice.json` holds 646 entries and there is exactly one `model_url` between them, a single 3.0 GB backbone; `qwen3tts.json` holds 15 over one 4.2 GB talker. The entries differ in the voice id, the display name, the language and the `engine_options` that get applied at synthesis time, and in nothing else. The loaded-voice cache was keyed by voice id, so every one of those entries built its own `InferenceSession` over the identical file, kept its own copy of the weights, and was charged the whole model size against `max_loaded_bytes`. One omnivoice voice would evict another to make room for the same graph — `en` loaded, evicted for `es`, loaded again — and an 8 GB container was OOM-killed four times with 6.4 to 7.2 GB of anonymous memory.

`make_session` now hands back the session already loaded for a model instead of building a second one. The key is the model file (real path, size and modification time) together with the resolved providers and the optimized-graph cache directory, so only calls that would have produced identical sessions ever share one, and a file replaced on disk gets a fresh session rather than a stale one. Sessions are held weakly, so a graph is freed as soon as the last voice using it goes away, and nothing has to remember to release anything. Each voice keeps its own config, phonemizer, adapter and engine options over the shared weights, which is what makes the audio different, so distinct voices still render distinct audio. `PHOONNX_SHARE_ONNX_SESSIONS=0` restores a private session per voice, and a caller that passes its own `sess_options` always gets one.

The cache now charges memory per artifact key rather than per voice id. A voice whose weights are already in memory is admitted without evicting anything, so 646 omnivoice voices cost one 3 GB load instead of 646, and eviction no longer picks a victim whose removal would free nothing.

The same rework fixes the second half of the problem, which is that `_evict_for` never bounded peak memory. It made room by popping a dictionary entry while the request that asked for the evicted voice held it for the whole synthesis — three to five minutes for these models — so the budget described the cache rather than the memory, and two concurrent qwen3tts voices peaked at 8714 MiB against an 8192 MiB limit. Voices are now tracked by weak reference, what counts as resident is what is in memory, and a load waits while memory that is in use could still come back. The wait is bounded by `load_wait_timeout` (300 seconds by default) and every path that frees memory wakes the waiters, so a budget can never turn into a hang.

Verified live on an 8 GB container with `max_loaded_bytes: 3GB`, synthesizing six omnivoice voices in sequence: the backbone and its decoder load once, every later voice logs a session reuse instead of a load, and the six WAVs differ. The added tests fail against `dev` — two voices over one model build two sessions there, and twenty voices over one model evict each other down to one resident — and pass here. Excluding the training suites that write more than 100 GB (`test_preprocess_pipeline`, `test_torch_compile_training`, `test_training_audit_fixes`, `test_trim_silence_edges`, `test_vad_trim_determinism`, `test_vits_audio_logging`, `test_vits_lightning`, `test_vits_split`, `test_vits_streaming`, `test_vocoder_training_preflight`, `test_yourtts_training`), the suite goes from 45 failed / 2209 passed on `dev` to 45 failed / 2228 passed here, with an identical failure set — all of them missing optional dependencies.


The residency wait relied on a released voice's weak reference dying, but a loaded voice holds a cycle back to itself through its adapter, so plain reference counting never frees one and the wait sat out the full timeout even when the memory it needed was already unreachable; the reservation path now calls `gc.collect()` to break that cycle before waiting and again at the timeout. The post-load eviction step ran after the incoming voice was already tracked, which made it always see its own key as already resident and skip evicting anything regardless of the voice's measured size — it now runs before that tracking call, so it can make room once a cold voice's real on-disk size is known. Chatterbox's auxiliary graphs (`speech_encoder`, `embed_tokens`, `conditional_decoder`, about 1.19GB per voice) built their own `InferenceSession` outside `make_session`, so identical graphs across voices sharing a checkpoint were neither shared nor counted against the budget; they now go through the same `make_session` as every other graph. `session_key` also now includes the size and modification time of a model's external-weights sidecar file, not just the graph file itself, so replacing the sidecar under a stable stub graph no longer serves a stale session over weights that are gone; and the per-model build lock is dropped once the session it guards is published, instead of staying in the lock table for as long as the process runs.


The first `gc.collect()` in the residency wait ran unconditionally, on every budgeted load, whether or not there was already room — hundreds of milliseconds on a large heap, and paid even by a cache hit for an already-resident key. It now runs once, right before the wait would actually block, gated on the same condition that decides whether the loop waits at all; the second collect at the timeout is unchanged. `session_key`'s external-data sidecar probe only checked the model file's resolved real path, which under a hub-cache layout is the blob a symlink points at, with no sidecar beside it — the sidecar sits next to the symlink in the snapshot directory instead, so a model fetched through the hub cache never had its sidecar folded into the key. It now probes both the path as given and its resolved real path.
