### PR TITLE
fix: degrade to unstressed text when diacritization fails

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -967,7 +967,11 @@ def get_conversion(phonemizer, voice_config: "VoiceConfig",
         return graph, (lambda text: text)
 
     def _vocalize(text, **_):
-        return diacritize(text, lang, diacritizer_model=model)
+        try:
+            return diacritize(text, lang, diacritizer_model=model)
+        except Exception as e:
+            LOG.warning(f"diacritization failed for lang={lang}: {e} — synthesizing unstressed text")
+            return text
 
     graph.register(Edge("text", DIACRITIZED, _vocalize))
     graph.register(Edge(DIACRITIZED, alpha, phonemize))

--- a/tests/test_diacritize_degrades_on_failure.py
+++ b/tests/test_diacritize_degrades_on_failure.py
@@ -1,0 +1,58 @@
+"""Diacritization is optional prosody enrichment. If the backend raises
+(e.g. stressonnx.UnsupportedLanguageError for a language it doesn't cover),
+synthesis must degrade to the unstressed input text instead of 500ing —
+matching the degradation contract already used by phoonnx.lang_preprocess's
+russian_add_stress. Regression for a production failure where a regional
+voice (e.g. ru-RU) hard-failed synthesis because the diacritize graph edge
+propagated the exception unguarded.
+"""
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+import scriptconv.diacritics as scd
+from phoonnx.config import Alphabet, SynthesisConfig
+from phoonnx.util import LOG
+from phoonnx.voice import TTSVoice
+
+
+def _make_voice():
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.phonetic_spellings = None
+    voice.phonemizer = MagicMock()
+    voice.phonemizer.phonemize_lazy = MagicMock(return_value=iter([list("test")]))
+    voice.config = types.SimpleNamespace(
+        alphabet=Alphabet.IPA,
+        lang_code="ru-RU",
+        add_diacritics=True,
+        diacritizer_model=None,
+        sample_rate=22050,
+    )
+    voice.adapter = MagicMock()
+    voice.phonemes_to_ids = lambda phonemes: [1] * len(phonemes)
+    voice.phoneme_ids_to_audio = lambda phoneme_ids, syn_config=None, language_ids=None, include_alignments=False: np.zeros(4, dtype=np.float32)
+    return voice
+
+
+class TestDiacritizeDegradesOnFailure(unittest.TestCase):
+    def test_diacritize_failure_degrades_to_unstressed_text_with_warning(self):
+        voice = _make_voice()
+        syn_config = SynthesisConfig(alphabet=Alphabet.GRAPHEMES, normalize_audio=False)
+
+        def _raise(t, l="und", **k):
+            raise RuntimeError("UnsupportedLanguageError('ru-RU')")
+
+        with patch.object(scd, "diacritize", side_effect=_raise), \
+             patch.object(LOG, "warning") as mock_warn:
+            list(voice.synthesize("privet", syn_config))
+
+        voice.phonemizer.phonemize_lazy.assert_called_once()
+        called_text = voice.phonemizer.phonemize_lazy.call_args[0][0]
+        self.assertEqual(called_text, "privet")
+        mock_warn.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

On a production TTS server, synthesis for a regional-code voice (ru-RU) returned a 500 with the diacritizer backend raising an unsupported-language error deep in the request path. The traceback showed the exception coming from phoonnx's optional stress/diacritization enrichment step, which had no guard around the call into scriptconv's diacritizer.

`_vocalize` in `phoonnx/config.py` is registered as a graph edge on the text-to-DIACRITIZED conversion step and calls `scriptconv.diacritics.diacritize(text, lang, diacritizer_model=model)` directly. Diacritization is meant to be an optional enrichment — the equivalent stress step in `phoonnx/lang_preprocess.py` (`russian_add_stress`) already wraps its `stressonnx` call in `except Exception`, logs a warning, and falls back to the unstressed input text. `_vocalize` had no such guard, so any backend failure (missing model, unsupported language, network hiccup fetching a diacritizer) propagated all the way through `ConversionGraph.convert` and killed the whole synthesis request instead of just skipping the enrichment.

This PR wraps the `diacritize` call in `_vocalize` with the same try/except pattern, logging a warning naming the language and the exception and returning the original text unchanged on failure, matching the degradation contract used elsewhere in the codebase for optional prosody/enrichment steps.

The included regression test patches `scriptconv.diacritics.diacritize` to raise and asserts that synthesis still proceeds using the unstressed input text with a warning logged, rather than the exception propagating. Reverting only the fix (keeping the test) reproduces the production failure: the test raises `RuntimeError` from inside `ConversionGraph.convert` -> `_vocalize`, confirming the test is a real regression check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synthesis now continues when text diacritization fails, using the original unvocalized text instead.
  * A warning is logged when diacritization cannot be completed.

* **Tests**
  * Added coverage confirming synthesis completes successfully and passes the original text to phonemization after a diacritization failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->