### PR TITLE
fix: close every redirect hop and fix leading-silence bug in voice.py

### DIFF
--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -109,11 +109,14 @@ def _fetch_reference_audio(url: str, timeout: int = 10,
     byte at a time would otherwise hold a synthesis worker open forever.
     """
     import requests
+    from contextlib import ExitStack
 
     started = time.monotonic()
     _check_reference_url(url)
-    with requests.get(url, timeout=timeout, stream=True,
-                      allow_redirects=False) as r:
+    with ExitStack() as stack:
+        r = stack.enter_context(
+            requests.get(url, timeout=timeout, stream=True,
+                        allow_redirects=False))
         hops = 0
         while r.is_redirect or r.is_permanent_redirect:
             hops += 1
@@ -124,8 +127,11 @@ def _fetch_reference_audio(url: str, timeout: int = 10,
             # innocent-looking URL into a request to a private address.
             _check_reference_url(target)
             r.close()
-            r = requests.get(target, timeout=timeout, stream=True,
-                             allow_redirects=False)
+            # Entered on the stack too, so every hop — including this final
+            # one, whose body is streamed below — gets closed on the way out.
+            r = stack.enter_context(
+                requests.get(target, timeout=timeout, stream=True,
+                            allow_redirects=False))
         r.raise_for_status()
 
         suffix = os.path.splitext(urlparse(url).path)[1] or ".wav"
@@ -996,6 +1002,9 @@ class TTSVoice:
 
         first_chunk = True
         for audio_chunk in self.synthesize(text, syn_config=syn_config):
+            if not first_chunk:
+                wav_file.writeframes(silence_int16_bytes)
+
             if first_chunk:
                 if set_wav_format:
                     # the chunk is authoritative once we have one
@@ -1004,9 +1013,6 @@ class TTSVoice:
                     wav_file.setnchannels(audio_chunk.sample_channels)
 
                 first_chunk = False
-
-            if not first_chunk:
-                wav_file.writeframes(silence_int16_bytes)
 
             wav_file.writeframes(audio_chunk.audio_int16_bytes)
 

--- a/tests/test_voice_redirect_and_silence.py
+++ b/tests/test_voice_redirect_and_silence.py
@@ -1,0 +1,152 @@
+"""Two independent defects in phoonnx/voice.py.
+
+``_fetch_reference_audio`` follows redirects manually (rebinding ``r`` inside
+a ``with requests.get(...) as r:`` block) so the response actually streamed
+to disk is never closed by the context manager, leaking a pooled connection
+on every redirected fetch.
+
+``synthesize_wav`` clears ``first_chunk`` before checking it, so silence gets
+written before the first chunk too instead of only between chunks.
+"""
+import unittest
+import wave
+from dataclasses import dataclass, field
+from typing import List
+from unittest.mock import MagicMock, patch
+
+
+class _FakeResponse:
+    """Records whether close() was called, like requests.Response."""
+
+    def __init__(self, url, redirect=False, permanent_redirect=False,
+                 location=None, chunks=None):
+        self.url = url
+        self.is_redirect = redirect
+        self.is_permanent_redirect = permanent_redirect
+        self.headers = {"Location": location} if location else {}
+        self._chunks = chunks or [b"abc"]
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    def raise_for_status(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.close()
+
+    def iter_content(self, chunk_size=8192):
+        for c in self._chunks:
+            yield c
+
+
+class TestRedirectedFetchClosesEveryResponse(unittest.TestCase):
+    def test_final_response_is_closed(self):
+        from phoonnx.voice import _fetch_reference_audio
+
+        first = _FakeResponse("http://example.com/a", redirect=True,
+                               location="http://example.com/b")
+        second = _FakeResponse("http://example.com/b", chunks=[b"hello"])
+        responses = [first, second]
+
+        def fake_get(url, timeout=None, stream=None, allow_redirects=None):
+            return responses.pop(0)
+
+        with patch("requests.get", side_effect=fake_get), \
+                patch("phoonnx.voice._check_reference_url"):
+            path = _fetch_reference_audio("http://example.com/a")
+
+        try:
+            self.assertTrue(first.closed, "the intermediate hop must be closed")
+            self.assertTrue(
+                second.closed,
+                "the final response (the one actually streamed to disk) "
+                "must be closed too — it leaked its pooled connection")
+        finally:
+            import os
+            os.unlink(path)
+
+    def test_redirect_target_is_still_validated_per_hop(self):
+        from phoonnx.voice import _fetch_reference_audio
+
+        first = _FakeResponse("http://example.com/a", redirect=True,
+                               location="http://example.com/b")
+        second = _FakeResponse("http://example.com/b", chunks=[b"hello"])
+        responses = [first, second]
+
+        def fake_get(url, timeout=None, stream=None, allow_redirects=None):
+            return responses.pop(0)
+
+        with patch("requests.get", side_effect=fake_get), \
+                patch("phoonnx.voice._check_reference_url") as checker:
+            path = _fetch_reference_audio("http://example.com/a")
+        import os
+        os.unlink(path)
+
+        checked = [c.args[0] for c in checker.call_args_list]
+        self.assertIn("http://example.com/a", checked)
+        self.assertIn("http://example.com/b", checked)
+
+
+@dataclass
+class _FakeChunk:
+    sample_rate: int = 16000
+    sample_width: int = 2
+    sample_channels: int = 1
+    audio_float_array: object = None
+    phonemes: List[str] = field(default_factory=list)
+    phoneme_ids: List[int] = field(default_factory=list)
+
+    @property
+    def audio_int16_bytes(self):
+        return b"\x01\x02"
+
+
+class TestSentenceSilencePlacement(unittest.TestCase):
+    def test_silence_only_between_chunks_not_before_first(self):
+        """``sentence_silence`` is hardcoded to 0.0 in the source, so the
+        silence bytes computed from it are always ``b""`` and the placement
+        bug is invisible on real output. To exercise the placement logic
+        itself we patch the single ``bytes(...)`` call the function makes
+        (for computing ``silence_int16_bytes``) so it stands in for a
+        non-zero silence duration, then drive the real, unpatched
+        ``synthesize_wav`` with a stubbed chunk generator.
+        """
+        from phoonnx.voice import TTSVoice
+
+        voice = MagicMock(spec=TTSVoice)
+        voice.config = MagicMock()
+        voice.config.sample_rate = 16000
+
+        chunks = [_FakeChunk(), _FakeChunk(), _FakeChunk()]
+        voice.synthesize.return_value = iter(chunks)
+
+        wav_file = MagicMock(spec=wave.Wave_write)
+
+        silence_marker = b"SILENCE"
+        with patch("phoonnx.voice.bytes", return_value=silence_marker):
+            TTSVoice.synthesize_wav(voice, "hello. world. again.", wav_file)
+
+        calls = [c.args[0] for c in wav_file.writeframes.call_args_list]
+        self.assertEqual(
+            calls.count(silence_marker), 2,
+            "3 chunks must produce exactly 2 between-chunk silence writes")
+        self.assertNotEqual(
+            calls[0], silence_marker,
+            "the first writeframes call must be the first audio chunk, "
+            "never silence")
+        self.assertEqual(calls, [
+            b"\x01\x02",     # chunk 1
+            silence_marker,  # silence before chunk 2
+            b"\x01\x02",     # chunk 2
+            silence_marker,  # silence before chunk 3
+            b"\x01\x02",     # chunk 3
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

Two small, independent defects in `phoonnx/voice.py`, fixed together since both are minor and in the same file.

`_fetch_reference_audio` opens the first response with `with requests.get(...) as r:` and then rebinds `r` to a new response on each redirect hop. The `with` block only closes whatever object it was originally entered with, so the final response — the one whose body is actually streamed to the temp file — was never closed, leaking a pooled connection on every fetch that follows a redirect. The fix uses a `contextlib.ExitStack` so every hop's response is entered and closed on the way out, including the last one, while keeping the existing per-hop SSRF re-check and the manual `close()` on superseded hops exactly as they were.

`synthesize_wav` clears `first_chunk` before checking it, so `if not first_chunk: writeframes(silence)` was already true by the time it ran for the very first chunk. Whenever `sentence_silence` is non-zero this adds silence before the first sentence and shifts every subsequent gap by one position. The fix reorders the check so silence is only written between chunks, never before the first one. `sentence_silence` is still hardcoded to `0.0` in this file, so the fix has no effect on current output — it only corrects the ordering for whenever that value becomes configurable.

Both fixes are covered by new regression tests in `tests/test_voice_redirect_and_silence.py`, which mock `requests.get` (recording `close()` calls) and drive `synthesize_wav` with a stubbed chunk generator, since `sentence_silence` needed a stand-in for a non-zero value to make the ordering bug observable. I confirmed both tests fail against the unfixed source — the redirect test on "the final response ... must be closed too" and the silence test on "3 != 2: 3 chunks must produce exactly 2 between-chunk silence writes" — and pass after the fix, including the pre-existing `tests/test_per_request_cloning.py` suite, which continues to pass unchanged.

The full non-training test suite (excluding `test_vits_*`, `test_yourtts_*`, `test_vocoder_*`, and similar) passes except for `test_coldstart_warmup_cache.py`, which is already red on unmodified `dev` because the optional `onnx` package isn't installed in this environment; that failure is unrelated to this change.