### PR TITLE
fix: stop cross-request voice-clone bleed on shared OmniVoice/Spark-TTS adapters

### DIFF
--- a/phoonnx/engines/omnivoice.py
+++ b/phoonnx/engines/omnivoice.py
@@ -123,7 +123,6 @@ class OmniVoiceAdapter(BaseOnnxAdapter):
         self.decoder: Optional[onnxruntime.InferenceSession] = None
         self.tokenizer = None
         self._params: Dict[str, Any] = {}
-        self._reference_text: Optional[str] = None
         self._estimator = RuleDurationEstimator()
         self._ref_cache_key: Optional[tuple] = None
         self._ref_cache: Tuple[Optional[np.ndarray], Optional[float]] = (None, None)
@@ -192,12 +191,13 @@ class OmniVoiceAdapter(BaseOnnxAdapter):
         — its ``prompt_tokens`` are phoneme ids and mean nothing here. A cloning
         reference's transcription is kept as a *string*, because upstream joins it to the
         target text before tokenizing (:func:`combine_text`) rather than concatenating two
-        token sequences.
+        token sequences. It travels to :meth:`synthesize` on ``request.params`` rather than
+        on ``self`` — this adapter instance is shared across concurrent requests (one
+        ``TTSVoice``/adapter per voice_id under the threaded server), and stashing it here
+        would let one request's reference text bleed into another's audio.
         """
         if self.tokenizer is None:
             raise RuntimeError("OmniVoice voice missing bpe_tokenizer_path in engine_params")
-        reference_text = getattr(syn_config, "speaker_reference_text", None)
-        self._reference_text = add_punctuation(reference_text) if reference_text else None
         return [self._encode(text)] if text.strip() else []
 
     def _decode_ids(self, ids: np.ndarray) -> str:
@@ -444,12 +444,15 @@ class OmniVoiceAdapter(BaseOnnxAdapter):
         params = request.params
         text = self._decode_ids(request.phoneme_ids)
 
+        reference_text = params.get("speaker_reference_text")
+        reference_text = add_punctuation(reference_text) if reference_text else None
+
         ref_codes = ref_rms = None
         reference = params.get("reference_audio")
         if reference is not None:
             ref_codes, ref_rms = self.encode_reference(reference[0], int(reference[1]))
-        ref_text = self._reference_text if ref_codes is not None else None
-        if ref_codes is None and self._reference_text:
+        ref_text = reference_text if ref_codes is not None else None
+        if ref_codes is None and reference_text:
             LOG.warning("OmniVoice: a reference transcription was given without a "
                         "reference clip — ignoring it")
 

--- a/phoonnx/engines/sparktts.py
+++ b/phoonnx/engines/sparktts.py
@@ -214,7 +214,6 @@ class SparkTTSAdapter(BaseOnnxAdapter):
         self.preset_global_tokens: Optional[np.ndarray] = None
         self.special: Dict[str, int] = {}
         self._params: Dict[str, Any] = {}
-        self._reference_text_ids: Optional[List[int]] = None
         self._reference_cache_key: Optional[tuple] = None
         self._reference_cache: Tuple[np.ndarray, Optional[np.ndarray]] = (None, None)
         self.past_names: List[str] = []
@@ -287,18 +286,17 @@ class SparkTTSAdapter(BaseOnnxAdapter):
         Only the *content* is tokenized here. The control tokens and the speaker stream
         are added in :meth:`synthesize`, which is where the speaker is known.
 
-        A cloning reference's transcription is tokenized here too. It is text for this
-        model, so it goes through the same subword BPE as the content — not through the
-        shared phonemizer path, whose ``prompt_tokens`` are phoneme ids for the
-        phoneme-based in-context engines and mean nothing to Spark-TTS. The whole text is
-        encoded before the first chunk is synthesized, so one transcription is in place
-        for every chunk of the call.
+        A cloning reference's transcription is text for this model too, so it goes through
+        the same subword BPE as the content — not through the shared phonemizer path,
+        whose ``prompt_tokens`` are phoneme ids for the phoneme-based in-context engines
+        and mean nothing to Spark-TTS. It is tokenized in :meth:`synthesize`, from
+        ``request.params``, rather than here on ``self``: this adapter instance is shared
+        across concurrent requests (one ``TTSVoice``/adapter per voice_id under the
+        threaded server), and stashing it here would let one request's reference
+        transcription bleed into another's audio.
         """
         if self.tokenizer is None:
             raise RuntimeError("Spark-TTS voice missing bpe_tokenizer_path in engine_params")
-        reference_text = getattr(syn_config, "speaker_reference_text", None)
-        self._reference_text_ids = (self.tokenizer.tokenize(reference_text)
-                                    if reference_text else None)
         return [self.tokenizer.tokenize(chunk) for chunk in chunk_text(text) if chunk.strip()]
 
     # ------------------------------------------------------------------
@@ -343,20 +341,23 @@ class SparkTTSAdapter(BaseOnnxAdapter):
             self.semantic_tokenizer.run(None, {"feat": feat})[0], np.int64).reshape(-1)
         return global_tokens, semantic
 
-    def _resolve_speaker(self, request: AdapterSynthesisRequest
+    def _resolve_speaker(self, request: AdapterSynthesisRequest, prompt_text_ids: Optional[List[int]]
                          ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
         """Pick the speaker for this call: the reference clip if given, else the preset.
 
         Long text is synthesized one chunk per call, so the reference is encoded once and
-        reused for the rest of the chunks rather than re-run per sentence.
+        reused for the rest of the chunks rather than re-run per sentence. The cache is
+        keyed on the clip and on whether a transcription came along with it, so two
+        requests cloning from different clips (or the same clip with/without a
+        transcription) never share a cache entry.
         """
         ref = request.params.get("reference_audio")
         if ref is not None:
             audio = np.asarray(ref[0], np.float32).reshape(-1)
-            key = (hash(audio.tobytes()), int(ref[1]), bool(self._reference_text_ids))
+            key = (hash(audio.tobytes()), int(ref[1]), bool(prompt_text_ids))
             if self._reference_cache_key != key:
                 self._reference_cache = self.tokenize_reference(
-                    audio, int(ref[1]), with_semantic=bool(self._reference_text_ids))
+                    audio, int(ref[1]), with_semantic=bool(prompt_text_ids))
                 self._reference_cache_key = key
             return self._reference_cache
         if self.preset_global_tokens is None:
@@ -426,8 +427,9 @@ class SparkTTSAdapter(BaseOnnxAdapter):
         if self.tokenizer is None:
             raise RuntimeError("Spark-TTS voice missing bpe_tokenizer_path in engine_params")
 
-        global_tokens, prompt_semantic = self._resolve_speaker(request)
-        prompt_text_ids = self._reference_text_ids
+        reference_text = request.params.get("speaker_reference_text")
+        prompt_text_ids = self.tokenizer.tokenize(reference_text) if reference_text else None
+        global_tokens, prompt_semantic = self._resolve_speaker(request, prompt_text_ids)
         prompt = self.build_prompt(
             np.asarray(request.phoneme_ids, np.int64).reshape(-1).tolist(),
             global_tokens, prompt_text_ids, prompt_semantic)

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -1090,6 +1090,12 @@ class TTSVoice:
         if syn_config.speaker_reference_text:
             params["prompt_tokens"] = self._prompt_token_ids(
                 syn_config.speaker_reference_text, syn_config.speaker_reference_lang)
+            # Raw string, for text-token adapters (OmniVoice, Spark-TTS) that tokenize
+            # the reference transcription themselves rather than through the shared
+            # phonemizer. Carried on the per-call request rather than adapter state so
+            # concurrent calls sharing one adapter instance never see each other's
+            # reference transcription.
+            params["speaker_reference_text"] = syn_config.speaker_reference_text
         if syn_config.exaggeration is not None:
             params["exaggeration"] = syn_config.exaggeration
         if syn_config.temperature is not None:

--- a/tests/test_omnivoice.py
+++ b/tests/test_omnivoice.py
@@ -590,7 +590,9 @@ def test_decode_codes_without_a_decoder_says_what_is_missing():
         ad.decode_codes(np.zeros((NUM_CODEBOOKS, 3), np.int64))
 
 
-def test_encode_text_keeps_the_reference_transcription_as_text():
+def test_encode_text_does_not_stash_reference_state_on_the_adapter():
+    # the reference transcription travels on request.params, not on self -- this
+    # adapter instance is shared across concurrent requests
     ad = _adapter()
 
     class _Syn:
@@ -598,19 +600,38 @@ def test_encode_text_keeps_the_reference_transcription_as_text():
 
     ids = ad.encode_text("target", voice=None, syn_config=_Syn())
     assert ids == [[ord(c) for c in "target"]]
-    # punctuation is added, and it stays a string -- the prompt joins strings, not ids
-    assert ad._reference_text == "Reference clip."
+    assert not hasattr(ad, "_reference_text")
 
 
-def test_encode_text_without_a_reference_clears_stale_state():
-    ad = _adapter()
-    ad._reference_text = "left over"
+def test_synthesize_uses_the_reference_text_from_request_params_not_from_encode_text():
+    """Regression: encode_text used to stash the reference transcription on self, which
+    the shared adapter (one per voice_id under the threaded server) could serve to a
+    different, concurrently-running request's synthesize() call. It must come from
+    request.params instead."""
+    ad = _adapter(decoder=_FakeDecoder())
+    sess = _FakeBackbone()
+    ad.encode_reference = lambda audio, sr: (np.zeros((NUM_CODEBOOKS, 2), np.int64), 0.1)
 
-    class _Syn:
-        speaker_reference_text = None
+    class _SynA:
+        speaker_reference_text = "Request A reference"
 
-    ad.encode_text("target", voice=None, syn_config=_Syn())
-    assert ad._reference_text is None
+    class _SynB:
+        speaker_reference_text = "Request B reference"
+
+    # simulate interleaving: request A's encode_text runs, then request B's encode_text
+    # runs on the same shared adapter (as would happen under a threaded server), and
+    # only then does request A's synthesize() run.
+    ad.encode_text("a text", voice=None, syn_config=_SynA())
+    ad.encode_text("b text", voice=None, syn_config=_SynB())
+
+    ref_audio = (np.zeros(SAMPLE_RATE, np.float32), SAMPLE_RATE)
+    req_a = _req([ord(c) for c in "a text"], num_step=1,
+                speaker_reference_text="Request A reference", reference_audio=ref_audio)
+    ad.synthesize(req_a, sess)
+
+    prompt = ad._decode_ids(sess.calls[0]["input_ids"][0, 0])
+    assert "Request A reference" in prompt
+    assert "Request B reference" not in prompt
 
 
 def test_empty_text_yields_no_chunks():

--- a/tests/test_sparktts.py
+++ b/tests/test_sparktts.py
@@ -161,9 +161,11 @@ def test_encode_text_uses_the_models_own_bpe():
     assert ad.encode_text("hi!", None, None) == [[ord("h"), ord("i"), ord("!")]]
 
 
-def test_encode_text_tokenizes_the_reference_transcription_with_the_same_bpe():
+def test_encode_text_does_not_stash_reference_state_on_the_adapter():
     # the transcription is text for this model, so it must not come from the shared
-    # phonemizer path (whose prompt_tokens are phoneme ids for ZipVoice-style engines)
+    # phonemizer path (whose prompt_tokens are phoneme ids for ZipVoice-style engines).
+    # It also must not be stashed on self -- this adapter instance is shared across
+    # concurrent requests, and reads it back from request.params in synthesize() instead.
     ad = _adapter()
 
     class _Bpe:
@@ -175,10 +177,7 @@ def test_encode_text_tokenizes_the_reference_transcription_with_the_same_bpe():
 
     ad.tokenizer = _Bpe()
     ad.encode_text("hi", None, _Syn())
-    assert ad._reference_text_ids == [ord("a"), ord("b")]
-    # a later call without a transcription clears it, so a stale reference never leaks
-    ad.encode_text("hi", None, None)
-    assert ad._reference_text_ids is None
+    assert not hasattr(ad, "_reference_text_ids")
 
 
 def test_encode_text_without_a_tokenizer_is_an_error():
@@ -258,8 +257,8 @@ def test_reference_encoding_is_reused_across_chunks():
     ad.speaker_tokenizer = _Sess()
     audio = np.sin(np.linspace(0, 200, 16000)).astype(np.float32)
     req = _req(reference_audio=(audio, 16000))
-    ad._resolve_speaker(req)
-    ad._resolve_speaker(req)
+    ad._resolve_speaker(req, None)
+    ad._resolve_speaker(req, None)
     assert len(calls) == 1
 
 
@@ -611,6 +610,41 @@ def test_synthesize_filters_out_non_semantic_token_ids_before_the_vocoder():
     feed = ad.vocoder.calls[0]
     assert feed["semantic_tokens"].tolist() == [[42]]   # only the one valid token survives
     assert result.extras == {"semantic_token_count": 1}
+
+
+def test_synthesize_uses_the_reference_text_from_request_params_not_from_encode_text():
+    """Regression: encode_text used to stash the tokenized reference transcription on
+    self, which the shared adapter (one per voice_id under the threaded server) could
+    serve to a different, concurrently-running request's synthesize() call. It must come
+    from request.params instead."""
+    base = SPECIAL["<|bicodec_semantic_0|>"]
+    eos = SPECIAL["<|im_end|>"]
+
+    class _Bpe:
+        def tokenize(self, text):
+            return [ord(c) for c in text]
+
+    ad, session = _synth_ready_adapter([base + 1, eos])
+    ad.tokenizer = _Bpe()
+
+    class _SynA:
+        speaker_reference_text = "AAA"
+
+    class _SynB:
+        speaker_reference_text = "BBB"
+
+    # simulate interleaving: request A's encode_text runs, then request B's encode_text
+    # runs on the same shared adapter (as would happen under a threaded server), and
+    # only then does request A's synthesize() run.
+    ad.encode_text("hi", None, _SynA())
+    ad.encode_text("hi", None, _SynB())
+
+    req_a = _req(speaker_reference_text="AAA")
+    ad.synthesize(req_a, session)
+
+    prompt = session.calls[0]["input_ids"][0].tolist()
+    assert [ord(c) for c in "AAA"] == prompt[2:5]
+    assert [ord(c) for c in "BBB"] != prompt[2:5]
 
 
 def test_synthesize_returns_silence_when_nothing_survives_the_filter_and_skips_the_vocoder():

--- a/tests/test_speaker_reference_text_request_params.py
+++ b/tests/test_speaker_reference_text_request_params.py
@@ -1,0 +1,99 @@
+"""Regression test for phoonnx/voice.py:TTSVoice.phoneme_ids_to_audio.
+
+PR #404 moved a cloning reference's transcription off adapter instance state
+(shared across concurrent requests under the threaded ovos-tts-server) and onto
+the per-call ``AdapterSynthesisRequest.params`` dict instead, so OmniVoice/
+Spark-TTS's ``synthesize`` reads ``request.params["speaker_reference_text"]``
+rather than something stashed by a possibly-different, interleaved request's
+``encode_text``. This test locks down the other half of that fix: the line in
+``phoneme_ids_to_audio`` that actually puts it there.
+
+Deleting that one line degrades silently -- ``request.params`` would just be
+missing the key, which the engines already treat as "no reference transcription
+was given" (their normal, warning-free no-cloning path) -- so nothing else in
+the non-training suite catches its absence. This test drives
+``phoneme_ids_to_audio`` directly against a mocked adapter and asserts on the
+``AdapterSynthesisRequest`` the adapter actually received.
+"""
+import types
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from phoonnx.config import Alphabet, SynthesisConfig
+from phoonnx.engines.base import AdapterSynthesisResult
+from phoonnx.voice import TTSVoice
+
+
+def _make_voice():
+    """A TTSVoice with a mocked adapter and no real ONNX/phonemizer work.
+
+    ``config.alphabet`` doesn't matter here -- ``phoneme_ids_to_audio`` builds
+    ``request.params`` before any alphabet dispatch, straight from
+    ``syn_config``, so a plain phoneme-model config exercises the same code.
+    """
+    voice = TTSVoice.__new__(TTSVoice)
+    voice.config = types.SimpleNamespace(
+        alphabet=Alphabet.IPA,
+        lang_code="en",
+        sample_rate=22050,
+        noise_scale=None,
+        length_scale=None,
+        noise_w_scale=None,
+        engine_params={},
+        hop_length=256,
+    )
+    voice.adapter = MagicMock()
+    voice.adapter.default_params.return_value = {}
+    voice.adapter.synthesize.return_value = AdapterSynthesisResult(
+        audio=np.zeros(4, dtype=np.float32))
+    voice._alignment_session = None
+    voice.session = MagicMock()
+    # the reference transcription also feeds _prompt_token_ids (in-context
+    # engines' phoneme prompt) via the voice's own phonemizer -- stub both.
+    voice.phonemize = MagicMock(return_value=[["r", "e", "f"]])
+    voice.phonemes_to_ids = MagicMock(return_value=[1, 2, 3])
+    return voice
+
+
+class TestSpeakerReferenceTextReachesRequestParams(unittest.TestCase):
+    def test_speaker_reference_text_lands_in_request_params(self):
+        voice = _make_voice()
+        syn_config = SynthesisConfig(speaker_reference_text="A reference clip transcript")
+
+        voice.phoneme_ids_to_audio([1, 2, 3], syn_config=syn_config)
+
+        request = voice.adapter.synthesize.call_args[0][0]
+        self.assertEqual(request.params.get("speaker_reference_text"),
+                         "A reference clip transcript")
+
+    def test_absent_when_no_reference_text_was_given(self):
+        voice = _make_voice()
+        voice.phoneme_ids_to_audio([1, 2, 3], syn_config=SynthesisConfig())
+
+        request = voice.adapter.synthesize.call_args[0][0]
+        self.assertNotIn("speaker_reference_text", request.params)
+
+    def test_each_chunk_of_a_multi_chunk_call_sees_its_own_fresh_params(self):
+        """phoneme_ids_to_audio is called once per sentence/chunk by
+        TTSVoice.synthesize; params (including speaker_reference_text) are
+        rebuilt from syn_config on every call, not shared/mutated in place."""
+        voice = _make_voice()
+        syn_config = SynthesisConfig(speaker_reference_text="Shared reference text")
+
+        voice.phoneme_ids_to_audio([1, 2], syn_config=syn_config)
+        voice.phoneme_ids_to_audio([3, 4], syn_config=syn_config)
+
+        self.assertEqual(voice.adapter.synthesize.call_count, 2)
+        first_request = voice.adapter.synthesize.call_args_list[0][0][0]
+        second_request = voice.adapter.synthesize.call_args_list[1][0][0]
+        for request in (first_request, second_request):
+            self.assertEqual(request.params.get("speaker_reference_text"),
+                             "Shared reference text")
+        # each chunk got its own params dict -- mutating one must never affect the other
+        self.assertIsNot(first_request.params, second_request.params)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

OmniVoice and Spark-TTS both tokenize a cloning reference's transcription in `encode_text` and used to stash the result on the adapter instance (`self._reference_text` / `self._reference_text_ids`), reading it back later in `synthesize`. Under `ovos-tts-server`, one `TTSVoice` (and its adapter) is cached per voice_id and shared across concurrent threaded requests, and `encode_text` runs lazily, interleaved with `synthesize` across different calls. That let request B's `encode_text` overwrite request A's reference transcription before A's `synthesize` read it, so A could come back as its own cloning codes glued to B's reference text — a silent correctness bug, not a crash.

The transcription now travels on the per-call `AdapterSynthesisRequest.params` dict instead of adapter state, the same channel already used for `reference_audio` and `prompt_tokens`. `TTSVoice.phoneme_ids_to_audio` adds `params["speaker_reference_text"]`, and both adapters read it back inside `synthesize` rather than from `self`. Spark-TTS's `_resolve_speaker` cache-key logic (whether a transcription accompanies the clip) is threaded through as an explicit argument for the same reason, since it used to read the same stale instance attribute.

Fail-before, adapter half: reverting only the source changes while keeping the new tests makes `test_synthesize_uses_the_reference_text_from_request_params_not_from_encode_text` fail in both `tests/test_omnivoice.py` and `tests/test_sparktts.py`, with request B's reference text landing in request A's synthesis prompt (asserted directly against the fake backbone/LM session's recorded input). `test_encode_text_does_not_stash_reference_state_on_the_adapter` and `test_reference_encoding_is_reused_across_chunks` (Spark-TTS) also fail before the fix.

Fail-before, `TTSVoice` half: the one-line `params["speaker_reference_text"] = syn_config.speaker_reference_text` assignment in `phoneme_ids_to_audio` is the other load-bearing piece, and it degrades silently if lost — a missing key just looks like "no reference transcription was given" to both engines, so nothing in the adapter-level tests catches it. `tests/test_speaker_reference_text_request_params.py` drives `phoneme_ids_to_audio` directly against a mocked adapter and asserts on the `AdapterSynthesisRequest` it received, including that two chunks of the same call each get their own freshly-built `params` (not a shared mutable dict). Deleting that one line makes two of its three tests fail with `None != <the given transcription>`; both pass again with the line restored.

The full non-training suite passes at the same rate as `origin/dev` (a handful of pre-existing failures/errors from missing optional deps such as `onnx`, `torch`, `ahotts-g2p`, none of them touching `voice.py`, `omnivoice.py`, or `sparktts.py`); the three touched test files (`tests/test_omnivoice.py`, `tests/test_sparktts.py`, `tests/test_speaker_reference_text_request_params.py`) are fully green, 118 tests total.

Left the Spark-TTS reference-text BPE tokenization inside `synthesize` (so it now runs once per chunk instead of once per call, as it did when cached via `encode_text`): it's a single cheap tokenize of a short string, and hoisting it back out would mean reintroducing an instance-level cache — the exact pattern this fix removes — for a saving too small to justify that.