### PR TITLE
docs: memory budgeting and OOM diagnosis for self-hosted servers

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,8 +2,9 @@
 
 This page is for operators running the phoonnx TTS server as a public or long-lived
 service. It covers persisting the voice cache, prefetching voice weights before serving
-traffic, health checks, resource sizing, and verifying that `mycroft.conf` actually
-applied. For the image itself and its quick start, see [docker.md](docker.md).
+traffic, health checks, resource sizing and memory budgeting, diagnosing OOM kills,
+prosody enrichment behavior, and verifying that `mycroft.conf` actually applied. For
+the image itself and its quick start, see [docker.md](docker.md).
 
 ## Persist the cache volume
 
@@ -87,6 +88,91 @@ loaded voice holds an ONNX Runtime session in memory in addition to its weight f
 on disk; the batteries-included image also carries the full phonemizer and cloning
 dependency set regardless of which voices you use. Disk needs one voice's weights per
 prefetched voice, on the same volume as the cache so a restart does not lose them.
+
+A catalog family sharing one underlying model — the `omnivoice` and `qwen3tts`
+entries, for example — is still one voice-config entry per model artifact: each
+cached voice id owns its own session, so loading several voices from the same
+family loads several sessions, not one shared one. Weight size, not entry count, is
+what dominates memory: a piper voice is on the order of tens of megabytes, an
+omnivoice voice on the order of gigabytes.
+
+The shipped image runs `ovos-tts-server` as a single ASGI app instance passed
+directly to `uvicorn.run()`, with no `--workers` flag and no process manager — it is
+one process, one worker, no fan-out. Memory multiplies with worker count only for
+an operator who fronts the plugin's ASGI app with their own multi-worker deployment
+(a `gunicorn`/`uvicorn` invocation using an import string, e.g.
+`uvicorn app:server --workers 4`) instead of the bundled entrypoint: each worker
+process there loads its own `PhoonnxTTSPlugin` and its own voice cache. This is
+distinct from how many *clients* one worker can serve concurrently, which does not
+multiply memory the same way.
+
+## Memory budgeting
+
+`max_loaded_bytes` (see [ovos_plugin.md](ovos_plugin.md#voice-caching)) bounds how
+much voice weight the plugin keeps resident, evicting the least-recently-used
+unpinned voice to make room for a new one. It is a soft, in-process limit — it has
+no visibility into the phonemizer, the ONNX Runtime arena, or per-request buffers,
+none of which it counts against the budget.
+
+The container's cgroup memory limit is the real backstop, and it is a hard kill, not
+an eviction. Set `max_loaded_bytes` well below that limit, leaving headroom for the
+runtime itself, whichever phonemizer backends are loaded, and in-flight request
+buffers. A budget set close to the cgroup limit does not fail safely: instead of
+evicting a voice to stay under budget, the process gets OOM-killed by the kernel
+mid-request. A budget with real headroom trades occasional cache misses (a voice
+reloading from disk) for a server that never gets killed outright.
+
+### Diagnosing OOM kills
+
+In the shipped image the server execs as PID 1 — no supervisor, no worker children —
+so an OOM kill terminates the container outright, and `docker inspect <container>
+--format '{{.RestartCount}}'` under a `restart: unless-stopped` policy does
+increment and is a valid signal there. `RestartCount` only undercounts in a
+deployment where a supervisor or a multi-process server (see the multi-worker note
+above) respawns children *inside* the container without the container itself
+restarting — a kill there never touches `RestartCount`.
+
+Either way, the kernel log is what distinguishes an OOM kill from any other crash or
+exit code, and it works regardless of process model:
+
+```bash
+journalctl -k | grep -i "killed process"
+```
+
+or, without `journalctl`, `dmesg | grep -i "killed process"`. The kernel logs the
+killed process by its `comm` — for the shipped image this is `python3.12` (the
+interpreter behind the `ovos-tts-server` console-script shebang), not `phoonnx` or
+`ovos-tts-server`, so name matching will not find it. Identify the victim by the
+`memcg`/cgroup path in the same OOM report instead — it contains the container id.
+Once confirmed, the fix is to lower `max_loaded_bytes`, raise the container's memory
+limit, or both.
+
+## Prosody enrichment degrades instead of failing
+
+Voices that enrich text before synthesis — Arabic/Hebrew diacritization
+(`add_diacritics`, `diacritizer_model`) and per-language script transforms such as
+Russian stress marking (`stressonnx`) — never abort synthesis when that enrichment
+fails or its backend is missing. Each falls back to the plain, unenriched text and
+logs a warning:
+
+```
+diacritization failed for lang=ar: <error> — synthesizing unstressed text
+stressonnx not installed — Russian stress skipped
+```
+
+The voice still speaks; it loses the stress or vocalization cues that make the
+target script unambiguous. Grep the server logs for these warnings to see whether an
+optional enrichment dependency is missing rather than assuming a silent voice
+quality regression is a synthesis failure.
+
+## Language codes and enrichment backends
+
+A voice id carries a full regional code (`ru_RU`, `pt-PT`, ...), but the enrichment
+backends above key off the base language only — `ru`, not `ru_RU` or `ru-RU`. What
+determines whether a voice gets stress marking, script transforms, or diacritization
+is whether its base language has an entry, not the region. When configuring or
+auditing enrichment for a voice, check the base language rather than the full
+regional code.
 
 ## Verify the configuration actually applied
 

--- a/docs/ovos_plugin.md
+++ b/docs/ovos_plugin.md
@@ -162,7 +162,17 @@ See [cloning.md](cloning.md) for the cloning keys in detail.
 
 ### Voice Caching
 
-Loaded voices are cached in memory (`self.voices` dict) to avoid re-loading on every utterance. The first call for a new voice ID triggers a download if needed.
+Loaded voices are cached in memory (`self.voices` dict) to avoid re-loading on every utterance. The first call for a new voice ID triggers a download if needed. Each cached voice id owns its own ONNX Runtime session — a family of catalog entries that share one underlying model (for example the `omnivoice` or `qwen3tts` voice-config variants) still costs one load per entry, not one for the whole family.
+
+Two config keys bound how much stays resident:
+
+| Option | Meaning |
+|--------|---------|
+| `max_loaded_voices` | Maximum number of voices resident at once (pinned ones included). Unset never evicts anything. |
+| `max_loaded_bytes` | Memory budget for resident voice weights, as a plain byte count or a size string (`"3GB"`, `"512 MB"`, `"1.5GiB"` — `KB/MB/GB/TB` are powers of 1000, `KiB/MiB/GiB/TiB` powers of 1024). Unset never evicts anything. |
+| `pinned_voices` | Voice id or list of voice ids to load at startup and never evict, regardless of the other limits. |
+
+A voice bigger than the whole `max_loaded_bytes` budget still loads rather than being refused — it evicts everything evictable first and logs a warning that memory use will exceed the budget. See [deployment.md](deployment.md#memory-budgeting) for sizing this against the container's memory limit.
 
 ### Refreshing Voices
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This folds operationally-verified learnings about self-hosting phoonnx (typically via ovos-tts-server in a container) into `docs/deployment.md` and `docs/ovos_plugin.md`. No new docs page was needed — `docs/deployment.md` already covers cache, prefetch, health checks, and resource sizing, so the new material extends it in place and is already linked from the README and docker.md.

Added to `docs/ovos_plugin.md`: a table documenting `max_loaded_voices`, `max_loaded_bytes`, and `pinned_voices` (verified against `PhoonnxTTSPlugin.__init__` and `_parse_max_bytes`/`_parse_max_loaded` in `phoonnx/opm.py`), plus a note that a catalog family sharing one model (omnivoice, qwen3tts) still costs one cache entry and one ONNX session per voice id — there is no cross-entry session sharing in `get_model`/`self.voices`.

Added to `docs/deployment.md`:
- Memory budgeting: `max_loaded_bytes` is a soft, in-process eviction budget with no visibility into the runtime, phonemizer, or per-request buffers; the container's cgroup limit is the real backstop, so the budget needs headroom below it.
- A multi-worker paragraph scoped correctly: the shipped image runs `ovos-tts-server` as a single ASGI app instance passed to `uvicorn.run()` with no `--workers` flag and no process manager (verified in `ovos_tts_server/__main__.py`), so memory only multiplies for an operator who fronts the plugin's app with their own multi-worker `gunicorn`/`uvicorn` import-string deployment instead of the bundled entrypoint. Client concurrency against one worker is called out as a separate concern.
- Diagnosing OOM kills: the shipped image execs the server as PID 1 with no supervisor (verified in `docker-entrypoint.sh`'s `exec ovos-tts-server ...`), so `docker inspect --format '{{.RestartCount}}'` under a restart policy is a valid signal there — it only undercounts in a deployment where a supervisor or multi-process server respawns children inside the container without the container restarting. `journalctl -k` / `dmesg` grepped for "killed process" is recommended regardless, because it distinguishes an OOM kill from any other crash; the text now tells readers to identify the victim by the cgroup/memcg path in the OOM report (it contains the container id) rather than by process name, since the kernel logs the interpreter's `comm` (`python3.12`), not `phoonnx` or `ovos-tts-server`.
- Prosody enrichment degrades instead of failing: diacritization failures and missing `stressonnx` fall back to unenriched text with a logged warning rather than aborting synthesis — verified in `get_conversion`/`_vocalize` in `phoonnx/config.py` and `russian_add_stress` in `phoonnx/lang_preprocess.py`.
- Language codes and enrichment backends: voice ids carry regional codes (`ru_RU`, etc.) but `SCRIPT_TRANSFORMS` in `phoonnx/lang_preprocess.py` keys off the base language only (`ru`), so base-language support is what determines whether enrichment applies.

## Verification

- `phoonnx/opm.py`: `max_loaded_bytes`/`max_loaded_voices`/`pinned_voices` config keys, `_parse_max_bytes` unit table and rejection behavior, `_reserve`/`_evict_for` eviction and overshoot-warning logic, `get_model`/`self.voices` per-voice-id caching (no cross-entry sharing).
- `phoonnx/config.py`: `get_conversion`/`_vocalize` diacritization fallback and its exact warning text.
- `phoonnx/lang_preprocess.py`: `russian_add_stress` fallback and warning text, `SCRIPT_TRANSFORMS` dict keyed by base language.
- `phoonnx/tokenizer.py`: `_script_transform` looks up `SCRIPT_TRANSFORMS` by the bare language token, not the regional code.
- `Dockerfile` / `docker-entrypoint.sh`: server execs as PID 1, no supervisor.
- `ovos_tts_server/__main__.py` (installed package): `uvicorn.run(server, host=..., port=...)` with an app instance and no `--workers` argument or flag.

Did not find in current source, so not claimed: cross-voice model/session sharing for omnivoice/qwen3tts families (each cache entry loads its own session), and any phoonnx-side multi-worker config knob — worker fan-out is documented as an operator-side deployment choice outside the bundled entrypoint, not a phoonnx setting.