### PR TITLE
fix: pin alpha floors for engine deps missing from the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY . /app
 # - setuptools<81 keeps ovos-plugin-manager's pkg_resources usage working.
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir "setuptools<81" ".[all]" ovos-tts-server \
+    && pip install --no-cache-dir "setuptools<81" ".[all]" "ovos-tts-server[mcp]>=1.14.1a2" \
     && (python -m spacy download en_core_web_sm || true) \
     && (python -m unidic download || true)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "langcodes",
     "ovos-number-parser>=0.4.0",
     "ovos-date-parser>=0.6.4a1",
-    "scriptconv[phonemizers]>=0.0.4a19",
+    "scriptconv[phonemizers]>=0.0.4a23",
     "unicode_rbnf",
     "click",
     "requests",
@@ -282,12 +282,37 @@ all = [
     # scriptconv splits its phonemizers per language, so the base set
     # alone leaves "all" without Portuguese, Arabic, English, Japanese
     # and Chinese backends, and a voice that asks for one fails at
-    # synthesis with an ImportError.
-    "scriptconv[phonemizers,pt-phonemizers,ar-phonemizers,en-phonemizers,ja-phonemizers,zh-phonemizers,tashkeel]>=0.0.4a19",
+    # synthesis with an ImportError. The "goruut", "stress" and "pt" extras
+    # pull in pygoruut (phoneme_type == "pygoruut" in phoonnx/config.py),
+    # stressonnx (Russian stress marks, phoonnx/lang_preprocess.py) and
+    # bifonia (scriptconv's own Portuguese backend) respectively — without
+    # them a bare `scriptconv[phonemizers,...]` install silently drops those
+    # backends and the corresponding voices fail at synthesis time. "he"
+    # pulls in phonikud-onnx: phoonnx/config.py routes Hebrew phonemization
+    # ("phoneme_type": "phonikud" in the voice_index) through scriptconv,
+    # which auto-provisions the phonikud ONNX model, so scriptconv[he] is
+    # the correct spelling rather than depending on phonikud-onnx directly.
+    # >=0.0.4a23: the release that actually fixes the "he" extra (pulls in
+    # both phonikud and phonikud-onnx), the zh alias map, MissingLanguageError,
+    # and the stress-routing fix — a19 predates all four.
+    "scriptconv[phonemizers,pt-phonemizers,ar-phonemizers,en-phonemizers,ja-phonemizers,zh-phonemizers,tashkeel,goruut,stress,pt,he]>=0.0.4a23",
+    # scriptconv's own "stress" extra floors stressonnx at >=0.0.2, which
+    # resolves to the latest *stable* release. The BCP-47 language resolver
+    # phoonnx needs only shipped in the 0.0.3 alpha train, so it must be
+    # floor-pinned here explicitly or a bare-name resolution silently installs
+    # the older stable and the resolver is missing.
+    "stressonnx>=0.0.3a2",
     "text2tashkeel",
     "epitran",
-    "gruut[de]>=2.3.0,<3.0", "gruut[en]>=2.3.0,<3.0", "gruut[ja]>=2.3.0,<3.0",
-    "gruut[vi]>=2.3.0,<3.0", "gruut[zh]>=2.3.0,<3.0",
+    # Only the languages the voice_index actually routes through gruut
+    # (phoneme_type == "gruut") — de, en, fr, it, nl, ru, es, sv, sw across
+    # mimic3/glowtts/fastpitch/coqui_vits voices. ja/vi/zh are kept as-is
+    # (misaki/spacy handle those languages; gruut has no ja/vi/zh extra, so
+    # those entries are pre-existing no-ops, out of scope here).
+    "gruut[de]>=2.3.0,<3.0", "gruut[en]>=2.3.0,<3.0", "gruut[es]>=2.3.0,<3.0",
+    "gruut[fr]>=2.3.0,<3.0", "gruut[it]>=2.3.0,<3.0", "gruut[ja]>=2.3.0,<3.0",
+    "gruut[nl]>=2.3.0,<3.0", "gruut[ru]>=2.3.0,<3.0", "gruut[sv]>=2.3.0,<3.0",
+    "gruut[sw]>=2.3.0,<3.0", "gruut[vi]>=2.3.0,<3.0", "gruut[zh]>=2.3.0,<3.0",
     "misaki[en]", "misaki[ja]", "misaki[vi]", "misaki[zh]",
     "ahotts-g2p>=0.1.0",
     "spacy>=3.7,<4.0",
@@ -299,6 +324,20 @@ all = [
     # Indic Parler needs the compiled reader; `all` is what the image installs,
     # and it carried a working Indic Parler before.
     "tokenizers",
+    # test-only reference readers for phoonnx's own pure-Python tokenizer.json
+    # / tokenizer.model readers (phoonnx/_bpe.py, phoonnx/_sentencepiece.py):
+    # the Docker image ships engines (Indic Parler, Pocket TTS) that route
+    # through those readers, so the packages that define the on-disk formats
+    # need to be present at runtime too, not just in the [test] extra.
+    "sentencepiece",
+    # Pocket TTS voice state loading (phoonnx/engines/pockettts.py).
+    "safetensors",
+    # Griffin-Lim vocoder fallback (phoonnx/engines/vocoders/griffinlim.py).
+    "librosa>=0.9.2,<1",
+    # streaming VITS model splitting (phoonnx/onnx_surgery.py).
+    "onnx<1.18",
+    # optional post-synthesis audio super-resolution (phoonnx/voice.py).
+    "audiosronnx",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

The Docker image installed a bare `ovos-tts-server`, which resolves to the latest stable release (1.13.4) and carries a known event-loop-blocking bug in the TTS server. The deployed container needs `ovos-tts-server[mcp]>=1.14.1a2`, so the Dockerfile's pip line now installs that spec directly instead of the bare name.

A bare package name always resolves to the newest stable release, and that is a trap whenever a needed fix has only shipped as a prerelease: `scriptconv`'s own `stress` extra floors `stressonnx` at `>=0.0.2` (its latest stable), but the BCP-47 language resolver phoonnx actually needs only exists in the 0.0.3 alpha train. That means `phoonnx[all]` was silently installing an older, less capable `stressonnx` even though `stressonnx` was technically "in" the dependency graph. The fix adds an explicit `stressonnx>=0.0.3a2` floor pin directly in phoonnx's `[all]` extra so it isn't left to scriptconv's transitive (stable-floored) pin.

Separately, the `[all]` extra — what the Docker image installs via `.[all]` — was missing a set of engine and phonemizer dependencies outright: scriptconv's `goruut`/`stress`/`pt`/`he` sub-extras (which carry `pygoruut`, `stressonnx`, `bifonia`, and now `phonikud`+`phonikud-onnx`), plus `sentencepiece`, `safetensors`, `librosa`, `onnx`, and `audiosronnx`. None of these were gated behind any extra reachable from `[all]`, so voices routing through the Pocket TTS, Indic Parler, Griffin-Lim, streaming-VITS-split, or super-resolution paths failed at synthesis time in the deployed container despite `.[all]` looking exhaustive on the surface. Hebrew voices route through scriptconv's own phonikud auto-provisioning (see the comment in `phoonnx/config.py`), so `scriptconv[he]` is the correct spelling for the Hebrew fix rather than depending on `phonikud-onnx` directly.

Both places phoonnx pins `scriptconv` (the core dependency and the `[all]` extra) are floor-bumped to `>=0.0.4a23`, the release that actually fixes the `he` extra to carry both `phonikud` and `phonikud-onnx`, adds the zh alias map and `MissingLanguageError`, and fixes stress routing — the prior `>=0.0.4a19` floor predates all four.

The `gruut` language set in `[all]` is scoped to what the voice_index catalog actually routes through gruut (`phoneme_type == "gruut"` across the mimic3/glowtts/fastpitch/coqui_vits configs): `de`, `en`, `es`, `fr`, `it`, `nl`, `ru`, `sv`, `sw`. The pre-existing `ja`/`vi`/`zh` gruut entries are left untouched — gruut defines no such extras (those languages route through misaki/spacy instead), so they were already no-ops and fixing that is out of scope here.

Verified with a `pip install --dry-run` resolution of the exact spec set the Dockerfile installs (`.[all]` plus `ovos-tts-server[mcp]>=1.14.1a2`, run in a throwaway venv against this branch's `pyproject.toml`, rebased onto current `dev`). The resulting install plan resolves `scriptconv-0.0.4a23` (pulling both `phonikud-0.4.1` and `phonikud-onnx-1.0.6` via the fixed `he` extra), `stressonnx-0.0.3a2`, `ovos-tts-server-1.14.1a2`, `bifonia-0.1.1`, `pygoruut-0.8.1`, `audiosronnx-0.0.1`, `sentencepiece-0.2.2`, `safetensors-0.8.0`, `librosa-0.11.0`, `onnx-1.17.0`, and `gruut_lang_{de,en,es,fr,it,nl,ru,sv,sw}` at their expected versions — confirming every alpha floor and every previously-missing dependency named above is now reachable from `.[all]`. The image itself was not built (too heavy for this check); the dry-run resolution against the identical spec set is the gate.