### PR TITLE
docs: point to OVOS G2P plugin

### DIFF
--- a/docs/ovos_plugin.md
+++ b/docs/ovos_plugin.md
@@ -5,6 +5,11 @@ engine. phoonnx ships a TTS plugin for the [OpenVoiceOS](https://openvoiceos.com
 ecosystem via `PhoonnxTTSPlugin`, registered under the `opm.tts` entry point
 `ovos-tts-plugin-phoonnx`.
 
+Looking for standalone grapheme-to-phoneme (G2P) instead of TTS? See
+[phonemizers.md](phonemizers.md#g2p-for-ovos) — that's
+[ovos-scriptconv-g2p-plugin](https://github.com/TigreGotico/ovos-scriptconv-g2p-plugin),
+a separate OPM plugin.
+
 ## Configuration
 
 In your OpenVoiceOS `mycroft.conf` or skills config, set:

--- a/docs/phonemizers.md
+++ b/docs/phonemizers.md
@@ -159,6 +159,17 @@ supports) is not a phonemizer method — it is a separate step exposed as
 phonemizing when a voice enables `add_diacritics`. scriptconv owns the
 diacritizer backends and auto-provisions the Hebrew phonikud model.
 
+## G2P for OVOS
+
+This phonemizer layer was extracted into [scriptconv](https://github.com/TigreGotico/scriptconv);
+phoonnx now depends on it and keeps thin compatibility shims for the names
+above. OVOS users who want grapheme-to-phoneme conversion on its own, without
+the rest of phoonnx's TTS pipeline, should use
+[ovos-scriptconv-g2p-plugin](https://github.com/TigreGotico/ovos-scriptconv-g2p-plugin),
+an OPM `opm.g2p` plugin built directly on scriptconv — see its
+[docs/ovos.md](https://github.com/TigreGotico/scriptconv/blob/dev/docs/ovos.md)
+for install and configuration.
+
 ## Attribution
 
 phoonnx wraps and, where licensing allows, bundles domain-specific G2P work, including:


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

phoonnx's phonemizer layer was extracted into scriptconv a while back and phoonnx keeps compatibility shims over it, but nothing in these docs pointed OVOS users toward the standalone path — someone who wants G2P without the rest of phoonnx's TTS pipeline had no way to find ovos-scriptconv-g2p-plugin from here.

This adds a short "G2P for OVOS" note at the end of phonemizers.md (a few sentences, the substance lives on scriptconv's own docs/ovos.md, added in a companion PR) and a one-line cross-reference near the top of ovos_plugin.md, both placed away from the sections PR #406 touches so the two shouldn't conflict.

## Test plan
- [ ] Docs-only change, no code touched
- [ ] Links resolve (scriptconv docs/ovos.md link depends on TigreGotico/scriptconv#104 merging)