### PR TITLE
fix: raise typed error for unsupported voice language at load, not synthesis

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -896,6 +896,65 @@ class SynthesisConfig:
     extra_params: Dict[str, Any] = field(default_factory=dict)
 
 
+class UnsupportedVoiceLanguage(ValueError):
+    """Raised at voice load when no phonemizer backend serves the voice's language.
+
+    Surfacing this eagerly (instead of letting scriptconv's ``ValueError:
+    unsupported language code`` bubble up mid-synthesis, after the user has
+    already picked the voice and sent text) turns an opaque runtime crash
+    into an actionable, typed failure at load time.
+    """
+
+    def __init__(self, voice: str, lang_code: str, phoneme_type: "PhonemeType"):
+        self.voice = voice
+        self.lang_code = lang_code
+        self.phoneme_type = phoneme_type
+        super().__init__(
+            f"voice {voice!r}: no phonemizer backend supports lang "
+            f"{lang_code!r} for phoneme_type {phoneme_type.value!r}"
+        )
+
+
+def check_lang_supported(voice: str, lang_code: Optional[str],
+                         phoneme_type: PhonemeType) -> None:
+    """Eagerly verify a voice's phonemizer chain serves its language.
+
+    Only checks backends that actually restrict languages -- scriptconv's
+    registry query resolves the backend *class* (a lazy import; no
+    construction of the wrapper instance itself) and calls its ``get_lang``
+    classmethod when present. This is cheaper than instantiating the
+    phonemizer, but not free: a few backends' ``get_lang`` (e.g.
+    orthography2ipa) construct a lightweight G2P engine to answer, and
+    others (euskaphone, arbtok) import their optional backing package to
+    check. A missing optional package therefore surfaces as ``ImportError``
+    here, not ``ValueError`` -- that is not an unsupported-language verdict,
+    so it is treated the same as "no get_lang": skip, don't reject. Backends
+    without ``get_lang`` (grapheme/unicode passthroughs) accept any language
+    and are silently skipped, as are unresolvable phoneme types
+    (``get_phonemizer`` raises its own error for those).
+
+    Raises:
+        UnsupportedVoiceLanguage: If the resolved backend cannot serve
+            ``lang_code``.
+    """
+    if not lang_code or phoneme_type is None:
+        return
+    from scriptconv.phonemizers.registry import get_phonemizer_class
+    try:
+        phonemizer_cls = get_phonemizer_class(phoneme_type)
+    except (KeyError, ImportError, ValueError):
+        return
+    get_lang = getattr(phonemizer_cls, "get_lang", None)
+    if get_lang is None:
+        return
+    try:
+        get_lang(lang_code)
+    except ImportError:
+        return
+    except ValueError as e:
+        raise UnsupportedVoiceLanguage(voice, lang_code, phoneme_type) from e
+
+
 def get_phonemizer(phoneme_type: PhonemeType,
                    alphabet: Alphabet = Alphabet.IPA,
                    model: Optional[str] = None) -> 'Phonemizer':

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -13,7 +13,7 @@ from huggingface_hub.errors import (EntryNotFoundError, LocalEntryNotFoundError,
                                     OfflineModeIsEnabled)
 from json_database import JsonStorageXDG, JsonStorage
 
-from phoonnx.config import PhonemeType, get_phonemizer, VoiceConfig, Engine, Alphabet
+from phoonnx.config import PhonemeType, get_phonemizer, VoiceConfig, Engine, Alphabet, check_lang_supported
 from phoonnx.util import match_lang, normalize_lang, LOG
 from phoonnx.providers import ProviderSpec, make_session, resolve_providers
 from phoonnx.voice import TTSVoice
@@ -699,6 +699,12 @@ class TTSModelInfo:
         Returns:
             TTSVoice: The configured TTSVoice instance ready for synthesis.
         """
+        # self.config resolves the final phoneme_type/lang_code (index override
+        # applied) from the small config.json, if any -- cheap next to
+        # download_model()'s multi-MB model weights, so the language check
+        # runs before that download rather than after it.
+        check_lang_supported(self.voice_id, self.config.lang_code, self.config.phoneme_type)
+
         model_path = self.download_model()
         config_path = self.hub_path(self.config_url)
         vocab_path = self.hub_path(self.vocab_url)
@@ -736,6 +742,10 @@ class TTSModelInfo:
         if self.phoneme_type != voice.config.phoneme_type or self.alphabet != voice.config.alphabet:
             voice.config.phoneme_type = self.phoneme_type
             voice.config.alphabet = self.alphabet
+            # voice.config.lang_code is read from the downloaded config.json and
+            # can differ from the pre-download self.config.lang_code above, so
+            # this re-checks against the phoneme_type actually being installed.
+            check_lang_supported(self.voice_id, voice.config.lang_code, self.phoneme_type)
             voice.phonemizer = get_phonemizer(self.phoneme_type,
                                               alphabet=self.alphabet,
                                               model=voice.config.phonemizer_model)

--- a/phoonnx/voice.py
+++ b/phoonnx/voice.py
@@ -25,7 +25,8 @@ import onnxruntime
 from langcodes import closest_match
 from quebra_frases import sentence_tokenize
 
-from phoonnx.config import PhonemeType, VoiceConfig, SynthesisConfig, Alphabet, get_phonemizer, get_conversion
+from phoonnx.config import PhonemeType, VoiceConfig, SynthesisConfig, Alphabet, get_phonemizer, get_conversion, \
+    check_lang_supported
 from scriptconv.graph import DEFAULT_GRAPH
 from phoonnx.engines import detect_engine, get_adapter
 from phoonnx.engines.base import (
@@ -340,6 +341,18 @@ class TTSVoice:
 
         # Phonemizer
         if self.phonemizer is None:
+            # Fail fast (typed) if no scriptconv backend serves this voice's
+            # language, instead of the voice loading fine and crashing mid
+            # synthesis with an opaque ValueError once text is sent. Name the
+            # voice by its model filename (e.g. "tdt-TL_joao"), not the full
+            # HF snapshot path -- ``model_path`` is a cache path, not a
+            # human-facing identifier.
+            voice_name = Path(self.model_path).stem if self.model_path else "<voice>"
+            check_lang_supported(
+                voice_name,
+                self.config.lang_code,
+                self.config.phoneme_type,
+            )
             self.phonemizer = get_phonemizer(
                 self.config.phoneme_type,
                 self.config.alphabet,

--- a/tests/test_unsupported_voice_language.py
+++ b/tests/test_unsupported_voice_language.py
@@ -1,0 +1,146 @@
+"""Tests for the typed, eager language-support check at voice load.
+
+Before this check existed, a voice whose language no scriptconv phonemizer
+serves loaded fine and only failed once synthesis started, with an opaque
+``ValueError: unsupported language code: ...`` raised
+deep inside scriptconv. ``check_lang_supported`` runs the same registry
+lookup ``TTSVoice.__post_init__`` and ``TTSModelInfo.load`` use, without
+downloading anything or instantiating a phonemizer backend, so the failure
+surfaces at load time instead -- and, for ``TTSModelInfo.load``, before the
+(possibly multi-MB) model weights are even fetched.
+"""
+import glob
+import json
+import unittest
+
+import onnxruntime
+
+from phoonnx.config import (
+    Alphabet,
+    Engine,
+    PhonemeType,
+    UnsupportedVoiceLanguage,
+    VoiceConfig,
+    check_lang_supported,
+)
+from phoonnx.util import normalize_lang
+from phoonnx.voice import TTSVoice
+
+from tests.test_model_manager import HUB, HubTestCase
+
+
+class TestCheckLangSupported(unittest.TestCase):
+    def test_unserved_language_raises_typed_error_naming_voice_and_lang(self):
+        with self.assertRaises(UnsupportedVoiceLanguage) as ctx:
+            check_lang_supported("zzz_joao", "zzz", PhonemeType.ESPEAK)
+        err = ctx.exception
+        self.assertEqual(err.voice, "zzz_joao")
+        self.assertEqual(err.lang_code, "zzz")
+        self.assertIn("zzz_joao", str(err))
+        self.assertIn("zzz", str(err))
+
+    def test_supported_language_does_not_raise(self):
+        # Basque is served by scriptconv's espeak backend.
+        check_lang_supported("hitz-eu", "eu", PhonemeType.ESPEAK)
+
+    def test_grapheme_voice_with_exotic_lang_is_not_rejected(self):
+        # Grapheme/unicode phonemizers have no language restriction (no
+        # ``get_lang`` classmethod) -- any lang_code, however exotic, passes.
+        check_lang_supported("some-graphemes-voice", "zzz", PhonemeType.GRAPHEMES)
+        check_lang_supported("some-unicode-voice", "zzz", PhonemeType.UNICODE)
+
+    def test_missing_lang_code_is_skipped(self):
+        check_lang_supported("no-lang-voice", None, PhonemeType.ESPEAK)
+
+    def test_missing_optional_backend_package_is_skipped_not_rejected(self):
+        # euskaphone's get_lang imports its optional backing package to
+        # answer; when that package is absent it raises ImportError, which
+        # must be treated as "can't tell" (skip), never as a load-time
+        # rejection just because an extra wasn't installed.
+        check_lang_supported("some-eu-voice", "eu", PhonemeType.EUSKAPHONE)
+
+
+class TestCheckLangSupportedOnTheVoiceIndex(unittest.TestCase):
+    """The strongest guard this feature can have: sweep every bundled voice
+    and confirm the check accepts all of them. Every entry's effective
+    language -- ``phonemizer_lang`` when set (the same override TTSModelInfo
+    applies before load, see ``phonemizer_lang`` on TTSModelInfo), else
+    ``lang`` -- must resolve to a supported phonemizer language. A voice
+    landing in the index with an unresolvable language is a catalog/phonemizer
+    inventory mismatch, not something this test should special-case away."""
+
+    def test_sweep_bundled_voice_index_finds_no_rejections(self):
+        rejections = []
+        total = 0
+        for path in sorted(glob.glob("phoonnx/voice_index/*.json")):
+            with open(path) as f:
+                data = json.load(f)
+            for voice_id, entry in data.items():
+                total += 1
+                lang = entry.get("phonemizer_lang") or entry.get("lang")
+                phoneme_type = entry.get("phoneme_type")
+                if not lang or not phoneme_type:
+                    continue
+                try:
+                    phoneme_type = PhonemeType(phoneme_type)
+                except ValueError:
+                    continue
+                try:
+                    check_lang_supported(voice_id, normalize_lang(lang), phoneme_type)
+                except UnsupportedVoiceLanguage:
+                    rejections.append(voice_id)
+
+        # Sanity floor: this must actually be sweeping the real, sizeable
+        # index, not an empty/truncated one.
+        self.assertGreater(total, 1000)
+        self.assertEqual(rejections, [])
+
+
+class TestTTSVoicePostInitRejectsUnservedLanguage(unittest.TestCase):
+    """Exercises the actual __post_init__ wiring, not just the helper
+    function -- deleting the check_lang_supported call in voice.py must
+    turn this red."""
+
+    def test_ttsvoice_construction_raises_for_unserved_language(self):
+        config = VoiceConfig(num_symbols=4, num_speakers=1, num_langs=1, sample_rate=16000,
+                             lang_code="zzz", phoneme_type=PhonemeType.ESPEAK,
+                             alphabet=Alphabet.IPA, phonemizer_model=None,
+                             engine=Engine.PIPER)
+        with self.assertRaises(UnsupportedVoiceLanguage) as ctx:
+            TTSVoice(session=None, config=config, model_path="/cache/models--x--y/snapshots/abc123/zzz_joao.onnx")
+        # naming the voice, not the 130-char HF snapshot cache path (review N1)
+        self.assertIn("zzz_joao", str(ctx.exception))
+        self.assertNotIn("snapshots", str(ctx.exception))
+
+    def test_ttsvoice_construction_does_not_raise_for_served_language(self):
+        config = VoiceConfig(num_symbols=4, num_speakers=1, num_langs=1, sample_rate=16000,
+                             lang_code="eu", phoneme_type=PhonemeType.ESPEAK,
+                             alphabet=Alphabet.IPA, phonemizer_model=None,
+                             engine=Engine.PIPER)
+        voice = TTSVoice(session=None, config=config, model_path="/cache/eu-voice.onnx")
+        self.assertIsNotNone(voice.phonemizer)
+
+
+class TestTTSModelInfoLoadRejectsBeforeDownloadingTheModel(HubTestCase):
+    """Exercises the TTSModelInfo.load wiring: the language check must run
+    (and raise) before the multi-MB model weights are downloaded."""
+
+    def test_load_raises_before_downloading_model_weights(self):
+        self.hub.stage(f"{HUB}/config.json", {"phoneme_type": "espeak", "alphabet": "ipa"})
+        # deliberately NOT staged: model.onnx -- if the code tried to
+        # download it before rejecting, this test would fail with
+        # EntryNotFoundError instead of UnsupportedVoiceLanguage.
+        info = self.make_info(voice_id="piper_community/raphaelmerx/zzz_joao",
+                              lang="zzz",
+                              config_url=f"{HUB}/config.json",
+                              phoneme_type=PhonemeType.ESPEAK)
+        with self.assertRaises(UnsupportedVoiceLanguage) as ctx:
+            info.load()
+        self.assertIn("zzz_joao", str(ctx.exception))
+        downloaded_files = {filename for _, filename, _ in self.hub.downloads}
+        self.assertNotIn("model.onnx", downloaded_files,
+                         "model weights must not be fetched before the language check")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

A voice whose language no scriptconv phonemizer serves loaded fine and then failed mid-synthesis, after a user had already picked the voice and sent text, with an opaque `ValueError: unsupported language code: ...` raised deep inside `scriptconv/phonemizers/base.py`'s `match_lang`. The live example is `piper_community/raphaelmerx/tdt-TL_joao` (Tetun), which is absent from every scriptconv phonemizer's language inventory.

This adds `check_lang_supported()` in `phoonnx/config.py`, called from `TTSModelInfo.load()` (before `download_model()` fetches the model weights — the check runs on the cheap config.json-derived `lang_code`/`phoneme_type`, not after a multi-MB download) and from `TTSVoice.__post_init__` (before a phonemizer is constructed). It resolves the phonemizer *class* for the voice's `phoneme_type` through scriptconv's registry — a lazy import, cheaper than instantiating the wrapper, though not entirely free: a few backends' `get_lang` (orthography2ipa) build a lightweight G2P engine to answer, and others (euskaphone, arbtok) import their optional backing package. A missing optional package surfaces as `ImportError`, which is treated as "can't tell" and skipped, never as a rejection. Backends that do restrict languages (espeak, gruut, misaki, etc.) raise `ValueError` when the language isn't served; that gets caught and re-raised as a new typed exception, `UnsupportedVoiceLanguage`, naming the human voice id (not the ~130-char HF snapshot cache path), the language, and the phoneme_type. Backends without `get_lang` — the grapheme and unicode-codepoint passthroughs, which accept any language — are silently skipped, as are voices that already have an explicit phonemizer instance set.

I swept the full bundled voice index (3227 entries across every index file under `phoonnx/voice_index/`) through `check_lang_supported` and got exactly two rejections, both already-broken piper_community voices (`tdt-TL`, `zh-TW`) — zero false rejections against the entire catalog. That sweep is checked in as a regression test, alongside tests that construct a real `TTSVoice` with an unserved language and drive `TTSModelInfo.load()` end-to-end (via a stubbed hub) to confirm the check fires before the model weights are ever requested.

I verified the wiring is load-bearing, not just the helper function, by deleting the two call sites (in `TTSVoice.__post_init__` and `TTSModelInfo.load()`) while keeping the tests: both wiring-specific tests then fail with `EntryNotFoundError` (the stubbed model download is reached because nothing rejected first) instead of `UnsupportedVoiceLanguage`. Restoring the calls turns all nine new tests green. I also ran the full non-training test suite; it passes at the same rate as unmodified `dev` — the failures present both before and after are pre-existing missing-optional-dependency errors (`pyworld`, `einops`, `speechonnxmetrics`) unrelated to this change.