### PR TITLE
fix: transformers VITS tokenizer null language falls back to caller lang_code

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -651,7 +651,7 @@ class VoiceConfig:
             add_blank = True
             if tokenizer_config:
                 add_blank = tokenizer_config.get("add_blank", add_blank)
-                lang_code = tokenizer_config.get("language", lang_code)
+                lang_code = tokenizer_config.get("language") or lang_code
                 config["blank"] = tokenizer_config.get("pad_token", config.get("blank", DEFAULT_BLANK_TOKEN))
 
             tokenizer = TTSTokenizer(

--- a/tests/test_config_detection_edges.py
+++ b/tests/test_config_detection_edges.py
@@ -74,6 +74,17 @@ class TestTransformersVocabBranchMissingTokenizerConfigKeys(unittest.TestCase):
                                     lang_code="en")
         self.assertIsNotNone(vc.tokenizer)
 
+    def test_null_language_in_tokenizer_config_falls_back_to_lang_code(self):
+        # transformers-converted VITS tokenizer configs (e.g. kakao-enterprise/vits-ljs)
+        # ship "language": null, which is a present key with value None -- dict.get()
+        # returns that None rather than falling back to the caller-supplied lang_code.
+        vocab = {"_": 0, "a": 1, "b": 2}
+        tok_cfg = {"add_blank": True, "language": None, "pad_token": "_"}
+        vc = VoiceConfig.from_dict({}, vocab=vocab, tokenizer_config=tok_cfg,
+                                    phoneme_type="graphemes", alphabet="unicode",
+                                    lang_code="en")
+        self.assertEqual(vc.lang_code, "en")
+
 
 class TestVoiceAdapterResolutionForMissingEngines(unittest.TestCase):
     """voice.py ~L227-238: Engine.PHOONNX and Engine.TRANSFORMERS have no


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

`hf_community/kakao-enterprise/vits-ljs` reports `TTSModelInfo.lang='en'` but the resulting `VoiceConfig.lang_code` comes out `'und'` in production. The cause is in `VoiceConfig.from_dict`'s transformers/vocab branch: `tokenizer_config.get("language", lang_code)` only falls back to the default when the key is absent, but transformers-converted VITS tokenizer configs ship `"language": null` explicitly, so the key is present with value `None` and `dict.get` happily returns that `None`. It then overwrites the caller-supplied `lang_code` from the model index, and `__post_init__`'s `normalize_lang(self.lang_code or "und")` stamps the voice as `und`.

The fix swaps to `tokenizer_config.get("language") or lang_code`, so a genuinely declared language in the tokenizer config still wins, but a null or missing one falls back to whatever the caller passed in (typically derived from `TTSModelInfo.lang`).

I swept `from_dict` for the same `.get(key, fallback)` shape on other keys that HF-style configs are known to null out. The neighboring `add_blank` and `pad_token` lookups in the same branch have the identical structural risk, but I could not find a real shipped config where those keys are explicitly null, so I left them alone per the "only fix what you can demonstrate" scope.

Added a regression test in `tests/test_config_detection_edges.py` that builds a `tokenizer_config` with `"language": None` plus an explicit `lang_code="en"` and asserts the resulting `VoiceConfig.lang_code` stays `"en"`. Confirmed fail-before: reverting only the source line makes the test fail with `AssertionError: 'und' != 'en'`; restoring the fix makes it pass. The full `test_config_detection_edges.py` + `test_config_detection.py` + `test_native_config.py` suite (80 tests, 4 subtests) passes unchanged after the fix.