### PR TITLE
fix: unwrap list-valued phoneme ids in Vocabulary.from_phoonnx_config

### DIFF
--- a/phoonnx/tokenizer.py
+++ b/phoonnx/tokenizer.py
@@ -245,7 +245,12 @@ class Vocabulary:
         Returns:
             Vocabulary: Vocabulary populated with the parsed char-to-index map and configured special tokens.
         """
-        char2idx: Dict[str, int] = cfg.get("phoneme_id_map", {})
+        # Some hybrid configs (phoonnx_version present but Piper-style phoneme_id_map)
+        # carry list-valued ids, e.g. "a": [14]; unwrap those like from_piper_config does.
+        char2idx: Dict[str, int] = {
+            char: (idx[0] if isinstance(idx, (list, tuple)) else idx)
+            for char, idx in cfg.get("phoneme_id_map", {}).items()
+        }
         pad: Optional[str] = cfg.get("pad") or DEFAULT_PAD_TOKEN
         eos: Optional[str] = cfg.get("eos") or DEFAULT_EOS_TOKEN
         bos: Optional[str] = cfg.get("bos") or DEFAULT_BOS_TOKEN

--- a/tests/test_tokenizer_vocab.py
+++ b/tests/test_tokenizer_vocab.py
@@ -385,6 +385,29 @@ class TestVocabularyAndTokenizerFromPhoonnxConfig(unittest.TestCase):
         self.assertTrue(tok.use_eos_bos)
         self.assertFalse(tok.add_blank_word)
 
+    def test_vocabulary_from_phoonnx_config_unwraps_list_valued_ids(self):
+        # eu-antton-medium / eu-maider-medium (piper_community/itzune) carry
+        # "phoonnx_version" but a Piper-style list-valued phoneme_id_map, e.g.
+        # "a": [14]; those ids must be unwrapped to plain ints like from_piper_config.
+        import numpy as np
+
+        cfg = {"phoneme_id_map": {"a": [14], "b": [5, 99]}}
+        voc = Vocabulary.from_phoonnx_config(cfg)
+        self.assertEqual(voc.char2idx, {"a": 14, "b": 5})
+        self.assertTrue(all(isinstance(v, int) for v in voc.char2idx.values()))
+
+        # unfixed: list values give a list-of-lists here, and np.expand_dims
+        # turns that into rank-3 input that ONNX Runtime rejects (expects rank 2).
+        ids = np.array([voc.char2idx["a"], voc.char2idx["b"]], dtype=np.int64)
+        batched = np.expand_dims(ids, 0)
+        self.assertEqual(batched.ndim, 2)
+
+    def test_vocabulary_from_phoonnx_config_int_valued_ids_unchanged(self):
+        cfg = {"phoneme_id_map": {"a": 0, "b": 1}}
+        voc = Vocabulary.from_phoonnx_config(cfg)
+        self.assertEqual(voc.char2idx, {"a": 0, "b": 1})
+        self.assertTrue(all(isinstance(v, int) for v in voc.char2idx.values()))
+
     def test_tokenizer_from_phoonnx_config_explicit_flags_respected(self):
         cfg = {"phoneme_id_map": {"a": 0}, "add_blank_char": False, "blank_at_end": False,
                "blank_at_start": False, "use_eos_bos": False, "add_blank_word": True}


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

Two voices from the piper_community/itzune collection, eu-antton-medium and eu-maider-medium, crash in ONNX Runtime with "Invalid rank for input: input Got: 3 Expected: 2". Their config.json files on the OpenVoiceOS/phoonnx-vits mirror are hybrids: they carry "phoonnx_version" (so VoiceConfig.is_phoonnx routes them to Vocabulary.from_phoonnx_config) but their phoneme_id_map values are Piper-style lists, e.g. "a": [14], instead of plain ints.

from_phoonnx_config assumed int values and passed the map straight through, so each phoneme id stayed wrapped in a one-element list. Building the numpy array of ids then produced shape (T, 1), and the subsequent expand_dims produced rank 3, which ONNX Runtime rejects since it expects rank 2.

The fix unwraps list-valued ids in from_phoonnx_config using the same idiom from_piper_config already uses (idx[0] when the value is a list or tuple), without touching config detection order or the mirror config files themselves. A scan of all 310 piper-engine catalog configs found these two voices as the only ones with this hybrid shape.

Added regression tests in tests/test_tokenizer_vocab.py covering a phoonnx-version config with list-valued phoneme_id_map (asserting the ids come out as ints and that batching the resulting array yields rank 2) and confirming a normal int-valued phoonnx config is unaffected. Reverting only the source change makes the new list-valued test fail with {'a': [14], 'b': [5, 99]} != {'a': 14, 'b': 5}; with the fix restored, the full 61-test tests/test_tokenizer_vocab.py suite passes.