### PR TITLE
feat: add requires_reference catalog flag for reference-only voices

### DIFF
--- a/phoonnx/cli.py
+++ b/phoonnx/cli.py
@@ -15,6 +15,8 @@ def print_voice_info(voice: TTSModelInfo):
     click.echo(f"  Phoneme Type: {voice.phoneme_type}")
     click.echo(f"  Model URL:   {voice.model_url}")
     click.echo(f"  Config URL:  {voice.config_url}")
+    if voice.requires_reference:
+        click.echo(f"  Requires reference: yes (needs speaker_reference / a style path)")
     click.echo("-" * 40)
 
 

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -306,6 +306,13 @@ class TTSModelInfo:
     # placeholders that get resolved once those fields are known
     display_name: Optional[str] = None
 
+    # True when this voice cannot synthesize from a bare (text, lang) request:
+    # it needs a caller-supplied reference (e.g. a cloning engine's
+    # ``reference_audio``, or a StyleTTS2/Kokoro graph with no baked-in style
+    # and no ``engine_params['style_path']``). A catalog sweep can use this to
+    # skip these voices instead of rediscovering the same failures every run.
+    requires_reference: bool = False
+
     def to_dict(self) -> Dict[str, Any]:
         """
         Serialize every field to a JSON-safe dict, matching the format used by the

--- a/phoonnx/voice_index/chatterbox.json
+++ b/phoonnx/voice_index/chatterbox.json
@@ -13,7 +13,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "en-US"
+        "lang": "en-US",
+        "requires_reference": true
     },
     "chatterbox/turbo/en": {
         "voice_id": "chatterbox/turbo/en",
@@ -29,7 +30,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "en-US"
+        "lang": "en-US",
+        "requires_reference": true
     },
     "chatterbox/multilingual/ar": {
         "voice_id": "chatterbox/multilingual/ar",
@@ -45,7 +47,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar"
+        "lang": "ar",
+        "requires_reference": true
     },
     "chatterbox/multilingual/bg": {
         "voice_id": "chatterbox/multilingual/bg",
@@ -61,7 +64,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "bg-BG"
+        "lang": "bg-BG",
+        "requires_reference": true
     },
     "chatterbox/multilingual/cs": {
         "voice_id": "chatterbox/multilingual/cs",
@@ -77,7 +81,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "cs-CZ"
+        "lang": "cs-CZ",
+        "requires_reference": true
     },
     "chatterbox/multilingual/da": {
         "voice_id": "chatterbox/multilingual/da",
@@ -93,7 +98,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "da-DK"
+        "lang": "da-DK",
+        "requires_reference": true
     },
     "chatterbox/multilingual/de": {
         "voice_id": "chatterbox/multilingual/de",
@@ -109,7 +115,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "de-DE"
+        "lang": "de-DE",
+        "requires_reference": true
     },
     "chatterbox/multilingual/el": {
         "voice_id": "chatterbox/multilingual/el",
@@ -125,7 +132,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "el-GR"
+        "lang": "el-GR",
+        "requires_reference": true
     },
     "chatterbox/multilingual/en": {
         "voice_id": "chatterbox/multilingual/en",
@@ -141,7 +149,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "en-US"
+        "lang": "en-US",
+        "requires_reference": true
     },
     "chatterbox/multilingual/es": {
         "voice_id": "chatterbox/multilingual/es",
@@ -157,7 +166,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "es-ES"
+        "lang": "es-ES",
+        "requires_reference": true
     },
     "chatterbox/multilingual/fi": {
         "voice_id": "chatterbox/multilingual/fi",
@@ -173,7 +183,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "fi-FI"
+        "lang": "fi-FI",
+        "requires_reference": true
     },
     "chatterbox/multilingual/fr": {
         "voice_id": "chatterbox/multilingual/fr",
@@ -189,7 +200,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "fr-FR"
+        "lang": "fr-FR",
+        "requires_reference": true
     },
     "chatterbox/multilingual/he": {
         "voice_id": "chatterbox/multilingual/he",
@@ -205,7 +217,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "he-IL"
+        "lang": "he-IL",
+        "requires_reference": true
     },
     "chatterbox/multilingual/hi": {
         "voice_id": "chatterbox/multilingual/hi",
@@ -221,7 +234,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "hi-IN"
+        "lang": "hi-IN",
+        "requires_reference": true
     },
     "chatterbox/multilingual/hu": {
         "voice_id": "chatterbox/multilingual/hu",
@@ -237,7 +251,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "hu-HU"
+        "lang": "hu-HU",
+        "requires_reference": true
     },
     "chatterbox/multilingual/it": {
         "voice_id": "chatterbox/multilingual/it",
@@ -253,7 +268,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "it-IT"
+        "lang": "it-IT",
+        "requires_reference": true
     },
     "chatterbox/multilingual/ja": {
         "voice_id": "chatterbox/multilingual/ja",
@@ -269,7 +285,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ja-JP"
+        "lang": "ja-JP",
+        "requires_reference": true
     },
     "chatterbox/multilingual/ko": {
         "voice_id": "chatterbox/multilingual/ko",
@@ -285,7 +302,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ko-KR"
+        "lang": "ko-KR",
+        "requires_reference": true
     },
     "chatterbox/multilingual/ms": {
         "voice_id": "chatterbox/multilingual/ms",
@@ -301,7 +319,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ms-MY"
+        "lang": "ms-MY",
+        "requires_reference": true
     },
     "chatterbox/multilingual/nl": {
         "voice_id": "chatterbox/multilingual/nl",
@@ -317,7 +336,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "nl-NL"
+        "lang": "nl-NL",
+        "requires_reference": true
     },
     "chatterbox/multilingual/no": {
         "voice_id": "chatterbox/multilingual/no",
@@ -333,7 +353,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "no-NO"
+        "lang": "no-NO",
+        "requires_reference": true
     },
     "chatterbox/multilingual/pl": {
         "voice_id": "chatterbox/multilingual/pl",
@@ -349,7 +370,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "pl-PL"
+        "lang": "pl-PL",
+        "requires_reference": true
     },
     "chatterbox/multilingual/pt": {
         "voice_id": "chatterbox/multilingual/pt",
@@ -365,7 +387,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "pt-PT"
+        "lang": "pt-PT",
+        "requires_reference": true
     },
     "chatterbox/multilingual/ro": {
         "voice_id": "chatterbox/multilingual/ro",
@@ -381,7 +404,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ro-RO"
+        "lang": "ro-RO",
+        "requires_reference": true
     },
     "chatterbox/multilingual/ru": {
         "voice_id": "chatterbox/multilingual/ru",
@@ -397,7 +421,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ru-RU"
+        "lang": "ru-RU",
+        "requires_reference": true
     },
     "chatterbox/multilingual/sk": {
         "voice_id": "chatterbox/multilingual/sk",
@@ -413,7 +438,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "sk-SK"
+        "lang": "sk-SK",
+        "requires_reference": true
     },
     "chatterbox/multilingual/sv": {
         "voice_id": "chatterbox/multilingual/sv",
@@ -429,7 +455,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "sv-SE"
+        "lang": "sv-SE",
+        "requires_reference": true
     },
     "chatterbox/multilingual/sw": {
         "voice_id": "chatterbox/multilingual/sw",
@@ -445,7 +472,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "sw"
+        "lang": "sw",
+        "requires_reference": true
     },
     "chatterbox/multilingual/ta": {
         "voice_id": "chatterbox/multilingual/ta",
@@ -461,7 +489,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ta-IN"
+        "lang": "ta-IN",
+        "requires_reference": true
     },
     "chatterbox/multilingual/tr": {
         "voice_id": "chatterbox/multilingual/tr",
@@ -477,7 +506,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "tr-TR"
+        "lang": "tr-TR",
+        "requires_reference": true
     },
     "chatterbox/multilingual/vi": {
         "voice_id": "chatterbox/multilingual/vi",
@@ -493,7 +523,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "vi-VN"
+        "lang": "vi-VN",
+        "requires_reference": true
     },
     "chatterbox/multilingual/zh": {
         "voice_id": "chatterbox/multilingual/zh",
@@ -509,7 +540,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "zh-CN"
+        "lang": "zh-CN",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/eg": {
         "voice_id": "chatterbox/lahgtna/eg",
@@ -525,7 +557,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-EG"
+        "lang": "ar-EG",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/sa": {
         "voice_id": "chatterbox/lahgtna/sa",
@@ -541,7 +574,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-SA"
+        "lang": "ar-SA",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/mo": {
         "voice_id": "chatterbox/lahgtna/mo",
@@ -557,7 +591,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-MA"
+        "lang": "ar-MA",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/iq": {
         "voice_id": "chatterbox/lahgtna/iq",
@@ -573,7 +608,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-IQ"
+        "lang": "ar-IQ",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/lb": {
         "voice_id": "chatterbox/lahgtna/lb",
@@ -589,7 +625,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-LB"
+        "lang": "ar-LB",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/sd": {
         "voice_id": "chatterbox/lahgtna/sd",
@@ -605,7 +642,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-SD"
+        "lang": "ar-SD",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/ly": {
         "voice_id": "chatterbox/lahgtna/ly",
@@ -621,7 +659,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-LY"
+        "lang": "ar-LY",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/sy": {
         "voice_id": "chatterbox/lahgtna/sy",
@@ -637,7 +676,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-SY"
+        "lang": "ar-SY",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/tn": {
         "voice_id": "chatterbox/lahgtna/tn",
@@ -653,7 +693,8 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-TN"
+        "lang": "ar-TN",
+        "requires_reference": true
     },
     "chatterbox/lahgtna/ps": {
         "voice_id": "chatterbox/lahgtna/ps",
@@ -669,6 +710,7 @@
         "phoneme_type": "unicode",
         "alphabet": "unicode",
         "engine": "chatterbox",
-        "lang": "ar-PS"
+        "lang": "ar-PS",
+        "requires_reference": true
     }
 }

--- a/phoonnx/voice_index/styletts2.json
+++ b/phoonnx/voice_index/styletts2.json
@@ -25,7 +25,8 @@
     "engine": "styletts2",
     "lang": "es",
     "speaker_encoder_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/bsc-es-styletts2/style_encoder.onnx",
-    "speaker_encoder_type": "styletts2_style"
+    "speaker_encoder_type": "styletts2_style",
+    "requires_reference": true
   },
   "bsc/es-cml3946": {
     "voice_id": "bsc/es-cml3946",
@@ -136,7 +137,8 @@
     "engine": "styletts2",
     "lang": "ca",
     "speaker_encoder_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/bsc-ca-styletts2/style_encoder.onnx",
-    "speaker_encoder_type": "styletts2_style"
+    "speaker_encoder_type": "styletts2_style",
+    "requires_reference": true
   },
   "bsc/ca-bet": {
     "voice_id": "bsc/ca-bet",

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -648,6 +648,65 @@ class TestTTSModelInfoStringEnumCoercion(HubTestCase):
         info = self.make_info(engine="piper", phoneme_type="espeak", display_name="{engine}/{phoneme_type}")
         self.assertEqual(info.display_name, "piper/espeak")
 
+    def test_requires_reference_defaults_false(self):
+        info = self.make_info(engine="piper")
+        self.assertFalse(info.requires_reference)
+
+    def test_requires_reference_round_trips_through_to_dict(self):
+        info = self.make_info(engine="chatterbox", requires_reference=True)
+        self.assertTrue(info.requires_reference)
+        d = info.to_dict()
+        self.assertTrue(d["requires_reference"])
+        restored = TTSModelInfo(**d)
+        self.assertTrue(restored.requires_reference)
+
+
+class TestChatterboxIndexRequiresReference(unittest.TestCase):
+    """Chatterbox is a zero-shot cloning engine: every catalog entry needs a
+    caller-supplied reference clip and can never succeed from a bare
+    (text, lang) request. The index carries that as ``requires_reference``
+    so a catalog sweep can skip these instead of rediscovering the same
+    failure every run."""
+
+    def test_every_chatterbox_entry_is_flagged(self):
+        index_dir = Path(__file__).resolve().parents[1] / "phoonnx" / "voice_index"
+        with open(index_dir / "chatterbox.json", "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertGreater(len(data), 0)
+        for voice_id, voice_dict in data.items():
+            info = TTSModelInfo(**voice_dict)
+            self.assertTrue(info.requires_reference, f"{voice_id} should require a reference clip")
+
+
+class TestStyleTTS2IndexRequiresReference(unittest.TestCase):
+    """bsc/es-styletts2 and bsc/ca-styletts2 are the zero-shot cloning variants
+    of the BSC StyleTTS2 voices: their ONNX graph declares a ``style`` input
+    but the index entry carries no ``style_url``, so synthesis needs a
+    caller-supplied ``speaker_reference``. Their siblings (``bsc/es-cml*``,
+    ``bsc/ca-bet`` etc.) share the same graph but add a fixed ``style_url``
+    for one speaker, so they synthesize from a bare (text, lang) request and
+    must NOT carry the flag."""
+
+    def _load(self):
+        index_dir = Path(__file__).resolve().parents[1] / "phoonnx" / "voice_index"
+        with open(index_dir / "styletts2.json", "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_zero_shot_bsc_entries_are_flagged(self):
+        data = self._load()
+        for voice_id in ("bsc/es-styletts2", "bsc/ca-styletts2"):
+            info = TTSModelInfo(**data[voice_id])
+            self.assertTrue(info.requires_reference, f"{voice_id} should require a reference clip")
+
+    def test_fixed_style_siblings_are_not_flagged(self):
+        data = self._load()
+        siblings = [vid for vid in data if vid.startswith("bsc/es-cml") or (
+            vid.startswith("bsc/ca-") and vid != "bsc/ca-styletts2")]
+        self.assertGreater(len(siblings), 0)
+        for voice_id in siblings:
+            info = TTSModelInfo(**data[voice_id])
+            self.assertFalse(info.requires_reference, f"{voice_id} carries a style_url and should not require a reference clip")
+
 
 class ManagerTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

Some catalog entries can never synthesize from a bare (text, lang) request. Chatterbox is a zero-shot cloning engine: every entry in its bundled index needs a caller-supplied reference clip (`params['reference_audio']`) and the engine already raises a clear `RuntimeError` for this. `bsc/es-styletts2` and `bsc/ca-styletts2` are the zero-shot cloning variants of the BSC StyleTTS2 voices: their ONNX graph declares a `style` input, but the index entry carries no `style_url`, so the adapter has nothing to condition on without a caller-supplied `speaker_reference`. Their siblings (`bsc/es-cml*`, `bsc/ca-bet`, `bsc/ca-eli`, and the rest of the named-speaker family) share the exact same graph but pin a fixed `style_url` for one speaker, so they synthesize fine from a bare request. A validation sweep over the catalog was rediscovering all of these as failures on every run, with nothing in the index distinguishing them from voices that work out of the box.

This adds a `requires_reference` boolean field (default `False`) to `TTSModelInfo`. It flows through the existing kwargs-based construction (`TTSModelInfo(**dict)`) and the `asdict()`-based serialization, so no hand-maintained field list needed updating, and the flag survives the index-JSON to TTSModelInfo to dict round trip. It's set true for every entry in `chatterbox.json` and for the two zero-shot BSC StyleTTS2 entries, and surfaced in `phoonnx-voices list-voices --verbose`.

`OpenVoiceOS/phoonnx_es-ES_dii_espeak` was also suspected of needing a reference, and my first check of it was wrong: I called `get_tts()` without passing `voice=`, which silently fell through to an unrelated default voice and "succeeded" against the wrong model. Re-checked with the voice id passed explicitly, it's a plain single-speaker VITS-style model with no style or reference dependency at all, and its real failure mode is an onnxruntime `Invalid rank for input` error - a separate, unrelated bug. Left unflagged.

Tests: a round-trip test (construct with `requires_reference=True`, serialize via `to_dict()`, reconstruct, flag survives), a default-False test, a catalog test asserting every `chatterbox.json` entry carries the flag, a catalog test asserting the two zero-shot `bsc/*-styletts2` entries carry it, and a catalog test asserting their fixed-style siblings (`bsc/es-cml*`, `bsc/ca-*` minus the zero-shot entry) do not. All were checked fail-before/pass-after by reverting only the JSON/dataclass changes: each raised `TypeError`/`AttributeError` or asserted false before the fix and passed after. Full relevant suite (`test_model_manager.py`, `test_opm.py`, `test_cli.py`) is green; the wider `pytest tests/` run has pre-existing failures from missing training-only dependencies (librosa, WORLD, UTMOS) and one dev-wide stale espeak-alias test, unrelated to this change.