### PR TITLE
test: zh-TW resolves through the espeak Chinese alias map

### DIFF
--- a/tests/test_phonemizer_mul.py
+++ b/tests/test_phonemizer_mul.py
@@ -36,13 +36,12 @@ class TestEspeakGetLang(unittest.TestCase):
         # "pt" is -- get_lang lowercases and strips the region.
         self.assertEqual(EspeakPhonemizer.get_lang("pt-BR"), "pt")
 
-    def test_zh_tw_has_no_close_match_raises_valueerror_not_keyerror(self):
-        # zh-TW has no exact/base entry ("zh" isn't in ESPEAK_LANGS either,
-        # only "cmn"), and langcodes' tag_distance finds nothing close enough
-        # -- this must raise the controlled ValueError from match_lang,
-        # never a raw KeyError from a dict/table lookup.
-        with self.assertRaises(ValueError):
-            EspeakPhonemizer.get_lang("zh-TW")
+    def test_zh_tw_resolves_via_chinese_alias_map(self):
+        # ESPEAK_LANGS has no bare "zh" entry, only "cmn"/"yue"; scriptconv's
+        # espeak wrapper maps BCP-47 Chinese tags onto those voices explicitly,
+        # so region-tagged Chinese resolves instead of raising.
+        self.assertIn(EspeakPhonemizer.get_lang("zh-TW"),
+                      EspeakPhonemizer.ESPEAK_LANGS)
 
     def test_completely_unknown_lang_raises_valueerror_not_keyerror(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The test suite pinned the old failure mode for region-tagged Chinese: it asserted that `EspeakPhonemizer.get_lang("zh-TW")` raises, which was true only because scriptconv's espeak wrapper had no mapping from BCP-47 Chinese tags onto its `cmn`/`yue` voices. scriptconv now carries that alias map, so the tag resolves and every phoonnx CI run fails on this one assertion.

The test now asserts the current contract: `zh-TW` resolves to a member of `ESPEAK_LANGS`. The neighbouring guards (unknown languages still raise the controlled ValueError, regional tags still fall back to their base language) are unchanged and keep covering the error path this test originally cared about.

Verified locally against the released scriptconv: the full `tests/test_phonemizer_mul.py` file passes (48 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Traditional Chinese language handling by resolving the `zh-TW` alias to a supported language.
  * Prevented an unnecessary error when using the `zh-TW` language code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->