### PR TITLE
fix: let phonemizer_lang override lang_code independently of catalogue lang

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -313,6 +313,15 @@ class TTSModelInfo:
     # skip these voices instead of rediscovering the same failures every run.
     requires_reference: bool = False
 
+    # Override for the phonemizer's lang_code, when it differs from ``lang``.
+    # ``lang`` is catalogue-facing (listings, get_lang_voices) and is not always
+    # the language the model was actually trained to phonemize — some index
+    # entries carry a dialect/locale code (e.g. "tdt-TL") no phonemizer serves,
+    # while the model itself was trained with a different phonemizer voice
+    # (e.g. Portuguese espeak). When set, this field — not ``lang`` — becomes
+    # the lang_code override passed into VoiceConfig.from_dict.
+    phonemizer_lang: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         """
         Serialize every field to a JSON-safe dict, matching the format used by the
@@ -349,7 +358,8 @@ class TTSModelInfo:
             if self.phonemizer_model:
                 config["phonemizer_model"] = self.phonemizer_model
 
-            lang_code = normalize_lang(self.lang) if self.lang else None
+            override_lang = self.phonemizer_lang or self.lang
+            lang_code = normalize_lang(override_lang) if override_lang else None
             alphabet = self.alphabet if self.alphabet else None
             phoneme_type = self.phoneme_type if self.phoneme_type else None
             engine = self.engine if self.engine else None

--- a/phoonnx/voice_index/piper_community.json
+++ b/phoonnx/voice_index/piper_community.json
@@ -134,6 +134,7 @@
         "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-vits/resolve/main/piper_community__raphaelmerx__tdt-TL_joao/model.onnx",
         "phoneme_type": "espeak",
         "lang": "tdt-TL",
+        "phonemizer_lang": "pt",
         "tokens_url": null,
         "tokenizer_config_url": null,
         "vocab_url": null,

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -708,6 +708,60 @@ class TestStyleTTS2IndexRequiresReference(unittest.TestCase):
             self.assertFalse(info.requires_reference, f"{voice_id} carries a style_url and should not require a reference clip")
 
 
+class TestPhonemizerLangOverride(HubTestCase):
+    """piper_community/raphaelmerx/tdt-TL_joao is a healthy voice trained with
+    Portuguese espeak (its own config.json says espeak voice "pt"), but the
+    catalogue lang "tdt-TL" is display/discovery metadata only -- no
+    phonemizer serves Tetun. ``phonemizer_lang`` lets the index say which
+    language the voice actually phonemizes as, without disturbing ``lang``
+    (which stays catalogue-facing, e.g. for get_lang_voices).
+    """
+
+    def test_field_round_trips_through_to_dict_and_kwargs(self):
+        info = self.make_info(lang="tdt-TL", phonemizer_lang="pt")
+        d = info.to_dict()
+        self.assertEqual(d["phonemizer_lang"], "pt")
+        rehydrated = TTSModelInfo(**d)
+        self.assertEqual(rehydrated.phonemizer_lang, "pt")
+        self.assertEqual(rehydrated.lang, "tdt-TL")
+
+    def test_default_is_none_and_survives_round_trip(self):
+        info = self.make_info(lang="en-US")
+        self.assertIsNone(info.phonemizer_lang)
+        d = info.to_dict()
+        self.assertIsNone(d["phonemizer_lang"])
+        self.assertIsNone(TTSModelInfo(**d).phonemizer_lang)
+
+    def test_phonemizer_lang_wins_over_catalogue_lang_for_config_resolution(self):
+        # No config_url: config resolution starts from the graphemes/unicode
+        # default dict, isolating exactly what feeds VoiceConfig.from_dict's
+        # lang_code override.
+        info = self.make_info(lang="tdt-TL", phonemizer_lang="pt",
+                              phoneme_type="espeak", alphabet="ipa",
+                              engine="piper")
+        self.assertEqual(info.config.lang_code, "pt")
+        # lang stays the catalogue-facing value; unaffected by the override.
+        self.assertEqual(info.lang, "tdt-TL")
+
+    def test_without_phonemizer_lang_index_lang_still_wins(self):
+        # Regression guard for the kakao-enterprise/vits-ljs shape: an entry
+        # with lang="en-US" and no phonemizer_lang must still resolve to the
+        # index lang, exactly as before this field existed.
+        info = self.make_info(lang="en-US", phoneme_type="espeak",
+                              alphabet="ipa", engine="piper")
+        self.assertEqual(info.config.lang_code, "en-US")
+
+    def test_real_tdt_tl_joao_entry_carries_phonemizer_lang(self):
+        import json as _json
+        from importlib import resources
+        with resources.files("phoonnx.voice_index").joinpath(
+                "piper_community.json").open("r", encoding="utf-8") as f:
+            index = _json.load(f)
+        entry = index["piper_community/raphaelmerx/tdt-TL_joao"]
+        self.assertEqual(entry["phonemizer_lang"], "pt")
+        self.assertEqual(entry["lang"], "tdt-TL")
+
+
 class ManagerTestCase(unittest.TestCase):
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

piper_community/raphaelmerx/tdt-TL_joao is a healthy voice trained with Portuguese espeak — its own config.json declares espeak voice "pt" and language.code "pt", and live-verified locally: neutralizing the index lang and loading the voice with lang_code "pt" synthesizes 82KB of audio without error. It fails in normal use only because TTSModelInfo.load() passes the catalogue's index lang ("tdt-TL", which is correct as display/discovery metadata for a Tetun voice) as the lang_code override fed into VoiceConfig.from_dict. That override beats the model's own working phonemizer config, and no phonemizer in the tree serves Tetun, so synthesis fails.

The override's precedence can't simply be flipped globally, since other index entries (e.g. hf_community/kakao-enterprise/vits-ljs) rely on the index lang winning over a null or wrong model-supplied config. This PR instead adds an optional `phonemizer_lang` field to `TTSModelInfo`, following the same asdict/kwargs round-trip discipline as the recent `requires_reference` field. When `phonemizer_lang` is set, it becomes the lang_code override passed into `VoiceConfig.from_dict`, so the voice phonemizes as that language, while `lang` stays untouched as the catalogue-facing value used for listings and `get_lang_voices`. When the field is absent, behavior is byte-identical to before. The tdt-TL_joao entry in `piper_community.json` now carries `"phonemizer_lang": "pt"`.

I intentionally left `cli.py` untouched: PR #418 (requires_reference, still draft) is the natural place to decide how catalog-only fields surface in `--verbose` listings, and I didn't want to collide with it.

Tests were added to `tests/test_model_manager.py` covering the field's round-trip through `to_dict`/kwargs construction, the config-resolution precedence with and without `phonemizer_lang` set (including a regression guard for the kakao-enterprise shape, where the index lang must still win with no override present), and an assertion that the real tdt-TL_joao index entry carries the field. Reverting only the source change (keeping the new tests) drops 4 of the 5 new tests to failure — a TypeError on the unexpected `phonemizer_lang` kwarg and a KeyError confirming the index entry lacked the field — and all 5 pass with the fix applied. The full `tests/test_model_manager.py` suite (79 tests) passes.