### PR TITLE
refactor: per-format config loader registry

### DIFF
--- a/phoonnx/config.py
+++ b/phoonnx/config.py
@@ -202,77 +202,27 @@ class VoiceConfig:
 
     @staticmethod
     def is_mimic3(config: dict[str, Any]) -> bool:
-        # https://huggingface.co/mukowaty/mimic3-voices
-
-        # mimic3 models indicate a phonemizer strategy in their config
-        if ("phonemizer" not in config or
-                not isinstance(config["phonemizer"], str)):
-            return False
-
-        # mimic3 models include a "phonemes" section with token info
-        if "phonemes" not in config or not isinstance(config["phonemes"], dict):
-            return False
-
-        # validate phonemizer type as expected by mimic3
-        phonemizer = config["phonemizer"]
-        # class Phonemizer(str, Enum):
-        #     SYMBOLS = "symbols"
-        #     GRUUT = "gruut"
-        #     ESPEAK = "espeak"
-        #     EPITRAN = "epitran"
-        if phonemizer not in ["symbols", "gruut", "espeak", "epitran"]:
-            return False
-
-        return True
+        """Whether *config* is a mimic3 voice."""
+        from phoonnx.config_loaders import LoadRequest, Mimic3Loader
+        return Mimic3Loader.detect(LoadRequest(config=config))
 
     @staticmethod
     def is_piper(config: dict[str, Any]) -> bool:
-        if "piper_version" in config:
-            return True
-        # an explicitly declared non-piper engine wins over shape-sniffing: a
-        # canonical config (e.g. engine="coqui" with an espeak phoneme_id_map)
-        # must not be mistaken for piper just because it phonemizes with espeak.
-        engine = config.get("engine")
-        if engine and engine not in ("piper", Engine.PIPER, Engine.PIPER.value):
-            return False
-        # piper models indicate a phonemizer strategy in their config
-        if ("phoneme_type" not in config or
-                not isinstance(config["phoneme_type"], str)):
-            return False
-
-        # piper models include a "phoneme_id_map" section mapping phonemes to int
-        pid = config.get("phoneme_id_map")
-        if not isinstance(pid, dict) or not pid:
-            return False
-
-        # piper's phoneme_id_map values are *lists* ([id, ...]); a flat
-        # phoneme -> int map is the canonical phoonnx/coqui shape, not piper.
-        if not all(isinstance(v, (list, tuple)) for v in pid.values()):
-            return False
-
-        # validate phonemizer type as expected by piper
-        phonemizer = config["phoneme_type"]
-        if phonemizer not in ["text", "espeak"]:
-            return False
-
-        return True
+        """Whether *config* is a piper voice."""
+        from phoonnx.config_loaders import LoadRequest, PiperLoader
+        return PiperLoader.detect(LoadRequest(config=config))
 
     @staticmethod
     def is_coqui_vits(config: dict[str, Any]) -> bool:
-        # coqui vits grapheme models include a "characters" section with token info
-        if "characters" not in config or not isinstance(config["characters"], dict):
-            return False
-
-        # double check this was trained with coqui
-        if config["characters"].get("characters_class", "") not in ["TTS.tts.models.vits.VitsCharacters",
-                                                                    "TTS.tts.utils.text.characters.Graphemes"]:
-            return False
-
-        return True
+        """Whether *config* is a Coqui VITS grapheme voice."""
+        from phoonnx.config_loaders import CoquiLoader, LoadRequest
+        return CoquiLoader.detect(LoadRequest(config=config))
 
     @staticmethod
     def is_phoonnx(config: dict[str, Any]) -> bool:
-        return "phoonnx_version" in config
+        """Whether *config* is a native phoonnx voice."""
+        from phoonnx.config_loaders import LoadRequest, PhoonnxLoader
+        return PhoonnxLoader.detect(LoadRequest(config=config))
 
     @staticmethod
     def from_dict(config: dict[str, Any],  # phoonnx/piper/coqui/mimic3
@@ -287,459 +237,53 @@ class VoiceConfig:
                    bpe_tokenizer_json: Optional[str] = None,
                    lang_tokens: Optional[Dict[str, str]] = None) -> "VoiceConfig":
         """
-        Create a VoiceConfig from a model configuration dictionary and optional external phoneme data.
-        
-        Builds a VoiceConfig by detecting the model engine (Phoonnx, Piper, Mimic3, Transformers or Coqui), deriving tokenizer and alphabet, and applying model-specific defaults and inference settings. Provided optional arguments override corresponding values found in the config.
-        
+        Build a VoiceConfig from a model configuration dictionary and its optional
+        companion files.
+
+        The config's format is recognised by the loader registry in
+        :mod:`phoonnx.config_loaders`, which yields the fields that differ per
+        format (tokenizer, engine, phoneme type, alphabet, language, diacritics);
+        :func:`~phoonnx.config_loaders.resolve_overrides` then folds in the
+        caller's overrides, and everything format-independent — audio, inference
+        scales, speaker and language maps, special tokens — is read straight off
+        the config here.
+
         Parameters:
-            config (dict[str, Any]): Parsed model configuration dictionary.
-            tokens_txt (Optional[str]): Path to an external tokens file (.txt or .json) used to build or override the tokenizer vocabulary.
-            lang_code (Optional[str]): Language code to override the config's language selection.
-            phoneme_type (Optional[PhonemeType]): Phoneme type name to override the config's phoneme_type value.
-            alphabet (Optional[Alphabet]): Alphabet name to override or supply the resulting VoiceConfig alphabet.
-        
-        Returns:
-            VoiceConfig: A populated VoiceConfig instance with tokenizer, alphabet, engine, phoneme_type, inference settings, and token tokens derived from the inputs.
-        
+            config: Parsed model configuration dictionary. Loaders may normalise
+                it in place (special tokens, a defaulted sample rate).
+            vocab: Token vocabulary of a transformers export.
+            tokenizer_config: ``tokenizer_config.json`` of a transformers export.
+            tokens_txt: Path to an external tokens file (``.txt`` or ``.json``),
+                required by mimic3 voices and by sherpa-onnx style models.
+            bpe_tokenizer_json: Path to a ``tokenizer.json``, required by Chatterbox.
+            lang_code, phoneme_type, alphabet, engine: Overrides that win over the
+                config's own values, except where the format pins them.
+            engine_params: Locally-resolved adapter parameters; these win over the
+                config's own ``engine_params``.
+            lang_tokens: Overrides the config's BCP47 -> language-token map.
+
         Raises:
-            ValueError: If the config is identified as a Mimic3 model but no phonemes_txt is provided.
+            ValueError: If the detected format needs a companion file that was
+                not provided.
         """
-        blank_type = BlankBetween.TOKENS_AND_WORDS
-        lang_code = lang_code or config.get("lang_code")
-        phoneme_type = phoneme_type or config.get("phoneme_type")
-        alphabet = alphabet or config.get("alphabet")
-        diacritics = False
-        ar_diacritizer_model = None
+        from phoonnx.config_loaders import LoadRequest, load_voice_fields
 
-        if (engine == Engine.CHATTERBOX or
-                (isinstance(engine, str) and engine == "chatterbox") or
-                config.get("engine") == "chatterbox"):
-            # Chatterbox tokenizes raw text with its own BPE; the multilingual variant
-            # uses ChatterboxMTLTokenizer (detected by the [SPACE] token).
-            engine = Engine.CHATTERBOX
-            if not bpe_tokenizer_json:
-                raise ValueError("Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)")
-            from phoonnx.tokenizer import load_chatterbox_tokenizer
-            tokenizer = load_chatterbox_tokenizer(bpe_tokenizer_json)
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.UNICODE
-            # Arabic/Hebrew need vocalization (niqqud/tashkeel) for correct pronunciation.
-            diacritics = (lang_code or "").lower().startswith(("ar", "he"))
-            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
-            config.setdefault("num_symbols", tokenizer._tok.get_vocab_size())
+        loaded = load_voice_fields(LoadRequest(
+            config=config,
+            vocab=vocab,
+            tokenizer_config=tokenizer_config,
+            tokens_txt=tokens_txt,
+            bpe_tokenizer_json=bpe_tokenizer_json,
+            lang_code=lang_code or config.get("lang_code"),
+            phoneme_type=phoneme_type or config.get("phoneme_type"),
+            alphabet=alphabet or config.get("alphabet"),
+            engine=engine,
+        ))
+        LOG.debug(f"phonemizer: {loaded.phoneme_type}")
 
-        elif (engine == Engine.LLASA or
-                (isinstance(engine, str) and engine == "llasa") or
-                config.get("engine") == "llasa"):
-            # Llasa consumes raw text: the adapter owns the whole text -> id path
-            # (chat-template prompt assembly, then the checkpoint's own BPE, loaded
-            # from engine_params), so no phonemizer/tokenizer vocabulary is built
-            # here. Alphabet.GRAPHEMES routes TTSVoice.synthesize() through
-            # adapter.encode_text(). XCodec2 output is 16 kHz mono.
-            engine = Engine.LLASA
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 16000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.NEUTTS or
-                (isinstance(engine, str) and engine == "neutts") or
-                config.get("engine") == "neutts"):
-            # NeuTTS consumes raw text: the adapter owns the whole text -> id path
-            # (espeak-ng phonemization, prompt assembly, then the checkpoint's own BPE,
-            # all loaded from engine_params), so no phonemizer/tokenizer vocabulary is
-            # built here. Alphabet.GRAPHEMES routes TTSVoice.synthesize() through
-            # adapter.encode_text(). NeuCodec output is 24 kHz mono.
-            engine = Engine.NEUTTS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.ORPHEUS or
-                (isinstance(engine, str) and engine == "orpheus") or
-                config.get("engine") == "orpheus"):
-            # Orpheus consumes raw text: the adapter owns the whole text -> id path
-            # (voice-name prefix, the served control tokens, then the checkpoint's own
-            # BPE from engine_params), so no phonemizer/tokenizer vocabulary is built
-            # here. The emotive tags (<laugh>, <sigh>, ...) are ordinary text that the
-            # same BPE encodes, so they must not be phonemized away. Alphabet.GRAPHEMES
-            # routes TTSVoice.synthesize() through adapter.encode_text(). SNAC output is
-            # 24 kHz mono.
-            engine = Engine.ORPHEUS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.MOSSTTS or
-                (isinstance(engine, str) and engine == "mosstts") or
-                config.get("engine") == "mosstts"):
-            # MOSS-TTS-Nano consumes raw text: the adapter owns text -> id conversion
-            # via its own SentencePiece model (loaded from engine_params), so no
-            # phonemizer/tokenizer vocabulary is built here. Alphabet.GRAPHEMES routes
-            # TTSVoice.synthesize() through adapter.encode_text(). Native output is
-            # 48 kHz (stereo, downmixed to mono by the adapter).
-            engine = Engine.MOSSTTS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 48000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.SUPERTONIC or
-                (isinstance(engine, str) and engine == "supertonic") or
-                config.get("engine") == "supertonic"):
-            # SuperTonic consumes raw text directly: the adapter owns text -> id
-            # conversion via its own unicode-codepoint indexer (loaded from
-            # engine_params), so no phonemizer/tokenizer vocabulary is needed here.
-            # Alphabet.GRAPHEMES routes TTSVoice.synthesize() through
-            # adapter.encode_text() instead of the phonemizer pipeline.
-            engine = Engine.SUPERTONIC
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 44100)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.POCKETTTS or
-                (isinstance(engine, str) and engine == "pockettts") or
-                config.get("engine") == "pockettts"):
-            # Pocket TTS consumes raw text directly: the adapter tokenizes with the
-            # bundle's own SentencePiece model (loaded from engine_params), so no
-            # phonemizer or vocabulary is needed here. Alphabet.GRAPHEMES routes
-            # TTSVoice.synthesize() through adapter.encode_text().
-            engine = Engine.POCKETTTS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.SPARKTTS or
-                (isinstance(engine, str) and engine == "sparktts") or
-                config.get("engine") == "sparktts"):
-            # Spark-TTS consumes raw text: the adapter owns text -> id conversion with the
-            # model's own subword BPE (loaded from engine_params, like SuperTonic's
-            # indexer), so no phonemizer vocabulary is needed here. Alphabet.GRAPHEMES
-            # routes TTSVoice.synthesize() through adapter.encode_text().
-            engine = Engine.SPARKTTS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 16000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.INDIC_PARLER or
-                (isinstance(engine, str) and engine == "indic_parler") or
-                config.get("engine") == "indic_parler"):
-            # Indic Parler-TTS consumes raw text and a natural-language voice description.
-            # The adapter owns both: the prompt tokenizer (the checkpoint's own vocabulary)
-            # and the description tokenizer (the Flan-T5 one) are two *different*
-            # vocabularies loaded from engine_params, so no phonemizer vocabulary is built
-            # here. Alphabet.GRAPHEMES routes TTSVoice.synthesize() through
-            # adapter.encode_text(). DAC runs at 44.1 kHz.
-            engine = Engine.INDIC_PARLER
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 44100)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.OMNIVOICE or
-                (isinstance(engine, str) and engine == "omnivoice") or
-                config.get("engine") == "omnivoice"):
-            # OmniVoice consumes raw text: the adapter owns text -> id conversion with
-            # the model's own Qwen3 subword BPE (loaded from engine_params, like
-            # Spark-TTS), so no phonemizer vocabulary is needed here. Alphabet.GRAPHEMES
-            # routes TTSVoice.synthesize() through adapter.encode_text().
-            engine = Engine.OMNIVOICE
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.MAGPIE or
-                (isinstance(engine, str) and engine == "magpie") or
-                config.get("engine") == "magpie"):
-            # Magpie consumes raw text: the adapter owns text -> id conversion with the
-            # checkpoint's own aggregated tokenizer (loaded from engine_params), so no
-            # phonemizer vocabulary is needed here. Alphabet.GRAPHEMES routes
-            # TTSVoice.synthesize() through adapter.encode_text().
-            engine = Engine.MAGPIE
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 22050)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.ARKTTS or
-                (isinstance(engine, str) and engine == "arktts") or
-                config.get("engine") == "arktts"):
-            # ArkTTS consumes raw text: the adapter owns text -> id conversion with the
-            # model's own subword BPE (loaded from engine_params, like Qwen3-TTS), so no
-            # phonemizer vocabulary is needed here. Alphabet.GRAPHEMES routes
-            # TTSVoice.synthesize() through adapter.encode_text().
-            engine = Engine.ARKTTS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 44100)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.QWEN3TTS or
-                (isinstance(engine, str) and engine == "qwen3tts") or
-                config.get("engine") == "qwen3tts"):
-            # Qwen3-TTS consumes raw text: the adapter owns text -> id conversion with
-            # the model's own subword BPE (loaded from engine_params, like Spark-TTS),
-            # so no phonemizer vocabulary is needed here. Alphabet.GRAPHEMES routes
-            # TTSVoice.synthesize() through adapter.encode_text().
-            engine = Engine.QWEN3TTS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif (engine == Engine.OUTETTS or
-                (isinstance(engine, str) and engine == "outetts") or
-                config.get("engine") == "outetts"):
-            # OuteTTS consumes raw text: the adapter owns text -> id conversion with the
-            # checkpoint's own tokenizer (loaded from engine_params), so no phonemizer
-            # vocabulary is needed here. Alphabet.GRAPHEMES routes
-            # TTSVoice.synthesize() through adapter.encode_text().
-            engine = Engine.OUTETTS
-            phoneme_type = phoneme_type or PhonemeType.UNICODE
-            alphabet = alphabet or Alphabet.GRAPHEMES
-            config.setdefault("audio", {}).setdefault("sample_rate", 24000)
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
-                add_blank_char=False,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=False,
-                blank_at_start=False,
-            )
-
-        elif VoiceConfig.is_phoonnx(config):
-            engine = engine or config.get("engine") or Engine.PHOONNX
-
-            lang_code = lang_code or config.get("lang_code")
-            phoneme_type = phoneme_type or config.get("phoneme_type", PhonemeType.ESPEAK)
-            alphabet = alphabet or Alphabet(config.get("alphabet", "ipa"))
-            diacritics = config.get("inference", {}).get("add_diacritics", True)
-            ar_diacritizer_model = config.get("inference", {}).get("diacritizer_model", None)
-
-            # Preserve the model's own special tokens when present (a native
-            # config may use any pad/blank/bos/eos); fall back to phoonnx defaults.
-            config["pad"] = config.get("pad") or DEFAULT_PAD_TOKEN
-            config["blank"] = config.get("blank") or DEFAULT_BLANK_TOKEN
-            config["bos"] = config.get("bos") or DEFAULT_BOS_TOKEN
-            config["eos"] = config.get("eos") or DEFAULT_EOS_TOKEN
-
-            tokenizer = TTSTokenizer.from_phoonnx_config(config)
-
-        # check if model was trained for PiperTTS
-        elif VoiceConfig.is_piper(config):
-            engine =  engine or Engine.PIPER
-
-            lang_code = lang_code or (config.get("language", {}).get("code") or
-                         config.get("espeak", {}).get("voice"))
-            diacritics = (lang_code or "").startswith("ar")
-            phoneme_type = phoneme_type or config.get("phoneme_type", PhonemeType.ESPEAK)
-            if phoneme_type == "text":
-                phoneme_type = PhonemeType.UNICODE
-                alphabet = Alphabet.UNICODE
-            elif phoneme_type == "pygoruut":
-                # special case: neurlang models
-                phoneme_type = PhonemeType.GORUUT
-                alphabet = Alphabet.IPA
-            else:
-                alphabet = alphabet or Alphabet.IPA
-
-            # not configurable in piper
-            config["pad"] =  DEFAULT_PAD_TOKEN
-            config["blank"] = DEFAULT_BLANK_TOKEN
-            config["blank_word"] = DEFAULT_BLANK_WORD_TOKEN
-            config["bos"] = DEFAULT_BOS_TOKEN
-            config["eos"] = DEFAULT_EOS_TOKEN
-
-            tokenizer = TTSTokenizer.from_piper_config(config)
-
-        # check if model was trained for Mimic3
-        elif VoiceConfig.is_mimic3(config):
-            engine =  engine or Engine.MIMIC3
-
-            if not tokens_txt:
-                raise ValueError("mimic3 models require an external phonemes.txt file in addition to the config")
-            lang_code = config.get("text_language")
-            phoneme_type = phoneme_type or config.get("phonemizer", PhonemeType.GRUUT)
-            # read phoneme settings
-            phoneme_cfg = config.get("phonemes", {})
-            blank_type = BlankBetween(phoneme_cfg.get("blank_between", "tokens_and_words"))
-            config.update(phoneme_cfg)
-
-            if phoneme_type == "symbols":
-                # Mimic3 "symbols" models are grapheme models
-                # symbol map comes from phonemes_txt
-                phoneme_type = PhonemeType.GRAPHEMES
-                alphabet = Alphabet.UNICODE
-            else:
-                alphabet = alphabet or Alphabet.IPA
-
-            tokenizer = TTSTokenizer.from_mimic3_config(config, tokens_txt)
-
-        # check if model was trained with Coqui
-        elif VoiceConfig.is_coqui_vits(config):
-            engine =  engine or Engine.COQUI
-            phoneme_type = phoneme_type or PhonemeType.GRAPHEMES
-            alphabet = alphabet or Alphabet.UNICODE
-
-            # NOTE: lang code usually not provided and often wrong :(
-            ds = config.get("datasets", [])
-            if ds and not lang_code:
-                lang_code = ds[0].get("language")
-
-            tokenizer = TTSTokenizer.from_coqui_config(config)
-        # for models trained with transformers
-        elif vocab:
-            add_blank = True
-            if tokenizer_config:
-                add_blank = tokenizer_config.get("add_blank", add_blank)
-                lang_code = tokenizer_config.get("language") or lang_code
-                config["blank"] = tokenizer_config.get("pad_token", config.get("blank", DEFAULT_BLANK_TOKEN))
-
-            tokenizer = TTSTokenizer(
-                Vocabulary(char2idx=vocab, blank=config.get("blank", DEFAULT_BLANK_TOKEN)),
-                add_blank_char=add_blank,
-                add_blank_word=False,
-                use_eos_bos=False,
-                blank_at_end=add_blank,
-                blank_at_start=add_blank
-            )
-
-        # for sherpa-onnx style models with tokens.txt only
-        elif tokens_txt:
-            if tokens_txt.endswith(".txt"):
-                # mimic3 / MMS / sherpa
-                with open(tokens_txt, "r", encoding="utf-8") as ids_file:
-                    tokenizer = TTSTokenizer(
-                        Vocabulary.from_tokens_txt(ids_file.read()),
-                        add_blank_char=True,
-                        add_blank_word=False,
-                        use_eos_bos=True,
-                        blank_at_end=True,
-                        blank_at_start=True
-                    )
-
-            elif tokens_txt.endswith(".json"):
-                with open(tokens_txt, "r", encoding="utf-8") as ids_file:
-                    tokenizer = TTSTokenizer(
-                        Vocabulary(char2idx=json.load(ids_file), pad=config["pad"]),
-                        add_blank_char=True,
-                        add_blank_word=False,
-                        use_eos_bos=True,
-                        blank_at_end=True,
-                        blank_at_start=True
-                    )
-
-        # Canonical config: the model ships its own phoneme_id_map (and declares
-        # engine / phoneme_type / alphabet). Use those values directly --
-        # config-shape engine detection is deprecated, so honour what the config
-        # declares instead of guessing or rejecting it.
-        else:
-            engine = engine or config.get("engine") or Engine.PHOONNX
-            phoneme_type = phoneme_type or config.get("phoneme_type", PhonemeType.GRAPHEMES)
-            alphabet = alphabet or Alphabet(config.get("alphabet", "ipa"))
-            diacritics = config.get("inference", {}).get("add_diacritics", False)
-            ar_diacritizer_model = config.get("inference", {}).get("diacritizer_model", ar_diacritizer_model)
-            config["pad"] = config.get("pad") or DEFAULT_PAD_TOKEN
-            config["blank"] = config.get("blank") or DEFAULT_BLANK_TOKEN
-            config["bos"] = config.get("bos") or DEFAULT_BOS_TOKEN
-            config["eos"] = config.get("eos") or DEFAULT_EOS_TOKEN
-            tokenizer = TTSTokenizer.from_phoonnx_config(config)
-        phoneme_type = PhonemeType(phoneme_type) if isinstance(phoneme_type, str) else phoneme_type
-        LOG.debug(f"phonemizer: {phoneme_type}")
         inference = config.get("inference", {})
-        engine = engine or Engine.PHOONNX
         return VoiceConfig(
-            tokenizer=tokenizer,
+            tokenizer=loaded.tokenizer,
             num_langs=config.get("num_langs", 1),
             num_symbols=config.get("num_symbols", 256),
             num_speakers=config.get("num_speakers", 1),
@@ -747,16 +291,16 @@ class VoiceConfig:
             noise_scale=inference.get("noise_scale", DEFAULT_NOISE_SCALE),
             length_scale=inference.get("length_scale", DEFAULT_LENGTH_SCALE),
             noise_w_scale=inference.get("noise_w", DEFAULT_NOISE_W_SCALE),
-            add_diacritics=diacritics,
-            diacritizer_model=ar_diacritizer_model,
+            add_diacritics=loaded.add_diacritics,
+            diacritizer_model=loaded.diacritizer_model,
             hop_length=config.get("hop_length", DEFAULT_HOP_LENGTH),
-            lang_code=lang_code,
-            alphabet=Alphabet(alphabet) if isinstance(alphabet, str) else alphabet,
-            engine=Engine(engine) if isinstance(engine, str) else engine,
+            lang_code=loaded.lang_code,
+            alphabet=loaded.alphabet,
+            engine=loaded.engine,
             phonemizer_model=config.get("phonemizer_model"),
-            phoneme_type=PhonemeType(phoneme_type) if isinstance(phoneme_type, str) else phoneme_type,
+            phoneme_type=loaded.phoneme_type,
             speaker_id_map=config.get("speaker_id_map", {}),
-            blank_between=BlankBetween(blank_type) if isinstance(blank_type, str) else blank_type,
+            blank_between=BlankBetween(loaded.blank_between),
             blank_at_start=config.get("blank_at_start", True),
             blank_at_end=config.get("blank_at_end", True),
             pad_token=config.get("pad"),

--- a/phoonnx/config_loaders.py
+++ b/phoonnx/config_loaders.py
@@ -1,0 +1,561 @@
+"""
+Per-format ``config.json`` loaders.
+
+A voice config can arrive in any of a dozen shapes: phoonnx's own native
+format, a piper or mimic3 or Coqui checkpoint, a bare transformers vocabulary,
+a sherpa ``tokens.txt``, or one of the codec-LM engines that ship no phoneme
+vocabulary at all.  Each shape is handled by a loader that knows how to
+recognise it (:meth:`ConfigLoader.detect`) and how to turn it into the handful
+of fields that vary per format (:meth:`ConfigLoader.load`).
+
+:func:`load_voice_fields` walks :data:`LOADERS` in order and returns the first
+match, falling back to :class:`CanonicalLoader`.  **Order is significant** and
+mirrors the historical detection ladder:
+
+* the raw-text codec-LM loaders come first because they key off a declared
+  engine name and must win before any shape-sniffing runs;
+* ``phoonnx`` precedes ``piper`` because a native config that phonemizes with
+  espeak carries a piper-shaped ``phoneme_id_map`` and would otherwise be
+  claimed by the piper loader;
+* ``vocab`` (transformers) and ``tokens_txt`` (sherpa) come last because they
+  are decided by what the caller passed alongside the config, not by the config
+  itself, and any real config shape should win over them.
+
+A loader may consult the caller's values — a format's own defaults sometimes
+depend on them — but it never decides the precedence between them and its own.
+:func:`resolve_overrides` does that once, for every format, right after the
+loader returns.
+"""
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, List, Optional, Type, Union
+
+from scriptconv.phonemizers.enums import Alphabet, Phonemizer as PhonemeType
+
+from phoonnx.config import Engine
+
+from phoonnx.tokenizer import (TTSTokenizer, Vocabulary, BlankBetween,
+                               DEFAULT_BLANK_WORD_TOKEN, DEFAULT_BLANK_TOKEN,
+                               DEFAULT_PAD_TOKEN, DEFAULT_BOS_TOKEN, DEFAULT_EOS_TOKEN)
+
+
+@dataclass
+class LoadRequest:
+    """Everything a loader may look at.
+
+    ``lang_code``, ``phoneme_type`` and ``alphabet`` arrive pre-merged: the
+    caller's kwarg if it gave one, else the config's own value, so a loader
+    that needs to branch on the effective value (piper's ``text`` models,
+    mimic3's ``symbols`` models) sees what the caller asked for.  ``engine`` is
+    the caller's kwarg alone — the config's ``engine`` key is a per-format
+    concern and each loader decides what to do with it.
+    """
+
+    config: Dict[str, Any]
+    vocab: Optional[Dict[str, Any]] = None
+    tokenizer_config: Optional[Dict[str, Any]] = None
+    tokens_txt: Optional[str] = None
+    bpe_tokenizer_json: Optional[str] = None
+    lang_code: Optional[str] = None
+    phoneme_type: Optional[Union[str, PhonemeType]] = None
+    alphabet: Optional[Union[str, Alphabet]] = None
+    engine: Optional[Union[str, Any]] = None
+
+
+@dataclass
+class LoadedFields:
+    """The format-specific half of a :class:`~phoonnx.config.VoiceConfig`.
+
+    Every value may be ``None``; the dataclass' own ``__post_init__`` owns the
+    final defaulting (alphabet, lang code, diacritics).  ``pinned`` names the
+    fields the format fixes for correctness — see :func:`resolve_overrides`.
+    """
+
+    tokenizer: Optional[TTSTokenizer] = None
+    engine: Optional[Any] = None
+    lang_code: Optional[str] = None
+    phoneme_type: Optional[Union[str, PhonemeType]] = None
+    alphabet: Optional[Union[str, Alphabet]] = None
+    add_diacritics: Optional[bool] = False
+    diacritizer_model: Optional[str] = None
+    blank_between: Union[str, BlankBetween] = BlankBetween.TOKENS_AND_WORDS
+    pinned: FrozenSet[str] = field(default_factory=frozenset)
+
+
+def resolve_overrides(loaded: LoadedFields, request: LoadRequest) -> LoadedFields:
+    """Apply the caller's overrides to a loader's output, in place.
+
+    The precedence, for ``lang_code``, ``phoneme_type``, ``alphabet`` and
+    ``engine``:
+
+    1. a field the loader **pinned** wins over everything — the format binds it
+       to its tokenizer vocabulary, so honouring the caller would produce
+       wrong token ids (piper's ``text``/``pygoruut`` models, mimic3's
+       ``symbols`` models and its ``text_language``, a transformers
+       ``tokenizer_config`` language, a codec-LM engine named by the config);
+    2. otherwise the caller's kwarg wins;
+    3. otherwise the loader's value, which already folded in the config's own.
+
+    Every step is null-safe by ``or``: a config carrying an explicit ``null``
+    falls through to the next source rather than pinning ``None``.
+    ``engine`` additionally defaults to :data:`~phoonnx.config.Engine.PHOONNX`
+    when nothing supplies one.
+    """
+    if "lang_code" not in loaded.pinned:
+        loaded.lang_code = request.lang_code or loaded.lang_code
+    if "phoneme_type" not in loaded.pinned:
+        loaded.phoneme_type = request.phoneme_type or loaded.phoneme_type
+    if "alphabet" not in loaded.pinned:
+        loaded.alphabet = request.alphabet or loaded.alphabet
+    if "engine" not in loaded.pinned:
+        loaded.engine = request.engine or loaded.engine or Engine.PHOONNX
+    return loaded
+
+
+class ConfigLoader:
+    """Base class for a per-format loader."""
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        """Whether this loader owns *request*.
+
+        Takes the whole request rather than just the config because two
+        formats (transformers, sherpa) are identified by the companion files
+        the caller passed, not by the config's own keys.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        """Build the format-specific fields, without applying caller overrides.
+
+        May mutate ``request.config`` — several formats normalise their special
+        tokens or fold a nested section into the top level, and the values are
+        read back out of the config when the VoiceConfig is assembled.
+
+        Raises ``ValueError`` when the format needs a companion file the caller
+        did not pass.
+        """
+        raise NotImplementedError
+
+
+def _adapter_owned_tokenizer() -> TTSTokenizer:
+    """An empty tokenizer, for engines whose adapter owns the text -> id path."""
+    return TTSTokenizer(
+        Vocabulary(char2idx={}, pad=DEFAULT_PAD_TOKEN),
+        add_blank_char=False,
+        add_blank_word=False,
+        use_eos_bos=False,
+        blank_at_end=False,
+        blank_at_start=False,
+    )
+
+
+class RawTextLoader(ConfigLoader):
+    """Codec-LM engines that consume raw text.
+
+    The adapter owns the whole text -> id path (prompt assembly plus the
+    checkpoint's own subword tokenizer, loaded from ``engine_params``), so no
+    phoneme vocabulary is built here and ``Alphabet.GRAPHEMES`` routes
+    ``TTSVoice.synthesize()`` through ``adapter.encode_text()``.  Subclasses
+    supply only the engine, its codec's sample rate, and — where the adapter
+    wants codepoints rather than words — a different alphabet.
+
+    These loaders pin ``engine``: they are selected *by* the engine name, so
+    the name is the identity of the branch, not a preference.
+    """
+
+    ENGINE: Any = None
+    SAMPLE_RATE: int = 24000
+    ALPHABET: Alphabet = Alphabet.GRAPHEMES
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        name = cls.ENGINE.value
+        return request.engine == name or request.config.get("engine") == name
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        request.config.setdefault("audio", {}).setdefault("sample_rate", cls.SAMPLE_RATE)
+        return LoadedFields(
+            tokenizer=_adapter_owned_tokenizer(),
+            engine=cls.ENGINE,
+            lang_code=request.lang_code,
+            phoneme_type=request.phoneme_type or PhonemeType.UNICODE,
+            alphabet=request.alphabet or cls.ALPHABET,
+            pinned=frozenset({"engine"}),
+        )
+
+
+class ChatterboxLoader(RawTextLoader):
+    """Chatterbox: raw text through its own BPE, loaded from ``tokenizer.json``.
+
+    The multilingual variant uses ChatterboxMTLTokenizer, detected by the
+    ``[SPACE]`` token.  Unlike the other codec-LM engines it keeps
+    ``Alphabet.UNICODE``, and it vocalizes Arabic and Hebrew, which need
+    niqqud/tashkeel restored for a correct pronunciation.
+    """
+
+    ENGINE = Engine.CHATTERBOX
+    SAMPLE_RATE = 24000
+    ALPHABET = Alphabet.UNICODE
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        if not request.bpe_tokenizer_json:
+            raise ValueError("Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)")
+        from phoonnx.tokenizer import load_chatterbox_tokenizer
+        tokenizer = load_chatterbox_tokenizer(request.bpe_tokenizer_json)
+        config = request.config
+        config.setdefault("audio", {}).setdefault("sample_rate", cls.SAMPLE_RATE)
+        config.setdefault("num_symbols", tokenizer._tok.get_vocab_size())
+        return LoadedFields(
+            tokenizer=tokenizer,
+            engine=Engine.CHATTERBOX,
+            lang_code=request.lang_code,
+            phoneme_type=request.phoneme_type or PhonemeType.UNICODE,
+            alphabet=request.alphabet or cls.ALPHABET,
+            add_diacritics=(request.lang_code or "").lower().startswith(("ar", "he")),
+            pinned=frozenset({"engine"}),
+        )
+
+
+class PhoonnxLoader(ConfigLoader):
+    """phoonnx's own native format."""
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        return "phoonnx_version" in request.config
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        config = request.config
+        inference = config.get("inference", {})
+        # before any config write: an unknown alphabet raises, and the caller's
+        # dict must come back untouched when it does
+        alphabet = request.alphabet or Alphabet(config.get("alphabet", "ipa"))
+
+        # Preserve the model's own special tokens when present (a native
+        # config may use any pad/blank/bos/eos); fall back to phoonnx defaults.
+        config["pad"] = config.get("pad") or DEFAULT_PAD_TOKEN
+        config["blank"] = config.get("blank") or DEFAULT_BLANK_TOKEN
+        config["bos"] = config.get("bos") or DEFAULT_BOS_TOKEN
+        config["eos"] = config.get("eos") or DEFAULT_EOS_TOKEN
+
+        return LoadedFields(
+            tokenizer=TTSTokenizer.from_phoonnx_config(config),
+            engine=config.get("engine"),
+            lang_code=request.lang_code or config.get("lang_code"),
+            phoneme_type=request.phoneme_type or config.get("phoneme_type", PhonemeType.ESPEAK),
+            alphabet=alphabet,
+            add_diacritics=inference.get("add_diacritics", True),
+            diacritizer_model=inference.get("diacritizer_model", None),
+        )
+
+
+class PiperLoader(ConfigLoader):
+    """piper checkpoints.
+
+    ``text`` and ``pygoruut`` models pin both the phoneme type and the
+    alphabet: their vocabulary is the model's own character or goruut token
+    set, so a caller-supplied alphabet would mis-tokenise.
+    """
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        config = request.config
+        if "piper_version" in config:
+            return True
+        # an explicitly declared non-piper engine wins over shape-sniffing: a
+        # canonical config (e.g. engine="coqui" with an espeak phoneme_id_map)
+        # must not be mistaken for piper just because it phonemizes with espeak.
+        engine = config.get("engine")
+        if engine and engine not in ("piper", Engine.PIPER, Engine.PIPER.value):
+            return False
+        # piper models indicate a phonemizer strategy in their config
+        if ("phoneme_type" not in config or
+                not isinstance(config["phoneme_type"], str)):
+            return False
+
+        # piper models include a "phoneme_id_map" section mapping phonemes to int
+        pid = config.get("phoneme_id_map")
+        if not isinstance(pid, dict) or not pid:
+            return False
+
+        # piper's phoneme_id_map values are *lists* ([id, ...]); a flat
+        # phoneme -> int map is the canonical phoonnx/coqui shape, not piper.
+        if not all(isinstance(v, (list, tuple)) for v in pid.values()):
+            return False
+
+        return config["phoneme_type"] in ("text", "espeak")
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        config = request.config
+
+        lang_code = request.lang_code or (config.get("language", {}).get("code") or
+                                          config.get("espeak", {}).get("voice"))
+        phoneme_type = request.phoneme_type or config.get("phoneme_type", PhonemeType.ESPEAK)
+        alphabet = request.alphabet
+        pinned = set()
+        if phoneme_type == "text":
+            phoneme_type, alphabet = PhonemeType.UNICODE, Alphabet.UNICODE
+            pinned = {"phoneme_type", "alphabet"}
+        elif phoneme_type == "pygoruut":
+            # special case: neurlang models
+            phoneme_type, alphabet = PhonemeType.GORUUT, Alphabet.IPA
+            pinned = {"phoneme_type", "alphabet"}
+        else:
+            alphabet = alphabet or Alphabet.IPA
+
+        # not configurable in piper
+        config["pad"] = DEFAULT_PAD_TOKEN
+        config["blank"] = DEFAULT_BLANK_TOKEN
+        config["blank_word"] = DEFAULT_BLANK_WORD_TOKEN
+        config["bos"] = DEFAULT_BOS_TOKEN
+        config["eos"] = DEFAULT_EOS_TOKEN
+
+        return LoadedFields(
+            tokenizer=TTSTokenizer.from_piper_config(config),
+            engine=Engine.PIPER,
+            lang_code=lang_code,
+            phoneme_type=phoneme_type,
+            alphabet=alphabet,
+            add_diacritics=(lang_code or "").startswith("ar"),
+            pinned=frozenset(pinned),
+        )
+
+
+class Mimic3Loader(ConfigLoader):
+    """mimic3 voices (https://huggingface.co/mukowaty/mimic3-voices).
+
+    The language always comes from the config's ``text_language`` — mimic3
+    gruut vocabularies are language-specific, so it is pinned.  ``symbols``
+    models are grapheme models whose symbol map lives in the tokens file, so
+    they pin the phoneme type and alphabet too.
+    """
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        config = request.config
+        # mimic3 models indicate a phonemizer strategy in their config
+        if ("phonemizer" not in config or
+                not isinstance(config["phonemizer"], str)):
+            return False
+
+        # mimic3 models include a "phonemes" section with token info
+        if "phonemes" not in config or not isinstance(config["phonemes"], dict):
+            return False
+
+        return config["phonemizer"] in ("symbols", "gruut", "espeak", "epitran")
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        config = request.config
+        if not request.tokens_txt:
+            raise ValueError("mimic3 models require an external phonemes.txt file in addition to the config")
+
+        phoneme_type = request.phoneme_type or config.get("phonemizer", PhonemeType.GRUUT)
+        phoneme_cfg = config.get("phonemes", {})
+        blank_between = BlankBetween(phoneme_cfg.get("blank_between", "tokens_and_words"))
+        config.update(phoneme_cfg)
+
+        pinned = {"lang_code"}
+        if phoneme_type == "symbols":
+            phoneme_type, alphabet = PhonemeType.GRAPHEMES, Alphabet.UNICODE
+            pinned |= {"phoneme_type", "alphabet"}
+        else:
+            alphabet = request.alphabet or Alphabet.IPA
+
+        return LoadedFields(
+            tokenizer=TTSTokenizer.from_mimic3_config(config, request.tokens_txt),
+            engine=Engine.MIMIC3,
+            lang_code=config.get("text_language"),
+            phoneme_type=phoneme_type,
+            alphabet=alphabet,
+            blank_between=blank_between,
+            pinned=frozenset(pinned),
+        )
+
+
+class CoquiLoader(ConfigLoader):
+    """Coqui VITS grapheme models."""
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        characters = request.config.get("characters")
+        if not isinstance(characters, dict):
+            return False
+        # double check this was trained with coqui
+        return characters.get("characters_class", "") in ("TTS.tts.models.vits.VitsCharacters",
+                                                          "TTS.tts.utils.text.characters.Graphemes")
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        config = request.config
+        # NOTE: lang code usually not provided and often wrong :(
+        ds = config.get("datasets", [])
+        lang_code = request.lang_code
+        if ds and not lang_code:
+            lang_code = ds[0].get("language")
+
+        return LoadedFields(
+            tokenizer=TTSTokenizer.from_coqui_config(config),
+            engine=Engine.COQUI,
+            lang_code=lang_code,
+            phoneme_type=request.phoneme_type or PhonemeType.GRAPHEMES,
+            alphabet=request.alphabet or Alphabet.UNICODE,
+        )
+
+
+class TransformersLoader(ConfigLoader):
+    """Models exported from transformers, identified by a companion ``vocab``.
+
+    A ``tokenizer_config`` names the language the vocabulary was built for,
+    which pins ``lang_code``.
+    """
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        return bool(request.vocab)
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        config, tok_cfg = request.config, request.tokenizer_config
+        add_blank = True
+        lang_code = request.lang_code
+        pinned = set()
+        if tok_cfg:
+            add_blank = tok_cfg.get("add_blank", add_blank)
+            if tok_cfg.get("language"):
+                lang_code = tok_cfg["language"]
+                pinned = {"lang_code"}
+            config["blank"] = tok_cfg.get("pad_token", config.get("blank", DEFAULT_BLANK_TOKEN))
+
+        tokenizer = TTSTokenizer(
+            Vocabulary(char2idx=request.vocab, blank=config.get("blank", DEFAULT_BLANK_TOKEN)),
+            add_blank_char=add_blank,
+            add_blank_word=False,
+            use_eos_bos=False,
+            blank_at_end=add_blank,
+            blank_at_start=add_blank,
+        )
+        return LoadedFields(
+            tokenizer=tokenizer,
+            lang_code=lang_code,
+            phoneme_type=request.phoneme_type,
+            alphabet=request.alphabet,
+            pinned=frozenset(pinned),
+        )
+
+
+class TokensTxtLoader(ConfigLoader):
+    """sherpa-onnx style models that ship only a tokens file."""
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        return bool(request.tokens_txt)
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        path = request.tokens_txt
+        with open(path, "r", encoding="utf-8") as ids_file:
+            if path.endswith(".txt"):
+                # mimic3 / MMS / sherpa
+                vocabulary = Vocabulary.from_tokens_txt(ids_file.read())
+            elif path.endswith(".json"):
+                vocabulary = Vocabulary(char2idx=json.load(ids_file), pad=request.config["pad"])
+            else:
+                raise ValueError(f"unsupported tokens file (expected .txt or .json): {path}")
+
+        tokenizer = TTSTokenizer(
+            vocabulary,
+            add_blank_char=True,
+            add_blank_word=False,
+            use_eos_bos=True,
+            blank_at_end=True,
+            blank_at_start=True,
+        )
+        return LoadedFields(
+            tokenizer=tokenizer,
+            lang_code=request.lang_code,
+            phoneme_type=request.phoneme_type,
+            alphabet=request.alphabet,
+        )
+
+
+class CanonicalLoader(ConfigLoader):
+    """The fallback: a config that ships its own ``phoneme_id_map``.
+
+    Config-shape engine detection is deprecated, so a config that declares its
+    engine, phoneme type and alphabet is honoured as-is rather than guessed at
+    or rejected.  Unlike the native phoonnx format it does not assume espeak
+    phonemes or diacritization.
+    """
+
+    @classmethod
+    def detect(cls, request: LoadRequest) -> bool:
+        return True
+
+    @classmethod
+    def load(cls, request: LoadRequest) -> LoadedFields:
+        config = request.config
+        inference = config.get("inference", {})
+        # before any config write: an unknown alphabet raises, and the caller's
+        # dict must come back untouched when it does
+        alphabet = request.alphabet or Alphabet(config.get("alphabet", "ipa"))
+
+        config["pad"] = config.get("pad") or DEFAULT_PAD_TOKEN
+        config["blank"] = config.get("blank") or DEFAULT_BLANK_TOKEN
+        config["bos"] = config.get("bos") or DEFAULT_BOS_TOKEN
+        config["eos"] = config.get("eos") or DEFAULT_EOS_TOKEN
+
+        return LoadedFields(
+            tokenizer=TTSTokenizer.from_phoonnx_config(config),
+            engine=config.get("engine"),
+            lang_code=request.lang_code,
+            phoneme_type=request.phoneme_type or config.get("phoneme_type", PhonemeType.GRAPHEMES),
+            alphabet=alphabet,
+            add_diacritics=inference.get("add_diacritics", False),
+            diacritizer_model=inference.get("diacritizer_model", None),
+        )
+
+
+def _raw_text_loader(engine: Engine, sample_rate: int) -> Type[RawTextLoader]:
+    """A :class:`RawTextLoader` for an engine that differs only in sample rate."""
+    return type(f"{engine.name.title()}Loader", (RawTextLoader,),
+                {"ENGINE": engine, "SAMPLE_RATE": sample_rate,
+                 "__doc__": RawTextLoader.__doc__})
+
+
+LOADERS: List[Type[ConfigLoader]] = [
+    ChatterboxLoader,
+    _raw_text_loader(Engine.LLASA, 16000),
+    _raw_text_loader(Engine.NEUTTS, 24000),
+    _raw_text_loader(Engine.ORPHEUS, 24000),
+    _raw_text_loader(Engine.MOSSTTS, 48000),
+    _raw_text_loader(Engine.SUPERTONIC, 44100),
+    _raw_text_loader(Engine.POCKETTTS, 24000),
+    _raw_text_loader(Engine.SPARKTTS, 16000),
+    _raw_text_loader(Engine.INDIC_PARLER, 44100),
+    _raw_text_loader(Engine.OMNIVOICE, 24000),
+    _raw_text_loader(Engine.MAGPIE, 22050),
+    _raw_text_loader(Engine.ARKTTS, 44100),
+    _raw_text_loader(Engine.QWEN3TTS, 24000),
+    _raw_text_loader(Engine.OUTETTS, 24000),
+    PhoonnxLoader,
+    PiperLoader,
+    Mimic3Loader,
+    CoquiLoader,
+    TransformersLoader,
+    TokensTxtLoader,
+    CanonicalLoader,
+]
+
+
+def load_voice_fields(request: LoadRequest) -> LoadedFields:
+    """Detect *request*'s format, load it, and apply the caller's overrides."""
+    for loader in LOADERS:
+        if loader.detect(request):
+            return resolve_overrides(loader.load(request), request)
+    raise RuntimeError("no config loader matched")  # pragma: no cover

--- a/tests/differential/corpus.py
+++ b/tests/differential/corpus.py
@@ -1,0 +1,123 @@
+"""
+A corpus of voice configs covering every loader in :mod:`phoonnx.config_loaders`.
+
+Each case is a config dict plus the companion arguments that identify its
+format, and every case is run against :data:`KWARG_SETS` — so the corpus
+exercises the detection registry and the override contract together.  Cases
+that *raise* are part of the corpus: which error a malformed config produces is
+behaviour too.
+
+The corpus is data, not assertions.  :mod:`tests.differential.runner` turns it
+into a snapshot; ``tests/test_config_differential.py`` compares that snapshot
+against the committed golden file, and the same runner compares two git refs
+when a refactor needs to prove it changed nothing.
+"""
+import json
+import os
+from typing import Any, Dict, List, Tuple
+
+
+def _write_tokens(tmpdir: str) -> Tuple[str, str]:
+    """Write the two shapes of external token file, returning their paths."""
+    txt = os.path.join(tmpdir, "phonemes.txt")
+    with open(txt, "w", encoding="utf-8") as f:
+        f.write("\n".join(f"{i} {c}" for i, c in enumerate("abcdefgh_ ")))
+    js = os.path.join(tmpdir, "tokens.json")
+    with open(js, "w", encoding="utf-8") as f:
+        json.dump({c: i for i, c in enumerate("abcdef_")}, f)
+    return txt, js
+
+
+def _piper(phoneme_type: str) -> Dict[str, Any]:
+    return {"piper_version": "1.0", "phoneme_type": phoneme_type,
+            "phoneme_id_map": {"a": [1], "b": [2], "_": [0]},
+            "language": {"code": "pt"}, "audio": {"sample_rate": 22050},
+            "num_symbols": 3}
+
+
+def _mimic3(phonemizer: str) -> Dict[str, Any]:
+    return {"phonemizer": phonemizer,
+            "phonemes": {"blank_between": "tokens", "phoneme_separator": " "},
+            "text_language": "de", "audio": {"sample_rate": 22050}}
+
+
+COQUI = {"characters": {"characters_class": "TTS.tts.models.vits.VitsCharacters",
+                        "characters": "abcdef", "punctuations": "!?.", "pad": "_",
+                        "eos": "&", "bos": "*", "blank": "<BLNK>"},
+         "datasets": [{"language": "gl"}], "audio": {"sample_rate": 22050}}
+NATIVE = {"phoonnx_version": "1.0", "engine": "vits", "phoneme_type": "espeak",
+          "alphabet": "ipa", "lang_code": "pt", "audio": {"sample_rate": 22050},
+          "phoneme_id_map": {"a": 1, "b": 2, "_": 0},
+          "inference": {"add_diacritics": True, "diacritizer_model": "rawi"}}
+# a config whose keys are present but explicitly null: every fallback must be
+# `get(k) or default`, never `get(k, default)`
+NATIVE_NULLS = {"phoonnx_version": "1.0", "engine": None, "phoneme_type": None,
+                "alphabet": None, "lang_code": None, "pad": None, "blank": None,
+                "phoneme_id_map": {"a": 1, "_": 0}, "inference": {"add_diacritics": None}}
+# a native config whose phoneme_id_map has piper's list-valued shape: only the
+# registry order keeps the piper loader from claiming it
+NATIVE_PIPER_SHAPED = {"phoonnx_version": "1.0", "phoneme_type": "espeak",
+                       "phoneme_id_map": {"a": [1], "b": [2], "_": [0]},
+                       "lang_code": "pt", "audio": {"sample_rate": 22050}}
+NATIVE_BAD_ALPHABET = {"phoonnx_version": "1.0", "alphabet": "not-an-alphabet",
+                       "phoneme_id_map": {"a": 1, "_": 0}}
+CANONICAL = {"engine": "matcha", "phoneme_type": "gruut", "alphabet": "ipa",
+             "phoneme_id_map": {"a": 1, "_": 0}, "audio": {"sample_rate": 22050},
+             "inference": {"add_diacritics": True}}
+CANONICAL_BARE = {"phoneme_id_map": {"a": 1, "_": 0}}
+CANONICAL_BAD_ALPHABET = {"engine": "matcha", "alphabet": "not-an-alphabet",
+                          "phoneme_id_map": {"a": 1, "_": 0}}
+
+# (engine name, its codec's sample rate); the loaders differ in nothing else
+CODEC_ENGINES = [("llasa", 16000), ("neutts", 24000), ("orpheus", 24000),
+                 ("mosstts", 48000), ("supertonic", 44100), ("pockettts", 24000),
+                 ("sparktts", 16000), ("indic_parler", 44100), ("omnivoice", 24000),
+                 ("magpie", 22050), ("arktts", 44100), ("qwen3tts", 24000),
+                 ("outetts", 24000)]
+
+KWARG_SETS: List[Dict[str, Any]] = [
+    {},
+    {"lang_code": "xx"},
+    {"phoneme_type": "gruut"},
+    {"alphabet": "arpa"},
+    {"engine": "coqui"},
+    {"lang_code": "xx", "phoneme_type": "espeak", "alphabet": "ipa", "engine": "matcha"},
+    {"lang_tokens": {"pt": "<pt>"}, "engine_params": {"x": 1}},
+]
+
+
+def build(tmpdir: str) -> List[Tuple[str, Dict[str, Any], Dict[str, Any]]]:
+    """Return ``(name, config, companion kwargs)`` triples, writing token files to *tmpdir*."""
+    tokens_txt, tokens_json = _write_tokens(tmpdir)
+    cases: List[Tuple[str, Dict[str, Any], Dict[str, Any]]] = []
+    for phoneme_type in ("espeak", "text", "pygoruut", "bogus"):
+        cases.append((f"piper:{phoneme_type}", _piper(phoneme_type), {}))
+    for phonemizer in ("gruut", "espeak", "epitran", "symbols"):
+        cases.append((f"mimic3:{phonemizer}", _mimic3(phonemizer), {"tokens_txt": tokens_txt}))
+        cases.append((f"mimic3-notokens:{phonemizer}", _mimic3(phonemizer), {}))
+    cases += [
+        ("coqui", COQUI, {}),
+        ("native", NATIVE, {}),
+        ("native-nulls", NATIVE_NULLS, {}),
+        ("native-piper-shaped", NATIVE_PIPER_SHAPED, {}),
+        ("native-bad-alphabet", NATIVE_BAD_ALPHABET, {}),
+        ("canonical", CANONICAL, {}),
+        ("canonical-bare", CANONICAL_BARE, {}),
+        ("canonical-bad-alphabet", CANONICAL_BAD_ALPHABET, {}),
+        ("transformers", {"num_symbols": 5}, {"vocab": {"a": 1, "b": 2, "_": 0}}),
+        ("transformers-tokcfg", {"num_symbols": 5},
+         {"vocab": {"a": 1, "_": 0},
+          "tokenizer_config": {"add_blank": False, "language": "ro", "pad_token": "<pad>"}}),
+        ("transformers-tokcfg-nolang", {"num_symbols": 5},
+         {"vocab": {"a": 1, "_": 0}, "tokenizer_config": {"add_blank": True}}),
+        ("sherpa-txt", {}, {"tokens_txt": tokens_txt}),
+        ("sherpa-json", {"pad": "_"}, {"tokens_txt": tokens_json}),
+    ]
+    for engine, _ in CODEC_ENGINES:
+        cases.append((f"codec-cfg:{engine}", {"engine": engine}, {}))
+        cases.append((f"codec-kwarg:{engine}", {}, {"engine": engine}))
+    cases.append(("chatterbox-nobpe", {"engine": "chatterbox"}, {}))
+    # an engine kwarg disagreeing with a config that names a codec engine: the
+    # config wins, because the codec loader was selected by that name
+    cases.append(("codec-conflict", {"engine": "llasa"}, {"engine": "piper"}))
+    return cases

--- a/tests/differential/golden.json
+++ b/tests/differential/golden.json
@@ -1,0 +1,17690 @@
+{
+ "canonical-bad-alphabet|0": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "canonical-bad-alphabet|1": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "canonical-bad-alphabet|2": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "canonical-bad-alphabet|3": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bad-alphabet|4": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "canonical-bad-alphabet|5": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bad-alphabet|6": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "canonical-bare|0": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bare|1": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bare|2": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bare|3": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bare|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bare|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical-bare|6": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical|0": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": "gruut"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical|1": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": "gruut"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical|2": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": "gruut"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical|3": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": "gruut"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical|4": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": "gruut"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical|5": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": "gruut"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "canonical|6": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "matcha",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true
+   },
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": "gruut"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "chatterbox-nobpe|0": {
+  "config_after": {
+   "engine": "chatterbox"
+  },
+  "raised": "ValueError: Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)"
+ },
+ "chatterbox-nobpe|1": {
+  "config_after": {
+   "engine": "chatterbox"
+  },
+  "raised": "ValueError: Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)"
+ },
+ "chatterbox-nobpe|2": {
+  "config_after": {
+   "engine": "chatterbox"
+  },
+  "raised": "ValueError: Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)"
+ },
+ "chatterbox-nobpe|3": {
+  "config_after": {
+   "engine": "chatterbox"
+  },
+  "raised": "ValueError: Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)"
+ },
+ "chatterbox-nobpe|4": {
+  "config_after": {
+   "engine": "chatterbox"
+  },
+  "raised": "ValueError: Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)"
+ },
+ "chatterbox-nobpe|5": {
+  "config_after": {
+   "engine": "chatterbox"
+  },
+  "raised": "ValueError: Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)"
+ },
+ "chatterbox-nobpe|6": {
+  "config_after": {
+   "engine": "chatterbox"
+  },
+  "raised": "ValueError: Chatterbox voices require a tokenizer.json (bpe_tokenizer_json)"
+ },
+ "codec-cfg:arktts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "arktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:arktts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "arktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:arktts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "arktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:arktts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "arktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:arktts|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "arktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:arktts|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "arktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:arktts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "arktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:indic_parler|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "indic_parler"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:indic_parler|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "indic_parler"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:indic_parler|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "indic_parler"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:indic_parler|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "indic_parler"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:indic_parler|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "indic_parler"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:indic_parler|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "indic_parler"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:indic_parler|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "indic_parler"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:llasa|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:llasa|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:llasa|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:llasa|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:llasa|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:llasa|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:llasa|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:magpie|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "engine": "magpie"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:magpie|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "engine": "magpie"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:magpie|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "engine": "magpie"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:magpie|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "engine": "magpie"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:magpie|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "engine": "magpie"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:magpie|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "engine": "magpie"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:magpie|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "engine": "magpie"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:mosstts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   },
+   "engine": "mosstts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:mosstts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   },
+   "engine": "mosstts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:mosstts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   },
+   "engine": "mosstts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:mosstts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   },
+   "engine": "mosstts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:mosstts|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   },
+   "engine": "mosstts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:mosstts|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   },
+   "engine": "mosstts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:mosstts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   },
+   "engine": "mosstts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:neutts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "neutts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:neutts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "neutts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:neutts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "neutts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:neutts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "neutts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:neutts|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "neutts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:neutts|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "neutts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:neutts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "neutts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:omnivoice|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "omnivoice"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:omnivoice|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "omnivoice"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:omnivoice|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "omnivoice"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:omnivoice|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "omnivoice"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:omnivoice|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "omnivoice"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:omnivoice|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "omnivoice"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:omnivoice|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "omnivoice"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:orpheus|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "orpheus"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:orpheus|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "orpheus"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:orpheus|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "orpheus"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:orpheus|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "orpheus"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:orpheus|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "orpheus"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:orpheus|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "orpheus"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:orpheus|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "orpheus"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:outetts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "outetts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:outetts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "outetts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:outetts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "outetts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:outetts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "outetts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:outetts|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "outetts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:outetts|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "outetts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:outetts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "outetts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:pockettts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "pockettts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:pockettts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "pockettts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:pockettts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "pockettts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:pockettts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "pockettts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:pockettts|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "pockettts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:pockettts|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "pockettts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:pockettts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "pockettts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:qwen3tts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "qwen3tts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:qwen3tts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "qwen3tts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:qwen3tts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "qwen3tts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:qwen3tts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "qwen3tts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:qwen3tts|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "qwen3tts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:qwen3tts|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "qwen3tts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:qwen3tts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   },
+   "engine": "qwen3tts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:sparktts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "sparktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:sparktts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "sparktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:sparktts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "sparktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:sparktts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "sparktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:sparktts|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "sparktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:sparktts|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "sparktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:sparktts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "sparktts"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:supertonic|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "supertonic"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:supertonic|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "supertonic"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:supertonic|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "supertonic"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:supertonic|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "supertonic"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:supertonic|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "supertonic"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:supertonic|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "supertonic"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-cfg:supertonic|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   },
+   "engine": "supertonic"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-conflict|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-conflict|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-conflict|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-conflict|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-conflict|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-conflict|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-conflict|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   },
+   "engine": "llasa"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:arktts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:arktts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:arktts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:arktts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:arktts|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:arktts|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:arktts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "arktts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:indic_parler|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:indic_parler|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:indic_parler|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:indic_parler|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:indic_parler|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:indic_parler|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:indic_parler|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "indic_parler",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:llasa|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:llasa|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:llasa|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:llasa|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:llasa|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:llasa|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:llasa|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "llasa",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:magpie|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:magpie|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:magpie|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:magpie|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:magpie|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:magpie|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:magpie|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "magpie",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:mosstts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:mosstts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:mosstts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:mosstts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:mosstts|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:mosstts|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:mosstts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 48000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mosstts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 48000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:neutts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:neutts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:neutts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:neutts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:neutts|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:neutts|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:neutts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "neutts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:omnivoice|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:omnivoice|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:omnivoice|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:omnivoice|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:omnivoice|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:omnivoice|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:omnivoice|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "omnivoice",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:orpheus|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:orpheus|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:orpheus|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:orpheus|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:orpheus|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:orpheus|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:orpheus|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "orpheus",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:outetts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:outetts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:outetts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:outetts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:outetts|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:outetts|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:outetts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "outetts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:pockettts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:pockettts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:pockettts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:pockettts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:pockettts|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:pockettts|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:pockettts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "pockettts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:qwen3tts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:qwen3tts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:qwen3tts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:qwen3tts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:qwen3tts|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:qwen3tts|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:qwen3tts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 24000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "qwen3tts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 24000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:sparktts|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:sparktts|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:sparktts|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:sparktts|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:sparktts|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:sparktts|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:sparktts|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 16000
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "sparktts",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:supertonic|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:supertonic|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:supertonic|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:supertonic|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:supertonic|4": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:supertonic|5": {
+  "config_after": {
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {},
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "codec-kwarg:supertonic|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 44100
+   }
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "graphemes",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "supertonic",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 44100,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "coqui|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "characters": {
+    "blank": "<BLNK>",
+    "bos": "*",
+    "characters": "abcdef",
+    "characters_class": "TTS.tts.models.vits.VitsCharacters",
+    "eos": "&",
+    "pad": "_",
+    "punctuations": "!?."
+   },
+   "datasets": [
+    {
+     "language": "gl"
+    }
+   ]
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "gl-ES",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<BLNK>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": "*",
+    "char2idx": {
+     "!": 1,
+     ".": 3,
+     "<BLNK>": 10,
+     "?": 2,
+     "_": 0,
+     "a": 4,
+     "b": 5,
+     "c": 6,
+     "d": 7,
+     "e": 8,
+     "f": 9
+    },
+    "eos": "&",
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "coqui|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "characters": {
+    "blank": "<BLNK>",
+    "bos": "*",
+    "characters": "abcdef",
+    "characters_class": "TTS.tts.models.vits.VitsCharacters",
+    "eos": "&",
+    "pad": "_",
+    "punctuations": "!?."
+   },
+   "datasets": [
+    {
+     "language": "gl"
+    }
+   ]
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<BLNK>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": "*",
+    "char2idx": {
+     "!": 1,
+     ".": 3,
+     "<BLNK>": 10,
+     "?": 2,
+     "_": 0,
+     "a": 4,
+     "b": 5,
+     "c": 6,
+     "d": 7,
+     "e": 8,
+     "f": 9
+    },
+    "eos": "&",
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "coqui|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "characters": {
+    "blank": "<BLNK>",
+    "bos": "*",
+    "characters": "abcdef",
+    "characters_class": "TTS.tts.models.vits.VitsCharacters",
+    "eos": "&",
+    "pad": "_",
+    "punctuations": "!?."
+   },
+   "datasets": [
+    {
+     "language": "gl"
+    }
+   ]
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "gl-ES",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<BLNK>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": "*",
+    "char2idx": {
+     "!": 1,
+     ".": 3,
+     "<BLNK>": 10,
+     "?": 2,
+     "_": 0,
+     "a": 4,
+     "b": 5,
+     "c": 6,
+     "d": 7,
+     "e": 8,
+     "f": 9
+    },
+    "eos": "&",
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "coqui|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "characters": {
+    "blank": "<BLNK>",
+    "bos": "*",
+    "characters": "abcdef",
+    "characters_class": "TTS.tts.models.vits.VitsCharacters",
+    "eos": "&",
+    "pad": "_",
+    "punctuations": "!?."
+   },
+   "datasets": [
+    {
+     "language": "gl"
+    }
+   ]
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "gl-ES",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<BLNK>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": "*",
+    "char2idx": {
+     "!": 1,
+     ".": 3,
+     "<BLNK>": 10,
+     "?": 2,
+     "_": 0,
+     "a": 4,
+     "b": 5,
+     "c": 6,
+     "d": 7,
+     "e": 8,
+     "f": 9
+    },
+    "eos": "&",
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "coqui|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "characters": {
+    "blank": "<BLNK>",
+    "bos": "*",
+    "characters": "abcdef",
+    "characters_class": "TTS.tts.models.vits.VitsCharacters",
+    "eos": "&",
+    "pad": "_",
+    "punctuations": "!?."
+   },
+   "datasets": [
+    {
+     "language": "gl"
+    }
+   ]
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "gl-ES",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<BLNK>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": "*",
+    "char2idx": {
+     "!": 1,
+     ".": 3,
+     "<BLNK>": 10,
+     "?": 2,
+     "_": 0,
+     "a": 4,
+     "b": 5,
+     "c": 6,
+     "d": 7,
+     "e": 8,
+     "f": 9
+    },
+    "eos": "&",
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "coqui|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "characters": {
+    "blank": "<BLNK>",
+    "bos": "*",
+    "characters": "abcdef",
+    "characters_class": "TTS.tts.models.vits.VitsCharacters",
+    "eos": "&",
+    "pad": "_",
+    "punctuations": "!?."
+   },
+   "datasets": [
+    {
+     "language": "gl"
+    }
+   ]
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<BLNK>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": "*",
+    "char2idx": {
+     "!": 1,
+     ".": 3,
+     "<BLNK>": 10,
+     "?": 2,
+     "_": 0,
+     "a": 4,
+     "b": 5,
+     "c": 6,
+     "d": 7,
+     "e": 8,
+     "f": 9
+    },
+    "eos": "&",
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "coqui|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "characters": {
+    "blank": "<BLNK>",
+    "bos": "*",
+    "characters": "abcdef",
+    "characters_class": "TTS.tts.models.vits.VitsCharacters",
+    "eos": "&",
+    "pad": "_",
+    "punctuations": "!?."
+   },
+   "datasets": [
+    {
+     "language": "gl"
+    }
+   ]
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "gl-ES",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<BLNK>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": "*",
+    "char2idx": {
+     "!": 1,
+     ".": 3,
+     "<BLNK>": 10,
+     "?": 2,
+     "_": 0,
+     "a": 4,
+     "b": 5,
+     "c": 6,
+     "d": 7,
+     "e": 8,
+     "f": 9
+    },
+    "eos": "&",
+    "pad": "_",
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3-notokens:epitran|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:epitran|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:epitran|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:epitran|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:epitran|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:epitran|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:epitran|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:espeak|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:espeak|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:espeak|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:espeak|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:espeak|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:espeak|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:espeak|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:gruut|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:gruut|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:gruut|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:gruut|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:gruut|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:gruut|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:gruut|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:symbols|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:symbols|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:symbols|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:symbols|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:symbols|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:symbols|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3-notokens:symbols|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "raised": "ValueError: mimic3 models require an external phonemes.txt file in addition to the config"
+ },
+ "mimic3:epitran|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "epitran",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:epitran|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "epitran",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:epitran|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:epitran|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "epitran",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:epitran|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "epitran",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:epitran|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:epitran|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "epitran",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "epitran",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:espeak|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:espeak|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:espeak|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:espeak|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:espeak|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:espeak|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:espeak|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "espeak",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:gruut|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:gruut|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:gruut|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:gruut|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:gruut|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:gruut|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:gruut|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "gruut",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:symbols|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:symbols|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:symbols|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:symbols|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:symbols|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:symbols|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "mimic3:symbols|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank_between": "tokens",
+   "phoneme_separator": " ",
+   "phonemes": {
+    "blank_between": "tokens",
+    "phoneme_separator": " "
+   },
+   "phonemizer": "symbols",
+   "text_language": "de"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "mimic3",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "de",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": " ",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-bad-alphabet|0": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "native-bad-alphabet|1": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "native-bad-alphabet|2": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "native-bad-alphabet|3": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-bad-alphabet|4": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "native-bad-alphabet|5": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-bad-alphabet|6": {
+  "config_after": {
+   "alphabet": "not-an-alphabet",
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'not-an-alphabet' is not a valid Alphabet"
+ },
+ "native-nulls|0": {
+  "config_after": {
+   "alphabet": null,
+   "blank": null,
+   "engine": null,
+   "inference": {
+    "add_diacritics": null
+   },
+   "lang_code": null,
+   "pad": null,
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": null,
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: None is not a valid Alphabet"
+ },
+ "native-nulls|1": {
+  "config_after": {
+   "alphabet": null,
+   "blank": null,
+   "engine": null,
+   "inference": {
+    "add_diacritics": null
+   },
+   "lang_code": null,
+   "pad": null,
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": null,
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: None is not a valid Alphabet"
+ },
+ "native-nulls|2": {
+  "config_after": {
+   "alphabet": null,
+   "blank": null,
+   "engine": null,
+   "inference": {
+    "add_diacritics": null
+   },
+   "lang_code": null,
+   "pad": null,
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": null,
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: None is not a valid Alphabet"
+ },
+ "native-nulls|3": {
+  "config_after": {
+   "alphabet": null,
+   "blank": "_",
+   "bos": "^",
+   "engine": null,
+   "eos": "$",
+   "inference": {
+    "add_diacritics": null
+   },
+   "lang_code": null,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": null,
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-nulls|4": {
+  "config_after": {
+   "alphabet": null,
+   "blank": null,
+   "engine": null,
+   "inference": {
+    "add_diacritics": null
+   },
+   "lang_code": null,
+   "pad": null,
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": null,
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: None is not a valid Alphabet"
+ },
+ "native-nulls|5": {
+  "config_after": {
+   "alphabet": null,
+   "blank": "_",
+   "bos": "^",
+   "engine": null,
+   "eos": "$",
+   "inference": {
+    "add_diacritics": null
+   },
+   "lang_code": null,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": null,
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-nulls|6": {
+  "config_after": {
+   "alphabet": null,
+   "blank": null,
+   "engine": null,
+   "inference": {
+    "add_diacritics": null
+   },
+   "lang_code": null,
+   "pad": null,
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1
+   },
+   "phoneme_type": null,
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: None is not a valid Alphabet"
+ },
+ "native-piper-shaped|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-piper-shaped|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-piper-shaped|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-piper-shaped|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-piper-shaped|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-piper-shaped|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native-piper-shaped|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "eos": "$",
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native|0": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vits",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true,
+    "diacritizer_model": "rawi"
+   },
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1,
+    "b": 2
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'vits' is not a valid Engine"
+ },
+ "native|1": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vits",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true,
+    "diacritizer_model": "rawi"
+   },
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1,
+    "b": 2
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'vits' is not a valid Engine"
+ },
+ "native|2": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vits",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true,
+    "diacritizer_model": "rawi"
+   },
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1,
+    "b": 2
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'vits' is not a valid Engine"
+ },
+ "native|3": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vits",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true,
+    "diacritizer_model": "rawi"
+   },
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1,
+    "b": 2
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'vits' is not a valid Engine"
+ },
+ "native|4": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vits",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true,
+    "diacritizer_model": "rawi"
+   },
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1,
+    "b": 2
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": "rawi",
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native|5": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vits",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true,
+    "diacritizer_model": "rawi"
+   },
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1,
+    "b": 2
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": true,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": "rawi",
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "native|6": {
+  "config_after": {
+   "alphabet": "ipa",
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "bos": "^",
+   "engine": "vits",
+   "eos": "$",
+   "inference": {
+    "add_diacritics": true,
+    "diacritizer_model": "rawi"
+   },
+   "lang_code": "pt",
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": 0,
+    "a": 1,
+    "b": 2
+   },
+   "phoneme_type": "espeak",
+   "phoonnx_version": "1.0"
+  },
+  "raised": "ValueError: 'vits' is not a valid Engine"
+ },
+ "piper:bogus|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "bogus",
+   "piper_version": "1.0"
+  },
+  "raised": "ValueError: 'bogus' is not a valid Phonemizer"
+ },
+ "piper:bogus|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "bogus",
+   "piper_version": "1.0"
+  },
+  "raised": "ValueError: 'bogus' is not a valid Phonemizer"
+ },
+ "piper:bogus|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "bogus",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:bogus|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "bogus",
+   "piper_version": "1.0"
+  },
+  "raised": "ValueError: 'bogus' is not a valid Phonemizer"
+ },
+ "piper:bogus|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "bogus",
+   "piper_version": "1.0"
+  },
+  "raised": "ValueError: 'bogus' is not a valid Phonemizer"
+ },
+ "piper:bogus|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "bogus",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:bogus|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "bogus",
+   "piper_version": "1.0"
+  },
+  "raised": "ValueError: 'bogus' is not a valid Phonemizer"
+ },
+ "piper:espeak|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:espeak|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:espeak|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:espeak|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:espeak|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:espeak|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:espeak|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "espeak",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:pygoruut|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "pygoruut",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "goruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:pygoruut|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "pygoruut",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "goruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:pygoruut|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "pygoruut",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:pygoruut|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "pygoruut",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "goruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:pygoruut|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "pygoruut",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "goruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:pygoruut|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "pygoruut",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:pygoruut|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "pygoruut",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "goruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:text|0": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "text",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:text|1": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "text",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:text|2": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "text",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:text|3": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "text",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:text|4": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "text",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:text|5": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "text",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "piper:text|6": {
+  "config_after": {
+   "audio": {
+    "sample_rate": 22050
+   },
+   "blank": "_",
+   "blank_word": " ",
+   "bos": "^",
+   "eos": "$",
+   "language": {
+    "code": "pt"
+   },
+   "num_symbols": 3,
+   "pad": "_",
+   "phoneme_id_map": {
+    "_": [
+     0
+    ],
+    "a": [
+     1
+    ],
+    "b": [
+     2
+    ]
+   },
+   "phoneme_type": "text",
+   "piper_version": "1.0"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": "^",
+   "diacritizer_model": null,
+   "engine": "piper",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": "$",
+   "hop_length": 256,
+   "lang_code": "pt",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 3,
+   "pad_token": "_",
+   "phoneme_type": "unicode",
+   "phonemizer_model": null,
+   "sample_rate": 22050,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": "^",
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": "$",
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-json|0": {
+  "config_after": {
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 6,
+     "a": 0,
+     "b": 1,
+     "c": 2,
+     "d": 3,
+     "e": 4,
+     "f": 5
+    },
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-json|1": {
+  "config_after": {
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 6,
+     "a": 0,
+     "b": 1,
+     "c": 2,
+     "d": 3,
+     "e": 4,
+     "f": 5
+    },
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-json|2": {
+  "config_after": {
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 6,
+     "a": 0,
+     "b": 1,
+     "c": 2,
+     "d": 3,
+     "e": 4,
+     "f": 5
+    },
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-json|3": {
+  "config_after": {
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 6,
+     "a": 0,
+     "b": 1,
+     "c": 2,
+     "d": 3,
+     "e": 4,
+     "f": 5
+    },
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-json|4": {
+  "config_after": {
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 6,
+     "a": 0,
+     "b": 1,
+     "c": 2,
+     "d": 3,
+     "e": 4,
+     "f": 5
+    },
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-json|5": {
+  "config_after": {
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 6,
+     "a": 0,
+     "b": 1,
+     "c": 2,
+     "d": 3,
+     "e": 4,
+     "f": 5
+    },
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-json|6": {
+  "config_after": {
+   "pad": "_"
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": "_",
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 6,
+     "a": 0,
+     "b": 1,
+     "c": 2,
+     "d": 3,
+     "e": 4,
+     "f": 5
+    },
+    "eos": null,
+    "pad": "_",
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-txt|0": {
+  "config_after": {},
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-txt|1": {
+  "config_after": {},
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-txt|2": {
+  "config_after": {},
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-txt|3": {
+  "config_after": {},
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-txt|4": {
+  "config_after": {},
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-txt|5": {
+  "config_after": {},
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "sherpa-txt|6": {
+  "config_after": {},
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 256,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": null,
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {},
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": true
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg-nolang|0": {
+  "config_after": {
+   "blank": "_",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg-nolang|1": {
+  "config_after": {
+   "blank": "_",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg-nolang|2": {
+  "config_after": {
+   "blank": "_",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg-nolang|3": {
+  "config_after": {
+   "blank": "_",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg-nolang|4": {
+  "config_after": {
+   "blank": "_",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg-nolang|5": {
+  "config_after": {
+   "blank": "_",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg-nolang|6": {
+  "config_after": {
+   "blank": "_",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "_",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg|0": {
+  "config_after": {
+   "blank": "<pad>",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "<pad>",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "ro-RO",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<pad>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg|1": {
+  "config_after": {
+   "blank": "<pad>",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "<pad>",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "ro-RO",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<pad>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg|2": {
+  "config_after": {
+   "blank": "<pad>",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "<pad>",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "ro-RO",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<pad>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg|3": {
+  "config_after": {
+   "blank": "<pad>",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "<pad>",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "ro-RO",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<pad>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg|4": {
+  "config_after": {
+   "blank": "<pad>",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "<pad>",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "ro-RO",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<pad>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg|5": {
+  "config_after": {
+   "blank": "<pad>",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "<pad>",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "ro-RO",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<pad>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers-tokcfg|6": {
+  "config_after": {
+   "blank": "<pad>",
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": "<pad>",
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "ro-RO",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": false,
+    "add_blank_word": false,
+    "blank": "<pad>",
+    "blank_at_end": false,
+    "blank_at_start": false,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers|0": {
+  "config_after": {
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers|1": {
+  "config_after": {
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers|2": {
+  "config_after": {
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "gruut",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers|3": {
+  "config_after": {
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "arpa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers|4": {
+  "config_after": {
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "coqui",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers|5": {
+  "config_after": {
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "ipa",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "matcha",
+   "engine_params": {},
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "xx-US",
+   "lang_id_map": {},
+   "lang_tokens": {},
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "espeak",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ },
+ "transformers|6": {
+  "config_after": {
+   "num_symbols": 5
+  },
+  "voice_config": {
+   "add_diacritics": false,
+   "alphabet": "unicode",
+   "blank_at_end": true,
+   "blank_at_start": true,
+   "blank_between": "tokens_and_words",
+   "blank_token": null,
+   "bos_token": null,
+   "diacritizer_model": null,
+   "engine": "phoonnx",
+   "engine_params": {
+    "x": 1
+   },
+   "eos_token": null,
+   "hop_length": 256,
+   "lang_code": "und",
+   "lang_id_map": {},
+   "lang_tokens": {
+    "pt": "<pt>"
+   },
+   "length_scale": 1.0,
+   "noise_scale": 0.667,
+   "noise_w_scale": 0.8,
+   "num_langs": 1,
+   "num_speakers": 1,
+   "num_symbols": 5,
+   "pad_token": null,
+   "phoneme_type": "graphemes",
+   "phonemizer_model": null,
+   "sample_rate": 16000,
+   "speaker_id_map": {},
+   "tokenizer": {
+    "add_blank_char": true,
+    "add_blank_word": false,
+    "blank": "_",
+    "blank_at_end": true,
+    "blank_at_start": true,
+    "bos": null,
+    "char2idx": {
+     "_": 0,
+     "a": 1,
+     "b": 2
+    },
+    "eos": null,
+    "pad": null,
+    "use_eos_bos": false
+   },
+   "word_sep_token": " "
+  }
+ }
+}

--- a/tests/differential/runner.py
+++ b/tests/differential/runner.py
@@ -1,0 +1,113 @@
+"""
+Snapshot every corpus case through ``VoiceConfig.from_dict``.
+
+The snapshot records the whole resulting config — including the tokenizer's
+vocabulary and flags, and the caller's dict *after* the call, since loaders are
+allowed to normalise it in place — so a refactor that claims to preserve
+behaviour has something to prove it against.
+
+Run it as a script to write a snapshot::
+
+    python -m tests.differential.runner snapshot.json
+
+To compare two refs, snapshot each from its own worktree and diff the files::
+
+    git worktree add /tmp/before origin/dev
+    (cd /tmp/before && PYTHONPATH=$PWD python -m tests.differential.runner /tmp/before.json)
+    python -m tests.differential.runner /tmp/after.json
+    python -m tests.differential.runner --diff /tmp/before.json /tmp/after.json
+
+``--corpus-dir`` snapshots a directory of real ``config.json`` files instead of
+the synthetic corpus, which is how a catalog-wide sweep is run.
+"""
+import copy
+import dataclasses
+import glob
+import json
+import os
+import sys
+import tempfile
+from typing import Any, Dict, Optional
+
+from tests.differential import corpus
+
+
+def serialize(voice_config) -> Dict[str, Any]:
+    """Every field of a VoiceConfig, enums as values, tokenizer fully expanded."""
+    out = {}
+    for f in dataclasses.fields(voice_config):
+        value = getattr(voice_config, f.name)
+        if f.name != "tokenizer":
+            out[f.name] = getattr(value, "value", value)
+        elif value is None:
+            out[f.name] = None
+        else:
+            vocabulary = value.vocabulary
+            out[f.name] = {
+                "char2idx": dict(vocabulary.char2idx), "pad": vocabulary.pad,
+                "blank": vocabulary.blank, "bos": vocabulary.bos, "eos": vocabulary.eos,
+                "add_blank_char": value.add_blank_char,
+                "add_blank_word": value.add_blank_word,
+                "use_eos_bos": value.use_eos_bos,
+                "blank_at_start": value.blank_at_start,
+                "blank_at_end": value.blank_at_end,
+            }
+    return out
+
+
+def _run_one(config: Dict[str, Any], kwargs: Dict[str, Any]) -> Any:
+    from phoonnx.config import VoiceConfig
+    config = copy.deepcopy(config)
+    try:
+        voice_config = VoiceConfig.from_dict(config, **kwargs)
+    except Exception as e:
+        return {"raised": f"{type(e).__name__}: {e}",
+                "config_after": json.loads(json.dumps(config, default=str))}
+    return {"voice_config": serialize(voice_config),
+            "config_after": json.loads(json.dumps(config, default=str))}
+
+
+def snapshot(corpus_dir: Optional[str] = None) -> Dict[str, Any]:
+    """Run the corpus (or a directory of real configs) and return the results."""
+    results = {}
+    if corpus_dir:
+        for path in sorted(glob.glob(os.path.join(corpus_dir, "*.json"))):
+            config = json.load(open(path, encoding="utf-8"))
+            for i, kwargs in enumerate(corpus.KWARG_SETS):
+                results[f"{os.path.basename(path)}|{i}"] = _run_one(config, kwargs)
+        return results
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for name, config, companions in corpus.build(tmpdir):
+            for i, kwargs in enumerate(corpus.KWARG_SETS):
+                results[f"{name}|{i}"] = _run_one(config, {**companions, **kwargs})
+    return results
+
+
+GOLDEN = os.path.join(os.path.dirname(__file__), "golden.json")
+
+
+def main(argv) -> int:
+    if argv[:1] == ["--diff"]:
+        before, after = (json.load(open(p, encoding="utf-8")) for p in argv[1:3])
+        keys = sorted(set(before) | set(after))
+        differing = [k for k in keys if before.get(k) != after.get(k)]
+        print(f"{len(keys)} cases, {len(differing)} differing")
+        for key in differing:
+            print(f"--- {key}\n  before: {before.get(key)}\n  after:  {after.get(key)}")
+        return 1 if differing else 0
+
+    corpus_dir = None
+    if argv[:1] == ["--corpus-dir"]:
+        corpus_dir, argv = argv[1], argv[2:]
+    results = snapshot(corpus_dir)
+    out = argv[0] if argv else GOLDEN
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=1, sort_keys=True, default=str)
+        f.write("\n")
+    print(f"wrote {out}: {len(results)} cases")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_config_differential.py
+++ b/tests/test_config_differential.py
@@ -1,0 +1,25 @@
+import json
+import unittest
+
+from tests.differential import runner
+
+
+class TestConfigDifferential(unittest.TestCase):
+    """Every loader's output, pinned against a committed snapshot.
+
+    Regenerate with ``python -m tests.differential.runner`` when a change is
+    *meant* to alter what a config loads into, and justify each moved case in
+    the pull request.
+    """
+
+    def test_the_corpus_matches_the_golden_snapshot(self):
+        golden = json.load(open(runner.GOLDEN, encoding="utf-8"))
+        current = json.loads(json.dumps(runner.snapshot(), sort_keys=True, default=str))
+        self.assertEqual(sorted(golden), sorted(current), "corpus cases were added or removed")
+        for key in sorted(golden):
+            with self.subTest(case=key):
+                self.assertEqual(golden[key], current[key])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -1,0 +1,189 @@
+import json
+import os
+import tempfile
+import unittest
+
+from phoonnx.config import Alphabet, Engine, PhonemeType, VoiceConfig
+from phoonnx.config_loaders import (LOADERS, CanonicalLoader, ChatterboxLoader, CoquiLoader,
+                                    LoadedFields, LoadRequest, Mimic3Loader, PhoonnxLoader,
+                                    PiperLoader, RawTextLoader, TokensTxtLoader,
+                                    TransformersLoader, resolve_overrides)
+from phoonnx.util import normalize_lang
+
+
+def _tokens_txt():
+    """Path to a throwaway mimic3/sherpa style phonemes.txt."""
+    path = os.path.join(tempfile.mkdtemp(), "phonemes.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(f"{i} {c}" for i, c in enumerate("abcdef_ ")))
+    return path
+
+
+def _index(loader_cls):
+    return LOADERS.index(loader_cls)
+
+
+class TestRegistryOrder(unittest.TestCase):
+    def test_raw_text_loaders_come_before_every_shape_sniffing_loader(self):
+        first_shape = min(_index(c) for c in (PhoonnxLoader, PiperLoader, Mimic3Loader,
+                                              CoquiLoader))
+        raw = [c for c in LOADERS if issubclass(c, RawTextLoader)]
+        self.assertTrue(raw)
+        self.assertTrue(all(_index(c) < first_shape for c in raw))
+
+    def test_phoonnx_is_probed_before_piper(self):
+        self.assertLess(_index(PhoonnxLoader), _index(PiperLoader))
+
+    def test_companion_file_loaders_are_probed_last(self):
+        shape = max(_index(c) for c in (PhoonnxLoader, PiperLoader, Mimic3Loader, CoquiLoader))
+        self.assertGreater(_index(TransformersLoader), shape)
+        self.assertGreater(_index(TokensTxtLoader), shape)
+
+    def test_a_native_config_is_never_claimed_by_the_piper_loader(self):
+        # a native espeak voice carries a piper-shaped phoneme_id_map, so the
+        # registry order is what keeps it out of the piper loader
+        cfg = {"phoonnx_version": "1.0", "phoneme_type": "espeak",
+               "phoneme_id_map": {"a": [1], "_": [0]}, "lang_code": "pt"}
+        self.assertTrue(PiperLoader.detect(LoadRequest(config=dict(cfg))))
+        self.assertEqual(VoiceConfig.from_dict(dict(cfg)).engine, Engine.PHOONNX)
+
+    def test_canonical_loader_is_the_final_fallback(self):
+        self.assertIs(LOADERS[-1], CanonicalLoader)
+        self.assertTrue(CanonicalLoader.detect(LoadRequest(config={})))
+
+    def test_every_engine_is_registered_once(self):
+        engines = [c.ENGINE for c in LOADERS if issubclass(c, RawTextLoader)]
+        self.assertEqual(len(engines), len(set(engines)))
+        self.assertIn(Engine.CHATTERBOX, engines)
+
+
+class TestResolveOverrides(unittest.TestCase):
+    def test_caller_kwargs_win_over_loader_values(self):
+        loaded = LoadedFields(lang_code="pt", phoneme_type=PhonemeType.ESPEAK,
+                              alphabet=Alphabet.IPA, engine=Engine.COQUI)
+        resolve_overrides(loaded, LoadRequest(config={}, lang_code="de",
+                                              phoneme_type=PhonemeType.GRUUT,
+                                              alphabet=Alphabet.ARPA, engine=Engine.MATCHA))
+        self.assertEqual(loaded.lang_code, "de")
+        self.assertEqual(loaded.phoneme_type, PhonemeType.GRUUT)
+        self.assertEqual(loaded.alphabet, Alphabet.ARPA)
+        self.assertEqual(loaded.engine, Engine.MATCHA)
+
+    def test_pinned_fields_survive_the_caller(self):
+        loaded = LoadedFields(lang_code="pt", alphabet=Alphabet.UNICODE,
+                              pinned=frozenset({"lang_code", "alphabet"}))
+        resolve_overrides(loaded, LoadRequest(config={}, lang_code="de",
+                                              alphabet=Alphabet.ARPA))
+        self.assertEqual(loaded.lang_code, "pt")
+        self.assertEqual(loaded.alphabet, Alphabet.UNICODE)
+
+    def test_loader_value_is_kept_when_the_caller_passes_nothing(self):
+        loaded = LoadedFields(lang_code="pt", engine=Engine.PIPER)
+        resolve_overrides(loaded, LoadRequest(config={}))
+        self.assertEqual(loaded.lang_code, "pt")
+        self.assertEqual(loaded.engine, Engine.PIPER)
+
+    def test_engine_falls_back_to_phoonnx(self):
+        loaded = LoadedFields()
+        resolve_overrides(loaded, LoadRequest(config={}))
+        self.assertEqual(loaded.engine, Engine.PHOONNX)
+
+
+class TestPinnedFormats(unittest.TestCase):
+    def test_piper_text_models_pin_their_character_alphabet(self):
+        cfg = {"piper_version": "1.0", "phoneme_type": "text",
+               "phoneme_id_map": {"a": [1], "_": [0]}}
+        voice = VoiceConfig.from_dict(cfg, alphabet=Alphabet.ARPA)
+        self.assertEqual(voice.alphabet, Alphabet.UNICODE)
+        self.assertEqual(voice.phoneme_type, PhonemeType.UNICODE)
+
+    def test_mimic3_takes_its_language_from_the_config_not_the_caller(self):
+        # mimic3 gruut vocabularies are language-specific: honouring a caller
+        # language here would phonemize into a vocabulary the model never saw
+        cfg = {"phonemizer": "gruut", "phonemes": {}, "text_language": "de"}
+        voice = VoiceConfig.from_dict(cfg, tokens_txt=_tokens_txt(), lang_code="pt")
+        self.assertEqual(voice.lang_code, normalize_lang("de"))
+
+    def test_mimic3_symbols_models_pin_their_grapheme_alphabet(self):
+        cfg = {"phonemizer": "symbols", "phonemes": {}, "text_language": "de"}
+        voice = VoiceConfig.from_dict(cfg, tokens_txt=_tokens_txt(), alphabet=Alphabet.ARPA)
+        self.assertEqual(voice.alphabet, Alphabet.UNICODE)
+        self.assertEqual(voice.phoneme_type, PhonemeType.GRAPHEMES)
+
+    def test_a_transformers_tokenizer_config_language_beats_the_caller(self):
+        # the vocabulary was built for that language; the caller cannot re-point it
+        voice = VoiceConfig.from_dict({}, vocab={"a": 1, "_": 0},
+                                      tokenizer_config={"language": "ro"},
+                                      lang_code="pt")
+        self.assertEqual(voice.lang_code, normalize_lang("ro"))
+
+    def test_a_caller_language_survives_a_tokenizer_config_without_one(self):
+        voice = VoiceConfig.from_dict({}, vocab={"a": 1, "_": 0},
+                                      tokenizer_config={"add_blank": True},
+                                      lang_code="pt")
+        self.assertEqual(voice.lang_code, normalize_lang("pt"))
+
+    def test_a_config_naming_a_codec_engine_pins_it(self):
+        voice = VoiceConfig.from_dict({"engine": "llasa"}, engine=Engine.PIPER)
+        self.assertEqual(voice.engine, Engine.LLASA)
+
+    def test_chatterbox_needs_its_bpe_tokenizer(self):
+        with self.assertRaises(ValueError):
+            ChatterboxLoader.load(LoadRequest(config={"engine": "chatterbox"}))
+
+    def test_mimic3_needs_its_tokens_file(self):
+        with self.assertRaises(ValueError):
+            VoiceConfig.from_dict({"phonemizer": "gruut", "phonemes": {}})
+
+
+# (engine, sample rate its codec runs at, alphabet the adapter expects)
+RAW_TEXT_ENGINES = [
+    (Engine.CHATTERBOX, 24000, Alphabet.UNICODE),
+    (Engine.LLASA, 16000, Alphabet.GRAPHEMES),
+    (Engine.NEUTTS, 24000, Alphabet.GRAPHEMES),
+    (Engine.ORPHEUS, 24000, Alphabet.GRAPHEMES),
+    (Engine.MOSSTTS, 48000, Alphabet.GRAPHEMES),
+    (Engine.SUPERTONIC, 44100, Alphabet.GRAPHEMES),
+    (Engine.POCKETTTS, 24000, Alphabet.GRAPHEMES),
+    (Engine.SPARKTTS, 16000, Alphabet.GRAPHEMES),
+    (Engine.INDIC_PARLER, 44100, Alphabet.GRAPHEMES),
+    (Engine.OMNIVOICE, 24000, Alphabet.GRAPHEMES),
+    (Engine.MAGPIE, 22050, Alphabet.GRAPHEMES),
+    (Engine.ARKTTS, 44100, Alphabet.GRAPHEMES),
+    (Engine.QWEN3TTS, 24000, Alphabet.GRAPHEMES),
+    (Engine.OUTETTS, 24000, Alphabet.GRAPHEMES),
+]
+
+
+class TestRawTextLoaderDefaults(unittest.TestCase):
+    def test_the_table_covers_every_registered_raw_text_loader(self):
+        registered = {c.ENGINE for c in LOADERS if issubclass(c, RawTextLoader)}
+        self.assertEqual(registered, {e for e, _, _ in RAW_TEXT_ENGINES})
+
+    def test_each_engine_declares_its_codec_sample_rate_and_alphabet(self):
+        for engine, sample_rate, alphabet in RAW_TEXT_ENGINES:
+            with self.subTest(engine=engine):
+                cls = next(c for c in LOADERS
+                           if issubclass(c, RawTextLoader) and c.ENGINE is engine)
+                self.assertEqual(cls.SAMPLE_RATE, sample_rate)
+                self.assertEqual(cls.ALPHABET, alphabet)
+
+    def test_a_voice_is_built_with_its_engine_sample_rate(self):
+        # Chatterbox is excluded: it cannot load without its tokenizer.json
+        for engine, sample_rate, alphabet in RAW_TEXT_ENGINES:
+            if engine is Engine.CHATTERBOX:
+                continue
+            with self.subTest(engine=engine):
+                voice = VoiceConfig.from_dict({"engine": engine.value})
+                self.assertEqual(voice.engine, engine)
+                self.assertEqual(voice.sample_rate, sample_rate)
+                self.assertEqual(voice.alphabet, alphabet)
+                self.assertEqual(voice.phoneme_type, PhonemeType.UNICODE)
+
+    def test_a_config_sample_rate_is_never_overwritten(self):
+        voice = VoiceConfig.from_dict({"engine": "llasa", "audio": {"sample_rate": 48000}})
+        self.assertEqual(voice.sample_rate, 48000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 via Claude Code — NOT human-reviewed. Verify before acting.

`VoiceConfig.from_dict` had grown into a ~460-line elif ladder covering twenty-one config shapes. Every branch re-derived, in its own words, which of the caller's kwargs beat which of the config's values, and the fourteen codec-LM engines were copies of each other differing only in a sample rate. Adding a format meant adding a branch and hoping the precedence matched the neighbours.

Each format now has a loader class in `phoonnx/config_loaders.py`: `detect()` says whether it owns a config, `load()` produces the fields that actually vary per format (tokenizer, engine, language, phoneme type, alphabet, diacritics). The fourteen codec-LM engines collapse into one `RawTextLoader` base plus a table of `(engine, sample rate)` rows, so a new one is a line. The elif ladder becomes an ordered `LOADERS` registry, mirroring the engine-adapter registry in `phoonnx/engines/__init__.py`, and the ordering constraints that used to be implicit in the ladder are written down: the codec-LM loaders key off a declared engine name and must win before any shape-sniffing, `phoonnx` must be probed before `piper` because a native espeak config carries a piper-shaped `phoneme_id_map`, and the two loaders identified by companion files rather than by the config itself come last. `VoiceConfig.is_phoonnx` and friends stay where they are and delegate to their loaders.

The precedence lives in one place. `resolve_overrides` states the contract in its docstring: a field the format *pins* wins over everything, otherwise the caller's kwarg wins, otherwise the loader's value (which already folded in the config's own). Pinning is what the old ladder did silently — a piper `text` model forcing `Alphabet.UNICODE`, mimic3 taking its language from `text_language`, a transformers `tokenizer_config` naming the language its vocabulary was built for, a config that names a codec engine. Every step is null-safe by `or`, so a config carrying an explicit `null` falls through instead of pinning `None`. `from_dict` keeps its exact signature and now reads only the format-independent half of the config: audio, inference scales, speaker and language maps, special tokens.

This wave changes no behaviour, and `tests/differential/` is here so the later waves can say the same and be checked on it. It holds a 53-case corpus spanning every loader — piper espeak/text/pygoruut/bogus, all four mimic3 phonemizers with and without a tokens file, Coqui, native, a native config full of explicit nulls, a native config wearing piper's list-valued id map, canonical, transformers with and without a tokenizer config, sherpa `.txt` and `.json`, and each codec engine declared both by config and by kwarg — crossed with seven kwarg sets. The runner snapshots the whole result: the `VoiceConfig`, the caller's dict *after* the call (loaders normalise it in place), and the error raised by the cases that raise. It also runs against a directory of real `config.json` files, and against any two git refs, so a wave can diff itself against its base without inventing a harness each time. `tests/test_config_differential.py` pins the corpus to a committed golden file.

Evidence against current `dev`: the 1712 configs of the voice catalog crossed with the seven kwarg sets — 11984 results — are identical, as are all 371 corpus results. The full non-training suite keeps its exact 42-failure set (all pre-existing missing-optional-dep failures); passes go from 2160 to 2183 with the new tests, and `dir(phoonnx.config)` is unchanged.

One behaviour does change, deliberately: a `tokens_txt` whose name ends in neither `.txt` nor `.json` used to raise `UnboundLocalError` from a tokenizer that was never bound, and now raises a `ValueError` that says so. It is an unlikely path — it needs a voice shipping its tokens under some third extension — but not an unreachable one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified voice configuration loading for Piper, Mimic3, Coqui, Chatterbox, native, transformer, codec, and canonical formats.
  * Added automatic detection, normalization, companion-file validation, and format-specific defaults.
  * Added support for resolving caller-provided configuration overrides.

* **Tests**
  * Added comprehensive coverage for format detection, defaults, validation, override precedence, and compatibility across configuration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->