### PR TITLE
refactor: lease-based residency for the voice cache

### DIFF
--- a/docs/ovos_plugin.md
+++ b/docs/ovos_plugin.md
@@ -162,7 +162,7 @@ See [cloning.md](cloning.md) for the cloning keys in detail.
 
 ### Voice Caching
 
-Loaded voices are cached in memory (`self.voices` dict) to avoid re-loading on every utterance. The first call for a new voice ID triggers a download if needed. Each cached voice id owns its own ONNX Runtime session — a family of catalog entries that share one underlying model (for example the `omnivoice` or `qwen3tts` voice-config variants) still costs one load per entry, not one for the whole family.
+Loaded voices are cached in memory (`plugin.voice_cache`) to avoid re-loading on every utterance. The first call for a new voice ID triggers a download if needed. Memory is charged per model rather than per voice: a family of catalog entries that name the same graph (for example the `omnivoice` or `qwen3tts` voice-config variants) shares one ONNX Runtime session and counts against the budget once, however many of its voices are loaded.
 
 Two config keys bound how much stays resident:
 
@@ -171,8 +171,9 @@ Two config keys bound how much stays resident:
 | `max_loaded_voices` | Maximum number of voices resident at once (pinned ones included). Unset never evicts anything. |
 | `max_loaded_bytes` | Memory budget for resident voice weights, as a plain byte count or a size string (`"3GB"`, `"512 MB"`, `"1.5GiB"` — `KB/MB/GB/TB` are powers of 1000, `KiB/MiB/GiB/TiB` powers of 1024). Unset never evicts anything. |
 | `pinned_voices` | Voice id or list of voice ids to load at startup and never evict, regardless of the other limits. |
+| `load_wait_timeout` | Seconds a cold load waits for memory in use to come back before loading anyway. Defaults to 300; a memory bound must never become a hang. |
 
-A voice bigger than the whole `max_loaded_bytes` budget still loads rather than being refused — it evicts everything evictable first and logs a warning that memory use will exceed the budget. See [deployment.md](deployment.md#memory-budgeting) for sizing this against the container's memory limit.
+A voice whose own weights are bigger than the whole `max_loaded_bytes` budget is refused with `VoiceExceedsMemoryBudget` rather than loaded, because loading it is a guaranteed OOM kill. A voice that fits on its own but not beside what is already in memory waits for room, and takes it anyway once `load_wait_timeout` seconds pass, logging a warning that memory use will exceed the budget: a voice a request is still synthesizing with is charged to the budget until that request finishes, so there are moments when nothing can be evicted. See [deployment.md](deployment.md#memory-budgeting) for sizing this against the container's memory limit.
 
 ### Refreshing Voices
 

--- a/phoonnx/opm.py
+++ b/phoonnx/opm.py
@@ -10,51 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import gc
 import hashlib
-import math
 import os
-import re
 import tempfile
-import time
 import wave
-import weakref
 from contextlib import suppress
 from collections import OrderedDict
-import threading
-from dataclasses import dataclass, field
 from threading import RLock
-from typing import Dict, List, Optional
+from typing import List, Optional
 from ovos_utils.log import LOG
 from ovos_plugin_manager.templates.tts import TTS, TTSContext
 
 from phoonnx.model_manager import TTSModelManager, TTSModelInfo
 from phoonnx.voice import TTSVoice, SynthesisConfig
+from phoonnx.voice_cache import VoiceCache, VoiceExceedsMemoryBudget
 
-
-class VoiceExceedsMemoryBudget(RuntimeError):
-    """A voice's on-disk size alone is larger than ``max_loaded_bytes``.
-
-    Loading it is not a degraded path, it is a guaranteed OOM kill: a 15.4 GB
-    voice against a 5 GB budget in an 8 GiB cgroup killed the process, and the
-    container restarted straight back into the same load, over and over. The
-    size is known before the load is attempted whenever the voice was already
-    on disk from an earlier attempt (its own weights survive the restart even
-    though the process does not), which is exactly the case that used to
-    loop. Refusing here turns that loop into one failed request.
-    """
-
-
-@dataclass
-class _Loading:
-    """A load in progress, and how it ended.
-
-    Callers that arrive while a voice is loading wait on ``done`` and then read
-    ``error``: either the load succeeded and the voice is in the cache, or it
-    failed and they get the same exception rather than repeating the attempt.
-    """
-    done: threading.Event = field(default_factory=threading.Event)
-    error: Optional[BaseException] = None
+__all__ = ["PhoonnxTTSPlugin", "VoiceExceedsMemoryBudget"]
 
 
 class PhoonnxTTSPlugin(TTS):
@@ -75,75 +46,17 @@ class PhoonnxTTSPlugin(TTS):
         self.model_manager.load()
         self.model_manager.merge_default_voices()
 
-        # Ordered by least-recently-used, so eviction has an obvious victim.
-        self.voices: "OrderedDict[str, TTSVoice]" = OrderedDict()
-        self._voice_lock = RLock()
+        self.voice_cache = VoiceCache(
+            resolve=lambda voice_id: self.get_voice_info(voice_id),
+            load=lambda info: info.load(providers=self._providers()),
+            max_loaded_voices=self.config.get("max_loaded_voices"),
+            max_loaded_bytes=self.config.get("max_loaded_bytes"),
+            pinned_voices=self.config.get("pinned_voices"),
+            load_wait_timeout=self.config.get("load_wait_timeout"))
         # Cloned cache identities, most recent last. Bounded because the
         # reference that creates one comes from the request.
         self._cloned_caches: "OrderedDict[str, bool]" = OrderedDict()
         self._cloned_lock = RLock()
-        # One gate per voice currently being loaded, so simultaneous callers
-        # wait for the load already running instead of starting their own.
-        self._loading: Dict[str, threading.Event] = {}
-        # Bytes promised to loads that are running right now. A load allocates
-        # its memory before the cache ever sees it, so the budget has to be
-        # spent when the load starts, not when it finishes.
-        self._reserved_bytes = 0
-        # Signalled whenever a reservation is released, so a waiting loader
-        # can re-check whether it fits.
-        self._budget_free = threading.Condition(self._voice_lock)
-        # Voices that must never be evicted. A cold load costs seconds to
-        # minutes depending on the engine, while a resident voice answers in
-        # milliseconds, so the voices a deployment actually serves are worth
-        # keeping loaded.
-        pinned = self.config.get("pinned_voices") or []
-        # A single voice written as a bare string is the obvious way to get
-        # this wrong, and iterating it would pin one voice per character.
-        if isinstance(pinned, str):
-            pinned = [pinned]
-        # Order is kept so the first pin stays the first loaded; duplicates
-        # would otherwise inflate the ceiling that is raised to fit the pins.
-        self.pinned_voices: List[str] = list(dict.fromkeys(v for v in pinned if v))
-        # How many voices may be resident at once, pinned ones included.
-        # Unset keeps the previous behaviour: never evict anything.
-        self.max_loaded_voices = self._parse_max_loaded(
-            self.config.get("max_loaded_voices"))
-        if (self.max_loaded_voices is not None
-                and len(self.pinned_voices) > self.max_loaded_voices):
-            LOG.error(
-                f"{len(self.pinned_voices)} voices are pinned but "
-                f"max_loaded_voices is {self.max_loaded_voices}; raising the "
-                f"limit to fit them, because a pinned voice is a promise")
-            self.max_loaded_voices = len(self.pinned_voices)
-        # How many bytes of voice may be resident at once. A count cannot bound
-        # memory on a mixed catalog: a piper voice is ~60 MB and an omnivoice
-        # voice is ~2.2 GB, so the count that is safe for the big one wastes
-        # the cache for the small ones. Unset keeps the previous behaviour.
-        self.max_loaded_bytes = self._parse_max_bytes(
-            self.config.get("max_loaded_bytes"))
-        # Memory is charged per *model*, not per voice. A voice id is a
-        # catalog entry; the weights are the artifacts it names, and the
-        # bundled indexes name the same artifacts from hundreds of entries
-        # (646 omnivoice voices over one 3 GB backbone). Charging each entry
-        # separately made the cache evict a model to make room for itself.
-        self._voice_keys: Dict[str, str] = {}
-        # Measured size per artifact key. Never pruned: a key whose voices
-        # were all evicted may still be resident in a request that is
-        # mid-synthesis, and its size is what says so.
-        self._key_bytes: Dict[str, int] = {}
-        # Weak references to every voice object handed out, per artifact key,
-        # as a list: hashing a weak reference hashes what it points at, and a
-        # loaded voice is an unhashable dataclass.
-        # A voice the cache evicted is still in memory while the request that
-        # asked for it is synthesizing — minutes, for these models — so the
-        # cache is not what says whether the weights are resident. These
-        # references are, and they cost nothing to keep.
-        self._refs: Dict[str, list] = {}
-        # How long a load waits for memory another request is still using
-        # before giving up on the budget and loading anyway. Waiting forever
-        # would turn a memory bound into a hang.
-        self.load_wait_timeout = float(
-            self.config.get("load_wait_timeout") or 300)
         # Resolve the configured voice now, but do not load it. A voice that was
         # named explicitly and does not exist is a configuration error and still
         # raises here; an unset voice (or "default") resolves to the language's
@@ -154,23 +67,7 @@ class PhoonnxTTSPlugin(TTS):
         else:
             self.voice_info = self.get_default_voice(self.lang)
 
-        for voice_id in self.pinned_voices:
-            try:
-                self.get_model(voice_id)
-                LOG.info(f"pinned voice loaded: {voice_id}")
-            except Exception as e:
-                # A pinned voice that cannot load must not stop the service
-                # from starting; it simply is not resident.
-                LOG.error(f"pinned voice '{voice_id}' failed to load: {e}")
-        if (self.max_loaded_bytes is not None
-                and self._resident_bytes() > self.max_loaded_bytes):
-            # Said once, at startup, the way a too-small max_loaded_voices is.
-            # The pins win either way, so this is the only warning an operator
-            # gets that the budget they set is not the memory they will use.
-            LOG.error(
-                f"the pinned voices need {self._resident_bytes()} bytes, more "
-                f"than max_loaded_bytes ({self.max_loaded_bytes}); the pins "
-                f"win, so memory use will exceed the budget")
+        self.voice_cache.preload_pinned()
 
     def _cfg_opt(self, default, *keys):
         """
@@ -279,466 +176,20 @@ class PhoonnxTTSPlugin(TTS):
     def get_model(self, voice_id: str) -> TTSVoice:
         """
         Retrieve and cache the TTSVoice instance for a given voice identifier.
-        
+
         Parameters:
             voice_id (str): Identifier of the voice to load.
-        
+
         Returns:
             TTSVoice: The loaded voice model corresponding to `voice_id`.
-        
+
         Raises:
-            Exception: If `voice_id` is not found after refreshing available voices.
+            VoiceExceedsMemoryBudget: The voice cannot fit `max_loaded_bytes`
+                even on its own.
+            Exception: If `voice_id` is not found after refreshing available
+                voices.
         """
-        while True:
-            with self._voice_lock:
-                if voice_id in self.voices:
-                    # Touch it so the least recently used voice is evicted.
-                    self.voices.move_to_end(voice_id)
-                    return self.voices[voice_id]
-                waiting = self._loading.get(voice_id)
-                if waiting is None:
-                    # This caller owns the load; everyone else waits on it.
-                    self._loading[voice_id] = _Loading()
-                    break
-            # Another caller is loading this voice. Waiting costs nothing and
-            # saves a duplicate multi-gigabyte load.
-            waiting.done.wait()
-            if waiting.error is not None:
-                # Share the failure rather than each waiter retrying it in
-                # turn: the retries are serial, so N callers behind a slow
-                # failure would each wait for the one before. A later request
-                # still gets a fresh attempt, because the gate is gone by then.
-                raise waiting.error
-
-        # Everything from here is inside the try, so no failure can leave the
-        # gate installed. An unknown voice id raises out of get_voice_info, and
-        # that is a request parameter, so this path is reachable from outside.
-        reserved = 0
-        try:
-            with self._voice_lock:
-                info = self.get_voice_info(voice_id)
-
-            LOG.debug(f"Using voice: {voice_id}")
-            # Room is claimed BEFORE the load allocates anything. Evicting
-            # after the fact bounds the steady state and nothing else: four
-            # concurrent 2.2 GB loads each evicted the one before and the
-            # cache looked healthy, after the OOM killer had already taken
-            # the process.
-            reserved, measured, key = self._reserve(voice_id, info)
-            # Loaded outside the lock: a cold load takes seconds to minutes,
-            # and holding the lock would stall every other request meanwhile.
-            voice = info.load(providers=self._providers())
-
-        except BaseException as exc:
-            with self._voice_lock:
-                self._release(reserved)
-                gate = self._loading.pop(voice_id, None)
-            if gate is not None:
-                gate.error = exc
-                gate.done.set()
-            raise
-
-        else:
-            # Cached and released under one hold of the lock. Releasing the
-            # gate first would open a window in which the voice is neither
-            # cached nor being loaded, and a waiter that woke inside it would
-            # elect itself and start a second full cold load — the duplicate
-            # this gate exists to prevent.
-            #
-            # The try covers the measuring and the caching too. An exception
-            # raised here is not caught by the except above it — that is what
-            # `else` means — so anything that failed while storing the voice
-            # used to leave the gate installed with nothing to ever set it,
-            # and every later caller for that voice id waited on it forever.
-            try:
-                # Measured outside the lock: it only stats files, but it stats
-                # one per artifact and there is no reason to hold up every
-                # other request for it. A voice that could be measured before
-                # the load is not measured twice; one that could not (its
-                # files were not downloaded yet) now can be.
-                size = measured if measured else self._measure(voice_id, info)
-
-                with self._voice_lock:
-                    self._release(reserved)
-                    # Released exactly once: the failure path below runs the
-                    # same call, and releasing twice would shrink the budget
-                    # by a voice that was never holding it.
-                    reserved = 0
-                    self._key_bytes.setdefault(key, size)
-                    if voice_id not in self.voices:
-                        # Evicted before this voice is tracked: _evict_for
-                        # skips a key that is already resident, and this
-                        # voice's own weights would otherwise satisfy that
-                        # check against itself, making the post-load
-                        # eviction — the only one that sees a size measured
-                        # after a cold download — a permanent no-op.
-                        self._evict_for(voice_id, key, size)
-                        self.voices[voice_id] = voice
-                        self._voice_keys[voice_id] = key
-                    # Tracked once the eviction that might have needed this
-                    # voice's own key to still look unresident is done: from
-                    # here on the weights are in memory whether or not this
-                    # voice ends up cached, and the budget has to know that
-                    # for as long as the caller holds it.
-                    self._track(key, voice)
-                    self.voices.move_to_end(voice_id)
-                    cached = self.voices[voice_id]
-                    gate = self._loading.pop(voice_id, None)
-                if gate is not None:
-                    gate.done.set()
-                return cached
-
-            except BaseException as exc:
-                with self._voice_lock:
-                    self._release(reserved)
-                    gate = self._loading.pop(voice_id, None)
-                if gate is not None:
-                    gate.error = exc
-                    gate.done.set()
-                raise
-
-    @staticmethod
-    def _parse_max_loaded(value) -> Optional[int]:
-        """Normalize ``max_loaded_voices``; None means no limit."""
-        if value in (None, "", 0):
-            return None
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
-            LOG.error(f"ignoring invalid max_loaded_voices: {value!r}")
-            return None
-        if parsed < 1:
-            LOG.error(f"ignoring max_loaded_voices={parsed}, it must be at "
-                      f"least 1")
-            return None
-        return parsed
-
-    @staticmethod
-    def _parse_max_bytes(value) -> Optional[int]:
-        """Normalize ``max_loaded_bytes``; None means no budget.
-
-        Accepts a plain number of bytes (``6000000000``) or a human-friendly
-        size (``"6GB"``, ``"512 MB"``, ``"1.5GiB"``). ``KB/MB/GB/TB`` are
-        powers of 1000, ``KiB/MiB/GiB/TiB`` powers of 1024, as those suffixes
-        are defined.
-
-        An unusable value is rejected and the budget stays unset. It must never
-        end up as zero: a zero budget evicts every voice on every request, and
-        an unbounded cache is a far better answer to a typo than a cache that
-        cold-loads a multi-gigabyte model for each call.
-        """
-        if value in (None, "", 0):
-            return None
-        units = {"": 1, "B": 1,
-                 "KB": 10 ** 3, "MB": 10 ** 6, "GB": 10 ** 9, "TB": 10 ** 12,
-                 "KIB": 2 ** 10, "MIB": 2 ** 20, "GIB": 2 ** 30, "TIB": 2 ** 40}
-        if isinstance(value, bool):  # bools are ints in python
-            LOG.error(f"ignoring invalid max_loaded_bytes: {value!r}")
-            return None
-        if isinstance(value, (int, float)):
-            number, unit = float(value), ""
-        else:
-            text = str(value).strip().replace(" ", "")
-            match = re.fullmatch(r"([0-9]*\.?[0-9]+)([a-zA-Z]*)", text)
-            if not match:
-                LOG.error(f"ignoring invalid max_loaded_bytes: {value!r}")
-                return None
-            number, unit = float(match.group(1)), match.group(2).upper()
-        if unit not in units:
-            LOG.error(f"ignoring max_loaded_bytes={value!r}: unknown unit "
-                      f"'{unit}', expected one of {sorted(units)}")
-            return None
-        if not math.isfinite(number):
-            # YAML writes infinity as ``.inf`` and json.loads accepts
-            # ``Infinity``/``NaN``; int() raises on all three, and this is
-            # called from __init__, so an uncaught raise here is a plugin that
-            # will not start.
-            LOG.error(f"ignoring max_loaded_bytes={value!r}: not a finite "
-                      f"size")
-            return None
-        parsed = int(number * units[unit])
-        if parsed < 1:
-            LOG.error(f"ignoring max_loaded_bytes={value!r}, it must be at "
-                      f"least 1 byte")
-            return None
-        return parsed
-
-    def _measure(self, voice_id: str, info: TTSModelInfo) -> int:
-        """Size of a loaded voice in bytes, as a proxy: its files on disk.
-
-        See :meth:`TTSModelInfo.disk_size` for what that proxy does and does
-        not account for. Nothing is measured unless a budget is set, so a
-        deployment that does not use one pays nothing for this.
-
-        A voice that cannot be measured counts as free rather than as
-        infinite: refusing to cache a voice because its size is unknown would
-        turn a measurement problem into a synthesis problem.
-        """
-        if self.max_loaded_bytes is None:
-            return 0
-        try:
-            return int(info.disk_size())
-        except Exception as exc:
-            LOG.error(f"could not measure the size of voice '{voice_id}', "
-                      f"counting it as free: {exc}")
-            return 0
-
-    def _key_for(self, voice_id: str, info: TTSModelInfo) -> str:
-        """Artifact key of a voice: what it would share with another voice.
-
-        Falls back to the voice id when the catalog entry cannot name its
-        artifacts, which charges that voice on its own — the old behaviour,
-        and the safe direction to be wrong in.
-        """
-        try:
-            key = info.artifact_key()
-        except Exception as exc:
-            LOG.debug(f"voice '{voice_id}' has no artifact key ({exc}); "
-                      f"charging it on its own")
-            return voice_id
-        return key if isinstance(key, str) and key else voice_id
-
-    def _track(self, key: str, voice) -> None:
-        """Remember that ``voice`` holds the weights of ``key``, weakly.
-
-        Called with ``self._voice_lock`` held. The callback fires when the
-        last reference to the voice goes away — the request finished — and
-        wakes whoever is waiting for that memory.
-        """
-        try:
-            ref = weakref.ref(voice, lambda r, k=key: self._on_voice_released(k, r))
-        except TypeError:
-            # Not every object a caller can put here supports weak references
-            # (tests load stand-ins). Untracked voices are simply charged for
-            # as long as they are cached, exactly as before.
-            return
-        refs = self._refs.setdefault(key, [])
-        if not any(existing() is voice for existing in refs):
-            refs.append(ref)
-
-    def _on_voice_released(self, key: str, ref) -> None:
-        """A voice object was collected: its memory may now be free."""
-        with self._voice_lock:
-            refs = self._refs.get(key)
-            if refs is not None:
-                self._refs[key] = [r for r in refs if r is not ref and r() is not None]
-                if not self._refs[key]:
-                    self._refs.pop(key, None)
-            self._budget_free.notify_all()
-
-    def _live_count(self, key: str) -> int:
-        """How many voice objects still hold this key's weights."""
-        return sum(1 for ref in self._refs.get(key, ()) if ref() is not None)
-
-    def _resident_keys(self) -> "set[str]":
-        """Every artifact key whose weights are in memory right now.
-
-        Cached voices, plus voices the cache already evicted that a request
-        has not finished with. The second group is why the budget used to
-        undercount: eviction pops a dict entry, it does not free a model that
-        a caller is three minutes into synthesizing with.
-        """
-        keys = {self._voice_keys.get(v, v) for v in self.voices}
-        keys.update(k for k in list(self._refs) if self._live_count(k))
-        return keys
-
-    def _reserve(self, voice_id: str, info: TTSModelInfo) -> "tuple[int, int, str]":
-        """Claim budget for a load that has not started yet.
-
-        Returns ``(reserved, measured, key)``: the bytes claimed, the size the
-        voice could be measured at before loading (0 when it could not be),
-        and its artifact key.
-
-        A voice whose weights are already resident claims nothing and waits
-        for nothing: it is going to reuse the session that is already loaded,
-        so there is no second allocation to make room for.
-
-        Otherwise this waits until the voice fits beside what is resident and
-        what other loads have already claimed, evicting to make room. Three
-        rules keep it from ever becoming a hang:
-
-        - a loader waits only while memory could still come back — another
-          load in flight, or a resident voice no longer cached that a request
-          will eventually let go of — so a voice that fits beside nothing
-          does not wait for room that can never appear;
-        - a voice whose known on-disk size alone is bigger than the whole
-          budget is refused with ``VoiceExceedsMemoryBudget`` instead:
-          loading it is not "the memory in use will exceed the budget", it is
-          a guaranteed OOM kill, and on a size that is already known (the
-          case that matters: files that survived a previous, killed attempt)
-          there is no reason to repeat it;
-        - the wait is bounded by ``load_wait_timeout`` regardless, after which
-          the load proceeds and says so;
-        - every reservation is released on both the success and the failure
-          path, and each release wakes the waiters, as does the collection of
-          a voice object.
-
-        A voice whose files are not downloaded yet cannot be measured, and an
-        unknown size is treated as the whole budget: it loads alone. That
-        costs the cache once per voice, the first time it is ever fetched,
-        and it is the only honest way to keep an unknown allocation inside a
-        known bound.
-        """
-        key = self._key_for(voice_id, info)
-        if self.max_loaded_bytes is None:
-            return 0, 0, key
-        measured = self._measure(voice_id, info)
-        with self._budget_free:
-            if key in self._resident_keys():
-                LOG.debug(f"voice '{voice_id}' reuses weights that are "
-                          f"already loaded; charging nothing for it")
-                self._key_bytes.setdefault(key, measured)
-                return 0, measured, key
-            if measured > self.max_loaded_bytes:
-                # Known in advance, not merely estimated: refuse before
-                # touching eviction or the loader rather than guarantee an
-                # OOM kill. A voice whose size is not yet known (0, not yet
-                # downloaded) still falls through below, as before.
-                raise VoiceExceedsMemoryBudget(
-                    f"voice '{voice_id}' needs {measured} bytes on disk, "
-                    f"more than the whole max_loaded_bytes budget of "
-                    f"{self.max_loaded_bytes}; refusing to load it rather "
-                    f"than guarantee an out-of-memory kill")
-            need = measured if measured > 0 else self.max_loaded_bytes
-            deadline = time.monotonic() + self.load_wait_timeout
-            collected = False
-            while (self._over_budget(need)
-                   and (self._reserved_bytes or self._releasable_bytes())):
-                # A dropped voice is not actually gone the instant it is
-                # evicted: TTSVoice holds a reference cycle (its adapter
-                # points back at it), so CPython's refcounting alone never
-                # frees it and the weakref callback that wakes this wait
-                # never fires. gc.collect() breaks the cycle, but it walks
-                # the whole heap — hundreds of milliseconds on a large
-                # process — so it runs only once, right before the first
-                # wait, and only on the path that is actually about to
-                # wait; a load with headroom already never pays for it.
-                if not collected:
-                    collected = True
-                    gc.collect()
-                    if not self._over_budget(need):
-                        break
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    gc.collect()
-                    if not self._over_budget(need):
-                        break
-                    LOG.warning(
-                        f"waited {self.load_wait_timeout:.0f}s for room to "
-                        f"load '{voice_id}' and the memory in use did not "
-                        f"come back; loading it anyway, so memory use will "
-                        f"exceed the budget")
-                    break
-                self._budget_free.wait(remaining)
-            # Make the room now, so the bytes are free when the load takes
-            # them rather than after it already has.
-            self._evict_for(voice_id, key, need)
-            self._reserved_bytes += need
-        return need, measured, key
-
-    def _over_budget(self, need: int) -> bool:
-        """Whether admitting ``need`` more bytes would break the budget."""
-        return (self._resident_bytes() + self._reserved_bytes + need
-                > self.max_loaded_bytes)
-
-    def _releasable_bytes(self) -> int:
-        """Resident bytes that will come back on their own.
-
-        Weights that are no longer cached but are still held by a request in
-        flight. Nothing else can shrink without a caller finishing.
-        """
-        cached = {self._voice_keys.get(v, v) for v in self.voices}
-        return sum(self._key_bytes.get(k, 0)
-                   for k in self._resident_keys() if k not in cached)
-
-    def _release(self, reserved: int) -> None:
-        """Give back a reservation and wake whoever is waiting for room.
-
-        Called with ``self._voice_lock`` held.
-        """
-        if not reserved:
-            return
-        self._reserved_bytes = max(0, self._reserved_bytes - reserved)
-        self._budget_free.notify_all()
-
-    def _resident_bytes(self) -> int:
-        """Total measured size of the weights in memory right now."""
-        return sum(self._key_bytes.get(k, 0) for k in self._resident_keys())
-
-    def _drop(self, victim: str) -> None:
-        self.voices.pop(victim, None)
-        self._voice_keys.pop(victim, None)
-        LOG.debug(f"evicted least recently used voice: {victim}")
-
-    def _lru_victim(self) -> Optional[str]:
-        """The least recently used voice that may be evicted, if any."""
-        return next((v for v in self.voices if v not in self.pinned_voices),
-                    None)
-
-    def _byte_victim(self) -> Optional[str]:
-        """The least recently used voice whose eviction frees memory.
-
-        Evicting one of 646 voices that share a backbone frees nothing while
-        the others still reference it, and the eviction loop would otherwise
-        empty the whole cache discovering that one entry at a time.
-        """
-        for candidate in self.voices:
-            if candidate in self.pinned_voices:
-                continue
-            key = self._voice_keys.get(candidate, candidate)
-            others = [v for v in self.voices
-                      if v != candidate
-                      and self._voice_keys.get(v, v) == key]
-            if others:
-                continue
-            if self._live_count(key) > 1:
-                # Cached here and held by a request elsewhere.
-                continue
-            return candidate
-        return None
-
-    def _evict_for(self, incoming: str, key: str, size: int = 0) -> None:
-        """Make room for ``incoming``, never dropping a pinned voice.
-
-        Both bounds apply when both are set: a voice is evicted when either the
-        count or the byte budget would be exceeded.
-        """
-        if self.max_loaded_voices is not None:
-            while len(self.voices) >= self.max_loaded_voices:
-                victim = self._lru_victim()
-                if victim is None:
-                    # Everything resident is pinned: serve the request anyway
-                    # rather than evict a voice an operator asked us to keep.
-                    LOG.warning(
-                        f"all {len(self.voices)} loaded voices are pinned; "
-                        f"loading '{incoming}' above max_loaded_voices")
-                    break
-                self._drop(victim)
-
-        if self.max_loaded_bytes is None:
-            return
-
-        if key in self._resident_keys():
-            # Its weights are already in memory; admitting it costs nothing.
-            return
-
-        if size > self.max_loaded_bytes:
-            # Serving it is still better than not serving it. Everything
-            # evictable goes first, so the overshoot is as small as it can be.
-            LOG.warning(
-                f"voice '{incoming}' needs {size} bytes on disk, more than the "
-                f"whole max_loaded_bytes budget of {self.max_loaded_bytes}; "
-                f"loading it anyway, so memory use will exceed the budget")
-
-        while self.voices and self._over_budget(size):
-            victim = self._byte_victim()
-            if victim is None:
-                LOG.warning(
-                    f"nothing more can be evicted "
-                    f"({self._resident_bytes()} bytes resident); loading "
-                    f"'{incoming}' above max_loaded_bytes")
-                break
-            self._drop(victim)
+        return self.voice_cache.get(voice_id)
 
     def get_voice_info(self, voice_id: str) -> TTSModelInfo:
         """
@@ -843,97 +294,99 @@ class PhoonnxTTSPlugin(TTS):
         speaker_reference = speaker_reference or ref_wav
         speaker_reference_text = speaker_reference_text or ref_text
         speaker_reference_lang = speaker_reference_lang or ref_lang
-        if voice and voice != "default":
-            # load first so the model manager is refreshed if the voice
-            # isn't cached yet, then read its info (avoids a KeyError when a
-            # configured voice hasn't been fetched before)
-            model = self.get_model(voice)
-            voice_info = self.model_manager.voices[voice]
-        else:
-            voice_info = self.get_default_voice(lang or self.lang)
-            model = self.get_model(voice_info.voice_id)
+        # The voice info is read from the manager only after the load, which
+        # refreshes it: a configured voice that has never been fetched is not
+        # in the catalog until then.
+        voice_info = (None if voice and voice != "default"
+                      else self.get_default_voice(lang or self.lang))
+        voice_id = voice if voice_info is None else voice_info.voice_id
+        # Leased for the whole synthesis: the cache may evict the entry
+        # meanwhile, but the weights this call is using stay charged to the
+        # memory budget, so no concurrent load is admitted against them.
+        with self.voice_cache.lease(voice_id) as model:
+            voice_info = voice_info or self.model_manager.voices[voice_id]
 
-        synth_params = SynthesisConfig(
-            # speaker selection for multi-speaker voices (e.g. the Catalan
-            # multiaccent matxa model). ``speaker_id`` (int) or ``speaker``
-            # (name via the voice's speaker_id_map); ignored by single-speaker
-            # voices, which only have speaker 0.
-            speaker_id=self._resolve_speaker(voice_info),
-            enable_phonetic_spellings=self._cfg_opt(
-                voice_info.config.enable_phonetic_spellings
-                if hasattr(voice_info.config, "enable_phonetic_spellings") else True,
-                "enable_phonetic_spellings", "enable_phonetic_spelling"),
-            add_diacritics=self._cfg_opt(
-                voice_info.config.add_diacritics,  # arabic and hebrew only
-                "add_diacritics"),
-            noise_scale=self._cfg_opt(
-                voice_info.config.noise_scale,  # generator noise
-                "noise_scale", "noise-scale"),
-            length_scale=self._cfg_opt(
-                voice_info.config.length_scale,  # phoneme length
-                "length_scale", "length-scale"),
-            noise_w_scale=self._cfg_opt(
-                voice_info.config.noise_w_scale,  # phoneme width noise
-                "noise_w_scale", "noise_w", "noise-w"),
-            # zero-shot voice cloning. A path to a reference wav; cloning engines turn
-            # it into the conditioning signal. In-context engines (ZipVoice) also need
-            # the reference's transcription + its language, e.g.:
-            #   {"ref_wav": "/home/user/me.wav", "ref_text": "olá tudo bem",
-            #    "ref_lang": "pt"}   ->   clone a Portuguese voice speaking English
-            speaker_reference=speaker_reference or self._cfg_opt(
-                None, "speaker_reference", "ref_wav", "clone_voice"),
-            speaker_reference_text=speaker_reference_text or self._cfg_opt(
-                None, "speaker_reference_text", "ref_text"),
-            speaker_reference_lang=speaker_reference_lang or self._cfg_opt(
-                None, "speaker_reference_lang", "ref_lang"),
-            # optional post-synthesis audio super-resolution (audiosronnx), off unless
-            # switched on in mycroft.conf. The core TTSVoice loads the engine lazily and
-            # upscales each chunk; synthesize_wav takes the sample rate from the first
-            # chunk, so the WAV header follows.
-            super_resolution=bool(self._cfg_opt(False, "super_resolution")),
-            super_resolution_model=self._cfg_opt(None, "super_resolution_model"),
-        )
-        # Written beside the target and moved into place only once the
-        # synthesis has finished. Opening the target directly creates it
-        # before the audio exists, so a failure part-way leaves a valid but
-        # empty WAV — 44 bytes of header — where the cache expects the
-        # finished file. The cache decides by existence, so every later
-        # request for that sentence is then served silence with a 200, and
-        # nothing ever retries it.
-        # Written to a private temporary file and moved into place only once
-        # the synthesis has finished. Opening the destination directly creates
-        # it before the audio exists, so a failure part-way left a valid but
-        # empty WAV — 44 bytes of header — exactly where the cache looks. The
-        # cache decides by existence, so every later request for that sentence
-        # was answered with that silence and an HTTP 200, and nothing retried.
-        #
-        # The name is unique per call rather than "<target>.part": two requests
-        # for the same sentence and voice would otherwise share one temporary
-        # file, and whichever lost the race found it already renamed away.
-        directory = os.path.dirname(wav_file) or "."
-        handle, tmp_file = tempfile.mkstemp(dir=directory, suffix=".part")
-        os.close(handle)
-        try:
-            wav_out = wave.open(tmp_file, "wb")
+            synth_params = SynthesisConfig(
+                # speaker selection for multi-speaker voices (e.g. the Catalan
+                # multiaccent matxa model). ``speaker_id`` (int) or ``speaker``
+                # (name via the voice's speaker_id_map); ignored by single-speaker
+                # voices, which only have speaker 0.
+                speaker_id=self._resolve_speaker(voice_info),
+                enable_phonetic_spellings=self._cfg_opt(
+                    voice_info.config.enable_phonetic_spellings
+                    if hasattr(voice_info.config, "enable_phonetic_spellings") else True,
+                    "enable_phonetic_spellings", "enable_phonetic_spelling"),
+                add_diacritics=self._cfg_opt(
+                    voice_info.config.add_diacritics,  # arabic and hebrew only
+                    "add_diacritics"),
+                noise_scale=self._cfg_opt(
+                    voice_info.config.noise_scale,  # generator noise
+                    "noise_scale", "noise-scale"),
+                length_scale=self._cfg_opt(
+                    voice_info.config.length_scale,  # phoneme length
+                    "length_scale", "length-scale"),
+                noise_w_scale=self._cfg_opt(
+                    voice_info.config.noise_w_scale,  # phoneme width noise
+                    "noise_w_scale", "noise_w", "noise-w"),
+                # zero-shot voice cloning. A path to a reference wav; cloning engines turn
+                # it into the conditioning signal. In-context engines (ZipVoice) also need
+                # the reference's transcription + its language, e.g.:
+                #   {"ref_wav": "/home/user/me.wav", "ref_text": "olá tudo bem",
+                #    "ref_lang": "pt"}   ->   clone a Portuguese voice speaking English
+                speaker_reference=speaker_reference or self._cfg_opt(
+                    None, "speaker_reference", "ref_wav", "clone_voice"),
+                speaker_reference_text=speaker_reference_text or self._cfg_opt(
+                    None, "speaker_reference_text", "ref_text"),
+                speaker_reference_lang=speaker_reference_lang or self._cfg_opt(
+                    None, "speaker_reference_lang", "ref_lang"),
+                # optional post-synthesis audio super-resolution (audiosronnx), off unless
+                # switched on in mycroft.conf. The core TTSVoice loads the engine lazily and
+                # upscales each chunk; synthesize_wav takes the sample rate from the first
+                # chunk, so the WAV header follows.
+                super_resolution=bool(self._cfg_opt(False, "super_resolution")),
+                super_resolution_model=self._cfg_opt(None, "super_resolution_model"),
+            )
+            # Written beside the target and moved into place only once the
+            # synthesis has finished. Opening the target directly creates it
+            # before the audio exists, so a failure part-way leaves a valid but
+            # empty WAV — 44 bytes of header — where the cache expects the
+            # finished file. The cache decides by existence, so every later
+            # request for that sentence is then served silence with a 200, and
+            # nothing ever retries it.
+            # Written to a private temporary file and moved into place only once
+            # the synthesis has finished. Opening the destination directly creates
+            # it before the audio exists, so a failure part-way left a valid but
+            # empty WAV — 44 bytes of header — exactly where the cache looks. The
+            # cache decides by existence, so every later request for that sentence
+            # was answered with that silence and an HTTP 200, and nothing retried.
+            #
+            # The name is unique per call rather than "<target>.part": two requests
+            # for the same sentence and voice would otherwise share one temporary
+            # file, and whichever lost the race found it already renamed away.
+            directory = os.path.dirname(wav_file) or "."
+            handle, tmp_file = tempfile.mkstemp(dir=directory, suffix=".part")
+            os.close(handle)
             try:
-                model.synthesize_wav(sentence, wav_out, synth_params)
-                # Closed inside the try: the final flush is where a full disk
-                # surfaces, and swallowing that would publish a truncated file
-                # as a finished one — the very bug this avoids.
-                wav_out.close()
-            except BaseException:
-                # Now the failure is already on its way out. Closing a wave
-                # file that never got its parameters raises "# channels not
-                # specified", which would replace the engine's own exception
-                # and hide why the synthesis actually failed.
-                with suppress(Exception):
+                wav_out = wave.open(tmp_file, "wb")
+                try:
+                    model.synthesize_wav(sentence, wav_out, synth_params)
+                    # Closed inside the try: the final flush is where a full disk
+                    # surfaces, and swallowing that would publish a truncated file
+                    # as a finished one — the very bug this avoids.
                     wav_out.close()
+                except BaseException:
+                    # Now the failure is already on its way out. Closing a wave
+                    # file that never got its parameters raises "# channels not
+                    # specified", which would replace the engine's own exception
+                    # and hide why the synthesis actually failed.
+                    with suppress(Exception):
+                        wav_out.close()
+                    raise
+                os.replace(tmp_file, wav_file)
+            except BaseException:
+                with suppress(OSError):
+                    os.remove(tmp_file)
                 raise
-            os.replace(tmp_file, wav_file)
-        except BaseException:
-            with suppress(OSError):
-                os.remove(tmp_file)
-            raise
 
         return wav_file, None
 

--- a/phoonnx/voice_cache.py
+++ b/phoonnx/voice_cache.py
@@ -1,0 +1,626 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""A memory-bounded cache of loaded voices.
+
+A count of voices cannot bound memory on a mixed catalog: a piper voice is
+~60 MB and an omnivoice voice is ~2.2 GB, so the count that is safe for the big
+one wastes the cache for the small ones. The bound that matters is bytes, and it
+has to hold at the *peak*, because that is what the OOM killer reads: a cold
+load reserves its bytes before it allocates them, and concurrent loads are
+admitted only while they fit.
+
+Memory is charged per model, not per voice. A voice id is a catalog entry; the
+weights are the artifacts it names, and one bundled index names the same
+artifacts from hundreds of entries (646 omnivoice voices over one 3 GB
+backbone). Charging each entry separately makes the cache evict a model to make
+room for itself.
+"""
+import math
+import re
+import threading
+import time
+from collections import OrderedDict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple
+
+from ovos_utils.log import LOG
+
+from phoonnx.model_manager import TTSModelInfo
+from phoonnx.voice import TTSVoice
+
+
+class VoiceExceedsMemoryBudget(RuntimeError):
+    """A voice's on-disk size alone is larger than ``max_loaded_bytes``.
+
+    Loading it is not a degraded path, it is a guaranteed OOM kill: a 15.4 GB
+    voice against a 5 GB budget in an 8 GiB cgroup killed the process, and the
+    container restarted straight back into the same load, over and over. The
+    size is known before the load is attempted whenever the voice was already
+    on disk from an earlier attempt (its own weights survive the restart even
+    though the process does not), which is exactly the case that used to
+    loop. Refusing here turns that loop into one failed request.
+    """
+
+
+@dataclass
+class _Loading:
+    """A load in progress, and how it ended.
+
+    Callers that arrive while a voice is loading wait on ``done`` and then read
+    ``error``: either the load succeeded and the voice is in the cache, or it
+    failed and they get the same exception rather than repeating the attempt.
+    """
+    done: threading.Event = field(default_factory=threading.Event)
+    error: Optional[BaseException] = None
+
+
+def parse_max_voices(value) -> Optional[int]:
+    """Normalize ``max_loaded_voices``; None means no limit."""
+    if value in (None, "", 0):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        LOG.error(f"ignoring invalid max_loaded_voices: {value!r}")
+        return None
+    if parsed < 1:
+        LOG.error(f"ignoring max_loaded_voices={parsed}, it must be at least 1")
+        return None
+    return parsed
+
+
+def parse_max_bytes(value) -> Optional[int]:
+    """Normalize ``max_loaded_bytes``; None means no budget.
+
+    Accepts a plain number of bytes (``6000000000``) or a human-friendly
+    size (``"6GB"``, ``"512 MB"``, ``"1.5GiB"``). ``KB/MB/GB/TB`` are
+    powers of 1000, ``KiB/MiB/GiB/TiB`` powers of 1024, as those suffixes
+    are defined.
+
+    An unusable value is rejected and the budget stays unset. It must never
+    end up as zero: a zero budget evicts every voice on every request, and
+    an unbounded cache is a far better answer to a typo than a cache that
+    cold-loads a multi-gigabyte model for each call.
+    """
+    if value in (None, "", 0):
+        return None
+    units = {"": 1, "B": 1,
+             "KB": 10 ** 3, "MB": 10 ** 6, "GB": 10 ** 9, "TB": 10 ** 12,
+             "KIB": 2 ** 10, "MIB": 2 ** 20, "GIB": 2 ** 30, "TIB": 2 ** 40}
+    if isinstance(value, bool):  # bools are ints in python
+        LOG.error(f"ignoring invalid max_loaded_bytes: {value!r}")
+        return None
+    if isinstance(value, (int, float)):
+        number, unit = float(value), ""
+    else:
+        text = str(value).strip().replace(" ", "")
+        match = re.fullmatch(r"([0-9]*\.?[0-9]+)([a-zA-Z]*)", text)
+        if not match:
+            LOG.error(f"ignoring invalid max_loaded_bytes: {value!r}")
+            return None
+        number, unit = float(match.group(1)), match.group(2).upper()
+    if unit not in units:
+        LOG.error(f"ignoring max_loaded_bytes={value!r}: unknown unit "
+                  f"'{unit}', expected one of {sorted(units)}")
+        return None
+    if not math.isfinite(number):
+        # YAML writes infinity as ``.inf`` and json.loads accepts
+        # ``Infinity``/``NaN``; int() raises on all three, and this is called
+        # while the plugin is starting, so an uncaught raise here is a plugin
+        # that will not start.
+        LOG.error(f"ignoring max_loaded_bytes={value!r}: not a finite size")
+        return None
+    parsed = int(number * units[unit])
+    if parsed < 1:
+        LOG.error(f"ignoring max_loaded_bytes={value!r}, it must be at least "
+                  f"1 byte")
+        return None
+    return parsed
+
+
+def parse_pinned(value) -> List[str]:
+    """Normalize ``pinned_voices`` to an ordered list of distinct voice ids.
+
+    A single voice written as a bare string is the obvious way to get this
+    wrong, and iterating it would pin one voice per character. Order is kept so
+    the first pin stays the first loaded; duplicates would otherwise inflate
+    the ceiling that is raised to fit the pins.
+    """
+    if isinstance(value, str):
+        value = [value]
+    return list(dict.fromkeys(v for v in (value or []) if v))
+
+
+class VoiceCache:
+    """Loaded voices, bounded by a count of voices and a budget of bytes.
+
+    The cache is keyed by voice id and charged by artifact key. It never loads
+    the same voice twice at once, it never lets a load allocate memory the
+    budget has not admitted, and it never evicts a pinned voice.
+
+    Residency — the set of weights actually in memory — is *cached entries plus
+    leased entries*. Eviction removes a cache entry, it does not free a model a
+    request is three minutes into synthesizing with, so a caller that is using
+    a voice says so by holding a lease:
+
+        with cache.lease(voice_id) as voice:
+            voice.synthesize_wav(...)
+
+    A lease is a refcount, not a garbage-collection hint. That distinction is
+    the whole point: ``TTSVoice`` holds a reference cycle (its adapter points
+    back at it), so CPython's refcounting alone never frees a released voice
+    and its memory only comes back on a cyclic collection — which a budget
+    cannot wait on. With leases the cycle is irrelevant to the budget: memory
+    is charged from the moment a lease is taken until the moment it is
+    released, and releasing one wakes every loader waiting for room.
+
+    Parameters:
+        resolve: Maps a voice id to its catalog entry. Raises for an unknown id.
+        load: Loads a catalog entry's weights and returns the voice.
+        max_loaded_voices: Voices resident at once, pinned ones included.
+        max_loaded_bytes: Byte budget for resident weights.
+        pinned_voices: Voices that may never be evicted.
+        load_wait_timeout: Seconds a load waits for room before proceeding
+            anyway. Waiting forever would turn a memory bound into a hang.
+    """
+
+    def __init__(self,
+                 resolve: Callable[[str], TTSModelInfo],
+                 load: Callable[[TTSModelInfo], TTSVoice],
+                 max_loaded_voices=None,
+                 max_loaded_bytes=None,
+                 pinned_voices: Optional[Iterable[str]] = None,
+                 load_wait_timeout=None):
+        self._resolve = resolve
+        self._load = load
+        # Ordered by least-recently-used, so eviction has an obvious victim.
+        self.voices: "OrderedDict[str, TTSVoice]" = OrderedDict()
+        self._lock = RLock()
+        # Signalled whenever a reservation or a lease is released, so a waiting
+        # loader can re-check whether it fits.
+        self._budget_free = threading.Condition(self._lock)
+        # One gate per voice currently being loaded, so simultaneous callers
+        # wait for the load already running instead of starting their own.
+        self._loading: Dict[str, _Loading] = {}
+        # Bytes promised to loads that are running right now. A load allocates
+        # its memory before the cache ever sees it, so the budget has to be
+        # spent when the load starts, not when it finishes.
+        self._reserved_bytes = 0
+        # Artifact key per cached voice, and measured size per artifact key.
+        # Sizes are never pruned: a key whose voices were all evicted may still
+        # be leased by a request mid-synthesis, and its size is what says so.
+        self._voice_keys: Dict[str, str] = {}
+        self._key_bytes: Dict[str, int] = {}
+        # Outstanding leases per artifact key: how many callers are using those
+        # weights right now, whether or not the cache still lists them.
+        self._leases: Dict[str, int] = {}
+        # A cold load costs seconds to minutes depending on the engine, while a
+        # resident voice answers in milliseconds, so the voices a deployment
+        # actually serves are worth keeping loaded.
+        self.pinned_voices: List[str] = parse_pinned(pinned_voices)
+        self.max_loaded_voices = parse_max_voices(max_loaded_voices)
+        if (self.max_loaded_voices is not None
+                and len(self.pinned_voices) > self.max_loaded_voices):
+            LOG.error(
+                f"{len(self.pinned_voices)} voices are pinned but "
+                f"max_loaded_voices is {self.max_loaded_voices}; raising the "
+                f"limit to fit them, because a pinned voice is a promise")
+            self.max_loaded_voices = len(self.pinned_voices)
+        self.max_loaded_bytes = parse_max_bytes(max_loaded_bytes)
+        self.load_wait_timeout = float(load_wait_timeout or 300)
+
+    def preload_pinned(self) -> None:
+        """Load the pinned voices, reporting what does not fit.
+
+        A pinned voice that cannot load must not stop the service from
+        starting; it simply is not resident.
+        """
+        for voice_id in self.pinned_voices:
+            try:
+                self.get(voice_id)
+                LOG.info(f"pinned voice loaded: {voice_id}")
+            except Exception as e:
+                LOG.error(f"pinned voice '{voice_id}' failed to load: {e}")
+        if (self.max_loaded_bytes is not None
+                and self.resident_bytes() > self.max_loaded_bytes):
+            # Said once, at startup, the way a too-small max_loaded_voices is.
+            # The pins win either way, so this is the only warning an operator
+            # gets that the budget they set is not the memory they will use.
+            LOG.error(
+                f"the pinned voices need {self.resident_bytes()} bytes, more "
+                f"than max_loaded_bytes ({self.max_loaded_bytes}); the pins "
+                f"win, so memory use will exceed the budget")
+
+    def get(self, voice_id: str) -> TTSVoice:
+        """Return the loaded voice for ``voice_id``, loading it if needed.
+
+        The returned voice is not charged to the budget once the cache drops
+        it; a caller that is going to use the weights should hold a
+        :meth:`lease` instead.
+
+        Raises:
+            VoiceExceedsMemoryBudget: The voice cannot fit the budget alone.
+            Exception: ``voice_id`` is not in the catalog, or the load failed.
+        """
+        return self._acquire(voice_id, lease=False)[0]
+
+    @contextmanager
+    def lease(self, voice_id: str) -> Iterator[TTSVoice]:
+        """Hold a voice's weights resident for the duration of the block.
+
+        The lease is taken in the same critical section that finds or caches
+        the voice, so the weights are charged to the budget from before the
+        caller can see them until the block exits. While a lease is held the
+        cache may still evict the entry — that only removes the lookup, the
+        charge stays — and no other load is admitted against memory this
+        caller is using. Releasing the lease wakes every waiting loader.
+
+        Raises what :meth:`get` raises, before the block is entered.
+        """
+        voice, key = self._acquire(voice_id, lease=True)
+        try:
+            yield voice
+        finally:
+            with self._budget_free:
+                remaining = self._leases.get(key, 0) - 1
+                if remaining > 0:
+                    self._leases[key] = remaining
+                else:
+                    self._leases.pop(key, None)
+                self._budget_free.notify_all()
+
+    def resident_bytes(self) -> int:
+        """Total measured size of the weights in memory right now."""
+        with self._lock:
+            return sum(self._key_bytes.get(k, 0) for k in self._resident_keys())
+
+    def _acquire(self, voice_id: str, lease: bool) -> Tuple[TTSVoice, str]:
+        """Find or load ``voice_id``, optionally leasing it, and return its key."""
+        while True:
+            with self._lock:
+                if voice_id in self.voices:
+                    # Touch it so the least recently used voice is evicted.
+                    self.voices.move_to_end(voice_id)
+                    key = self._voice_keys.get(voice_id, voice_id)
+                    if lease:
+                        self._leases[key] = self._leases.get(key, 0) + 1
+                    return self.voices[voice_id], key
+                waiting = self._loading.get(voice_id)
+                if waiting is None:
+                    # This caller owns the load; everyone else waits on it.
+                    self._loading[voice_id] = _Loading()
+                    break
+            # Another caller is loading this voice. Waiting costs nothing and
+            # saves a duplicate multi-gigabyte load.
+            waiting.done.wait()
+            if waiting.error is not None:
+                # Share the failure rather than each waiter retrying it in
+                # turn: the retries are serial, so N callers behind a slow
+                # failure would each wait for the one before. A later request
+                # still gets a fresh attempt, because the gate is gone by then.
+                raise waiting.error
+
+        # Everything from here is inside the try, so no failure can leave the
+        # gate installed. An unknown voice id raises out of the catalog lookup,
+        # and that is a request parameter, so this path is reachable from
+        # outside.
+        reserved = 0
+        try:
+            with self._lock:
+                info = self._resolve(voice_id)
+
+            LOG.debug(f"Using voice: {voice_id}")
+            # Room is claimed BEFORE the load allocates anything. Evicting
+            # after the fact bounds the steady state and nothing else: four
+            # concurrent 2.2 GB loads each evicted the one before and the
+            # cache looked healthy, after the OOM killer had already taken
+            # the process.
+            reserved, measured, key = self._reserve(voice_id, info)
+            # Loaded outside the lock: a cold load takes seconds to minutes,
+            # and holding the lock would stall every other request meanwhile.
+            voice = self._load(info)
+
+        except BaseException as exc:
+            with self._lock:
+                self._release(reserved)
+                gate = self._loading.pop(voice_id, None)
+            if gate is not None:
+                gate.error = exc
+                gate.done.set()
+            raise
+
+        else:
+            # Cached and released under one hold of the lock. Releasing the
+            # gate first would open a window in which the voice is neither
+            # cached nor being loaded, and a waiter that woke inside it would
+            # elect itself and start a second full cold load — the duplicate
+            # this gate exists to prevent.
+            #
+            # The try covers the measuring and the caching too. An exception
+            # raised here is not caught by the except above it — that is what
+            # `else` means — so anything that failed while storing the voice
+            # used to leave the gate installed with nothing to ever set it,
+            # and every later caller for that voice id waited on it forever.
+            try:
+                # Measured outside the lock: it only stats files, but it stats
+                # one per artifact and there is no reason to hold up every
+                # other request for it. A voice that could be measured before
+                # the load is not measured twice; one that could not (its
+                # files were not downloaded yet) now can be.
+                size = measured if measured else self._measure(voice_id, info)
+
+                with self._lock:
+                    self._release(reserved)
+                    # Released exactly once: the failure path below runs the
+                    # same call, and releasing twice would shrink the budget
+                    # by a voice that was never holding it.
+                    reserved = 0
+                    self._key_bytes.setdefault(key, size)
+                    if voice_id not in self.voices:
+                        # Evicted before this voice is tracked: _evict_for
+                        # skips a key that is already resident, and this
+                        # voice's own weights would otherwise satisfy that
+                        # check against itself, making the post-load
+                        # eviction — the only one that sees a size measured
+                        # after a cold download — a permanent no-op.
+                        self._evict_for(voice_id, key, size)
+                        self.voices[voice_id] = voice
+                        self._voice_keys[voice_id] = key
+                    self.voices.move_to_end(voice_id)
+                    key = self._voice_keys.get(voice_id, key)
+                    cached = self.voices[voice_id]
+                    gate = self._loading.pop(voice_id, None)
+                    # Taken last, once nothing that could raise is left: a
+                    # lease that is handed out and then thrown away by an
+                    # exception on the way out is never released, and its
+                    # charge stays on the budget for the life of the process.
+                    if lease:
+                        self._leases[key] = self._leases.get(key, 0) + 1
+                if gate is not None:
+                    gate.done.set()
+                return cached, key
+
+            except BaseException as exc:
+                with self._lock:
+                    self._release(reserved)
+                    gate = self._loading.pop(voice_id, None)
+                if gate is not None:
+                    gate.error = exc
+                    gate.done.set()
+                raise
+
+    def _measure(self, voice_id: str, info: TTSModelInfo) -> int:
+        """Size of a loaded voice in bytes, as a proxy: its files on disk.
+
+        See :meth:`TTSModelInfo.disk_size` for what that proxy does and does
+        not account for. Nothing is measured unless a budget is set, so a
+        deployment that does not use one pays nothing for this.
+
+        A voice that cannot be measured counts as free rather than as
+        infinite: refusing to cache a voice because its size is unknown would
+        turn a measurement problem into a synthesis problem.
+        """
+        if self.max_loaded_bytes is None:
+            return 0
+        try:
+            return int(info.disk_size())
+        except Exception as exc:
+            LOG.error(f"could not measure the size of voice '{voice_id}', "
+                      f"counting it as free: {exc}")
+            return 0
+
+    def _key_for(self, voice_id: str, info: TTSModelInfo) -> str:
+        """Artifact key of a voice: what it would share with another voice.
+
+        Falls back to the voice id when the catalog entry cannot name its
+        artifacts, which charges that voice on its own — the safe direction to
+        be wrong in.
+        """
+        try:
+            key = info.artifact_key()
+        except Exception as exc:
+            LOG.debug(f"voice '{voice_id}' has no artifact key ({exc}); "
+                      f"charging it on its own")
+            return voice_id
+        return key if isinstance(key, str) and key else voice_id
+
+    def _resident_keys(self) -> Set[str]:
+        """Every artifact key whose weights are in memory right now.
+
+        Cached voices, plus leased voices the cache has already evicted.
+        Eviction pops a dict entry; it does not free a model a caller is
+        three minutes into synthesizing with.
+        """
+        keys = {self._voice_keys.get(v, v) for v in self.voices}
+        keys.update(k for k, n in self._leases.items() if n)
+        return keys
+
+    def _reserve(self, voice_id: str, info: TTSModelInfo) -> Tuple[int, int, str]:
+        """Claim budget for a load that has not started yet.
+
+        Returns ``(reserved, measured, key)``: the bytes claimed, the size the
+        voice could be measured at before loading (0 when it could not be),
+        and its artifact key.
+
+        A voice whose weights are already resident claims nothing and waits
+        for nothing: it is going to reuse the session that is already loaded,
+        so there is no second allocation to make room for.
+
+        Otherwise this waits until the voice fits beside what is resident and
+        what other loads have already claimed, evicting to make room. Three
+        rules keep it from ever becoming a hang:
+
+        - a loader waits only while memory could still come back — another
+          load in flight, or leased weights a caller will eventually let go of
+          — so a voice that fits beside nothing does not wait for room that can
+          never appear;
+        - a voice whose known on-disk size alone is bigger than the whole
+          budget is refused with ``VoiceExceedsMemoryBudget`` instead:
+          loading it is not "the memory in use will exceed the budget", it is
+          a guaranteed OOM kill, and on a size that is already known (the
+          case that matters: files that survived a previous, killed attempt)
+          there is no reason to repeat it;
+        - the wait is bounded by ``load_wait_timeout`` regardless, after which
+          the load proceeds and says so;
+        - every reservation is released on both the success and the failure
+          path, and each release wakes the waiters, as does every lease that
+          ends.
+
+        A voice whose files are not downloaded yet cannot be measured, and an
+        unknown size is treated as the whole budget: it loads alone. That
+        costs the cache once per voice, the first time it is ever fetched,
+        and it is the only honest way to keep an unknown allocation inside a
+        known bound.
+        """
+        key = self._key_for(voice_id, info)
+        if self.max_loaded_bytes is None:
+            return 0, 0, key
+        measured = self._measure(voice_id, info)
+        with self._budget_free:
+            if key in self._resident_keys():
+                LOG.debug(f"voice '{voice_id}' reuses weights that are "
+                          f"already loaded; charging nothing for it")
+                self._key_bytes.setdefault(key, measured)
+                return 0, measured, key
+            if measured > self.max_loaded_bytes:
+                # Known in advance, not merely estimated: refuse before
+                # touching eviction or the loader rather than guarantee an
+                # OOM kill. A voice whose size is not yet known (0, not yet
+                # downloaded) still falls through below.
+                raise VoiceExceedsMemoryBudget(
+                    f"voice '{voice_id}' needs {measured} bytes on disk, "
+                    f"more than the whole max_loaded_bytes budget of "
+                    f"{self.max_loaded_bytes}; refusing to load it rather "
+                    f"than guarantee an out-of-memory kill")
+            need = measured if measured > 0 else self.max_loaded_bytes
+            deadline = time.monotonic() + self.load_wait_timeout
+            while (self._over_budget(need)
+                   and (self._reserved_bytes or self._releasable_bytes())):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    LOG.warning(
+                        f"waited {self.load_wait_timeout:.0f}s for room to "
+                        f"load '{voice_id}' and the memory in use did not "
+                        f"come back; loading it anyway, so memory use will "
+                        f"exceed the budget")
+                    break
+                self._budget_free.wait(remaining)
+            # Make the room now, so the bytes are free when the load takes
+            # them rather than after it already has.
+            self._evict_for(voice_id, key, need)
+            self._reserved_bytes += need
+        return need, measured, key
+
+    def _over_budget(self, need: int) -> bool:
+        """Whether admitting ``need`` more bytes would break the budget."""
+        return (sum(self._key_bytes.get(k, 0) for k in self._resident_keys())
+                + self._reserved_bytes + need > self.max_loaded_bytes)
+
+    def _releasable_bytes(self) -> int:
+        """Resident bytes that will come back on their own.
+
+        Weights that are no longer cached but are still leased by a request in
+        flight. Nothing else can shrink without a caller finishing.
+        """
+        cached = {self._voice_keys.get(v, v) for v in self.voices}
+        return sum(self._key_bytes.get(k, 0)
+                   for k in self._resident_keys() if k not in cached)
+
+    def _release(self, reserved: int) -> None:
+        """Give back a reservation and wake whoever is waiting for room.
+
+        Called with ``self._lock`` held.
+        """
+        if not reserved:
+            return
+        self._reserved_bytes = max(0, self._reserved_bytes - reserved)
+        self._budget_free.notify_all()
+
+    def _drop(self, victim: str) -> None:
+        self.voices.pop(victim, None)
+        self._voice_keys.pop(victim, None)
+        LOG.debug(f"evicted least recently used voice: {victim}")
+
+    def _lru_victim(self) -> Optional[str]:
+        """The least recently used voice that may be evicted, if any."""
+        return next((v for v in self.voices if v not in self.pinned_voices),
+                    None)
+
+    def _byte_victim(self) -> Optional[str]:
+        """The least recently used voice whose eviction frees memory.
+
+        Evicting one of 646 voices that share a backbone frees nothing while
+        the others still reference it, and the eviction loop would otherwise
+        empty the whole cache discovering that one entry at a time.
+
+        Neither is a leased voice a candidate: the lease keeps its weights
+        charged, so dropping the entry frees nothing and only throws away the
+        lookup for a model that is still in memory, which the next request for
+        it then loads a second copy of.
+        """
+        for candidate in self.voices:
+            if candidate in self.pinned_voices:
+                continue
+            key = self._voice_keys.get(candidate, candidate)
+            others = [v for v in self.voices
+                      if v != candidate
+                      and self._voice_keys.get(v, v) == key]
+            if others or self._leases.get(key, 0):
+                continue
+            return candidate
+        return None
+
+    def _evict_for(self, incoming: str, key: str, size: int = 0) -> None:
+        """Make room for ``incoming``, never dropping a pinned voice.
+
+        Both bounds apply when both are set: a voice is evicted when either the
+        count or the byte budget would be exceeded.
+        """
+        if self.max_loaded_voices is not None:
+            while len(self.voices) >= self.max_loaded_voices:
+                victim = self._lru_victim()
+                if victim is None:
+                    # Everything resident is pinned: serve the request anyway
+                    # rather than evict a voice an operator asked us to keep.
+                    LOG.warning(
+                        f"all {len(self.voices)} loaded voices are pinned; "
+                        f"loading '{incoming}' above max_loaded_voices")
+                    break
+                self._drop(victim)
+
+        if self.max_loaded_bytes is None:
+            return
+
+        if key in self._resident_keys():
+            # Its weights are already in memory; admitting it costs nothing.
+            return
+
+        if size > self.max_loaded_bytes:
+            # Serving it is still better than not serving it. Everything
+            # evictable goes first, so the overshoot is as small as it can be.
+            LOG.warning(
+                f"voice '{incoming}' needs {size} bytes on disk, more than the "
+                f"whole max_loaded_bytes budget of {self.max_loaded_bytes}; "
+                f"loading it anyway, so memory use will exceed the budget")
+
+        while self.voices and self._over_budget(size):
+            victim = self._byte_victim()
+            if victim is None:
+                LOG.warning(
+                    f"nothing more can be evicted "
+                    f"({self.resident_bytes()} bytes resident); loading "
+                    f"'{incoming}' above max_loaded_bytes")
+                break
+            self._drop(victim)

--- a/tests/test_failed_synthesis_cache.py
+++ b/tests/test_failed_synthesis_cache.py
@@ -32,7 +32,9 @@ def _plugin(testcase, synth_side_effect=None):
     patchers = [
         patch("phoonnx.opm.TTSModelManager"),
         patch.object(PhoonnxTTSPlugin, "get_default_voice", return_value=MagicMock()),
-        patch.object(PhoonnxTTSPlugin, "get_model", return_value=model),
+        patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                     side_effect=lambda v: MagicMock(
+                         load=MagicMock(return_value=model))),
         patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
         patch.object(PhoonnxTTSPlugin, "_resolve_speaker", return_value=None),
     ]
@@ -148,7 +150,9 @@ class TestATruncatedWriteIsNotPublished(unittest.TestCase):
         patchers = [
             patch("phoonnx.opm.TTSModelManager"),
             patch.object(PhoonnxTTSPlugin, "get_default_voice", return_value=MagicMock()),
-            patch.object(PhoonnxTTSPlugin, "get_model", return_value=model),
+            patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                     side_effect=lambda v: MagicMock(
+                         load=MagicMock(return_value=model))),
             patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
             patch.object(PhoonnxTTSPlugin, "_resolve_speaker", return_value=None),
             patch("phoonnx.opm.wave.open", ShortWriter),

--- a/tests/test_in_flight_loads.py
+++ b/tests/test_in_flight_loads.py
@@ -12,8 +12,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 
-def _plugin(testcase, load_delay=0.2, **config):
-    """Build the plugin with a slow, counting loader."""
+def _plugin(testcase, load_delay=0.2, load_hook=None, **config):
+    """Build the plugin with a slow, counting loader.
+
+    ``load_hook`` runs inside the load, while it is in flight, so a test can
+    observe overlap directly instead of inferring it from a clock.
+    """
     from phoonnx.opm import PhoonnxTTSPlugin
 
     counts = {"loads": 0, "concurrent": 0, "peak": 0}
@@ -24,6 +28,8 @@ def _plugin(testcase, load_delay=0.2, **config):
             counts["loads"] += 1
             counts["concurrent"] += 1
             counts["peak"] = max(counts["peak"], counts["concurrent"])
+        if load_hook is not None:
+            load_hook()
         time.sleep(load_delay)
         with lock:
             counts["concurrent"] -= 1
@@ -100,20 +106,31 @@ class TestInFlightLoads(unittest.TestCase):
         self.assertEqual(len(errors), 4, "every caller should see the failure")
 
     def test_different_voices_still_load_in_parallel(self):
-        # The gate is per voice; it must not serialise unrelated loads.
-        plugin, counts = _plugin(self, load_delay=0.3)
-        threads = [threading.Thread(target=plugin.get_model, args=(f"v{i}",))
+        # The gate is per voice; it must not serialise unrelated loads. The
+        # evidence is the overlap itself rather than a wall clock: a clock
+        # cannot tell a serialised load from a busy machine, and every load
+        # here has to be in flight at the same instant or the barrier times
+        # out and the loads fail.
+        together = threading.Barrier(4, timeout=10)
+        plugin, counts = _plugin(self, load_delay=0, load_hook=together.wait)
+        errors = []
+
+        def ask(voice_id):
+            try:
+                plugin.get_model(voice_id)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=ask, args=(f"v{i}",))
                    for i in range(4)]
-        started = time.time()
         [t.start() for t in threads]
-        [t.join() for t in threads]
-        elapsed = time.time() - started
+        [t.join(timeout=30) for t in threads]
+        self.assertFalse([t for t in threads if t.is_alive()])
+        self.assertFalse(errors, f"four different voices did not load "
+                                 f"concurrently: {errors}")
         self.assertEqual(counts["loads"], 4)
-        # 0.3s of load each: fully parallel is ~0.3s, two-at-a-time is ~0.6s,
-        # fully serial is ~1.2s. The threshold has to reject partial
-        # serialisation, not just total serialisation.
-        self.assertLess(elapsed, 0.55,
-                        "four different voices should load concurrently")
+        self.assertEqual(counts["peak"], 4,
+                         "four different voices should load concurrently")
 
 
 class TestGateIsAlwaysReleased(unittest.TestCase):
@@ -141,7 +158,7 @@ class TestGateIsAlwaysReleased(unittest.TestCase):
         with self.assertRaises(Exception):
             plugin.get_model("nope")
         # The gate must be gone, or every later caller waits on it forever.
-        self.assertEqual(plugin._loading, {})
+        self.assertEqual(plugin.voice_cache._loading, {})
 
         done = threading.Event()
 
@@ -172,7 +189,7 @@ class TestGateIsAlwaysReleased(unittest.TestCase):
             t.join(timeout=10)
             self.assertFalse(t.is_alive(), "no caller may hang")
         self.assertEqual(len(errors), 6)
-        self.assertEqual(plugin._loading, {})
+        self.assertEqual(plugin.voice_cache._loading, {})
 
 
 class TestFailedLoadIsNotRetriedPerCaller(unittest.TestCase):
@@ -237,7 +254,7 @@ class TestGateReleasedWithTheCacheInsert(unittest.TestCase):
     """
 
     def test_a_waiter_woken_at_the_release_point_does_not_reload(self):
-        from phoonnx import opm as opm_module
+        from phoonnx import voice_cache as voice_cache_module
         from phoonnx.opm import PhoonnxTTSPlugin
 
         class YieldingEvent(threading.Event):
@@ -249,7 +266,7 @@ class TestGateReleasedWithTheCacheInsert(unittest.TestCase):
                 # elect itself and start its own load.
                 time.sleep(0.3)
 
-        real_loading = opm_module._Loading
+        real_loading = voice_cache_module._Loading
 
         def yielding_loading():
             gate = real_loading()
@@ -271,7 +288,7 @@ class TestGateReleasedWithTheCacheInsert(unittest.TestCase):
             patch.object(PhoonnxTTSPlugin, "get_voice_info",
                          side_effect=lambda v: MagicMock(load=counting)),
             patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
-            patch.object(opm_module, "_Loading", yielding_loading),
+            patch.object(voice_cache_module, "_Loading", yielding_loading),
         ]
         for pat in patchers:
             pat.start()
@@ -311,6 +328,7 @@ class TestTheGateSurvivesAFailureWhileCaching(unittest.TestCase):
 
     def _plugin_failing_after_load(self):
         from phoonnx.opm import PhoonnxTTSPlugin
+        from phoonnx.voice_cache import VoiceCache
 
         patchers = [
             patch("phoonnx.opm.TTSModelManager"),
@@ -321,7 +339,7 @@ class TestTheGateSurvivesAFailureWhileCaching(unittest.TestCase):
                              load=lambda **_kw: "a-loaded-voice")),
             patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
             # Fails only once the voice is loaded and is being cached.
-            patch.object(PhoonnxTTSPlugin, "_evict_for",
+            patch.object(VoiceCache, "_evict_for",
                          side_effect=RuntimeError("failed while caching")),
         ]
         for pat in patchers:
@@ -333,7 +351,7 @@ class TestTheGateSurvivesAFailureWhileCaching(unittest.TestCase):
         plugin = self._plugin_failing_after_load()
         with self.assertRaises(RuntimeError):
             plugin.get_model("wedged")
-        self.assertEqual(plugin._loading, {},
+        self.assertEqual(plugin.voice_cache._loading, {},
                          "the gate must not outlive the request that made it")
 
     def test_the_next_caller_does_not_hang(self):

--- a/tests/test_opm.py
+++ b/tests/test_opm.py
@@ -113,14 +113,14 @@ class TestInit(unittest.TestCase):
         self.assertEqual(mgr.load_calls, 1)
         self.assertEqual(plugin.voice_info.voice_id, v.voice_id)
         # resolved, not fetched: loading is deferred to the first synthesis
-        self.assertEqual(plugin.voices, {})
+        self.assertEqual(plugin.voice_cache.voices, {})
 
     def test_init_resolves_configured_voice(self):
         a = _FakeVoiceInfo("OpenVoiceOS/a")
         b = _FakeVoiceInfo("OpenVoiceOS/b")
         plugin, _ = _make_plugin(config={"voice": "OpenVoiceOS/b"}, voices=[a, b])
         self.assertEqual(plugin.voice_info.voice_id, "OpenVoiceOS/b")
-        self.assertEqual(plugin.voices, {})
+        self.assertEqual(plugin.voice_cache.voices, {})
 
 
 class TestVoiceResolution(unittest.TestCase):
@@ -363,5 +363,5 @@ class TestVoiceResolvedWithoutLoading(unittest.TestCase):
                     cfg["voice"] = voice
                 plugin = opm.PhoonnxTTSPlugin(config=cfg)
                 self.assertIsNotNone(plugin.voice_info)
-                self.assertEqual(plugin.voices, {},
+                self.assertEqual(plugin.voice_cache.voices, {},
                                  "boot must not load (download) the model")

--- a/tests/test_per_request_cloning.py
+++ b/tests/test_per_request_cloning.py
@@ -18,7 +18,9 @@ def _plugin(testcase, **config):
         patch("phoonnx.opm.TTSModelManager"),
         patch.object(PhoonnxTTSPlugin, "get_default_voice",
                      return_value=MagicMock()),
-        patch.object(PhoonnxTTSPlugin, "get_model", return_value=MagicMock()),
+        patch.object(PhoonnxTTSPlugin, "get_voice_info",
+                     side_effect=lambda v: MagicMock(
+                         load=MagicMock(return_value=MagicMock()))),
         patch.object(PhoonnxTTSPlugin, "_providers", return_value=None),
     ]
     for pat in patchers:

--- a/tests/test_shared_sessions.py
+++ b/tests/test_shared_sessions.py
@@ -291,9 +291,9 @@ class TestTheBudgetChargesTheModelOnce(unittest.TestCase):
                          max_loaded_bytes="3GB")
         for voice_id in keys:
             plugin.get_model(voice_id)
-        self.assertEqual(len(plugin.voices), 20,
+        self.assertEqual(len(plugin.voice_cache.voices), 20,
                          "voices over one model must not evict each other")
-        self.assertEqual(plugin._resident_bytes(), 3 * GB,
+        self.assertEqual(plugin.voice_cache.resident_bytes(), 3 * GB,
                          "one model in memory is one charge")
 
     def test_a_shared_model_is_not_reloaded_for_the_next_voice(self):
@@ -304,8 +304,8 @@ class TestTheBudgetChargesTheModelOnce(unittest.TestCase):
         plugin.get_model("omnivoice/en")
         plugin.get_model("omnivoice/es")
         plugin.get_model("omnivoice/en")
-        self.assertIn("omnivoice/en", plugin.voices)
-        self.assertIn("omnivoice/es", plugin.voices)
+        self.assertIn("omnivoice/en", plugin.voice_cache.voices)
+        self.assertIn("omnivoice/es", plugin.voice_cache.voices)
         del loads
 
     def test_a_second_model_still_evicts_the_first(self):
@@ -316,58 +316,91 @@ class TestTheBudgetChargesTheModelOnce(unittest.TestCase):
         first = plugin.get_model("omnivoice/en")
         del first
         plugin.get_model("qwen/vivian")
-        self.assertNotIn("omnivoice/en", plugin.voices)
-        self.assertEqual(plugin._resident_bytes(), 4 * GB)
+        self.assertNotIn("omnivoice/en", plugin.voice_cache.voices)
+        self.assertEqual(plugin.voice_cache.resident_bytes(), 4 * GB)
 
 
 class TestWhatIsActuallyResident(unittest.TestCase):
-    """Eviction pops a dict entry; it does not free a model in use."""
+    """Eviction pops a dict entry; it does not free a model in use.
+
+    A caller says it is using a voice by holding a lease. The lease is what
+    the budget counts, so weights stay charged for as long as a synthesis has
+    them, whether or not the cache still lists the voice.
+    """
 
     def test_an_evicted_voice_still_in_use_is_still_charged(self):
         keys = {"a": "model-a", "b": "model-b"}
         plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
-                         max_loaded_bytes="4GB")
-        held = plugin.get_model("a")       # caller keeps it, as a synthesis does
-        plugin.get_model("b")
-        self.assertNotIn("a", plugin.voices, "it was evicted from the cache")
-        self.assertEqual(plugin._resident_bytes(), 6 * GB,
-                         "but its weights are still in memory, and the OOM "
-                         "killer reads memory, not the cache")
-        self.assertIsNotNone(held)
+                         max_loaded_bytes="4GB", load_wait_timeout=0.2)
+        with plugin.voice_cache.lease("a"):    # as a synthesis does
+            plugin.voice_cache.voices.clear()
+            plugin.voice_cache._voice_keys.clear()
+            plugin.get_model("b")
+            self.assertNotIn("a", plugin.voice_cache.voices,
+                             "it is gone from the cache")
+            self.assertEqual(plugin.voice_cache.resident_bytes(), 6 * GB,
+                             "but its weights are still in memory, and the "
+                             "OOM killer reads memory, not the cache")
 
-    def test_the_charge_goes_away_when_the_request_finishes(self):
-        import gc
+    def test_a_voice_in_use_is_not_evicted_to_make_room(self):
+        # Dropping it would free nothing — the lease keeps the weights
+        # charged — and the next request for that voice would then load a
+        # second copy of a model that never left memory.
         keys = {"a": "model-a", "b": "model-b"}
         plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
-                         max_loaded_bytes="4GB")
-        held = plugin.get_model("a")
-        plugin.get_model("b")
-        del held
-        gc.collect()
-        self.assertEqual(plugin._resident_bytes(), 3 * GB)
+                         max_loaded_bytes="4GB", load_wait_timeout=0.2)
+        with plugin.voice_cache.lease("a") as held:
+            plugin.get_model("b")
+            self.assertIn("a", plugin.voice_cache.voices)
+            self.assertIs(plugin.get_model("a"), held,
+                          "the leased voice was served from the cache, not "
+                          "loaded again")
+
+    def test_a_cold_loaded_voice_is_charged_from_the_lease_that_loaded_it(self):
+        # The lease on a voice that was not cached yet is taken by the load
+        # itself, inside the same critical section that caches it. Without
+        # that, a voice would be charged only while the cache happens to
+        # still list it, which is exactly what a lease exists to outlive.
+        keys = {"a": "model-a"}
+        plugin = _plugin(self, keys, {"model-a": 3 * GB},
+                         max_loaded_bytes="4GB", load_wait_timeout=0.2)
+        with plugin.voice_cache.lease("a"):
+            plugin.voice_cache.voices.clear()
+            plugin.voice_cache._voice_keys.clear()
+            self.assertEqual(plugin.voice_cache._leases, {"model-a": 1})
+            self.assertEqual(plugin.voice_cache.resident_bytes(), 3 * GB)
+        self.assertEqual(plugin.voice_cache._leases, {})
+        self.assertEqual(plugin.voice_cache.resident_bytes(), 0)
+
+    def test_the_charge_goes_away_when_the_request_finishes(self):
+        keys = {"a": "model-a", "b": "model-b"}
+        plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
+                         max_loaded_bytes="4GB", load_wait_timeout=0.2)
+        with plugin.voice_cache.lease("a"):
+            plugin.voice_cache.voices.clear()
+            plugin.voice_cache._voice_keys.clear()
+            self.assertEqual(plugin.voice_cache.resident_bytes(), 3 * GB)
+        self.assertEqual(plugin.voice_cache.resident_bytes(), 0)
 
     def test_a_load_waits_for_memory_that_is_coming_back(self):
         import threading
-        import time
         keys = {"a": "model-a", "b": "model-b"}
         plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
                          max_loaded_bytes="4GB", load_wait_timeout=10)
-        held = plugin.get_model("a")
-        plugin.voices.clear()          # evicted, but the request holds it
-        plugin._voice_keys.clear()
-
         done = threading.Event()
 
         def ask():
             plugin.get_model("b")
             done.set()
 
-        thread = threading.Thread(target=ask, daemon=True)
-        thread.start()
-        self.assertFalse(done.wait(timeout=1),
-                         "the second model must not be admitted while the "
-                         "first is still resident")
-        del held                        # the synthesis finishes
+        with plugin.voice_cache.lease("a"):
+            plugin.voice_cache.voices.clear()   # evicted, but the lease holds it
+            plugin.voice_cache._voice_keys.clear()
+            thread = threading.Thread(target=ask, daemon=True)
+            thread.start()
+            self.assertFalse(done.wait(timeout=1),
+                             "the second model must not be admitted while the "
+                             "first is still resident")
         self.assertTrue(done.wait(timeout=10),
                         "and it must be admitted as soon as it can be")
         thread.join(timeout=5)
@@ -378,15 +411,14 @@ class TestWhatIsActuallyResident(unittest.TestCase):
         keys = {"a": "model-a", "b": "model-b"}
         plugin = _plugin(self, keys, {"model-a": 3 * GB, "model-b": 3 * GB},
                          max_loaded_bytes="4GB", load_wait_timeout=0.2)
-        held = plugin.get_model("a")
-        plugin.voices.clear()
-        plugin._voice_keys.clear()
-        with patch("phoonnx.opm.LOG") as log:
-            plugin.get_model("b")
-        self.assertIn("b", plugin.voices)
+        with plugin.voice_cache.lease("a"):
+            plugin.voice_cache.voices.clear()
+            plugin.voice_cache._voice_keys.clear()
+            with patch("phoonnx.voice_cache.LOG") as log:
+                plugin.get_model("b")
+        self.assertIn("b", plugin.voice_cache.voices)
         self.assertIn("exceed the budget",
                       " ".join(str(c) for c in log.warning.call_args_list))
-        self.assertIsNotNone(held)
 
 
 if __name__ == "__main__":

--- a/tests/test_voice_cache.py
+++ b/tests/test_voice_cache.py
@@ -38,7 +38,7 @@ class TestCacheCeiling(unittest.TestCase):
         plugin = _plugin(self)
         for i in range(5):
             plugin.get_model(f"v{i}")
-        self.assertEqual(len(plugin.voices), 5)
+        self.assertEqual(len(plugin.voice_cache.voices), 5)
 
     def test_limit_evicts_least_recently_used(self):
         plugin = _plugin(self, max_loaded_voices=2)
@@ -46,49 +46,49 @@ class TestCacheCeiling(unittest.TestCase):
         plugin.get_model("b")
         plugin.get_model("a")      # touch: "b" is now the oldest
         plugin.get_model("c")
-        self.assertEqual(len(plugin.voices), 2)
-        self.assertIn("a", plugin.voices)
-        self.assertIn("c", plugin.voices)
-        self.assertNotIn("b", plugin.voices)
+        self.assertEqual(len(plugin.voice_cache.voices), 2)
+        self.assertIn("a", plugin.voice_cache.voices)
+        self.assertIn("c", plugin.voice_cache.voices)
+        self.assertNotIn("b", plugin.voice_cache.voices)
 
     def test_invalid_limit_is_ignored(self):
         for bad in ("nonsense", -1, 0):
             with self.subTest(value=bad):
                 plugin = _plugin(self, max_loaded_voices=bad)
-                self.assertIsNone(plugin.max_loaded_voices)
+                self.assertIsNone(plugin.voice_cache.max_loaded_voices)
 
 
 class TestPinning(unittest.TestCase):
 
     def test_pinned_voice_is_loaded_at_startup(self):
         plugin = _plugin(self, pinned_voices=["keeper"])
-        self.assertIn("keeper", plugin.voices)
+        self.assertIn("keeper", plugin.voice_cache.voices)
 
     def test_pinned_voice_survives_eviction_pressure(self):
         plugin = _plugin(self, pinned_voices=["keeper"], max_loaded_voices=2)
         for i in range(6):
             plugin.get_model(f"passing{i}")
-        self.assertIn("keeper", plugin.voices,
+        self.assertIn("keeper", plugin.voice_cache.voices,
                       "a pinned voice must never be evicted")
 
     def test_limit_is_raised_to_fit_the_pins(self):
         # A limit smaller than the pin set is a contradiction; the pins win,
         # because they were named explicitly.
         plugin = _plugin(self, pinned_voices=["a", "b", "c"], max_loaded_voices=1)
-        self.assertEqual(plugin.max_loaded_voices, 3)
+        self.assertEqual(plugin.voice_cache.max_loaded_voices, 3)
         for v in ("a", "b", "c"):
-            self.assertIn(v, plugin.voices)
+            self.assertIn(v, plugin.voice_cache.voices)
 
     def test_a_single_pin_written_as_a_string_is_one_voice(self):
         # Iterating a bare string would pin one voice per character, and the
         # "pins win" rule would then raise the ceiling to fit all of them —
         # a typo would silently remove the bound entirely.
         plugin = _plugin(self, pinned_voices="OpenVoiceOS/foo")
-        self.assertEqual(plugin.pinned_voices, ["OpenVoiceOS/foo"])
+        self.assertEqual(plugin.voice_cache.pinned_voices, ["OpenVoiceOS/foo"])
 
     def test_duplicate_pins_are_collapsed(self):
         plugin = _plugin(self, pinned_voices=["a", "a", "b"], max_loaded_voices=5)
-        self.assertEqual(plugin.pinned_voices, ["a", "b"])
+        self.assertEqual(plugin.voice_cache.pinned_voices, ["a", "b"])
 
     def test_a_pinned_voice_that_cannot_load_does_not_stop_startup(self):
         from phoonnx.opm import PhoonnxTTSPlugin
@@ -99,7 +99,7 @@ class TestPinning(unittest.TestCase):
                              side_effect=RuntimeError("no such voice")), \
                 patch.object(PhoonnxTTSPlugin, "_providers", return_value=None):
             plugin = PhoonnxTTSPlugin(config={"pinned_voices": ["missing"]})
-        self.assertEqual(len(plugin.voices), 0)
+        self.assertEqual(len(plugin.voice_cache.voices), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_voice_cache_budget.py
+++ b/tests/test_voice_cache_budget.py
@@ -62,7 +62,7 @@ def _plugin(testcase, sizes=None, load_hook=None, **config):
 class TestSizeParsing(unittest.TestCase):
 
     def test_human_friendly_sizes(self):
-        from phoonnx.opm import PhoonnxTTSPlugin as P
+        from phoonnx import voice_cache as vc
         cases = {
             "6GB": 6 * 10 ** 9,
             "512MB": 512 * 10 ** 6,
@@ -76,44 +76,44 @@ class TestSizeParsing(unittest.TestCase):
         }
         for value, expected in cases.items():
             with self.subTest(value=value):
-                self.assertEqual(P._parse_max_bytes(value), expected)
+                self.assertEqual(vc.parse_max_bytes(value), expected)
 
     def test_infinite_and_nan_budgets_are_rejected_not_crashes(self):
         # YAML ".inf" and json.loads("Infinity"/"NaN") both land here as
         # floats, and int(inf) raises out of __init__, killing plugin startup.
-        from phoonnx.opm import PhoonnxTTSPlugin as P
+        from phoonnx import voice_cache as vc
         for value in (float("inf"), float("-inf"), float("nan"),
                       "1e400", 1e400):
             with self.subTest(value=value):
-                self.assertIsNone(P._parse_max_bytes(value))
+                self.assertIsNone(vc.parse_max_bytes(value))
 
     def test_an_infinite_budget_does_not_break_startup(self):
         plugin = _plugin(self, max_loaded_bytes=float("inf"))
-        self.assertIsNone(plugin.max_loaded_bytes)
+        self.assertIsNone(plugin.voice_cache.max_loaded_bytes)
         plugin.get_model("v")
-        self.assertIn("v", plugin.voices)
+        self.assertIn("v", plugin.voice_cache.voices)
 
     def test_unset_means_no_budget(self):
-        from phoonnx.opm import PhoonnxTTSPlugin as P
+        from phoonnx import voice_cache as vc
         for value in (None, "", 0):
             with self.subTest(value=value):
-                self.assertIsNone(P._parse_max_bytes(value))
+                self.assertIsNone(vc.parse_max_bytes(value))
 
     def test_invalid_sizes_are_rejected_not_read_as_zero(self):
         # A zero budget would evict every voice on every request, so a typo
         # must leave the cache unbounded rather than unusable.
-        from phoonnx.opm import PhoonnxTTSPlugin as P
+        from phoonnx import voice_cache as vc
         for value in ("nonsense", "6 gigabytes", "GB", "-1", -1, "1.2.3",
                       "6GBB", "0.4", True, [1], "12PB"):
             with self.subTest(value=value):
-                self.assertIsNone(P._parse_max_bytes(value))
+                self.assertIsNone(vc.parse_max_bytes(value))
 
     def test_an_invalid_budget_leaves_the_cache_unbounded(self):
         plugin = _plugin(self, max_loaded_bytes="nonsense")
-        self.assertIsNone(plugin.max_loaded_bytes)
+        self.assertIsNone(plugin.voice_cache.max_loaded_bytes)
         for i in range(4):
             plugin.get_model(f"v{i}")
-        self.assertEqual(len(plugin.voices), 4)
+        self.assertEqual(len(plugin.voice_cache.voices), 4)
 
 
 class TestByteBudget(unittest.TestCase):
@@ -126,9 +126,9 @@ class TestByteBudget(unittest.TestCase):
         plugin.get_model("b")
         plugin.get_model("a")       # touch: "b" is now the oldest
         plugin.get_model("big")
-        self.assertIn("big", plugin.voices)
-        self.assertNotIn("b", plugin.voices)
-        self.assertIn("a", plugin.voices)
+        self.assertIn("big", plugin.voice_cache.voices)
+        self.assertNotIn("b", plugin.voice_cache.voices)
+        self.assertIn("a", plugin.voice_cache.voices)
 
     def test_many_small_voices_but_only_one_big_one(self):
         # The case a count gets wrong: with max_loaded_voices=3 these small
@@ -138,32 +138,32 @@ class TestByteBudget(unittest.TestCase):
                          max_loaded_bytes="3GB")
         for i in range(20):
             plugin.get_model(f"small{i}")   # 10 MB each -> 200 MB resident
-        self.assertEqual(len(plugin.voices), 20)
+        self.assertEqual(len(plugin.voice_cache.voices), 20)
 
         plugin.get_model("omni")
-        self.assertIn("omni", plugin.voices)
-        self.assertLessEqual(plugin._resident_bytes(), 3 * GB)
+        self.assertIn("omni", plugin.voice_cache.voices)
+        self.assertLessEqual(plugin.voice_cache.resident_bytes(), 3 * GB)
 
         # Another small voice still fits alongside it; the budget is never
         # exceeded by voices that could have been evicted.
         plugin.get_model("small20")
-        self.assertIn("omni", plugin.voices)
-        self.assertLessEqual(plugin._resident_bytes(), 3 * GB)
+        self.assertIn("omni", plugin.voice_cache.voices)
+        self.assertLessEqual(plugin.voice_cache.resident_bytes(), 3 * GB)
 
     def test_two_big_voices_cannot_be_resident_together(self):
         plugin = _plugin(self, sizes={"omniA": 2200 * MB, "omniB": 2200 * MB},
                          max_loaded_bytes="3GB")
         plugin.get_model("omniA")
         plugin.get_model("omniB")
-        self.assertIn("omniB", plugin.voices)
-        self.assertNotIn("omniA", plugin.voices)
+        self.assertIn("omniB", plugin.voice_cache.voices)
+        self.assertNotIn("omniA", plugin.voice_cache.voices)
 
     def test_a_voice_bigger_than_the_whole_budget_is_refused_not_loaded(self):
         # Loading it is not a degraded path, it is a guaranteed OOM kill; a
         # 15.4 GB voice against a 5 GB budget in an 8 GiB cgroup produced
         # exactly that, and the container restart looped straight back into
         # the same load. The known size is refused before it is ever loaded.
-        from phoonnx.opm import VoiceExceedsMemoryBudget
+        from phoonnx.voice_cache import VoiceExceedsMemoryBudget
         plugin = _plugin(self, sizes={"huge": 8 * GB}, max_loaded_bytes="1GB")
         plugin.get_model("small")
         with self.assertRaises(VoiceExceedsMemoryBudget) as ctx:
@@ -171,25 +171,25 @@ class TestByteBudget(unittest.TestCase):
         self.assertIn("huge", str(ctx.exception))
         self.assertIn(str(8 * GB), str(ctx.exception))
         self.assertIn(str(10 ** 9), str(ctx.exception))
-        self.assertNotIn("huge", plugin.voices)
-        self.assertIn("small", plugin.voices,
+        self.assertNotIn("huge", plugin.voice_cache.voices)
+        self.assertIn("small", plugin.voice_cache.voices,
                       "a refused load must not disturb what is already resident")
-        self.assertEqual(plugin._voice_keys.keys() & plugin.voices.keys(),
-                         plugin.voices.keys())
+        self.assertEqual(plugin.voice_cache._voice_keys.keys() & plugin.voice_cache.voices.keys(),
+                         plugin.voice_cache.voices.keys())
 
     def test_a_refused_voice_leaves_no_accounting_behind(self):
-        from phoonnx.opm import VoiceExceedsMemoryBudget
+        from phoonnx.voice_cache import VoiceExceedsMemoryBudget
         plugin = _plugin(self, sizes={"huge": 8 * GB}, max_loaded_bytes="1GB")
         with self.assertRaises(VoiceExceedsMemoryBudget):
             plugin.get_model("huge")
-        self.assertNotIn("huge", plugin.voices)
-        self.assertNotIn("huge", plugin._voice_keys)
-        self.assertNotIn("huge", plugin._key_bytes)
-        self.assertEqual(plugin._reserved_bytes, 0)
+        self.assertNotIn("huge", plugin.voice_cache.voices)
+        self.assertNotIn("huge", plugin.voice_cache._voice_keys)
+        self.assertNotIn("huge", plugin.voice_cache._key_bytes)
+        self.assertEqual(plugin.voice_cache._reserved_bytes, 0)
         # A voice that actually fits still loads normally afterwards.
         model = plugin.get_model("small")
         self.assertEqual(model, "model:small")
-        self.assertIn("small", plugin.voices)
+        self.assertIn("small", plugin.voice_cache.voices)
 
     def test_a_voice_that_fits_alone_but_faces_pressure_still_evicts_not_refuses(self):
         # Regression guard: a voice that individually fits the budget, but not
@@ -203,8 +203,8 @@ class TestByteBudget(unittest.TestCase):
         plugin.get_model("a")
         model = plugin.get_model("b")
         self.assertEqual(model, "model:b")
-        self.assertIn("b", plugin.voices)
-        self.assertNotIn("a", plugin.voices,
+        self.assertIn("b", plugin.voice_cache.voices)
+        self.assertNotIn("a", plugin.voice_cache.voices,
                          "b displaces a rather than being refused")
 
     def test_no_budget_means_no_measuring(self):
@@ -222,7 +222,7 @@ class TestByteBudget(unittest.TestCase):
                            disk_size=MagicMock(side_effect=OSError("no")))
         with patch.object(plugin, "get_voice_info", return_value=broken):
             self.assertEqual(plugin.get_model("broken"), "model:broken")
-        self.assertIn("broken", plugin.voices)
+        self.assertIn("broken", plugin.voice_cache.voices)
 
 
 class TestBothBoundsTogether(unittest.TestCase):
@@ -231,7 +231,7 @@ class TestBothBoundsTogether(unittest.TestCase):
         plugin = _plugin(self, max_loaded_voices=2, max_loaded_bytes="100GB")
         for name in ("a", "b", "c"):
             plugin.get_model(name)
-        self.assertEqual(set(plugin.voices), {"b", "c"})
+        self.assertEqual(set(plugin.voice_cache.voices), {"b", "c"})
 
     def test_the_budget_still_evicts_when_the_count_is_roomy(self):
         sizes = {f"small{i}": 20 * MB for i in range(10)}
@@ -241,9 +241,9 @@ class TestBothBoundsTogether(unittest.TestCase):
         for i in range(10):
             plugin.get_model(f"small{i}")
         plugin.get_model("big")
-        self.assertIn("big", plugin.voices)
-        self.assertLess(len(plugin.voices), 11)
-        self.assertLessEqual(plugin._resident_bytes(), GB)
+        self.assertIn("big", plugin.voice_cache.voices)
+        self.assertLess(len(plugin.voice_cache.voices), 11)
+        self.assertLessEqual(plugin.voice_cache.resident_bytes(), GB)
 
 
 class TestPinningUnderBudgetPressure(unittest.TestCase):
@@ -252,10 +252,10 @@ class TestPinningUnderBudgetPressure(unittest.TestCase):
         plugin = _plugin(self, pinned_voices=["keeper"],
                          sizes={"keeper": 900 * MB, "big": 900 * MB},
                          max_loaded_bytes="1GB")
-        self.assertIn("keeper", plugin.voices)
+        self.assertIn("keeper", plugin.voice_cache.voices)
         for i in range(5):
             plugin.get_model(f"big{i}" if i else "big")
-        self.assertIn("keeper", plugin.voices,
+        self.assertIn("keeper", plugin.voice_cache.voices,
                       "a pinned voice must never be evicted")
 
     def test_pins_raise_the_effective_ceiling(self):
@@ -266,11 +266,11 @@ class TestPinningUnderBudgetPressure(unittest.TestCase):
                                 "p3": 900 * MB},
                          max_loaded_bytes="1GB")
         for pin in ("p1", "p2", "p3"):
-            self.assertIn(pin, plugin.voices)
-        self.assertGreater(plugin._resident_bytes(), GB)
+            self.assertIn(pin, plugin.voice_cache.voices)
+        self.assertGreater(plugin.voice_cache.resident_bytes(), GB)
 
     def test_pins_over_the_budget_are_reported_at_startup(self):
-        with patch("phoonnx.opm.LOG") as log:
+        with patch("phoonnx.voice_cache.LOG") as log:
             _plugin(self, pinned_voices=["p1", "p2"],
                     sizes={"p1": 900 * MB, "p2": 900 * MB},
                     max_loaded_bytes="1GB")
@@ -284,15 +284,15 @@ class TestPinningUnderBudgetPressure(unittest.TestCase):
         # still starts; the voice simply never becomes resident.
         plugin = _plugin(self, pinned_voices=["huge"],
                          sizes={"huge": 8 * GB}, max_loaded_bytes="1GB")
-        self.assertNotIn("huge", plugin.voices)
+        self.assertNotIn("huge", plugin.voice_cache.voices)
 
     def test_an_all_pinned_cache_serves_a_new_voice_anyway(self):
         plugin = _plugin(self, pinned_voices=["p1"],
                          sizes={"p1": 900 * MB, "extra": 900 * MB},
                          max_loaded_bytes="1GB")
         self.assertEqual(plugin.get_model("extra"), "model:extra")
-        self.assertIn("p1", plugin.voices)
-        self.assertIn("extra", plugin.voices)
+        self.assertIn("p1", plugin.voice_cache.voices)
+        self.assertIn("extra", plugin.voice_cache.voices)
 
 
 class TestConcurrentEviction(unittest.TestCase):
@@ -332,11 +332,11 @@ class TestConcurrentEviction(unittest.TestCase):
         self.assertFalse([t for t in threads if t.is_alive()],
                          "a stranded loading gate hangs callers forever")
         self.assertEqual(len(results), 8)
-        self.assertEqual(plugin._loading, {},
+        self.assertEqual(plugin.voice_cache._loading, {},
                          "every loading gate must be released")
-        self.assertEqual(set(plugin._voice_keys), set(plugin.voices),
+        self.assertEqual(set(plugin.voice_cache._voice_keys), set(plugin.voice_cache.voices),
                          "size bookkeeping must match the cache exactly")
-        self.assertLessEqual(plugin._resident_bytes(), 100 * MB)
+        self.assertLessEqual(plugin.voice_cache.resident_bytes(), 100 * MB)
 
     def test_repeated_concurrent_requests_for_an_evicted_voice(self):
         plugin = _plugin(self, max_loaded_bytes="50MB",
@@ -352,8 +352,8 @@ class TestConcurrentEviction(unittest.TestCase):
         [t.start() for t in threads]
         [t.join(timeout=30) for t in threads]
         self.assertFalse([t for t in threads if t.is_alive()])
-        self.assertEqual(plugin._loading, {})
-        self.assertEqual(set(plugin._voice_keys), set(plugin.voices))
+        self.assertEqual(plugin.voice_cache._loading, {})
+        self.assertEqual(set(plugin.voice_cache._voice_keys), set(plugin.voice_cache.voices))
 
 
 class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
@@ -384,8 +384,8 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
                 return
             with lock:
                 inflight = sum(size for v, size in live.items()
-                               if v not in plugin.voices)
-                total = inflight + plugin._resident_bytes()
+                               if v not in plugin.voice_cache.voices)
+                total = inflight + plugin.voice_cache.resident_bytes()
                 peak[0] = max(peak[0], total)
 
         def hook(voice_id):
@@ -419,15 +419,15 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
         self.assertFalse([t for t in workers if t.is_alive()],
                          "admission control must never deadlock")
         if expect_errors:
-            from phoonnx.opm import VoiceExceedsMemoryBudget
+            from phoonnx.voice_cache import VoiceExceedsMemoryBudget
             self.assertEqual(len(errors), len(voices))
             self.assertTrue(
                 all(isinstance(e, VoiceExceedsMemoryBudget) for e in errors),
                 f"unexpected errors: {errors}")
         else:
             self.assertFalse(errors, f"loads failed: {errors}")
-        self.assertEqual(plugin._loading, {})
-        self.assertEqual(set(plugin._voice_keys), set(plugin.voices))
+        self.assertEqual(plugin.voice_cache._loading, {})
+        self.assertEqual(set(plugin.voice_cache._voice_keys), set(plugin.voice_cache.voices))
         return plugin, peak[0]
 
     def test_four_concurrent_omnivoice_loads_stay_within_the_budget(self):
@@ -438,7 +438,7 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
                              f"peak {peak} bytes exceeded the 3 GB budget")
         # No two of these fit together, so the peak is one voice, not four.
         self.assertLessEqual(peak, 2200 * MB)
-        self.assertLessEqual(plugin._resident_bytes(), 3 * GB)
+        self.assertLessEqual(plugin.voice_cache.resident_bytes(), 3 * GB)
 
     def test_voices_that_fit_together_still_load_together(self):
         # Admission control must not serialise loads that the budget allows;
@@ -452,7 +452,7 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
         [t.start() for t in threads]
         [t.join(timeout=20) for t in threads]
         self.assertFalse([t for t in threads if t.is_alive()])
-        self.assertEqual(len(plugin.voices), 3)
+        self.assertEqual(len(plugin.voice_cache.voices), 3)
 
     def test_a_voice_larger_than_the_budget_is_refused_under_concurrency(self):
         # None of these can ever fit, by definition, so none may be let
@@ -463,7 +463,7 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
         sizes = {f"huge{i}": 4 * GB for i in range(3)}
         plugin, peak = self._run(list(sizes), sizes, "1GB",
                                  expect_errors=True)
-        self.assertEqual(len(plugin.voices), 0)
+        self.assertEqual(len(plugin.voice_cache.voices), 0)
         self.assertEqual(peak, 0)
 
     def test_pinned_voices_raise_the_peak_ceiling_but_only_by_themselves(self):
@@ -476,7 +476,7 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
                  "c": 900 * MB}
         plugin, peak = self._run(["a", "b", "c"], sizes, "3GB",
                                  threads={"pinned_voices": ["keeper"]})
-        self.assertIn("keeper", plugin.voices)
+        self.assertIn("keeper", plugin.voice_cache.voices)
         self.assertLessEqual(peak, 2 * GB + 900 * MB,
                              "pins raise the ceiling by their own size, "
                              "not by one voice per concurrent request")
@@ -485,12 +485,11 @@ class TestPeakMemoryUnderConcurrentColdLoads(unittest.TestCase):
 class _CyclicVoice:
     """A loaded voice stand-in shaped like the real ``TTSVoice``.
 
-    ``TTSVoice`` holds a reference back to itself through
-    ``adapter.voice``, so releasing the caller's last reference does not
-    make the refcount drop to zero — CPython only reclaims it on a cyclic
-    ``gc.collect()``. A leaf stand-in without this cycle would pass even a
-    residency fix that never calls ``gc.collect()`` at all, because a plain
-    ``del`` already frees a leaf object.
+    ``TTSVoice`` holds a reference back to itself through ``adapter.voice``,
+    so releasing the caller's last reference does not make the refcount drop
+    to zero — CPython only reclaims it on a cyclic collection. A leaf stand-in
+    would hide any residency rule that quietly depends on the collector,
+    because a plain ``del`` already frees a leaf object.
     """
 
     def __init__(self, voice_id):
@@ -531,93 +530,46 @@ def _cyclic_plugin(testcase, keys, sizes, **config):
 
 
 class TestCyclicVoiceResidency(unittest.TestCase):
-    """A voice held in a reference cycle must still be freed promptly.
+    """A voice in a reference cycle must not delay the next load.
 
-    Without an explicit ``gc.collect()`` on the load path, a request that
-    lets go of a cyclic voice never wakes the weakref callback that frees
-    its budget charge, and the next load for different weights sits out
-    the full ``load_wait_timeout`` before proceeding anyway.
+    Residency is the lease, not the garbage collector: weights are charged
+    from the moment a caller takes a lease until the moment it ends, so a
+    voice nobody is using is free immediately even though the cycle it sits
+    in means the object itself will not be reclaimed for a while yet.
     """
 
     def test_a_released_cyclic_voice_frees_its_charge_without_waiting(self):
         import gc
-        from unittest.mock import patch as _patch
-        # Python's own generational collector runs periodically on
-        # allocation counts, which could free the cycle by coincidence and
-        # make this test pass whether or not the residency code calls
-        # gc.collect() itself. Disabling automatic collection makes the only
-        # possible collector run the one _reserve is required to make.
+        # Automatic collection off, so nothing can break the cycle by
+        # coincidence. A budget that depended on the collector at all would
+        # sit out the whole load_wait_timeout below.
         gc.disable()
         self.addCleanup(gc.enable)
 
         keys = {"a": "model-a", "b": "model-b"}
-        # A timeout of a few seconds, not the 300s default: if the fix
-        # regresses, this test must fail fast rather than eat minutes of CI
-        # time sitting out the real production timeout.
+        # A timeout of a few seconds, not the 300s default: if this regresses,
+        # the test must fail fast rather than eat minutes of CI time sitting
+        # out the real production timeout.
         plugin = _cyclic_plugin(self, keys,
                                 {"model-a": 3 * GB, "model-b": 3 * GB},
                                 max_loaded_bytes="4GB",
                                 load_wait_timeout=3)
-        held = plugin.get_model("a")
-        plugin.voices.clear()          # evicted, but the cycle holds it
-        plugin._voice_keys.clear()
-        held = None                    # the caller's own reference is gone
+        with plugin.voice_cache.lease("a"):
+            self.assertEqual(plugin.voice_cache.resident_bytes(), 3 * GB,
+                             "a leased voice is charged for")
+        plugin.voice_cache.voices.clear()          # evicted, cycle still alive
+        plugin.voice_cache._voice_keys.clear()
 
         started = time.monotonic()
-        with _patch("phoonnx.opm.gc", wraps=gc) as gc_mock:
+        with patch("gc.collect") as collect:
             plugin.get_model("b")
         elapsed = time.monotonic() - started
 
-        self.assertIn("b", plugin.voices)
-        self.assertGreaterEqual(gc_mock.collect.call_count, 1,
-                                "the wait must call gc.collect() to break "
-                                "the cycle, not merely happen to succeed")
+        self.assertIn("b", plugin.voice_cache.voices)
+        collect.assert_not_called()
         self.assertLess(elapsed, 1.0,
-                        "a released cyclic voice must be collected and its "
-                        "budget freed well before the load_wait_timeout")
-
-
-class TestGcCollectIsGatedOnActuallyWaiting(unittest.TestCase):
-    """gc.collect() walks the whole heap; it must not tax every load.
-
-    It exists to break the reference cycle a released ``TTSVoice`` sits in,
-    so the residency wait does not run the full timeout for memory that is
-    already free. That is only relevant once a load is actually about to
-    wait for room — a load with plenty of budget headroom, or one that hits
-    an already-resident key, has no cycle to break and must not pay for the
-    collection anyway.
-    """
-
-    def test_ample_headroom_does_not_collect(self):
-        from unittest.mock import patch as _patch
-        plugin = _plugin(self, sizes={"a": 10 * MB}, max_loaded_bytes="1GB")
-        with _patch("phoonnx.opm.gc") as gc_mock:
-            plugin.get_model("a")
-        gc_mock.collect.assert_not_called()
-
-    def test_a_cache_hit_for_an_already_resident_key_does_not_collect(self):
-        from unittest.mock import patch as _patch
-        keys = {"a": "model-a", "b": "model-a"}
-        plugin = _plugin_shared_keys(self, keys, sizes={"model-a": 10 * MB},
-                                     max_loaded_bytes="1GB")
-        plugin.get_model("a")
-        with _patch("phoonnx.opm.gc") as gc_mock:
-            plugin.get_model("b")
-        gc_mock.collect.assert_not_called()
-
-    def test_a_load_that_must_wait_for_room_does_collect(self):
-        from unittest.mock import patch as _patch
-        keys = {"a": "model-a", "b": "model-b"}
-        plugin = _plugin_shared_keys(self, keys,
-                                     sizes={"model-a": 3 * GB, "model-b": 3 * GB},
-                                     max_loaded_bytes="4GB", load_wait_timeout=0.2)
-        held = plugin.get_model("a")
-        plugin.voices.clear()
-        plugin._voice_keys.clear()
-        with _patch("phoonnx.opm.gc", wraps=__import__("gc")) as gc_mock:
-            plugin.get_model("b")
-        self.assertGreaterEqual(gc_mock.collect.call_count, 1)
-        self.assertIsNotNone(held)
+                        "an unleased voice's budget charge is gone at once, "
+                        "not after the load_wait_timeout")
 
 
 class _WeakrefableVoice:
@@ -667,19 +619,19 @@ class TestSharedArtifactRefusal(unittest.TestCase):
     SIZES = {"orpheus-3b-en-onnx": 15_400_000_000}  # ~15.4 GB, one shared model
 
     def test_every_voice_over_one_shared_oversized_artifact_is_refused(self):
-        from phoonnx.opm import VoiceExceedsMemoryBudget
+        from phoonnx.voice_cache import VoiceExceedsMemoryBudget
         plugin = _plugin_shared_keys(self, self.KEYS, self.SIZES,
                                      max_loaded_bytes="8GB")
         for voice_id in self.KEYS:
             with self.subTest(voice_id=voice_id):
                 with self.assertRaises(VoiceExceedsMemoryBudget):
                     plugin.get_model(voice_id)
-        self.assertEqual(plugin.voices, {})
-        self.assertEqual(plugin._voice_keys, {})
-        self.assertEqual(plugin._key_bytes, {})
-        self.assertEqual(plugin._refs, {})
-        self.assertEqual(plugin._reserved_bytes, 0)
-        self.assertEqual(plugin._loading, {},
+        self.assertEqual(plugin.voice_cache.voices, {})
+        self.assertEqual(plugin.voice_cache._voice_keys, {})
+        self.assertEqual(plugin.voice_cache._key_bytes, {})
+        self.assertEqual(plugin.voice_cache._leases, {})
+        self.assertEqual(plugin.voice_cache._reserved_bytes, 0)
+        self.assertEqual(plugin.voice_cache._loading, {},
                          "every loading gate must be released on refusal, "
                          "not just the first one")
 
@@ -687,15 +639,15 @@ class TestSharedArtifactRefusal(unittest.TestCase):
         # A caller that retries the same voice id after a refusal must be
         # refused again, not admitted because an earlier attempt left the
         # shared key half-tracked.
-        from phoonnx.opm import VoiceExceedsMemoryBudget
+        from phoonnx.voice_cache import VoiceExceedsMemoryBudget
         plugin = _plugin_shared_keys(self, self.KEYS, self.SIZES,
                                      max_loaded_bytes="8GB")
         for _ in range(3):
             with self.assertRaises(VoiceExceedsMemoryBudget):
                 plugin.get_model("orpheus/en/dan")
         self.assertNotIn("orpheus-3b-en-onnx",
-                         {plugin._voice_keys.get(v, v) for v in plugin.voices})
-        self.assertEqual(plugin._reserved_bytes, 0)
+                         {plugin.voice_cache._voice_keys.get(v, v) for v in plugin.voice_cache.voices})
+        self.assertEqual(plugin.voice_cache._reserved_bytes, 0)
 
         # A small, unrelated voice still loads normally afterwards; the
         # repeated rejections did not poison the budget.
@@ -708,14 +660,14 @@ class TestSharedArtifactRefusal(unittest.TestCase):
                 plugin2.get_model(voice_id)
         model = plugin2.get_model("small")
         self.assertEqual(model.voice_id, "small")
-        self.assertIn("small", plugin2.voices)
+        self.assertIn("small", plugin2.voice_cache.voices)
 
     def test_concurrent_requests_across_the_family_all_refuse_cleanly(self):
         # Eight concurrent requests, one per sibling voice id sharing the one
         # oversized artifact: dedup is per voice id, so all eight run their
         # own _reserve concurrently rather than waiting on each other, and
         # none may deadlock or corrupt the shared key's accounting.
-        from phoonnx.opm import VoiceExceedsMemoryBudget
+        from phoonnx.voice_cache import VoiceExceedsMemoryBudget
         plugin = _plugin_shared_keys(self, self.KEYS, self.SIZES,
                                      max_loaded_bytes="8GB")
         errors = {}
@@ -737,9 +689,9 @@ class TestSharedArtifactRefusal(unittest.TestCase):
         self.assertTrue(
             all(isinstance(e, VoiceExceedsMemoryBudget) for e in errors.values()),
             f"unexpected errors: {errors}")
-        self.assertEqual(plugin.voices, {})
-        self.assertEqual(plugin._reserved_bytes, 0)
-        self.assertEqual(plugin._loading, {})
+        self.assertEqual(plugin.voice_cache.voices, {})
+        self.assertEqual(plugin.voice_cache._reserved_bytes, 0)
+        self.assertEqual(plugin.voice_cache._loading, {})
 
 
 class TestPostLoadEviction(unittest.TestCase):
@@ -791,13 +743,13 @@ class TestPostLoadEviction(unittest.TestCase):
         plugin_holder["p"] = plugin
         plugin.get_model("big")
 
-        self.assertIn("big", plugin.voices)
-        self.assertNotIn("extra", plugin.voices,
+        self.assertIn("big", plugin.voice_cache.voices)
+        self.assertNotIn("extra", plugin.voice_cache.voices,
                          "the post-load eviction must evict a voice that no "
                          "longer fits once the real size is known")
         import gc
         gc.collect()
-        self.assertLessEqual(plugin._resident_bytes(), 4 * GB)
+        self.assertLessEqual(plugin.voice_cache.resident_bytes(), 4 * GB)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 via Claude Code — NOT human-reviewed. Verify before acting.

The loaded-voice cache moves out of the OVOS plugin into `phoonnx/voice_cache.py`, and the way it decides what is resident changes from an inference to a fact. `VoiceCache` owns budget parsing, residency accounting, LRU and pinning, eviction, the in-flight load gate and the bounded wait; `opm.py` keeps the plugin wrapper and request handling and composes one. The plugin's public surface is untouched — `get_tts`, `get_model`, `get_voice_info`, the `max_loaded_bytes` / `max_loaded_voices` / `pinned_voices` / `load_wait_timeout` config keys and `PHOONNX_SHARE_ONNX_SESSIONS` all behave as before.

The interesting part is residency. Eviction pops a dict entry; it does not free a model a request is three minutes into synthesizing with, so the budget has to count weights that are in use but no longer cached. That used to be inferred from weak references to the voice objects handed out, which only works if a released voice is reclaimed promptly — and `TTSVoice` sits in a reference cycle, so CPython's refcounting never frees it and the weakref callback that wakes a waiting loader never fires. The workaround was a `gc.collect()` on the load path: a full heap walk, hundreds of milliseconds on a large process, inside the critical section every waiting load goes through.

A caller now says it is using a voice by holding a lease, and `get_tts` wraps its synthesis in one. Residency is cached entries plus leased entries; the lease is taken as the last thing that happens inside the critical section that finds or caches the voice, so the weights are charged from before the caller can see them until the block exits and nothing that could raise sits between handing a lease out and returning it. Eviction drops an unleased entry immediately, and the bounded wait is woken by lease releases rather than by a collection. The reference cycle stops being the budget's problem, and both `gc.collect()` calls are gone.

A voice someone is using is not an eviction victim. Dropping its entry frees nothing — the lease keeps the weights charged either way — and it throws away the lookup for a model that never left memory, so the next request for that voice loads a second copy. In a twelve-thread soak that one rule is the difference between 1981 cold loads and 6, at an identical peak.

Everything the existing tests lock still holds — peak memory under concurrent cold loads, refusal of a voice larger than the whole budget, one charge per shared artifact, pinning, one load per cold voice, the bounded wait that never becomes a hang. The tests that reached into the moved private attributes follow them to `plugin.voice_cache`, and the four that expressed "in use" by keeping a Python reference now express it by holding a lease, which is what "in use" means here. Three tests that asserted exactly when `gc.collect()` runs are gone with the calls; the cyclic-voice test that motivated them now asserts, with automatic collection disabled, that a released cyclic voice's charge is free immediately and that `gc.collect` is never called at all.

One test was flaky for a reason worth fixing while in this code: `test_different_voices_still_load_in_parallel` asserted four 0.3s loads finished in under 0.55s of wall clock, which fails on a loaded runner for reasons that have nothing to do with the gate. It now asserts the overlap directly — all four loads must be in flight at the same instant, through a barrier inside the loader — which is what it was always trying to measure and cannot be fooled by a slow machine.

Verified by running it: the full non-training suite has an identical failure set before and after (82 failed, 16 errors, all pre-existing and dependency-related on `dev`; 2130 → 2129 passed, the difference being three deleted gc tests and two added lease tests). A 12-thread soak over 8 voices under a 100 MB budget for six seconds completes 6914 leases and 2225 typed refusals from 6 cold loads, with no deadlock, no unexpected exception and no accounting drift, at the same 180 MB peak the current `dev` code reaches under the identical soak — with 3.3x the completed requests, because no load pays for a heap walk any more. Both new rules have tripwires: reverting the leased-entry guard fails `test_a_voice_in_use_is_not_evicted_to_make_room`, and deleting the load-path lease fails six tests including a new one that leases a never-before-cached voice and clears the cache under it.
