### PR TITLE
docs: link the TTS training notebooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ For anyone with a dataset who wants a new voice.
 3. [Preprocess reference](training/preprocess.md) — every `preprocess.py` flag
 4. [Training reference](training/training.md) — every `train.py` flag, engines, resume/fine-tune
 5. [Export](training/export.md) — checkpoint → ONNX, validating the exported voice
+6. [Training notebooks](training/quickstart.md#training-notebooks) — the golden path as a runnable Colab/Kaggle notebook
 
 ### Understand the internals (contributors and advanced users)
 For anyone extending phoonnx or debugging a voice.

--- a/docs/training/quickstart.md
+++ b/docs/training/quickstart.md
@@ -181,3 +181,16 @@ That's the full loop. From here:
 - Fine-tune onto a new speaker or resume training: [Training reference](training.md).
 - Train a different architecture (Matcha, GlowTTS, StyleTTS2, …): [engine guides](engines/matcha.md).
 - Ship the voice in a voice assistant: [OVOS plugin](../ovos_plugin.md).
+
+## Training notebooks
+
+For a runnable, Colab/Kaggle-ready walkthrough of this same golden path, see
+[`train_vits.ipynb`](https://github.com/TigreGotico/ml-notebooks/blob/main/tts/train_vits.ipynb)
+in the `ml-notebooks` repository. It clones phoonnx and drives the same
+`preprocess` → `train` → `export_onnx` CLIs described above end to end, producing a trained
+and exported ONNX voice without any local environment setup.
+
+If a dataset does not exist yet, [`tts_dataset_gen.ipynb`](https://github.com/TigreGotico/ml-notebooks/blob/main/tts/tts_dataset_gen.ipynb)
+generates one in the LJSpeech layout expected by [preprocess](#2-preprocess) by synthesizing
+speech from text in a donor voice, giving a ready-made `metadata.csv` and `wavs/` folder to
+feed straight into step 1 above.


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Adds a "Training notebooks" section to the training quickstart, linking the two runnable notebooks in `ml-notebooks` (`tts/train_vits.ipynb` for VITS training + ONNX export, and `tts/tts_dataset_gen.ipynb` for LJSpeech-style dataset generation from a donor voice) as a Colab/Kaggle-ready companion to the existing preprocess/train/export docs, and links the section from the docs front page's training path list.