### PR TITLE
feat: add logus2k/tts_eu_pt European Portuguese Kokoro voice

### DIFF
--- a/VOICES.md
+++ b/VOICES.md
@@ -2358,6 +2358,10 @@
 | `OpenVoiceOS/pipertts_pt-PT_miro` | `pt-PT` | `piper` | `espeak` |
 | `outetts/1B/pt` | `pt-PT` | `outetts` | `unicode` |
 | `piper/pt_PT-tugão-medium` | `pt-PT` | `piper` | `espeak` |
+| `logus2k/tts_eu_pt` | `pt-PT-x-lisbon` | `styletts2` | `tugaphone` |
+| `logus2k/tts_eu_pt-pm_alex` | `pt-PT-x-lisbon` | `styletts2` | `tugaphone` |
+| `logus2k/tts_eu_pt-pm_santa` | `pt-PT-x-lisbon` | `styletts2` | `tugaphone` |
+| `logus2k/tts_eu_pt-am_adam` | `pt-PT-x-lisbon` | `styletts2` | `tugaphone` |
 | `facebook/mms-tts-ptu-Bambam` | `ptu` | `transformers` | `graphemes` |
 | `omnivoice/pua` | `pua` | `omnivoice` | `unicode` |
 | `facebook/mms-tts-pui-Puinave` | `pui` | `transformers` | `graphemes` |

--- a/phoonnx/tokenizer.py
+++ b/phoonnx/tokenizer.py
@@ -1,3 +1,4 @@
+import unicodedata
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Mapping, List, Dict, Optional, Any, Set, Union
@@ -571,13 +572,25 @@ class TTSTokenizer:
                         compound_idxs += [i for i in range(i, i+n)]
                         break
 
+                if idx is None and len(char) == 1:
+                    # Phonemizers emit precomposed characters (e.g. U+00F5 "õ") while
+                    # some vocabularies (e.g. Kokoro/StyleTTS2) only know the base
+                    # letter plus a separate combining mark. Fall back to the
+                    # canonical decomposition before giving up on the character.
+                    decomposed = unicodedata.normalize("NFD", char)
+                    if len(decomposed) > 1 and all(c in self.vocabulary.char2idx for c in decomposed):
+                        idx = [self.vocabulary.char2idx[c] for c in decomposed]
+
                 if idx is None and char not in self.not_found_characters:
                     self.not_found_characters.add(char)
                     LOG.warning(f"Out-of-vocabulary phoneme {char!r} "
                                 f"(codepoints: {[hex(ord(c)) for c in char]}) "
                                 f"not found in vocabulary, dropping it")
 
-            token_ids.append(idx)
+            if isinstance(idx, list):
+                token_ids.extend(idx)
+            else:
+                token_ids.append(idx)
 
         # NOTE: mimic3 adds an extra word_blank at end, so we match that behaviour here
         #  instead of ending [..., BLANK, EOS] it ends with [..., BLANK, BLANK_WORD, BLANK, EOS]

--- a/phoonnx/voice_index/styletts2.json
+++ b/phoonnx/voice_index/styletts2.json
@@ -3169,5 +3169,61 @@
     "engine": "styletts2",
     "lang": "en-US",
     "style_url": "https://huggingface.co/OpenVoiceOS/phoonnx-kitten-tts/resolve/main/mini-0.1/expr-voice-5-f.bin"
+  },
+  "logus2k/tts_eu_pt": {
+    "voice_id": "logus2k/tts_eu_pt",
+    "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/model.onnx",
+    "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/config.json",
+    "vocab_url": null,
+    "tokenizer_config_url": null,
+    "tokens_url": null,
+    "phoneme_map_url": null,
+    "phoneme_type": "tugaphone",
+    "alphabet": "ipa",
+    "engine": "styletts2",
+    "lang": "pt-PT-x-lisbon",
+    "style_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/voices/tuga.bin"
+  },
+  "logus2k/tts_eu_pt-pm_alex": {
+    "voice_id": "logus2k/tts_eu_pt-pm_alex",
+    "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/model.onnx",
+    "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/config.json",
+    "vocab_url": null,
+    "tokenizer_config_url": null,
+    "tokens_url": null,
+    "phoneme_map_url": null,
+    "phoneme_type": "tugaphone",
+    "alphabet": "ipa",
+    "engine": "styletts2",
+    "lang": "pt-PT-x-lisbon",
+    "style_url": "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_alex.bin"
+  },
+  "logus2k/tts_eu_pt-pm_santa": {
+    "voice_id": "logus2k/tts_eu_pt-pm_santa",
+    "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/model.onnx",
+    "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/config.json",
+    "vocab_url": null,
+    "tokenizer_config_url": null,
+    "tokens_url": null,
+    "phoneme_map_url": null,
+    "phoneme_type": "tugaphone",
+    "alphabet": "ipa",
+    "engine": "styletts2",
+    "lang": "pt-PT-x-lisbon",
+    "style_url": "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_santa.bin"
+  },
+  "logus2k/tts_eu_pt-am_adam": {
+    "voice_id": "logus2k/tts_eu_pt-am_adam",
+    "model_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/model.onnx",
+    "config_url": "https://huggingface.co/OpenVoiceOS/phoonnx-styletts2/resolve/main/tuga-kokoro-pt/config.json",
+    "vocab_url": null,
+    "tokenizer_config_url": null,
+    "tokens_url": null,
+    "phoneme_map_url": null,
+    "phoneme_type": "tugaphone",
+    "alphabet": "ipa",
+    "engine": "styletts2",
+    "lang": "pt-PT-x-lisbon",
+    "style_url": "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_adam.bin"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "langcodes",
     "ovos-number-parser>=0.4.0",
     "ovos-date-parser>=0.6.4a1",
-    "scriptconv[phonemizers]>=0.0.4a23",
+    "scriptconv[phonemizers]>=0.0.4a25",
     "unicode_rbnf",
     "click",
     "requests",

--- a/tests/test_tokenizer_vocab.py
+++ b/tests/test_tokenizer_vocab.py
@@ -351,6 +351,44 @@ class TestCompoundPhonemeEncoding(unittest.TestCase):
         self.assertEqual(tok.encode("azb"), [0])
 
 
+class TestPrecomposedCharacterDecomposition(unittest.TestCase):
+    """Phonemizers emit precomposed nasal vowels (e.g. U+00E3 "ã") while
+    vocabularies like Kokoro/StyleTTS2 only know the base letter plus a
+    separate combining tilde (U+0303). Decompose before dropping."""
+
+    def test_precomposed_char_decomposes_to_base_plus_combining_mark(self):
+        # "ã" (U+00E3) NFD-decomposes to "a" (U+0061) + combining tilde (U+0303)
+        voc = Vocabulary(char2idx={"a": 0, "̃": 1}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("ã"), [0, 1])
+        self.assertEqual(tok.not_found_characters, set())
+
+    def test_precomposed_char_in_vocab_is_not_decomposed(self):
+        voc = Vocabulary(char2idx={"a": 0, "̃": 1, "ã": 2}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("ã"), [2])
+
+    def test_partial_decomposition_match_still_dropped(self):
+        # vocab only has the base letter, not the combining mark -> can't fully map
+        voc = Vocabulary(char2idx={"a": 0}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("ã"), [])
+        self.assertEqual(tok.not_found_characters, {"ã"})
+
+    def test_compound_token_still_wins_over_decomposition(self):
+        # "ã" is not in char2idx directly, but if a compound token happened to
+        # equal the precomposed char's neighbour sequence, compounds must still
+        # be matched first; here we assert decomposition doesn't break normal
+        # compound folding for unrelated ASCII compounds.
+        voc = Vocabulary(char2idx={"a": 0, "i": 1, "ai": 2, "̃": 3}, blank=None)
+        tok = TTSTokenizer(voc, add_blank_char=False, add_blank_word=False,
+                            use_eos_bos=False, blank_at_start=False, blank_at_end=False)
+        self.assertEqual(tok.encode("ai"), [2])
+
+
 class TestBosEosSafetyPath(unittest.TestCase):
     def test_pad_with_bos_eos_without_bos_returns_input_unchanged(self):
         voc = Vocabulary(char2idx={"a": 0}, bos=None, eos="$")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

Adds `logus2k/tts_eu_pt`, a Kokoro-82M fine-tune for European Portuguese (Lisbon lect) by Antonio Cruz (logus2k), Apache-2.0. Weights: https://huggingface.co/logus2k/kokoro_tts_eu_pt. The model is exported to the phoonnx StyleTTS2 single-graph contract (`input_ids` + `style` + `speed` -> waveform, plus a durations output) and hosted under `OpenVoiceOS/phoonnx-styletts2/tuga-kokoro-pt`, with the voicepack stored as a flat float32 style pack. The voice config aliases tugaphone symbols the Kokoro vocabulary does not have (ʀ→ʁ, ɫ→l, ASCII g→ɡ), the same approximations the upstream project trains and infers with.

The tokenizer fix in this branch decomposes precomposed phonemes into base letter plus combining mark when the vocabulary only holds the decomposed form. Kokoro-style vocabularies need this for nasal vowels: without it, every Kokoro Portuguese voice silently dropped its nasal vowels instead of raising or falling back.

Verification executed by the orchestrator:
- Torch vs onnxruntime waveform correlation: 0.9987 and 0.9984 at two different token lengths.
- ASR round trip with whisper-medium-pt on exported audio transcribed "O vinho verde custa vinte e cinco euros." exactly.
- QA gate through manual `TTSVoice.load`, the voice index (`TTSModelInfo.load`), and `PhoonnxTTSPlugin` all resolved engine `styletts2` / `TugaphonePhonemizer` / lang `pt-PT-x-lisbon`, and produced byte-identical audio per sentence across load paths.
- `get_lang_voices("pt-PT")` returns the voice with match distance 0.

Related changes in the phonemizer stack:
- TigreGotico/scriptconv#114 (merged) lets the `pt-PT-x-lisbon` lect reach tugaphone; older scriptconv releases phonemize the voice as generic pt-PT, which stays intelligible. TigreGotico/scriptconv#115 (merged) keeps clock times such as 16:30 in one chunk instead of splitting at the colon.
- TigreGotico/tugalex#32 (merged) fixes ASCII g in the lexicon data, and TigreGotico/tugaphone#101 makes tugaphone rebuild its on-disk lexicon cache when tugalex changes. The config alias in this voice covers older installs.

phoonnx splits sentences on punctuation before phonemizing, so Kokoro's punctuation tokens are never fed to the model; that is a possible follow-up. Abbreviation-aware sentence splitting ("D. Afonso" no longer ends a sentence) is in OpenVoiceOS/quebra_frases#16.


Three additional voice-index entries, `logus2k/tts_eu_pt-pm_alex`, `logus2k/tts_eu_pt-pm_santa`, and `logus2k/tts_eu_pt-am_adam`, reuse the same fine-tuned model with the original Kokoro male voicepacks (`pm_alex`, `pm_santa`, `am_adam`) as speakers, since the fine-tune keeps Kokoro's style space intact. In the ASR round trip all three transcribed the test sentence exactly, same as the trained speaker. The shipped `logus2k/tts_eu_pt` pack remains the trained speaker and the recommended default.



The scriptconv floor moves to 0.0.4a25, the release that passes sub-regional lects through to tugaphone.
