### PR TITLE
fix: pin IR version of test-built ONNX graphs to what onnxruntime accepts

### DIFF
--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -440,6 +440,8 @@ class TestExternalDataGraphLoads(HubTestCase):
             [weight])
         model = helper.make_model(
             graph, opset_imports=[helper.make_opsetid("", 13)])
+        # onnxruntime's supported IR version lags behind onnx releases; pin explicitly.
+        model.ir_version = 10
         onnx.save(model, str(build / "model.onnx"), save_as_external_data=True,
                   location="model.onnx_data", all_tensors_to_one_file=True,
                   size_threshold=0)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet via Claude Code — NOT human-reviewed. Verify before acting.

CI on Python 3.13 and 3.14 fails four tests in `tests/test_model_manager.py::TestExternalDataGraphLoads` with:

```
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from ... failed:
Unsupported model IR version: 14, max supported IR version: 13
```

On those interpreters CI resolves the prerelease `onnx==1.23.0` together with `onnxruntime==1.29.0`. `onnx` 1.23 stamps IR version 14 by default on freshly built graphs, but `onnxruntime` 1.29 only accepts up to IR version 13. Python 3.11/3.12 pin `onnx<1.18` in the test extra, so they never build a graph with the newer default IR version and the tests pass there. One of the four failing tests, `test_a_copy_outside_the_cache_would_not_load`, exists to check a different error path ("escapes model directory"); the IR-version load failure was masking that check.

The fix sets an explicit IR version on the one tiny graph builder in this test file that did not already pin one — `TestExternalDataGraphLoads._external_data_model` in `tests/test_model_manager.py` — matching the pattern already used everywhere else in the suite that builds ONNX graphs by hand (`tests/test_runtime_alignment.py`, `tests/test_alignment_concurrency.py`, `tests/test_chatterbox.py`, `tests/test_vits_split.py`, `tests/test_coldstart_warmup_cache.py`, `tests/test_shared_sessions.py`), all of which already call `model.ir_version = 8` or `9` after `helper.make_model(...)`. No dependency pins were touched.

Verification, run in a throwaway venv built with `uv` on Python 3.13 with `onnx==1.23.0rc1` and `onnxruntime==1.29.0` installed (the same combination CI resolves):

Before the fix, `pytest tests/test_model_manager.py -k ExternalDataGraphLoads`:
```
FAILED tests/test_model_manager.py::TestExternalDataGraphLoads::test_a_copy_outside_the_cache_would_not_load
FAILED tests/test_model_manager.py::TestExternalDataGraphLoads::test_a_self_hosted_external_data_graph_loads_too
FAILED tests/test_model_manager.py::TestExternalDataGraphLoads::test_load_opens_a_real_session_on_an_external_data_graph
FAILED tests/test_model_manager.py::TestExternalDataGraphLoads::test_the_graph_the_engine_is_handed_loads
4 failed, 84 deselected in 4.22s
```

After the fix, the same command:
```
4 passed, 84 deselected in 1.98s
```

The full `tests/test_model_manager.py` module: `88 passed in 2.86s`.

The broader test suite was also run for context: 99 failures and 16 collection errors remain, all attributable to optional dependencies not installed in this slim venv (torch, pytorch_lightning, tokenizers/scriptconv-adjacent modules, speechonnxmetrics, librosa-family vendor deps for F0 extraction) — none related to ONNX IR version, and none newly introduced by this change.
