### PR TITLE
fix: pass PYPI_TOKEN and MATRIX_TOKEN explicitly to cross-org release workflow

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -12,7 +12,9 @@ jobs:
   publish_stable:
     if: github.actor != 'github-actions[bot]'
     uses: OpenVoiceOS/gh-automations/.github/workflows/publish-stable.yml@dev
-    secrets: inherit
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
       branch: 'master'
       version_file: 'phoonnx/version.py'

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -14,7 +14,9 @@ jobs:
   publish_alpha:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     uses: OpenVoiceOS/gh-automations/.github/workflows/publish-alpha.yml@dev
-    secrets: inherit
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
       branch: 'dev'
       version_file: 'phoonnx/version.py'


### PR DESCRIPTION
🤖 Auto-generated by Claude Haiku via Claude Code — NOT human-reviewed. Verify before acting.

`secrets: inherit` does not cross organizations; gh-automations is in OpenVoiceOS while phoonnx is in TigreGotico, preventing PYPI_TOKEN from reaching the publish job. Every publish_alpha run since at least the August runs fails at the PyPI step with a trusted-publishing exchange error; PyPI's newest phoonnx is 1.3.4a1 while dev is at 1.91.0a1.