### PR TITLE
fix: keep digit ranges and scores intact in text normalization

### DIFF
--- a/phoonnx/normalization/text.py
+++ b/phoonnx/normalization/text.py
@@ -13,10 +13,24 @@ def _normalize_word_hyphen_digit(text: str) -> str:
     """
     Helper function to normalize words attached to digits with a hyphen,
     such as 'sub-23' -> 'sub 23'.
+
+    A hyphen (or en-dash/em-dash) directly between two digit runs, such as
+    '3-2' or '1139-1185', is left untouched: that is a score or a range,
+    not a word glued to a digit, and it is up to the phonemizer to read it
+    as such.
     """
-    # Regex to find a word (\w+) followed by a hyphen and a digit (\d+)
-    pattern = re.compile(r"(\w+)-(\d+)")
-    text = pattern.sub(r"\1 \2", text)
+    # Regex to find a word (\w+) followed by a hyphen/en-dash/em-dash and a
+    # digit (\d+).
+    pattern = re.compile(r"(\w+)[-–—](\d+)")
+
+    def _replace(match: "re.Match") -> str:
+        word_part = match.group(1)
+        if word_part.isdigit():
+            # digit-dash-digit is a range or score (e.g. '3-2', '1139-1185')
+            return match.group(0)
+        return f"{word_part} {match.group(2)}"
+
+    text = pattern.sub(_replace, text)
     return text
 
 def _normalize_word(word: str, full_lang: str, rbnf_engine) -> str:

--- a/tests/test_normalization_package.py
+++ b/tests/test_normalization_package.py
@@ -63,6 +63,29 @@ class TestPipelineStillNormalizes(unittest.TestCase):
         self.assertIn("Senhor", out)
         self.assertIn("quilogramas", out)
 
+    def test_digit_hyphen_digit_score_is_left_intact_pt(self):
+        # A score is a range, not a word glued to a digit: the phonemizer,
+        # not this pipeline, is responsible for reading "3-2" aloud.
+        out = normalization.normalize("O jogo é 3-2.", "pt-PT")
+        self.assertEqual(out, "O jogo é 3-2.")
+
+    def test_digit_hyphen_digit_score_is_left_intact_en(self):
+        out = normalization.normalize("The score is 3-2.", "en-US")
+        self.assertEqual(out, "The score is 3-2.")
+
+    def test_digit_hyphen_digit_page_range_is_left_intact(self):
+        out = normalization.normalize("páginas 1139-1185", "pt-PT")
+        self.assertEqual(out, "páginas 1139-1185")
+
+    def test_digit_en_dash_digit_range_is_left_intact(self):
+        out = normalization.normalize("páginas 1139–1185", "pt-PT")
+        self.assertEqual(out, "páginas 1139–1185")
+
+    def test_word_hyphen_digit_still_normalizes(self):
+        out = normalization.normalize("sub-23", "en-US")
+        self.assertNotIn("-", out)
+        self.assertIn("twenty", out.lower())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -193,7 +193,9 @@ class TestUtilFunctions(unittest.TestCase):
             ("word-123", "word 123"),
             ("no-hyphen", "no-hyphen"),  # no digit after hyphen
             ("just-text", "just-text"),  # no digit
-            #  ("123-456", "123-456"),     # no word before hyphen TODO Fix this one, should be pronounced number by number
+            ("123-456", "123-456"),  # digit-hyphen-digit is a range/score, left intact
+            ("3-2", "3-2"),  # score, left intact
+            ("1139–1185", "1139–1185"),  # en-dash range, left intact
         ]
 
         for input_text, expected in test_cases:


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet via Claude Code — NOT human-reviewed. Verify before acting.

`normalize()` deletes the dash between two digits before it ever reaches the phonemizer. A score like "O jogo é 3-2." came out as "O jogo é três dois.", and a page range like "páginas 1139-1185" came out as "páginas mil cento e trinta e nove mil cento e oitenta e cinco" — two bare numbers glued together with no indication a range was meant.

The cause is `_normalize_word_hyphen_digit` in `phoonnx/normalization/text.py`. It was written to split a word glued to a digit, such as "sub-23" -> "sub 23", but its regex `(\w+)-(\d+)` also matches digit-hyphen-digit, since `\w` matches digits too. So "3-2" gets split into "3 2" and each half is expanded as an independent cardinal.

A hyphen (or en-dash/em-dash) directly between two digit runs is a range or a score, not a word joined to a digit. The fix leaves such tokens untouched in that step, so the intact "3-2" reaches the word-by-word number pass, where `_normalize_number_word` already leaves it alone (it is not a plain number, not a fraction), and then reaches the phonemizer whole. `phoonnx/normalization/units.py` and `numbers.py` were checked and do not perform any dash handling that needed the same fix.

I verified by execution, in a fresh venv with `scriptconv[phonemizers]>=0.0.4a26` and `tugaphone>=1.3.6a1`, that `get_phonemizer("tugaphone").phonemize_string(normalize("O jogo é 3-2.", "pt-PT-x-lisbon").rstrip("."), "pt-PT-x-lisbon")` changes from `u ˈʒoɡu ˈɛ ˈtɾeʒ ˈdojʃ` (no range marker) before the fix to `u ˈʒoɡu ˈɛ ˈtɾez ɐ ˈdojʃ` (the " ɐ " between the two numbers, tugaphone's own range reading) after it.

The added and existing normalization tests (`tests/test_util.py`, `tests/test_normalization_package.py`) were run before and after the fix: the five new/updated cases fail against the original code and pass against the fix (82 passed / 29 subtests passed total after the fix, versus 5 failed / 79 passed / 27 subtests passed before it). The wider `tests/` run has pre-existing, unrelated collection errors and failures from missing heavy dependencies (torch, pytorch_lightning, tokenizer/config-detection extras) that were not installed for this fix and are unaffected by this change.
