### PR TITLE
fix: install ffmpeg in the Docker image so non-WAV output formats work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@
 FROM python:3.11-slim
 
 # System deps: espeak-ng (phonemization), libsndfile1 (soundfile, for cloning
-# reference audio), git/build tooling for any source wheels.
+# reference audio), ffmpeg (pydub encodes the non-WAV response formats of the
+# vendor-compat routers through it), git/build tooling for any source wheels.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         espeak-ng \
         libsndfile1 \
+        ffmpeg \
         git \
         build-essential \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 This page is for anyone setting up phoonnx. It covers the base install, exactly what each
-optional extra unlocks, the GPU runtime packages, and the one system dependency you may need.
+optional extra unlocks, the GPU runtime packages, and the system dependencies you may need.
 
 ## Requirements
 
@@ -136,6 +136,21 @@ brew install espeak-ng            # macOS
 
 The `phoonnx[espeak]` extra provides a pure-Python port of the eSpeak phonemizer (byte-for-byte
 parity with the binary) and needs no system package.
+
+## System dependency: ffmpeg
+
+phoonnx synthesises WAV and needs nothing extra to do it. A server that offers other
+containers — mp3, ogg, flac — encodes them with `pydub`, which shells out to `ffmpeg`.
+Without `ffmpeg` those requests fall back to WAV rather than failing, so the symptom is a
+response in the wrong format rather than an error.
+
+```bash
+sudo apt-get install ffmpeg   # Debian/Ubuntu
+sudo pacman -S ffmpeg          # Arch Linux
+brew install ffmpeg            # macOS
+```
+
+The published Docker image carries it.
 
 ## Docker
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

The Docker image could only return WAV. It serves ovos-tts-server, whose vendor-compat routers pass every non-WAV `response_format` to `audio_utils.convert_audio`, which encodes through pydub, and pydub shells out to ffmpeg. The image installed pydub but not the binary, so mp3, ogg and flac exports raised `FileNotFoundError: 'ffmpeg'` while the native WAV route kept working and hid the gap.

This adds `ffmpeg` to the apt-get install list (still `--no-install-recommends`, no meta packages) and extends the comment above it to say why the image needs it. Image size grows from 6.7 GB to 7.14 GB.

Evidence, executed on ser9 with the same probe script (a 2 s 440 Hz 22050 Hz mono WAV decoded with pydub, then exported to each format).

Current image `local/phoonnx:latest`, built from dev before this change:

```
ffmpeg: None
decoded wav ok, ms= 2000
mp3 FAIL FileNotFoundError [Errno 2] No such file or directory: 'ffmpeg'
ogg FAIL FileNotFoundError [Errno 2] No such file or directory: 'ffmpeg'
flac FAIL FileNotFoundError [Errno 2] No such file or directory: 'ffmpeg'
```

Image built from this branch (`docker build -t local/phoonnx:ffmpeg-201413 .`):

```
ffmpeg: /usr/bin/ffmpeg
decoded wav ok, ms= 2000
mp3 OK bytes= 8481
ogg OK bytes= 5848
flac OK bytes= 24660
```

`ffmpeg -version` inside the new image reports 7.1.5-0+deb13u1. This is independent of the PosixPath defect in ovos-tts-server that keeps the compat routers unreachable; both fixes are needed before the OpenAI-compatible endpoint returns non-WAV audio end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for encoding non-WAV server responses when `ffmpeg` is available.
  - The published Docker image now includes `ffmpeg`.

- **Documentation**
  - Documented `ffmpeg` as an optional dependency for non-WAV responses.
  - Clarified that WAV synthesis works without additional packages and that the system falls back to WAV when `ffmpeg` is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->