### PR TITLE
fix: keep the voice index when it cannot be read

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -12,7 +12,7 @@ from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import HF_HUB_CACHE
 from huggingface_hub.errors import (EntryNotFoundError, LocalEntryNotFoundError,
                                     OfflineModeIsEnabled)
-from json_database import JsonStorageXDG, JsonStorage
+from json_database import JsonStorageXDG, JsonStorage, load_commented_json
 
 from phoonnx.config import PhonemeType, get_phonemizer, VoiceConfig, Engine, Alphabet, check_lang_supported
 from phoonnx.util import match_lang, normalize_lang, LOG
@@ -29,6 +29,22 @@ def _tmp_path(dest: Path) -> Path:
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
     return dest.with_suffix(dest.suffix + ".part")
+
+
+def _parses(path: str) -> bool:
+    """Whether the index on disk is readable, by reading it.
+
+    An empty registry has two causes that look identical in memory: a file that
+    is genuinely empty, and one the storage layer could not parse. Only the
+    second is worth telling an operator about, and a size comparison answers
+    neither — ``{}\n`` is three bytes and perfectly valid, an empty file is
+    zero and is not.
+    """
+    try:
+        load_commented_json(path)
+        return True
+    except Exception:
+        return False
 
 
 def _is_cached(path: Path) -> bool:
@@ -858,7 +874,7 @@ class TTSModelManager:
         # and so is the evidence of what broke it.
         if not os.path.isfile(self.cache.path):
             self.cache.store()
-        elif not self.cache and os.path.getsize(self.cache.path) > 2:
+        elif not self.cache and not _parses(self.cache.path):
             LOG.error(f"voice index at {self.cache.path} could not be read and "
                       f"is being ignored; the catalog will look empty until it "
                       f"is rebuilt with 'phoonnx-voices update-cache'")

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -852,7 +852,16 @@ class TTSModelManager:
             self.cache = JsonStorage(cache_path)
         else:
             self.cache = JsonStorageXDG("voices", subfolder="phoonnx")
-        self.cache.store() # ensure file exists
+        # Create the file, never write over one that is already there. A
+        # cache that cannot be parsed loads as an empty registry, and storing
+        # that registry back replaces the index with "{}": the catalog is lost
+        # and so is the evidence of what broke it.
+        if not os.path.isfile(self.cache.path):
+            self.cache.store()
+        elif not self.cache and os.path.getsize(self.cache.path) > 2:
+            LOG.error(f"voice index at {self.cache.path} could not be read and "
+                      f"is being ignored; the catalog will look empty until it "
+                      f"is rebuilt with 'phoonnx-voices update-cache'")
 
     @property
     def all_voices(self) -> List[TTSModelInfo]:

--- a/tests/test_voice_index_preservation.py
+++ b/tests/test_voice_index_preservation.py
@@ -1,0 +1,51 @@
+"""The on-disk voice index survives a manager that cannot read it.
+
+An index that fails to parse loads as an empty registry. Writing that registry
+back replaces the file with ``{}``, which loses the catalog and the evidence of
+what broke it in the same step, so construction must never write over an index
+that is already there.
+"""
+import json
+import os
+import tempfile
+import unittest
+
+from phoonnx.model_manager import TTSModelManager
+
+
+class TestExistingIndexIsNotOverwritten(unittest.TestCase):
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.path = os.path.join(self.dir, "voices.json")
+
+    def test_an_unparseable_index_is_left_on_disk(self):
+        truncated = '{"a-voice": {"voice_id": "a-voice"}\n'
+        with open(self.path, "w") as f:
+            f.write(truncated)
+
+        TTSModelManager(cache_path=self.path)
+
+        with open(self.path) as f:
+            self.assertEqual(truncated, f.read())
+
+    def test_a_populated_index_survives_construction(self):
+        entry = {"a-voice": {"voice_id": "a-voice", "lang": "en-us"}}
+        with open(self.path, "w") as f:
+            json.dump(entry, f)
+
+        TTSModelManager(cache_path=self.path)
+
+        with open(self.path) as f:
+            self.assertEqual(entry, json.load(f))
+
+    def test_a_missing_index_is_created(self):
+        TTSModelManager(cache_path=self.path)
+
+        self.assertTrue(os.path.isfile(self.path))
+        with open(self.path) as f:
+            self.assertEqual({}, json.load(f))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_voice_index_preservation.py
+++ b/tests/test_voice_index_preservation.py
@@ -10,6 +10,10 @@ import os
 import tempfile
 import unittest
 
+from tempfile import mkdtemp
+from unittest.mock import patch
+
+from phoonnx import model_manager
 from phoonnx.model_manager import TTSModelManager
 
 
@@ -45,6 +49,40 @@ class TestExistingIndexIsNotOverwritten(unittest.TestCase):
         self.assertTrue(os.path.isfile(self.path))
         with open(self.path) as f:
             self.assertEqual({}, json.load(f))
+
+
+class TestUnreadableIndexIsNamedAccurately(unittest.TestCase):
+    """The diagnostic fires when the index did not parse, and only then.
+
+    Its whole purpose is to be believed. An operator who sees it on a healthy
+    empty index learns to ignore it, and then misses the real one.
+    """
+
+    def _construct_and_capture(self, contents):
+        path = os.path.join(mkdtemp(), "voices.json")
+        with open(path, "w") as handle:
+            handle.write(contents)
+        complaints = []
+        with patch.object(model_manager.LOG, "error", complaints.append):
+            model_manager.TTSModelManager(cache_path=path)
+        with open(path) as handle:
+            survived = handle.read()
+        return [c for c in complaints if "could not be read" in c], survived
+
+    def test_an_empty_object_with_a_newline_is_not_reported_as_broken(self):
+        errors, survived = self._construct_and_capture("{}\n")
+        self.assertEqual([], errors)
+        self.assertEqual("{}\n", survived)
+
+    def test_an_empty_file_is_reported_as_broken(self):
+        errors, survived = self._construct_and_capture("")
+        self.assertEqual(1, len(errors))
+        self.assertEqual("", survived)
+
+    def test_truncated_json_is_reported_as_broken(self):
+        errors, survived = self._construct_and_capture('{"a": ')
+        self.assertEqual(1, len(errors))
+        self.assertEqual('{"a": ', survived)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

The demo box was found with a two-byte `voices.json` and a catalog that reported nothing. This is how a machine gets into that state and stays there.

## What happens

`TTSModelManager.__init__` wrote the in-memory registry back to disk to make sure the file existed. `JsonStorage` loads the file first and, when it cannot parse it, logs and returns without populating anything — deliberately, so a torn read does not discard what is already in memory. The registry is therefore empty, and the very next line stores that empty registry over the file.

One unreadable read becomes permanent data loss, and it erases the evidence of its own cause at the same time. The machine then reports no voices, with nothing on disk to say why.

Reproduced before the fix:

```
BEFORE: '{"a-voice": {"voice_id": "a-voice"}\n'
AFTER : '{}'
```

## The change

Create the file only when it is absent. When an index is on disk but could not be read, say so loudly instead of quietly starting from nothing.

## Verification

`tests/test_voice_index_preservation.py` covers three cases: an unparseable index is left untouched, a populated index survives construction, and a missing index is still created. The first fails against `dev` and passes after; the other two pass in both, since they describe behaviour that was already right and is now guarded.

The rest of the suite is unchanged. Same command, same environment, before and after:

| | passed | failed |
|---|---|---|
| `dev` | 2240 | 128 |
| this branch | 2243 | 128 |

The three added passes are the new tests. The 128 failures and 37 collection errors are identical in both runs; they are the optional training dependencies (`torch`, `librosa`, `onnx`, `soundfile`, `pytorch_lightning`) missing from a bare editable install, and are untouched by this change.

## Review fix at this head

The diagnostic used `os.path.getsize(...) > 2` as a stand-in for "failed to parse" and
misfired in both directions. Replaced by attempting the parse, which is what the condition
always meant. Red-before reproduces both misfires:

| index on disk | before | after |
|---|---|---|
| `{}` + newline (3 bytes, valid) | reported broken | silent |
| empty file (0 bytes, unreadable) | silent | reported broken |

Neither misfire lost data. It matters because the message only works if it is believed: an
operator who sees it on a healthy empty index learns to ignore it, and then misses the real one.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing voice model indexes during startup, including valid and unreadable files.
  * Prevented unreadable index files from being overwritten.
  * Added clearer diagnostics when a voice index cannot be read.
  * Created a new empty index only when no index file exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->