### PR TITLE
fix: give each download its own temporary file

### DIFF
--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -36,6 +36,12 @@ def _tmp_path(dest: Path) -> Path:
     handle, tmp = tempfile.mkstemp(dir=dest.parent, prefix=dest.name + ".",
                                    suffix=".part")
     os.close(handle)
+    # mkstemp creates 0600 and os.replace carries the mode onto the artifact.
+    # Models are read by whoever serves them, which is not always the account
+    # that downloaded them: a shared HF_HOME, or a prefetch run as another user.
+    umask = os.umask(0)
+    os.umask(umask)
+    os.chmod(tmp, 0o666 & ~umask)
     return Path(tmp)
 
 
@@ -99,9 +105,11 @@ def _direct_stream(url: str, dest: Path, timeout: int = 120) -> Path:
 
     The body is written to a sibling ``.part`` file and only renamed onto
     ``dest`` once it has been fully received (and matches ``Content-Length``,
-    when the server sends one). An interrupted download therefore leaves at
-    most a stale ``.part`` file, never a truncated artifact that later runs
-    would mistake for a complete one.
+    when the server sends one), so no run ever sees a truncated artifact. A
+    download that fails or is interrupted removes its own scratch file; one
+    killed outright — SIGKILL, OOM, power loss — leaves it behind, and nothing
+    reclaims it, because a sweep on entry cannot tell an abandoned file from
+    one another download is still writing.
 
     This is the path for a self-hosted or mirrored voice, which the hub client
     cannot serve. It gets a private copy.

--- a/phoonnx/model_manager.py
+++ b/phoonnx/model_manager.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import os
 import re
+import tempfile
 import threading
 from dataclasses import asdict, dataclass, field
 from enum import Enum
@@ -23,12 +24,19 @@ from phoonnx.voice import TTSVoice
 def _tmp_path(dest: Path) -> Path:
     """Sibling scratch path used while a download is in flight.
 
+    The name is unique per call rather than "<target>.part": two fetches of the
+    same artifact would otherwise share one temporary file, interleaving their
+    bytes, and whichever lost the race would find it already renamed away.
+
     Every write goes through here, so this is also where the voice directory is
     created — a voice's directory should exist because something was written
     into it, not because its catalog entry was constructed.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
-    return dest.with_suffix(dest.suffix + ".part")
+    handle, tmp = tempfile.mkstemp(dir=dest.parent, prefix=dest.name + ".",
+                                   suffix=".part")
+    os.close(handle)
+    return Path(tmp)
 
 
 def _is_cached(path: Path) -> bool:

--- a/tests/test_concurrent_direct_download.py
+++ b/tests/test_concurrent_direct_download.py
@@ -5,6 +5,7 @@ into the same file. Their bytes interleave, and the one that fails first
 deletes the file the other is still writing, so a request that should have
 succeeded either fails or publishes a corrupt artifact.
 """
+import os
 import threading
 import unittest
 from pathlib import Path
@@ -68,6 +69,60 @@ class TestConcurrentDownloadsOfOneArtifact(unittest.TestCase):
 
         self.assertEqual([], errors)
         self.assertEqual(BODY, dest.read_bytes())
+
+
+class TestPublishedArtifact(unittest.TestCase):
+    """Properties of the file that ends up at the destination."""
+
+    def _fetch(self, dest):
+        class _Whole:
+            headers = {"Content-Length": str(len(BODY))}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def raise_for_status(self):
+                pass
+
+            def iter_content(self, chunk_size=CHUNK):
+                yield BODY
+
+        with patch.object(model_manager.requests, "get",
+                          side_effect=lambda *a, **kw: _Whole()):
+            model_manager._direct_stream("https://example.invalid/model.onnx", dest)
+
+    def test_the_model_is_readable_by_more_than_its_downloader(self):
+        """mkstemp creates 0600 and os.replace carries the mode onto the model.
+
+        A shared cache is served by an account that is not always the one that
+        filled it.
+        """
+        dest = Path(mkdtemp()) / "model.onnx"
+        self._fetch(dest)
+
+        umask = os.umask(0)
+        os.umask(umask)
+        self.assertEqual(0o666 & ~umask, dest.stat().st_mode & 0o777)
+
+    def test_a_download_leaves_another_downloads_scratch_file_alone(self):
+        """Nothing may sweep sibling scratch files on entry.
+
+        A sweep cannot distinguish an abandoned file from one another thread is
+        still writing, so it would restore the interleaving this module exists
+        to prevent.
+        """
+        dest = Path(mkdtemp()) / "model.onnx"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        in_flight = dest.parent / (dest.name + ".aaaa.part")
+        in_flight.write_bytes(b"another download is writing here")
+
+        self._fetch(dest)
+
+        self.assertTrue(in_flight.exists())
+        self.assertEqual(b"another download is writing here", in_flight.read_bytes())
 
 
 if __name__ == "__main__":

--- a/tests/test_concurrent_direct_download.py
+++ b/tests/test_concurrent_direct_download.py
@@ -1,0 +1,74 @@
+"""Two downloads of the same artifact do not share one temporary file.
+
+A fixed ``<target>.part`` name means concurrent fetches of the same URL write
+into the same file. Their bytes interleave, and the one that fails first
+deletes the file the other is still writing, so a request that should have
+succeeded either fails or publishes a corrupt artifact.
+"""
+import threading
+import unittest
+from pathlib import Path
+from tempfile import mkdtemp
+from unittest.mock import patch
+
+from phoonnx import model_manager
+
+
+BODY = b"x" * 4096
+CHUNK = 256
+
+
+class _Response:
+    """A streamed response that parks mid-body until every caller arrives."""
+
+    def __init__(self, barrier):
+        self.headers = {"Content-Length": str(len(BODY))}
+        self._barrier = barrier
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=CHUNK):
+        halfway = len(BODY) // 2
+        sent = 0
+        while sent < len(BODY):
+            if sent >= halfway and self._barrier is not None:
+                self._barrier.wait(timeout=10)
+                self._barrier = None
+            yield BODY[sent:sent + CHUNK]
+            sent += CHUNK
+
+
+class TestConcurrentDownloadsOfOneArtifact(unittest.TestCase):
+
+    def test_both_callers_get_the_whole_artifact(self):
+        dest = Path(mkdtemp()) / "model.onnx"
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def fetch():
+            try:
+                model_manager._direct_stream("https://example.invalid/model.onnx", dest)
+            except BaseException as e:
+                errors.append(e)
+
+        with patch.object(model_manager.requests, "get",
+                          side_effect=lambda *a, **kw: _Response(barrier)):
+            threads = [threading.Thread(target=fetch) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30)
+
+        self.assertEqual([], errors)
+        self.assertEqual(BODY, dest.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Closes the shared `.part` download race that the phoonnx audit roadmap has carried as open.

## What happens

`_tmp_path` returned `<target>.part`, one fixed name per destination. Two fetches of the same artifact therefore wrote into the same file. Their bytes interleaved, and whichever finished second found the file already renamed onto the destination, so a request that should have succeeded raised `FileNotFoundError` — and whatever the interleaving left behind was published as the artifact.

Reproduced deterministically with two threads parked mid-body on a barrier, against `dev`:

```
- []
+ [FileNotFoundError(2, 'No such file or directory')]
```

## The change

The temporary name is unique per call. `phoonnx/opm.py` already does exactly this for the synthesis cache, and its comment gives the same reason: "two requests for the same sentence and voice would otherwise share one temporary file, and whichever lost the race found it already renamed away". The download path had not been given the same treatment.

## Verification

`tests/test_concurrent_direct_download.py` fails against `dev` with the error above and passes here.

The rest of the suite is unchanged. Same command, same environment:

| | passed | failed |
|---|---|---|
| `dev` | 2240 | 128 |
| this branch | 2241 | 128 |

The one added pass is the new test. The 128 failures and 37 collection errors are identical in both runs and are the optional training dependencies missing from a bare editable install.

## Review fixes at this head

**Permissions.** `mkstemp` creates 0600 and `os.replace` carries that onto the published
artifact, so every model this path downloaded became owner-only. Invisible inside the image,
where one account downloads and serves; broken for a shared `HF_HOME` or a prefetch run as a
different user. A umask-respecting `chmod` restores the previous mode, asserted by a test —
red-before gives `420 != 384`, which is 0o644 against 0o600.

**The sweep was declined, and here is why.** The review also proposed sweeping sibling
`.part` files on entry, to restore the docstring's "at most one stale file" guarantee. That
remedy reintroduces the bug this PR exists to close: a sweep cannot tell an abandoned file
from one another thread is still writing. Measured rather than argued — a second caller
enters while a first has a scratch file in flight:

| | in-flight sibling survived |
|---|---|
| with the sweep | **False** |
| without it | **True** |

So the docstring now states the guarantee that actually holds — a failed or interrupted
download removes its own scratch file, one killed outright leaves it — and a test pins the
sibling's survival so no sweep is added later. The diagnosis was right; one of its two
remedies was not.


## Related

This is the same failure shape as the corrupt model and orphaned `.part` found in the demo box's cache volume. Those particular files are from an older cache layout that current code no longer reads, so this does not explain them, but it removes the way current code could produce them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

