### PR TITLE
fix: ship the training VAD model in the built distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,13 @@ Homepage = "https://github.com/TigreGotico/phoonnx"
 [project.optional-dependencies]
 test = [
     "pytest",
+    # tests/test_packaging_data.py builds a wheel to check that the
+    # training data files reach an installed distribution. It builds with
+    # --no-isolation, so the build backend must be present in this
+    # environment rather than fetched into an isolated one.
+    "build",
+    "setuptools>=68",
+    "wheel",
     # the training-engine tests train tiny models end-to-end, so the
     # coverage/test job needs torch; the CPU wheels come from the pinned
     # index below to avoid pulling the multi-GB CUDA build
@@ -371,6 +378,9 @@ where = ["."]
 
 [tool.setuptools.package-data]
 "phoonnx" = ["**/*"]
+# phoonnx_train.norm_audio opens this by path; without it an installed
+# phoonnx cannot preprocess audio at all.
+"phoonnx_train" = ["norm_audio/models/*.onnx"]
 
 [tool.uv]
 # CPU-only torch wheels for the test/coverage jobs (avoids the CUDA build)

--- a/tests/test_packaging_data.py
+++ b/tests/test_packaging_data.py
@@ -1,0 +1,54 @@
+"""The built distribution carries the data files the training code loads by path.
+
+Every other test here runs against the source checkout, where a data file is on
+disk whether or not packaging ships it, so a missing ``package-data`` entry is
+invisible to all of them and only shows up once someone installs a wheel.
+"""
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Files the training code opens by filesystem path at runtime, as they appear
+# inside the distribution.
+RUNTIME_DATA_FILES = ["phoonnx_train/norm_audio/models/silero_vad.onnx"]
+
+_IGNORED = shutil.ignore_patterns(".git", "build", "dist", "*.egg-info",
+                                  "__pycache__", ".venv", ".pytest_cache")
+
+
+@pytest.fixture(scope="module")
+def wheel_contents(tmp_path_factory):
+    """Names inside a wheel built from a pristine copy of the checkout.
+
+    The copy keeps setuptools' ``build/`` scratch tree out of the working
+    checkout, where a later build would sweep it up as a second copy of the
+    package.
+    """
+    tmp = tmp_path_factory.mktemp("packaging")
+    src = tmp / "src"
+    shutil.copytree(REPO_ROOT, src, ignore=_IGNORED)
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--no-isolation",
+         "--outdir", str(tmp / "dist")],
+        cwd=src, check=True, capture_output=True,
+    )
+    wheels = list((tmp / "dist").glob("*.whl"))
+    assert len(wheels) == 1, f"expected exactly one wheel, built {wheels}"
+    return set(zipfile.ZipFile(wheels[0]).namelist())
+
+
+@pytest.mark.parametrize("relpath", RUNTIME_DATA_FILES)
+def test_wheel_carries_runtime_data_file(wheel_contents, relpath):
+    assert relpath in wheel_contents
+
+
+def test_runtime_data_files_exist_in_checkout():
+    """Guards the list above against naming a file that has moved or gone."""
+    for relpath in RUNTIME_DATA_FILES:
+        assert (REPO_ROOT / relpath).is_file(), relpath


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

`phoonnx_train/norm_audio/models/silero_vad.onnx` is in the repository and reaches no wheel or sdist, because `[tool.setuptools.package-data]` covers only the `phoonnx` package. An installed phoonnx cannot preprocess audio at all: `make_silence_detector()` opens the model by path, so every worker process dies before the first utterance.

```
onnxruntime.capi.onnxruntime_pybind11_state.NoSuchFile: [ONNXRuntimeError] : 3 : NO_SUCHFILE :
Load model from .../site-packages/phoonnx_train/norm_audio/models/silero_vad.onnx failed. File doesn't exist
```

That is from a real run of `python -m phoonnx_train.preprocess` against a parquet corpus, in a venv holding phoonnx built from `dev`.

## Why the suite could not see it

Every other test runs against the source checkout, where the file is on disk whether or not packaging ships it. So `tests/test_packaging_data.py` builds a wheel from a pristine copy of the tree and looks inside the archive, which is the only place the gap is visible.

## Verified

Red before, green after, both executed on this branch:

```
$ pytest tests/test_packaging_data.py            # before the pyproject change
E  AssertionError: assert 'phoonnx_train/norm_audio/models/silero_vad.onnx' in {...}
1 failed, 1 passed in 2.23s

$ pytest tests/test_packaging_data.py            # after
2 passed in 2.04s
```

The structural check is not the whole proof. The fixed wheel was installed into a throwaway venv and the detector exercised, so the assertion is on a value rather than on a filename:

```
>>> make_silence_detector()
SileroVoiceActivityDetector
>>> detector(np.zeros(16000, dtype=np.float32))   # one second of silence
[0.00179315]
```

Near-zero speech probability on silence, from a model loaded out of the installed package.

## Scope

One file. The other non-`.py` files under `phoonnx_train` were checked and do not belong in the distribution: the StyleTTS2 `Utils/ASR/config.yml` and `Utils/PLBERT/config.yml` pair is downloaded to `~/.cache/phoonnx/styletts2_aux_en` at runtime by `styletts2/downloads.py` rather than read from the package, and monotonic_align's `core.c` and compiled `.so` are unused because `monotonic_align/__init__.py` calls `maximum_path_numpy`.

`build` joins the `[test]` extra because the new test builds a wheel.

## Not tested

Whether an sdist-then-wheel build carries the file. The check builds a wheel directly from the tree, which is what `pip install .` and the release workflow do, but a consumer building through an sdist takes a different path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
