### PR TITLE
fix: record which phonemizer produced the phonemes

### DIFF
--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from collections import Counter
+from importlib.metadata import PackageNotFoundError, packages_distributions, version
 from multiprocessing import JoinableQueue, Process, Queue
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple, Any, Set, Union, Callable
@@ -39,6 +40,27 @@ DEFAULT_SPECIAL_PHONEME_ID_MAP: Dict[str, int] = {
 }
 MAX_PHONEMES = 256
 # -----------------------------------------------------------------------------
+
+def phonemizer_registry(phonemizer: Any) -> Tuple[str, str]:
+    """Name the distribution the phonemizer class came from, and its version.
+
+    This is the registry that resolved the phonemizer, not the grapheme-to-
+    phoneme backend. For a phoneme type that shells out — espeak runs the system
+    ``espeak-ng`` binary — the backend and its version are not captured here and
+    nothing in the config identifies them.
+
+    Returns the distribution name and version, or the top-level module and an
+    empty version when the class comes from no installed distribution. Where
+    several distributions provide the same top-level module the lowest name
+    wins, so the field does not vary between machines with the same install.
+    """
+    module = type(phonemizer).__module__.split(".")[0]
+    dist = sorted(packages_distributions().get(module, [module]))[0]
+    try:
+        return dist, version(dist)
+    except PackageNotFoundError:
+        return dist, ""
+
 
 class PathEncoder(json.JSONEncoder):
     """JSON encoder for Path objects."""
@@ -788,6 +810,10 @@ def cli(
     audio_quality = config.audio_quality or config.output_dir.name
     dataset_name = config.dataset_name or config.output_dir.parent.name
 
+    # Phonemes taken from a dataset column were not produced here, so nothing
+    # about this environment reconstructs them. Naming a registry over them
+    # would be worse than naming nothing: a reader would believe the column is
+    # reproducible from a version that never touched it.
     config_data: Dict[str, Any] = {
         "dataset": dataset_name,
         "audio": {
@@ -809,17 +835,24 @@ def cli(
         "phoonnx_version": VERSION_STR,
     }
 
-    config_tmp = config.output_dir / "config.json.tmp"
-    with open(config_tmp, "w", encoding="utf-8") as config_file:
-        json.dump(config_data, config_file, ensure_ascii=False, indent=2)
-    config_tmp.rename(config.output_dir / "config.json")
+    # The previous config, read before it is overwritten: a resume needs both
+    # its counts and the registry version that produced them.
+    prior_config: Dict[str, Any] = {}
+    prior_config_path = config.output_dir / "config.json"
+    if resume_rows and prior_config_path.is_file():
+        prior_config = json.loads(prior_config_path.read_text(encoding="utf-8"))
 
     # --- Apply final phoneme IDs and write dataset.jsonl ---
     # Writes go to a temp file and are atomically renamed into place so an
     # interrupted run never leaves a half-written manifest. With --resume the
     # already-processed rows are re-emitted first, then the new rows appended.
+    # Counted here rather than off the result queue: three paths below drop a
+    # collected utterance before it reaches the manifest, so queue-side counts
+    # describe more rows than the file holds.
     _LOGGER.info("Writing dataset.jsonl...")
     valid_utterances_count: int = 0
+    written_phonemized: int = 0
+    written_from_column: int = 0
 
     tokenizer = TTSTokenizer.from_phoonnx_config(config_data)
 
@@ -896,8 +929,62 @@ def cli(
             )
             print("", file=dataset_file)
             valid_utterances_count += 1
+            if utt.phonemes_precomputed:
+                written_from_column += 1
+            else:
+                written_phonemized += 1
 
     dataset_tmp.rename(config.output_dir / "dataset.jsonl")
+
+    # --- Record which phonemizer produced the phonemes ---
+    #
+    # Written after the manifest so the counts describe the file that exists
+    # beside them, and so an interrupted run leaves no config claiming rows
+    # that were never written.
+    #
+    # A resumed run re-emits rows it never processed, so its own counts cover
+    # only part of the manifest. Fold the previous config's counts in and the
+    # pair keeps describing the whole file across any number of resumes. Two
+    # cases cannot be folded and then all four fields are omitted rather than
+    # left describing a subset: a previous config predating these keys, and one
+    # written by a different registry version, whose rows this run's version did
+    # not produce and must not be named over.
+    registry, registry_version = phonemizer_registry(phonemizer)
+    phonemized_total: Optional[int] = written_phonemized
+    from_column_total: Optional[int] = written_from_column
+    if resume_rows:
+        prior_phonemized = prior_config.get("phonemes_phonemized")
+        # A previous run that phonemized nothing named no registry, so there are
+        # no rows of its making to mis-attribute and its counts fold whatever
+        # version wrote them.
+        same_producer = (
+            prior_phonemized == 0
+            or (prior_config.get("phonemizer_registry") == registry
+                and prior_config.get("phonemizer_registry_version") == registry_version)
+        )
+        if (prior_phonemized is not None
+                and "phonemes_from_column" in prior_config
+                and same_producer):
+            phonemized_total += prior_phonemized
+            from_column_total += prior_config["phonemes_from_column"]
+        else:
+            phonemized_total = from_column_total = None
+
+    if phonemized_total is not None:
+        # Nothing was phonemized here, so no producer is claimed: the phonemes
+        # came out of a dataset column and this run cannot vouch for them.
+        if not phonemized_total:
+            registry, registry_version = "", ""
+        config_data["phonemizer_registry"] = registry
+        config_data["phonemizer_registry_version"] = registry_version
+        config_data["phonemes_phonemized"] = phonemized_total
+        config_data["phonemes_from_column"] = from_column_total
+
+    config_tmp = config.output_dir / "config.json.tmp"
+    with open(config_tmp, "w", encoding="utf-8") as config_file:
+        json.dump(config_data, config_file, ensure_ascii=False, indent=2)
+    config_tmp.rename(config.output_dir / "config.json")
+
     _LOGGER.info("Preprocessing complete. Wrote %d valid utterances to dataset.jsonl.", valid_utterances_count)
 
 

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -9,6 +9,7 @@ so no real phonemizer backend is needed, and real tiny WAV files on disk so
 the multiprocessing worker's audio path and the quality-filter scorers run
 for real, in seconds.
 """
+import importlib.metadata
 import io
 import json
 import queue
@@ -288,6 +289,206 @@ class TestFinetunePhonemeMap(unittest.TestCase):
             self.assertIn("absent from the final phoneme map", str(ctx.exception))
 
 
+class TestPhonemizerProvenance(unittest.TestCase):
+    """config.json must say whether these phonemes were produced here at all.
+
+    A phoneme string is decided by the phonemizer and the lect it was called
+    with, so a corpus recording neither cannot be compared against a fresh run.
+    Claiming a producer for phonemes read out of a dataset column is worse than
+    recording none: a reader concludes the column is reproducible from a version
+    that never touched it.
+    """
+
+    def test_phonemized_run_names_the_registry_and_its_version(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "a.jsonl"
+            _jsonl(src, [{"text": "hi", "audio": "a.wav"}])
+            out = tmp / "out"
+            import click.testing
+            result = click.testing.CliRunner().invoke(preprocess.cli, [
+                "-i", str(src), "-o", str(out), "-l", "en", "--skip-audio",
+                "--phoneme-type", "graphemes", "--alphabet", "unicode",
+                "--max-workers", "1",
+            ], catch_exceptions=False)
+            self.assertEqual(result.exit_code, 0, result.output)
+            config = json.loads((out / "config.json").read_text())
+            # The registry that resolved the phonemizer, not the g2p backend:
+            # phoonnx.config delegates the whole registry to scriptconv.
+            self.assertEqual(config["phonemizer_registry"], "scriptconv")
+            self.assertEqual(config["phonemizer_registry_version"],
+                             importlib.metadata.version("scriptconv"))
+            self.assertEqual(config["phonemes_phonemized"], 1)
+            self.assertEqual(config["phonemes_from_column"], 0)
+
+    def test_column_run_claims_no_producer(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "a.jsonl"
+            _jsonl(src, [{"text": "hi", "audio": "a.wav", "phon": "\u0294 \u0295"}])
+            out = tmp / "out"
+            result = _invoke([
+                "-i", str(src), "-o", str(out), "-l", "en", "--skip-audio",
+                "--phonemes-column", "phon",
+            ], catch_exceptions=False)
+            self.assertEqual(result.exit_code, 0, result.output)
+            config = json.loads((out / "config.json").read_text())
+            self.assertEqual(config["phonemizer_registry"], "")
+            self.assertEqual(config["phonemizer_registry_version"], "")
+            self.assertEqual(config["phonemes_phonemized"], 0)
+            self.assertEqual(config["phonemes_from_column"], 1)
+
+    def test_resumed_run_describes_the_whole_manifest(self):
+        """A resume re-emits rows it never processed; the counts must cover them.
+
+        Otherwise the config describes a strict subset of the manifest beside it
+        and overwrites the correct one -- naming a producer over rows the tool
+        never touched, which is the failure this whole change exists to avoid.
+        """
+        import click.testing
+
+        def run(src, out, rows, extra):
+            _jsonl(src, rows)
+            return click.testing.CliRunner().invoke(preprocess.cli, [
+                "-i", str(src), "-o", str(out), "-l", "en", "--skip-audio",
+                "--phoneme-type", "graphemes", "--alphabet", "ipa",
+                "--phonemes-column", "phon", "--max-workers", "1",
+            ] + extra, catch_exceptions=False)
+
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src, out = tmp / "a.jsonl", tmp / "out"
+            column_rows = [
+                {"text": "hi", "audio": "a.wav", "phon": "\u0294 \u0295"},
+                {"text": "ho", "audio": "b.wav", "phon": "\u0294 \u0295"},
+            ]
+            self.assertEqual(run(src, out, column_rows, []).exit_code, 0)
+            first = json.loads((out / "config.json").read_text())
+            self.assertEqual(first["phonemes_from_column"], 2)
+            self.assertEqual(first["phonemes_phonemized"], 0)
+            self.assertEqual(first["phonemizer_registry"], "")
+
+            self.assertEqual(
+                run(src, out, column_rows + [{"text": "hue", "audio": "c.wav"}],
+                    ["--resume"]).exit_code, 0)
+            second = json.loads((out / "config.json").read_text())
+            manifest_rows = sum(1 for _ in (out / "dataset.jsonl").open())
+            self.assertEqual(manifest_rows, 3)
+            self.assertEqual(second["phonemes_from_column"], 2)
+            self.assertEqual(second["phonemes_phonemized"], 1)
+            self.assertEqual(
+                second["phonemes_from_column"] + second["phonemes_phonemized"],
+                manifest_rows)
+
+    def test_resume_onto_a_config_without_the_counts_records_nothing(self):
+        """The split cannot be recovered from the manifest, so nothing is claimed."""
+        import click.testing
+
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src, out = tmp / "a.jsonl", tmp / "out"
+            _jsonl(src, [{"text": "hi", "audio": "a.wav"}])
+            argv = ["-i", str(src), "-o", str(out), "-l", "en", "--skip-audio",
+                    "--phoneme-type", "graphemes", "--alphabet", "ipa",
+                    "--max-workers", "1"]
+            self.assertEqual(
+                click.testing.CliRunner().invoke(
+                    preprocess.cli, argv, catch_exceptions=False).exit_code, 0)
+
+            # a config from before these keys existed
+            stale = json.loads((out / "config.json").read_text())
+            for key in ("phonemizer_registry", "phonemizer_registry_version",
+                        "phonemes_phonemized", "phonemes_from_column"):
+                stale.pop(key, None)
+            (out / "config.json").write_text(json.dumps(stale))
+
+            _jsonl(src, [{"text": "hi", "audio": "a.wav"},
+                         {"text": "hue", "audio": "c.wav"}])
+            self.assertEqual(
+                click.testing.CliRunner().invoke(
+                    preprocess.cli, argv + ["--resume"],
+                    catch_exceptions=False).exit_code, 0)
+            resumed = json.loads((out / "config.json").read_text())
+            for key in ("phonemizer_registry", "phonemizer_registry_version",
+                        "phonemes_phonemized", "phonemes_from_column"):
+                self.assertNotIn(key, resumed)
+
+    def test_counts_describe_the_manifest_when_a_row_is_dropped(self):
+        """Three paths drop a collected utterance after it has been counted.
+
+        They all live between the result queue and the manifest, and every
+        other test here runs --skip-audio, where the audio-too-short guard is
+        never reached and the drop is invisible. A count taken off the queue
+        therefore names a producer over a row that is not in the file.
+        """
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            short_wav, ok_wav = tmp / "short.wav", tmp / "ok.wav"
+            short_wav.write_bytes(_wav_bytes(seconds=0.1))
+            ok_wav.write_bytes(_wav_bytes(seconds=1.0))
+            src, out = tmp / "a.jsonl", tmp / "out"
+            # far more phonemes than a 0.1 s clip has spectrogram frames, so
+            # this row is dropped at the monotonic-alignment guard
+            _jsonl(src, [
+                {"text": "x" * 400, "audio": str(short_wav),
+                 "phon": " ".join("\u0294" * 400)},
+                {"text": "hi", "audio": str(ok_wav), "phon": "\u0294 \u0295"},
+            ])
+            result = _invoke([
+                "-i", str(src), "-o", str(out), "-l", "en",
+                "--phonemes-column", "phon", "--max-workers", "1",
+            ], catch_exceptions=False)
+            self.assertEqual(result.exit_code, 0, result.output)
+
+            config = json.loads((out / "config.json").read_text())
+            manifest_rows = sum(1 for _ in (out / "dataset.jsonl").open())
+            self.assertEqual(manifest_rows, 1, "expected the short clip to be dropped")
+            self.assertEqual(
+                config["phonemes_from_column"] + config["phonemes_phonemized"],
+                manifest_rows,
+                "counts describe rows that are not in the manifest")
+
+    def test_resume_under_a_different_registry_version_records_nothing(self):
+        """Folding across versions would name this run's version over rows it
+        never produced, which is the failure the whole change exists to avoid.
+        """
+        import click.testing
+
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src, out = tmp / "a.jsonl", tmp / "out"
+            _jsonl(src, [{"text": "hi", "audio": "a.wav"}])
+            argv = ["-i", str(src), "-o", str(out), "-l", "en", "--skip-audio",
+                    "--phoneme-type", "graphemes", "--alphabet", "ipa",
+                    "--max-workers", "1"]
+            self.assertEqual(
+                click.testing.CliRunner().invoke(
+                    preprocess.cli, argv, catch_exceptions=False).exit_code, 0)
+
+            first = json.loads((out / "config.json").read_text())
+            self.assertEqual(first["phonemes_phonemized"], 1)
+            # mark the existing rows as the work of an older release
+            first["phonemizer_registry_version"] = "0.0.1-ancient"
+            (out / "config.json").write_text(json.dumps(first))
+
+            _jsonl(src, [{"text": "hi", "audio": "a.wav"},
+                         {"text": "hue", "audio": "c.wav"}])
+            self.assertEqual(
+                click.testing.CliRunner().invoke(
+                    preprocess.cli, argv + ["--resume"],
+                    catch_exceptions=False).exit_code, 0)
+
+            resumed = json.loads((out / "config.json").read_text())
+            for key in ("phonemizer_registry", "phonemizer_registry_version",
+                        "phonemes_phonemized", "phonemes_from_column"):
+                self.assertNotIn(key, resumed)
+
+    def test_a_phonemizer_outside_any_distribution_names_its_module(self):
+        stub = type("StubPhonemizer", (), {"__module__": "not_a_distribution"})()
+        self.assertEqual(preprocess.phonemizer_registry(stub),
+                         ("not_a_distribution", ""))
+
+
 class TestJsonlPathOverrides(unittest.TestCase):
     def test_jsonl_audio_path_override_rewrites_wav_path(self):
         with TemporaryDirectory() as tmp:
@@ -528,3 +729,60 @@ class TestPhonemizeWorkerDirect(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestConfigIsWrittenAfterTheManifest(unittest.TestCase):
+    """The order is the guarantee, so something has to hold it in place.
+
+    `config.json` carries counts of what `dataset.jsonl` contains. Written
+    first, it describes a file that does not exist yet, and a run that dies in
+    between leaves a config claiming rows nothing ever wrote -- which a resume
+    then folds forward as though they were real.
+    """
+
+    def test_a_failed_manifest_write_leaves_no_config_behind(self):
+        real_rename = Path.rename
+
+        def _fail_on_the_manifest(self, target):
+            if Path(target).name == "dataset.jsonl":
+                raise OSError("no space left on device")
+            return real_rename(self, target)
+
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "a.jsonl"
+            _jsonl(src, [{"text": "hi", "audio": "a.wav", "phon": "h i"}])
+            out = tmp / "out"
+
+            with patch.object(Path, "rename", _fail_on_the_manifest):
+                result = _invoke([
+                    "-i", str(src), "-o", str(out), "-l", "en",
+                    "--phonemes-column", "phon", "--skip-audio",
+                ])
+
+            self.assertNotEqual(result.exit_code, 0, "the write was supposed to fail")
+            self.assertFalse(
+                (out / "dataset.jsonl").exists(), "the manifest should not exist")
+            self.assertFalse(
+                (out / "config.json").exists(),
+                "config.json describes a manifest that was never written")
+
+    def test_a_completed_run_writes_both_and_they_agree(self):
+        # The other half: the order must not be held by never getting there.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "a.jsonl"
+            _jsonl(src, [{"text": "hi", "audio": "a.wav", "phon": "h i"},
+                         {"text": "there", "audio": "b.wav", "phon": "e r"}])
+            out = tmp / "out"
+            result = _invoke([
+                "-i", str(src), "-o", str(out), "-l", "en",
+                "--phonemes-column", "phon", "--skip-audio",
+            ])
+            self.assertEqual(result.exit_code, 0, result.output)
+            rows = [x for x in (out / "dataset.jsonl").read_text().splitlines() if x]
+            config = json.loads((out / "config.json").read_text())
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(
+                config["phonemes_phonemized"] + config["phonemes_from_column"],
+                len(rows))


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

`config.json` records `phoonnx_version` and says nothing about the frontend, so a preprocessed corpus does not carry what turned its text into phonemes.

That version cannot stand in for it. What a grapheme becomes is decided by the phonemizer package and the lect it was called with, and those move independently of phoonnx. `--phoneme-type graphemes` is not even implemented here — it comes from `scriptconv`, and the new test pins that, because it is exactly the fact `phoonnx_version` hides.

## Why this is a receipt rather than a capability

A corpus whose phoneme column names neither the tool nor its version cannot be regenerated, cannot be compared against a fresh run, and cannot be told apart from one produced by something else that writes plausible IPA.

That is not hypothetical. A corpus in use here carries an `ipa` column with no recorded producer. Regenerating it with the frontend everything points to reproduces **19.0% of 480 rows exactly** — the rest differ in vowel quality and diacritization, so four rows in five would change if any pipeline regenerated that column. The card documents a fill rate twenty points from the measured one. None of that would have needed investigating had the build written two fields.

## The change

`config.json` gains four fields written together: `phonemizer_registry` and `phonemizer_registry_version`, naming the distribution that produced the phonemes, and `phonemes_phonemized` and `phonemes_from_column`, saying how many rows each source accounts for. A phonemizer belonging to no installed distribution records its top-level module and an empty version rather than raising, and where several distributions provide one module the lowest name wins so the field does not vary between machines with the same install.

Three properties the four fields have to keep, and each is a thing that went wrong before it was one:

**The counts describe the manifest, not the queue.** They are incremented in the write loop, beside `valid_utterances_count`, because three later paths drop a collected utterance before it reaches `dataset.jsonl` — an unknown speaker, empty phoneme ids, and the audio-too-short-for-its-text guard.

**`config.json` is written after `dataset.jsonl`.** The counts then describe a file that exists, and an interrupted run leaves no config claiming rows that were never written.

**A resume folds the previous config's counts only when the same producer wrote them.** Registry and version must both match, or all four fields are omitted rather than left describing a subset. The one exception is a previous run that phonemized nothing: it named no registry, so it has no rows of its making to mis-attribute.

Where nothing was phonemized in this run at all, no producer is claimed — the phonemes came from a dataset column and this run cannot vouch for them.

## Verified

```
$ pytest tests/test_preprocess_pipeline.py
29 passed
```

The version assertion is re-derived from `importlib.metadata` rather than compared against the value the code just wrote, so it cannot pass by agreeing with itself.

Two mutants, each red on exactly one test: reverting the counting to the result queue reddens `test_counts_describe_the_manifest_when_a_row_is_dropped`, and making the resume fold unconditionally reddens `test_resume_under_a_different_registry_version_records_nothing`.

## Review findings carried forward

Reviewed at `c2a4b5c` — SHIP-WITH-FIXES, `evidence/reviewer/pr461-phonemizer-provenance.md`. The head has moved since; both confirmed findings, and the one PLAUSIBLE, are addressed.

**Counts described more rows than the manifest held.** Reproduced with two rows, one of 400 characters against a 0.1 s clip: the config said 2, the manifest held 1, and on a resume the over-count folded forward permanently. Fixed by counting at the write loop. The reproduction is now `test_counts_describe_the_manifest_when_a_row_is_dropped`, and it uses real WAV files on disk — the review's sharpest point was that this defect needs the audio path and is invisible under `--skip-audio`, which every other test in that file uses.

**A resume named the current version over rows another version produced.** Reproduced as `scriptconv 0.0.4a19` claiming three rows, two of which came from a different release. Fixed by comparing the prior config's version as well as its counts.

**PLAUSIBLE: `packages_distributions()[0]` picked arbitrarily** where two distributions provide one top-level module. Not reproduced by the reviewer; addressed anyway by sorting, since the cost is one call and the symptom would be a field that differs between identical installs.

## Noticed while writing the test, not fixed here

`packages_distributions()` maps the top-level module `tests` to the `phoonnx` distribution — `[tool.setuptools.packages.find]` has `where = ["."]` and no include filter, so the wheel ships `tests` as an importable top-level package. Harmless to this change, and a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generated training configurations now include phonemizer source and version details.
  - Configuration metadata records how many phonemes were generated automatically versus supplied in advance.
  - Resumed processing preserves and updates these counts consistently, including compatibility with older configurations.

- **Bug Fixes**
  - Metadata is finalized only after the dataset manifest is successfully written.
  - Improved handling for dropped records and phonemizer version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->