### PR TITLE
fix: carry the random state through a VITS checkpoint

### DIFF
--- a/phoonnx_train/vits/lightning.py
+++ b/phoonnx_train/vits/lightning.py
@@ -162,6 +162,17 @@ class VitsModel(pl.LightningModule):
         return key
 
     def on_save_checkpoint(self, checkpoint: dict) -> None:
+        # Carry the random state, so a resumed run continues the shuffle
+        # sequence instead of restarting it. The train DataLoader takes
+        # shuffle=True with no generator, so its sampler draws a seed from the
+        # global RNG on every epoch; train.py seeds that RNG at process start.
+        # Without this, the first epoch after any resume replays epoch 0's batch
+        # order, and a run preempted each epoch trains on one ordering forever.
+        checkpoint["rng_state"] = {
+            "cpu": torch.get_rng_state(),
+            "cuda": torch.cuda.get_rng_state_all() if torch.cuda.is_available() else [],
+        }
+
         # Always persist CLEAN (uncompiled) keys: strip torch.compile's
         # "._orig_mod." wrapping so a checkpoint written during a --compile run
         # loads into an uncompiled consumer unchanged (old-consumer compat).
@@ -172,6 +183,22 @@ class VitsModel(pl.LightningModule):
             }
 
     def on_load_checkpoint(self, checkpoint: dict) -> None:
+        # Restore the random state first, so the shuffle sequence continues from
+        # where the run left off. A checkpoint written before this was recorded
+        # carries no rng_state and resumes as it always did.
+        rng_state = checkpoint.get("rng_state")
+        if rng_state:
+            torch.set_rng_state(rng_state["cpu"].cpu())
+            cuda_state = rng_state.get("cuda") or []
+            if cuda_state and torch.cuda.is_available():
+                if len(cuda_state) == torch.cuda.device_count():
+                    torch.cuda.set_rng_state_all(cuda_state)
+                else:
+                    _LOGGER.warning(
+                        "checkpoint carries %d cuda rng state(s) for %d device(s); "
+                        "leaving device rng untouched",
+                        len(cuda_state), torch.cuda.device_count())
+
         # Reconcile a checkpoint's keys with the CURRENT model in either
         # direction. First normalize to clean keys (strip any "._orig_mod."),
         # then re-insert the prefix only for submodules that are actually

--- a/tests/test_training_audit_fixes.py
+++ b/tests/test_training_audit_fixes.py
@@ -139,10 +139,18 @@ class TestCompileResumeMatrix(unittest.TestCase):
         self.assertEqual(list(unexpected), [])
 
     def test_missing_state_dict_is_noop(self):
+        # The compile-key rewrite must not invent a state_dict where there is
+        # none, which is what this guards. Saving does add the random state:
+        # that is unconditional by design, since every checkpoint has to carry
+        # it for a resume to continue the shuffle sequence, and making it
+        # depend on a state_dict being present would condition the library on
+        # this fixture. The key set is asserted exactly so a third key still
+        # turns this red.
         ckpt = {}
         _bare_model().on_load_checkpoint(ckpt)
         _bare_model().on_save_checkpoint(ckpt)
-        self.assertEqual(ckpt, {})
+        self.assertNotIn("state_dict", ckpt)
+        self.assertEqual(set(ckpt), {"rng_state"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vits_lightning.py
+++ b/tests/test_vits_lightning.py
@@ -274,6 +274,54 @@ class TestCheckpointSaveRestoreGlue(unittest.TestCase):
         self.assertEqual(model.hparams.gin_channels, 512)
 
 
+class TestCheckpointCarriesRandomState(unittest.TestCase):
+    """A resumed run must continue the shuffle sequence, not replay epoch 0.
+
+    The train DataLoader takes shuffle=True with no generator, so its sampler
+    draws a seed from the global RNG on every epoch, and train.py seeds that RNG
+    at process start. Without the random state in the checkpoint, the first
+    epoch after any resume repeats epoch 0's batch order -- so a run preempted
+    at each epoch boundary trains on one ordering forever, while nothing in the
+    logs says so.
+    """
+
+    @staticmethod
+    def _orders(n_epochs):
+        """Batch orders a process sees, mirroring the trainer's dataloader."""
+        loader = torch.utils.data.DataLoader(
+            list(range(24)), batch_size=4, shuffle=True)
+        return [[int(i) for batch in loader for i in batch] for _ in range(n_epochs)]
+
+    def test_resumed_run_continues_the_shuffle_sequence(self):
+        model = _build_model()
+
+        torch.manual_seed(1234)
+        uninterrupted = self._orders(2)
+        self.assertNotEqual(uninterrupted[0], uninterrupted[1],
+                            "epochs must differ, or this test proves nothing")
+
+        # A process that runs epoch 0, checkpoints, and is then replaced by a
+        # fresh process that seeds identically and resumes.
+        torch.manual_seed(1234)
+        self._orders(1)
+        checkpoint = {"state_dict": {}}
+        model.on_save_checkpoint(checkpoint)
+
+        torch.manual_seed(1234)
+        model.on_load_checkpoint(checkpoint)
+        resumed = self._orders(1)[0]
+
+        self.assertEqual(resumed, uninterrupted[1])
+        self.assertNotEqual(resumed, uninterrupted[0])
+
+    def test_checkpoint_without_random_state_still_loads(self):
+        """Checkpoints written before this was recorded must resume as before."""
+        model = _build_model()
+        checkpoint = {"state_dict": {}}
+        model.on_load_checkpoint(checkpoint)
+        self.assertNotIn("rng_state", checkpoint)
+
+
 class TestAddModelSpecificArgs(unittest.TestCase):
     def test_registers_expected_arguments(self):
         import argparse


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

**A resumed run replays epoch 0's batch order.**

`vits/lightning.py` builds the train DataLoader with `shuffle=True` and no generator, so PyTorch's `RandomSampler` draws a seed from the **global** RNG at each `__iter__`. `train.py` calls `torch.manual_seed(seed)` at process start. The checkpoint carried no random state — its top-level keys are `state_dict`, `optimizer_states`, `lr_schedulers`, `epoch`, `global_step`, `callbacks`, `loops`, `hyper_parameters`, `MixedPrecision`, nothing random.

So the first epoch after any resume draws the seed epoch 0 drew.

```
one process, three epochs:
  epoch 0: [12, 16, 5, 2, 11, 9, 3, 13, 10, 14]
  epoch 1: [13, 18, 0, 15, 11, 16, 2, 12, 14, 5]
  epoch 2: [15, 8, 11, 4, 12, 6, 18, 2, 5, 14]

fresh process, same seed, first epoch:
           [12, 16, 5, 2, 11, 9, 3, 13, 10, 14]   == epoch 0, != epoch 1
```

A run preempted at each epoch boundary therefore trains on **one ordering forever**, and nothing in the logs says so.

That is worse than a training state that fails to resume at all: a run that restarts its schedule announces itself by making no progress. This one looks like progress.

## The change

The random state travels in the checkpoint and is restored before the model keys are reconciled, so an interrupted run continues the sequence instead of restarting it.

**Uninterrupted runs are unaffected.** Nothing about how the order is drawn changes — only whether the draw continues across a process boundary. Existing results stay reproducible, which is why this is preferred over giving the DataLoader its own seeded generator: that would fix the bug by changing the order for every run, interrupted or not.

A checkpoint written before this carries no `rng_state` and resumes exactly as it did.

## Verified

Red at the merge base on a behavioural assertion, not a missing name:

```
$ pytest tests/test_vits_lightning.py::TestCheckpointCarriesRandomState   # merge base
E  AssertionError: Lists differ: [16, 2, 17, 20, 15, ...] != [5, 8, 19, 2, 11, ...]
1 failed, 1 passed

$ pytest tests/test_vits_lightning.py::TestCheckpointCarriesRandomState   # head
2 passed in 4.67s

$ pytest tests/test_vits_lightning.py                                     # whole file
33 passed in 58.89s
```

The gate is not vacuous — two mutations at head, each turning it red:

```
save the state but never restore it -> 1 failed, 1 passed
restore only the device half        -> 1 failed, 1 passed
unmutated                           -> 2 passed
```

The test asserts the resumed order equals the *next* uninterrupted epoch and differs from the first, and it asserts up front that consecutive epochs differ at all — otherwise it would prove nothing.

## Scope

VITS only. The same pattern may exist in the other engines' modules; each has its own checkpoint hooks and its own dataloader construction, and they are not audited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoints now preserve random-number generator state, allowing resumed training to continue shuffle sequences consistently.
  * Older checkpoints without random-state data remain compatible.
  * CUDA random state is restored when device counts match; mismatches leave the current state unchanged with a warning.

* **Tests**
  * Added coverage for deterministic resumed training and backward-compatible checkpoint loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->