### PR TITLE
perf: take the spectrogram frame count from the worker that wrote it

### DIFF
--- a/phoonnx_train/dataset_loaders.py
+++ b/phoonnx_train/dataset_loaders.py
@@ -67,19 +67,24 @@ class Utterance:
     # True when phonemes came from a dataset column and must not be
     # re-phonemized, normalized, or case-mangled
     phonemes_precomputed: bool = False
+    # Frames in the cached spectrogram, filled in by the worker that wrote it
+    spec_frames: Optional[int] = None
     # unmapped source columns, carried through into dataset.jsonl
     extras: Dict[str, Any] = field(default_factory=dict)
 
     def asdict(self) -> Dict[str, Any]:
         """Custom asdict to handle Path objects for JSON serialization.
 
-        The embedded audio bytes and the internal precomputed-phonemes flag are
-        dropped: bytes are not JSON serializable and only exist to feed audio
+        The embedded audio bytes, the internal precomputed-phonemes flag and the
+        spectrogram frame count are dropped: the count is a preprocessing-time
+        detail that the cached spectrogram already carries, and bytes are not
+        JSON serializable and only exist to feed audio
         processing, and the flag is a processing detail, not training data.
         """
         data = dataclasses.asdict(self)
         data.pop("audio_bytes", None)
         data.pop("phonemes_precomputed", None)
+        data.pop("spec_frames", None)
         for key, value in data.items():
             if isinstance(value, Path):
                 data[key] = str(value)

--- a/phoonnx_train/norm_audio/__init__.py
+++ b/phoonnx_train/norm_audio/__init__.py
@@ -31,7 +31,7 @@ def cache_norm_audio(
     window_length: int = 1024,
     hop_length: int = 256,
     ignore_cache: bool = False,
-) -> Tuple[Path, Path]:
+) -> Tuple[Path, Path, int]:
     audio_path = Path(audio_path).absolute()
     cache_dir = Path(cache_dir)
 
@@ -73,7 +73,11 @@ def cache_norm_audio(
         audio_norm_tensor = torch.FloatTensor(audio_norm_array).unsqueeze(0)
         torch.save(audio_norm_tensor, audio_norm_path)
 
-    # Compute spectrogram
+    # Compute spectrogram. The frame count goes back to the caller with the
+    # paths: whoever needs it downstream would otherwise read every cached
+    # spectrogram back off disk to ask its last dimension, and that read is
+    # serial while this is not.
+    audio_spec_tensor: Optional[torch.FloatTensor] = None
     if ignore_cache or (not audio_spec_path.exists()):
         if audio_norm_tensor is None:
             # Load pre-cached normalized audio
@@ -89,4 +93,9 @@ def cache_norm_audio(
         ).squeeze(0)
         torch.save(audio_spec_tensor, audio_spec_path)
 
-    return audio_norm_path, audio_spec_path
+    if audio_spec_tensor is None:
+        # A cache hit still has to read the file to know its length, but here
+        # that happens in whichever worker owns this utterance.
+        audio_spec_tensor = torch.load(audio_spec_path, map_location="cpu")
+
+    return audio_norm_path, audio_spec_path, audio_spec_tensor.size(-1)

--- a/phoonnx_train/preprocess.py
+++ b/phoonnx_train/preprocess.py
@@ -109,7 +109,7 @@ def phonemize_worker(
                     # Process audio if not skipping
                     if not config.skip_audio:
                         audio_path = ensure_audio_path(utt, config.cache_dir)
-                        utt.audio_norm_path, utt.audio_spec_path = cache_norm_audio(
+                        utt.audio_norm_path, utt.audio_spec_path, utt.spec_frames = cache_norm_audio(
                             audio_path,
                             config.cache_dir,
                             silence_detector,
@@ -861,8 +861,13 @@ def cli(
             # Monotonic alignment needs at least one spectrogram frame per
             # phoneme id; a shorter spectrogram means the audio does not
             # contain the full text (e.g. a truncated clip)
+            # The worker that wrote the spectrogram measured it; a run resumed
+            # from an earlier dataset.jsonl carries no count and is read back
+            # here, which is the only path that still touches the disk.
             if utt.audio_spec_path is not None:
-                spec_frames = torch.load(utt.audio_spec_path, map_location="cpu").size(-1)
+                spec_frames = utt.spec_frames
+                if spec_frames is None:
+                    spec_frames = torch.load(utt.audio_spec_path, map_location="cpu").size(-1)
                 if spec_frames < len(utt.phoneme_ids):
                     _LOGGER.warning(
                         "Skipping utterance with more phonemes (%d) than spectrogram frames (%d), "

--- a/tests/test_cache_norm_audio_frames.py
+++ b/tests/test_cache_norm_audio_frames.py
@@ -1,0 +1,76 @@
+"""`cache_norm_audio` reports the length of the spectrogram it caches.
+
+The preprocessor's too-short guard needs one number per utterance, and reading
+it back off disk afterwards is serial work in the parent process. The function
+that writes the spectrogram already holds it.
+"""
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import soundfile as sf
+import torch
+
+from phoonnx_train.norm_audio import cache_norm_audio, make_silence_detector
+
+
+def _speech_like(seconds: float, sample_rate: int = 22050) -> np.ndarray:
+    """A voiced-sounding tone burst: the detector has to keep something, or
+    the cached spectrogram is empty and the test measures nothing."""
+    t = np.linspace(0, seconds, int(seconds * sample_rate), endpoint=False)
+    f0 = 120.0
+    signal = sum(np.sin(2 * np.pi * f0 * k * t) / k for k in range(1, 12))
+    envelope = 0.5 * (1 - np.cos(2 * np.pi * np.clip(t / seconds, 0, 1)))
+    return (0.4 * signal * envelope).astype(np.float32)
+
+
+class TestCachedFrameCount(unittest.TestCase):
+    def setUp(self):
+        self.detector = make_silence_detector()
+
+    def _run(self, tmp, wav):
+        cache = tmp / "cache"
+        cache.mkdir(exist_ok=True)   # the caller owns this; cache_norm_audio does not
+        return cache_norm_audio(wav, cache, self.detector, 22050)
+
+    def test_the_count_matches_the_spectrogram_that_was_written(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            wav = tmp / "clip.wav"
+            sf.write(wav, _speech_like(1.0), 22050)
+
+            _norm, spec_path, frames = self._run(tmp, wav)
+            self.assertGreater(frames, 0)
+            self.assertEqual(frames,
+                             torch.load(spec_path, map_location="cpu").size(-1))
+
+    def test_a_cache_hit_reports_the_same_count_as_the_write(self):
+        # The second call computes nothing and must still answer, because a
+        # resumed or re-run preprocessing pass takes this path for every row.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            wav = tmp / "clip.wav"
+            sf.write(wav, _speech_like(1.0), 22050)
+
+            _n1, spec_path, first = self._run(tmp, wav)
+            self.assertTrue(spec_path.is_file())
+            _n2, _s2, second = self._run(tmp, wav)
+            self.assertEqual(first, second)
+
+    def test_a_longer_clip_reports_more_frames(self):
+        # Guards against returning a constant, which every equality above
+        # would still accept.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            short_wav, long_wav = tmp / "short.wav", tmp / "long.wav"
+            sf.write(short_wav, _speech_like(0.5), 22050)
+            sf.write(long_wav, _speech_like(2.0), 22050)
+
+            _n, _s, short_frames = self._run(tmp, short_wav)
+            _n, _s, long_frames = self._run(tmp, long_wav)
+            self.assertGreater(long_frames, short_frames)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -357,7 +357,7 @@ class TestSpectrogramTooShortSkip(unittest.TestCase):
             out = tmp / "out"
 
             def _fake_cache_norm_audio(audio_path, cache_dir, detector, sample_rate):
-                return norm_path, spec_path
+                return norm_path, spec_path, 1
 
             with patch.object(preprocess, "cache_norm_audio", _fake_cache_norm_audio):
                 with self.assertLogs("preprocess", level="WARNING") as logs:
@@ -528,3 +528,80 @@ class TestPhonemizeWorkerDirect(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFrameCountComesFromTheWorker(unittest.TestCase):
+    """The too-short guard stays; the serial re-read of every cached
+    spectrogram to obtain its length is what goes."""
+
+    def _one_row(self, tmp, phonemes="h i h i h i h i h i h i"):
+        wav = tmp / "clip.wav"
+        wav.write_bytes(_wav_bytes(seconds=0.05))
+        spec_path = tmp / "clip.spec.pt"
+        torch.save(torch.zeros(80, 1), spec_path)
+        norm_path = tmp / "clip.norm.pt"
+        torch.save(torch.zeros(1, 800), norm_path)
+        src = tmp / "a.jsonl"
+        _jsonl(src, [{"text": "hi", "audio": str(wav), "phon": phonemes}])
+        return src, norm_path, spec_path
+
+    def test_the_carried_count_is_used_without_reading_the_spectrogram(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src, norm_path, spec_path = self._one_row(tmp)
+
+            def _fake(audio_path, cache_dir, detector, sample_rate):
+                return norm_path, spec_path, 1
+
+            def _refuse(*args, **kwargs):
+                raise AssertionError("the spectrogram was read back off disk")
+
+            with patch.object(preprocess, "cache_norm_audio", _fake), \
+                    patch.object(preprocess.torch, "load", _refuse):
+                with self.assertLogs("preprocess", level="WARNING") as logs:
+                    result = _invoke([
+                        "-i", str(src), "-o", str(tmp / "out"), "-l", "en",
+                        "--phonemes-column", "phon",
+                    ])
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(any("too short for its text" in m for m in logs.output))
+
+    def test_a_row_without_a_count_still_falls_back_to_the_file(self):
+        # A run resumed from an earlier dataset.jsonl carries no count, and the
+        # guard must still fire rather than pass the utterance through.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src, norm_path, spec_path = self._one_row(tmp)
+
+            def _fake(audio_path, cache_dir, detector, sample_rate):
+                return norm_path, spec_path, None
+
+            with patch.object(preprocess, "cache_norm_audio", _fake):
+                with self.assertLogs("preprocess", level="WARNING") as logs:
+                    result = _invoke([
+                        "-i", str(src), "-o", str(tmp / "out"), "-l", "en",
+                        "--phonemes-column", "phon",
+                    ])
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(any("too short for its text" in m for m in logs.output))
+
+    def test_a_long_enough_utterance_is_still_written(self):
+        # The guard must not start rejecting what it used to accept.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src, norm_path, spec_path = self._one_row(tmp, phonemes="h i")
+            out = tmp / "out"
+
+            def _fake(audio_path, cache_dir, detector, sample_rate):
+                return norm_path, spec_path, 400
+
+            with patch.object(preprocess, "cache_norm_audio", _fake):
+                result = _invoke([
+                    "-i", str(src), "-o", str(out), "-l", "en",
+                    "--phonemes-column", "phon",
+                ])
+            self.assertEqual(result.exit_code, 0, result.output)
+            lines = [x for x in (out / "dataset.jsonl").read_text().splitlines() if x]
+            self.assertEqual(len(lines), 1)
+            # The count is a preprocessing-time detail and does not reach the manifest.
+            self.assertNotIn("spec_frames", json.loads(lines[0]))

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -627,3 +627,63 @@ class TestFrameCountComesFromTheWorker(unittest.TestCase):
             self.assertEqual(len(lines), 1)
             # The count is a preprocessing-time detail and does not reach the manifest.
             self.assertNotIn("spec_frames", json.loads(lines[0]))
+
+
+class TestTheWorkerStartsUnderWhateverTheDefaultIs(unittest.TestCase):
+    """The pickling question, asked by the suite rather than by a reader.
+
+    `phonemize_worker` is started with the live phonemizer in `args`, so it is
+    inherited under `fork` and pickled under `forkserver` -- which is Python
+    3.14's default on Linux. Two other classes in this file pin `fork` so a
+    patch applied in the parent reaches the child; that pin is what makes those
+    tests mean anything, and it is also what would stop the suite noticing if
+    `proc.start()` began failing on the default. These do not pin anything.
+
+    See TigreGotico/phoonnx#467 for what to do about the transfer itself. This
+    only ensures the suite finds out.
+    """
+
+    def test_the_phonemizer_handed_to_a_worker_can_survive_the_transfer(self):
+        # The property that breaks: under a non-fork start method the object in
+        # `args` is pickled. Checked directly, so it costs nothing and does not
+        # depend on which start method this interpreter happens to default to.
+        import multiprocessing
+        import pickle
+
+        from phoonnx.config import Alphabet, PhonemeType
+        from phoonnx_train.preprocess import get_phonemizer
+
+        phonemizer = get_phonemizer(PhonemeType.GRAPHEMES, Alphabet.UNICODE, "")
+        restored = pickle.loads(pickle.dumps(phonemizer))
+        self.assertEqual(type(restored), type(phonemizer))
+        self.assertIn(multiprocessing.get_start_method(),
+                      multiprocessing.get_all_start_methods())
+
+    def test_a_real_run_completes_on_the_default_start_method(self):
+        # End to end with no patching of `Process` and no fake phonemizer, so
+        # the workers start however this interpreter starts them. On 3.13 that
+        # is fork and on 3.14 forkserver; either way a failure here is the
+        # transfer failing, which is the thing worth learning from a suite.
+        import multiprocessing
+        import click.testing
+
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "a.jsonl"
+            _jsonl(src, [{"text": "hi", "audio": "a.wav"},
+                         {"text": "there", "audio": "b.wav"}])
+            out = tmp / "out"
+            result = click.testing.CliRunner().invoke(preprocess.cli, [
+                "-i", str(src), "-o", str(out), "-l", "en", "--skip-audio",
+                "--phoneme-type", "graphemes", "--alphabet", "unicode",
+                "--max-workers", "2",
+            ], catch_exceptions=False)
+
+            self.assertEqual(
+                result.exit_code, 0,
+                f"start method {multiprocessing.get_start_method()!r}: {result.output}")
+            lines = [x for x in (out / "dataset.jsonl").read_text().splitlines() if x]
+            self.assertEqual(
+                len(lines), 2,
+                f"workers produced {len(lines)} rows under "
+                f"{multiprocessing.get_start_method()!r}")

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -359,7 +359,14 @@ class TestSpectrogramTooShortSkip(unittest.TestCase):
             def _fake_cache_norm_audio(audio_path, cache_dir, detector, sample_rate):
                 return norm_path, spec_path, 1
 
-            with patch.object(preprocess, "cache_norm_audio", _fake_cache_norm_audio):
+            # Pinned to fork so the worker inherits the patch. Under the 3.14
+            # default the child re-imports, the real function runs, and this
+            # clip trips the guard on its own -- the assertion would hold while
+            # testing nothing the fake set up.
+            import multiprocessing
+            with patch.object(preprocess, "Process",
+                              multiprocessing.get_context("fork").Process), \
+                    patch.object(preprocess, "cache_norm_audio", _fake_cache_norm_audio):
                 with self.assertLogs("preprocess", level="WARNING") as logs:
                     result = _invoke([
                         "-i", str(src), "-o", str(out), "-l", "en", "--phonemes-column", "phon",
@@ -532,11 +539,19 @@ if __name__ == "__main__":
 
 class TestFrameCountComesFromTheWorker(unittest.TestCase):
     """The too-short guard stays; the serial re-read of every cached
-    spectrogram to obtain its length is what goes."""
+    spectrogram to obtain its length is what goes.
 
-    def _one_row(self, tmp, phonemes="h i h i h i h i h i h i"):
+    Two of these drive the real audio path rather than a fake, because the
+    workers are separate processes and only inherit a patch under the `fork`
+    start method. Python 3.14 defaults to `forkserver` on Linux, where a child
+    re-imports the module and sees the unpatched function; a test that patches
+    across that boundary passes or fails for reasons that have nothing to do
+    with the change.
+    """
+
+    def _one_row(self, tmp, phonemes="h i h i h i h i h i h i", seconds=0.05):
         wav = tmp / "clip.wav"
-        wav.write_bytes(_wav_bytes(seconds=0.05))
+        wav.write_bytes(_wav_bytes(seconds=seconds))
         spec_path = tmp / "clip.spec.pt"
         torch.save(torch.zeros(80, 1), spec_path)
         norm_path = tmp / "clip.norm.pt"
@@ -569,6 +584,13 @@ class TestFrameCountComesFromTheWorker(unittest.TestCase):
     def test_a_row_without_a_count_still_falls_back_to_the_file(self):
         # A run resumed from an earlier dataset.jsonl carries no count, and the
         # guard must still fire rather than pass the utterance through.
+        #
+        # This one does need the worker to see the fake, so it pins the fork
+        # start method for the duration. Under forkserver the child re-imports
+        # and the real function runs, which would leave the fallback branch
+        # untested while the assertion still passed.
+        import multiprocessing
+
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             src, norm_path, spec_path = self._one_row(tmp)
@@ -576,7 +598,9 @@ class TestFrameCountComesFromTheWorker(unittest.TestCase):
             def _fake(audio_path, cache_dir, detector, sample_rate):
                 return norm_path, spec_path, None
 
-            with patch.object(preprocess, "cache_norm_audio", _fake):
+            with patch.object(preprocess, "Process",
+                              multiprocessing.get_context("fork").Process), \
+                    patch.object(preprocess, "cache_norm_audio", _fake):
                 with self.assertLogs("preprocess", level="WARNING") as logs:
                     result = _invoke([
                         "-i", str(src), "-o", str(tmp / "out"), "-l", "en",
@@ -586,20 +610,18 @@ class TestFrameCountComesFromTheWorker(unittest.TestCase):
             self.assertTrue(any("too short for its text" in m for m in logs.output))
 
     def test_a_long_enough_utterance_is_still_written(self):
-        # The guard must not start rejecting what it used to accept.
+        # The guard must not start rejecting what it used to accept. Real audio
+        # and no fake: a second of speech against two phonemes clears the guard
+        # whichever process computed the count.
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
-            src, norm_path, spec_path = self._one_row(tmp, phonemes="h i")
+            src, _norm, _spec = self._one_row(tmp, phonemes="h i", seconds=1.0)
             out = tmp / "out"
 
-            def _fake(audio_path, cache_dir, detector, sample_rate):
-                return norm_path, spec_path, 400
-
-            with patch.object(preprocess, "cache_norm_audio", _fake):
-                result = _invoke([
-                    "-i", str(src), "-o", str(out), "-l", "en",
-                    "--phonemes-column", "phon",
-                ])
+            result = _invoke([
+                "-i", str(src), "-o", str(out), "-l", "en",
+                "--phonemes-column", "phon",
+            ])
             self.assertEqual(result.exit_code, 0, result.output)
             lines = [x for x in (out / "dataset.jsonl").read_text().splitlines() if x]
             self.assertEqual(len(lines), 1)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

## What it costs today

Preprocessing skips an utterance whose text needs more phoneme ids than its audio has spectrogram frames — monotonic alignment needs at least one frame per id, and a shorter spectrogram means the clip does not contain the full text. The check is right and stays.

Getting the number is what is wrong. `preprocess.py` loads every cached spectrogram back off disk to ask its last dimension, in the parent process, after every worker has finished:

```python
spec_frames = torch.load(utt.audio_spec_path, map_location="cpu").size(-1)
```

Measured on this box over 1,500 cached spectrograms drawn at random from a real run's cache: **23.8 ms each, 35.7 s for the sample**. A 30,461-row corpus projects to about **725 s of single-threaded work** re-reading files the workers had just written, and no number of workers touches it.

## What changes

`cache_norm_audio` holds the tensor at the moment it computes one, so it returns the frame count alongside the two paths it already returns, and the worker carries it on the `Utterance`.

- **A fresh run never reads the file.** The count comes from the tensor in hand.
- **A re-run over a warm cache still reads it**, because a `.pt` has no cheap header to interrogate — but the read happens in whichever worker owns that utterance, in parallel, instead of serially in the parent.

The guard is untouched and still fires. A row carrying no count — anything resumed from an earlier `dataset.jsonl` — falls back to loading the file rather than passing through unchecked, so resume cannot silently lose the check.

`spec_frames` stays out of `dataset.jsonl`. It is a preprocessing-time detail and the cached spectrogram already carries it; adding it to the manifest would change a written contract for nothing.

## Tests

Six new tests. Two mutants were run rather than assumed:

- **ignoring the carried count and always re-reading** reddens the two tests that assert the count is used, one of which patches `torch.load` in the preprocessor to raise if it is called at all
- **returning a constant instead of the real length** from the cache-hit path reddens the count-matches test and the longer-clip-more-frames test

That second mutant is why the longer-clip test exists: a constant is self-consistent, so "a cache hit reports the same count as the write" stays green under it and would have passed a broken implementation on its own.

The rest cover the guard's behaviour rather than its plumbing: a too-short utterance is still skipped from the carried count, a row with no count still falls back to the file and is still skipped, a long-enough utterance is still written, and the manifest still has no `spec_frames` key.


## A test that was passing for the wrong reason

The 3.14 job failed where 3.11 through 3.13 passed, and the difference was not this change. Python 3.14 defaults `multiprocessing` to `forkserver` on Linux where earlier versions default to `fork`, so a worker re-imports the module and never sees a patch applied in the parent. `test_a_long_enough_utterance_is_still_written` patched `cache_norm_audio` across that boundary, the real function ran, and the guard correctly dropped a row the test expected written.

Chasing it turned up the worse case in the same file. `TestSpectrogramTooShortSkip::test_utterance_shorter_than_its_phonemes_is_skipped` patches across the same boundary and **passes** on 3.14 — the fake never applies, the real path reaches the same verdict by another route, and the assertion holds while nothing the fake set up is exercised. A failing test tells you something; one that passes without touching its subject is indistinguishable from a working gate until somebody reads the log.

Both are fixed here. The long-enough-utterance test drives real audio with no fake at all, so it asserts the same thing under either start method. The two that genuinely need the worker to see a fake pin the fork context and say why. Verified both ways: 28 pass under the local default, 25 with the start method forced to forkserver.

The consequences beyond the tests — a per-worker cold start of the phonemizer, and a warm one failing to pickle outright — are filed as TigreGotico/phoonnx#467 rather than folded in here.

## Test run

Every test file touching `preprocess`, `dataset_loaders`, `norm_audio` or `Utterance` — 24 files: **534 passed, 13 subtests passed, 7 failed.** Locally under `fork`; the affected file also runs clean with the start method forced to `forkserver`.

All 7 failures reproduce on unmodified `origin/dev` in a separate clean worktree at the same commit: 5 in `test_quality_filter.py` (UTMOS and DNSMOS scorers), one in `test_fastpitch_training.py` and one in `test_misc_hardening.py`. None of them touch this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

